### PR TITLE
Full conversion to standalone project + travis fixup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,78 @@
-# Linux Build Configuration for Travis
-
 language: cpp
 
 os:
   - linux
 
 # Use Ubuntu 14.04 LTS (Trusty) as the Linux testing environment.
-sudo: required
 dist: trusty
+sudo: false
 
-env:
-  # Each line is a set of environment variables set before a build.
-  # Thus each line represents a different build configuration.
-  - BUILD_TYPE=Release
-  - BUILD_TYPE=Debug
+git:
+  depth: 1
+
+addons:
+  apt:
+    sources:
+    # adds deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty main
+    - llvm-toolchain-trusty
+    - ubuntu-toolchain-r-test
+    packages:
+    - llvm-7-tools
+    - llvm-7-dev
 
 compiler:
   - gcc
   - clang
 
-# To avoid Go bindings related issues in LIT tests, hide Go binaries from CMake
-install:
-  - rm -f `which go`
+env:
+  global:
+    - MAKEFLAGS="-j2"
+  matrix:
+    - BUILD_TYPE=Release BUILD_EXTERNAL=1 MAKE_TARGETS=""           MAKE_TEST_TARGET="test"
+    - BUILD_TYPE=Debug   BUILD_EXTERNAL=1 MAKE_TARGETS=""           MAKE_TEST_TARGET="test"
+    - BUILD_TYPE=Release BUILD_EXTERNAL=0 MAKE_TARGETS="llvm-spirv" MAKE_TEST_TARGET="check-llvm-spirv"
+    - BUILD_TYPE=Debug   BUILD_EXTERNAL=0 MAKE_TARGETS="llvm-spirv" MAKE_TEST_TARGET="check-llvm-spirv"
+  # some bug inside clang-5.0.0, works with 5.0.1
+
+matrix:
+  include:
+    - os: osx
+      env: BUILD_TYPE=Release BUILD_EXTERNAL=0 MAKE_TARGETS="llvm-spirv" MAKE_TEST_TARGET="check-llvm-spirv"
+      osx_image: xcode9.3
+
+    - os: osx
+      env: BUILD_TYPE=Debug BUILD_EXTERNAL=0 MAKE_TARGETS="llvm-spirv" MAKE_TEST_TARGET="check-llvm-spirv"
+      osx_image: xcode9.3
+  allow_failures:
+    - compiler: clang
+    - os: osx
+  fast_finish: true
 
 script:
+  - |
+    if [ $BUILD_EXTERNAL == "0" ]; then
+      mkdir llvm-spirv
+      mv * llvm-spirv
+      git clone https://git.llvm.org/git/llvm.git/ --depth 1
+      mv llvm-spirv llvm/tools/llvm-spirv
+    fi
   - mkdir build && cd build
-  - cmake -D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF -D CMAKE_COLOR_MAKEFILE:BOOL=ON -D LLVM_INCLUDE_EXAMPLES:BOOL=OFF -D LLVM_INCLUDE_TESTS:BOOL=ON -D LLVM_BUILD_TESTS:BOOL=ON -D LLVM_TARGETS_TO_BUILD="X86" -D LLVM_LIT_ARGS:STRING="-sv --no-progress-bar" -G "Unix Makefiles" -D CMAKE_BUILD_TYPE:STRING=${BUILD_TYPE}  ..
-  - make check-llvm -j 2
+  - |
+    if [ $BUILD_EXTERNAL == "1" ]; then
+      cmake .. \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DLLVM_BUILD_TOOLS=ON \
+        -DLLVM_EXTERNAL_LIT="/usr/lib/llvm-7/build/utils/lit/lit.py" \
+        -DLLVM_INCLUDE_TESTS=ON \
+        -DCMAKE_INSTALL_PREFIX=../install/ \
+        -G "Unix Makefiles"
+    else
+      cmake ../llvm/ \
+        -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+        -DLLVM_BUILD_TOOLS=ON \
+        -DLLVM_BUILD_TESTS=ON \
+        -DLLVM_INCLUDE_TESTS=ON \
+        -DLLVM_LIT_ARGS="-sv --no-progress-bar" \
+        -G "Unix Makefiles"
+    fi
+  - make $MAKE_TARGETS && make $MAKE_TEST_TARGET && if [ $BUILD_EXTERNAL == "1" ]; then make install; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,66 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 3.3)
+cmake_minimum_required(VERSION 3.3)
 
-# Name & Version
-PROJECT(LLVM_SPIRV
-        VERSION   0.1.0.0
-        LANGUAGES CXX)
+# check if we build inside llvm or not
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(BUILD_EXTERNAL YES)
+  project(LLVM_SPIRV
+    VERSION
+      0.1.0.0
+    LANGUAGES
+      CXX
+  )
 
-message(STATUS "LLVM-SPIRV found at ${CMAKE_CURRENT_SOURCE_DIR}")
+  set(CMAKE_CXX_STANDARD 11)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+  if(LLVM_INCLUDE_TESTS)
+    set(LLVM_TEST_COMPONENTS
+      llvm-as
+      llvm-dis
+    )
+  endif(LLVM_INCLUDE_TESTS)
+
+  find_package(LLVM 7.0.0 REQUIRED
+    COMPONENTS
+      Analysis
+      BitReader
+      BitWriter
+      Core
+      Support
+      TransformUtils
+      ${LLVM_TEST_COMPONENTS}
+  )
+  set(CMAKE_MODULE_PATH
+    ${CMAKE_MODULE_PATH}
+    ${LLVM_CMAKE_DIR}
+  )
+  include(AddLLVM)
+
+  message(STATUS "Found LLVM: ${LLVM_VERSION}")
+else(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(BUILD_EXTERNAL NO)
+endif(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+
 set(LLVM_SPIRV_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
-set(LLVM_SPIRV_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_subdirectory(lib/SPIRV)
+add_subdirectory(tools/llvm-spirv)
+if(LLVM_INCLUDE_TESTS)
+  add_subdirectory(test)
+endif(LLVM_INCLUDE_TESTS)
 
-SUBDIRS(lib/SPIRV tools/llvm-spirv test)
+install(
+  FILES
+    ${LLVM_SPIRV_INCLUDE_DIRS}/SPIRV.h
+  DESTINATION
+    include
+)
+
+get_target_property(LLVMSPIRVlib_LIBDIR LLVMSPIRVLib BINARY_DIR)
+configure_file(LLVMSPIRVLib.pc.in ${CMAKE_BINARY_DIR}/LLVMSPIRVLib.pc @ONLY)
+install(
+  FILES
+    ${CMAKE_BINARY_DIR}/LLVMSPIRVLib.pc
+  DESTINATION
+    ${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/pkgconfig
+)

--- a/LLVMSPIRVLib.pc.in
+++ b/LLVMSPIRVLib.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=@LLVMSPIRVlib_LIBDIR@
+includedir=${prefix}/include
+
+Name: LLVMSPIRVLib
+Description: LLVM/SPIR-V bi-directional translator
+Version: @LLVM_SPIRV_VERSION@
+URL: https://github.com/KhronosGroup/SPIRV-LLVM-Translator
+
+Libs: -L${libdir} -lLLVMSPIRVLib
+Cflags: -I${includedir}

--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -1,15 +1,9 @@
-include_directories(
-  ${LLVM_SPIRV_INCLUDE_DIRS}
-  ${CMAKE_CURRENT_SOURCE_DIR}/Mangler
-  ${CMAKE_CURRENT_SOURCE_DIR}/libSPIRV
-  ${CMAKE_CURRENT_SOURCE_DIR})
-
 option(SPIRV_USE_LLVM_API "Enable usage of LLVM API for libSPIRV." ON)
-if ( SPIRV_USE_LLVM_API )
+if(SPIRV_USE_LLVM_API)
   add_definitions(-D_SPIRV_LLVM_API)
-endif()
+endif(SPIRV_USE_LLVM_API)
 
-add_llvm_library(LLVMSPIRVLib
+add_llvm_library(LLVMSPIRVLib SHARED
   libSPIRV/SPIRVBasicBlock.cpp
   libSPIRV/SPIRVDebug.cpp
   libSPIRV/SPIRVDecorate.cpp
@@ -31,8 +25,8 @@ add_llvm_library(LLVMSPIRVLib
   OCLUtil.cpp
   SPIRVLowerBool.cpp
   SPIRVLowerConstExpr.cpp
-  SPIRVLowerOCLBlocks.cpp
   SPIRVLowerMemmove.cpp
+  SPIRVLowerOCLBlocks.cpp
   SPIRVReader.cpp
   SPIRVRegularizeLLVM.cpp
   SPIRVToOCL20.cpp
@@ -40,6 +34,19 @@ add_llvm_library(LLVMSPIRVLib
   SPIRVWriter.cpp
   SPIRVWriterPass.cpp
   TransOCLMD.cpp
-  )
+  LINK_COMPONENTS
+    Analysis
+    BitWriter
+    Core
+    Support
+    TransformUtils
+)
 
-add_dependencies(LLVMSPIRVLib intrinsics_gen)
+target_include_directories(LLVMSPIRVLib
+  PRIVATE
+    ${LLVM_INCLUDE_DIR}
+    ${LLVM_SPIRV_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libSPIRV
+    ${CMAKE_CURRENT_SOURCE_DIR}/Mangler
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,18 +1,42 @@
+# required by lit.site.cfg.py.in
+get_target_property(LLVM_SPIRV_DIR llvm-spirv BINARY_DIR)
+set(LLVM_SPIRV_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
   MAIN_CONFIG
-  ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
-  )
-
-list(APPEND LLVM_SPIRV_TEST_DEPS
-  FileCheck count not
-  llvm-as
-  llvm-dis
-  llvm-spirv
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
 )
+
+if(NOT BUILD_EXTERNAL)
+  set(LLVM_SPIRV_TEST_DEPS
+    count
+    FileCheck
+    not
+  )
+endif(NOT BUILD_EXTERNAL)
 
 add_lit_testsuite(check-llvm-spirv "Running the LLVM-SPIRV regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS ${LLVM_SPIRV_TEST_DEPS}
+  ARGS
+    --verbose
+  DEPENDS
+    ${LLVM_SPIRV_TEST_DEPS}
+    llvm-as
+    llvm-dis
+    llvm-spirv
+)
+
+# to enable a custom test target on cmake below 3.11
+# starting with 3.11 "test" is only reserved if ENABLE_TESTING(ON)
+if(BUILD_EXTERNAL)
+  cmake_policy(PUSH)
+  if(POLICY CMP0037 AND ${CMAKE_VERSION} VERSION_LESS "3.11.0")
+    cmake_policy(SET CMP0037 OLD)
+  endif(POLICY CMP0037 AND ${CMAKE_VERSION} VERSION_LESS "3.11.0")
+  add_custom_target(test
+    DEPENDS
+      check-llvm-spirv
   )
+  cmake_policy(POP)
+endif(BUILD_EXTERNAL)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -25,7 +25,7 @@ config.excludes = ['CMakeLists.txt']
 config.test_source_root = os.path.dirname(__file__)
 
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.llvm_obj_root, 'test')
+config.test_exec_root = os.path.join(config.test_run_dir, 'test_output')
 
 llvm_config.use_default_substitutions()
 
@@ -33,7 +33,7 @@ llvm_config.use_default_substitutions()
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 
-tool_dirs = [config.llvm_tools_dir]
+tool_dirs = [config.llvm_tools_dir, config.llvm_spirv_dir]
 
 tools = ['llvm-as', 'llvm-dis', 'llvm-spirv']
 

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -5,6 +5,7 @@ import sys
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"
 config.llvm_obj_root = "@LLVM_BINARY_DIR@"
 config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_spirv_dir = "@LLVM_SPIRV_DIR@"
 config.llvm_libs_dir = "@LLVM_LIBS_DIR@"
 config.llvm_shlib_dir = "@SHLIBDIR@"
 config.llvm_plugin_ext = "@LLVM_PLUGIN_EXT@"
@@ -13,6 +14,7 @@ config.host_triple = "@LLVM_HOST_TRIPLE@"
 config.target_triple = "@TARGET_TRIPLE@"
 config.host_arch = "@HOST_ARCH@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
+config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
 
 # Support substitution of the tools and libs dirs with user parameters. This is
 # used when we can't determine the tool dir at configuration time.
@@ -28,4 +30,4 @@ except KeyError:
 @LIT_SITE_CFG_IN_FOOTER@
 
 # Let the main config do the real work.
-lit_config.load_config(config, "@LLVM_SPIRV_SOURCE_DIR@/test/lit.cfg.py")
+lit_config.load_config(config, "@LLVM_SPIRV_TEST_SOURCE_DIR@/lit.cfg.py")

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -1,15 +1,15 @@
 set(LLVM_LINK_COMPONENTS
-  Analysis
-  BitReader
-  BitWriter
-  Core
   SPIRVLib
-  Support
-  TransformUtils
-  )
-
-include_directories(${LLVM_SPIRV_INCLUDE_DIRS})
+)
 
 add_llvm_tool(llvm-spirv
   llvm-spirv.cpp
-  )
+  # llvm_setup_rpath messes with the rpath making llvm-spirv not executable from the build directory
+  NO_INSTALL_RPATH
+)
+
+target_include_directories(llvm-spirv
+  PRIVATE
+    ${LLVM_INCLUDE_DIR}
+    ${LLVM_SPIRV_INCLUDE_DIRS}
+)


### PR DESCRIPTION
basically contains a complete rework of the CMake files, so that we can build the project without having to put it inside a llvm tree and build it there. A pkgconfig file is also added so that other projects can simply depend on LLVMSPIRVLib.
Travis was changed accordingly to be able to build and run the tests.

llvm-lit is a bit weirdly handled on each distribution. On Fedora I have a "python3-lit" package which provides a "lit" binary the build system uses. On Ubuntu you have to install llvm-X-tools and point LLVM_EXTERNAL_LIT to the correct lit.py file.

There were also some changes required to the lit files, so that lit doesn't try to create new directories in system paths.

Builds can be seen here until the project enables travis-ci:
https://travis-ci.org/karolherbst/SPIRV-LLVM-Translator

some Notes:
* Also one of the tests are crashing when built with clang and not gcc.

