### PR TITLE
Update SPIR-V/LLVM Translator to use new MemIntrinsics API

### DIFF
--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -79,7 +79,7 @@ public:
         // The source could be bit-cast from another type,
         // need the original type for the allocation of the temporary variable
         SrcTy = cast<BitCastInst>(Src)->getOperand(0)->getType();
-    auto Align = I.getAlignment();
+    auto Align = I.getSourceAlignment();
     auto Volatile = I.isVolatile();
     Value *NumElements = nullptr;
     uint64_t ElementsCount = 1;
@@ -94,10 +94,11 @@ public:
 
     auto *Alloca = Builder.CreateAlloca(SrcTy->getPointerElementType(),
         NumElements);
+    Alloca->setAlignment(Align);
     Builder.CreateLifetimeStart(Alloca);
-    Builder.CreateMemCpy(Alloca, Src, Length, Align, Volatile);
-    auto *SecondCpy = Builder.CreateMemCpy(Dest, Alloca, Length, Align,
-        Volatile);
+    Builder.CreateMemCpy(Alloca, Align, Src, Align, Length, Volatile);
+    auto *SecondCpy = Builder.CreateMemCpy(Dest, I.getDestAlignment(), Alloca,
+                                           Align, Length, Volatile);
     Builder.CreateLifetimeEnd(Alloca);
 
     SecondCpy->takeName(&I);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1257,7 +1257,7 @@ SPIRVValue *
 LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II, SPIRVBasicBlock *BB) {
   auto getMemoryAccess = [](MemIntrinsic *MI)->std::vector<SPIRVWord> {
     std::vector<SPIRVWord> MemoryAccess(1, MemoryAccessMaskNone);
-    if (SPIRVWord AlignVal = MI->getAlignment()) {
+    if (SPIRVWord AlignVal = MI->getDestAlignment()) {
       MemoryAccess[0] |= MemoryAccessAlignedMask;
       MemoryAccess.push_back(AlignVal);
     }
@@ -1313,9 +1313,10 @@ LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II, SPIRVBasicBlock *BB) {
     SPIRVValue *Target = transValue(MSI->getRawDest(), BB);
     return BM->addCopyMemorySizedInst(Target, Source, CompositeTy->getLength(),
                                       getMemoryAccess(MSI), BB);
-  }
-  break;
-  case Intrinsic::memcpy :
+  } break;
+  case Intrinsic::memcpy:
+    assert(cast<MemCpyInst>(II)->getSourceAlignment() ==
+           cast<MemCpyInst>(II)->getDestAlignment() && "Alignment mismatch!");
     return BM->addCopyMemorySizedInst(
       transValue(II->getOperand(0), BB),
       transValue(II->getOperand(1), BB),


### PR DESCRIPTION
Fixes #1