### PR TITLE
Always define LLVM_SPIRV_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.3)
 
+set(LLVM_SPIRV_VERSION 0.1.0.0)
+
 # check if we build inside llvm or not
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(BUILD_EXTERNAL YES)
   project(LLVM_SPIRV
     VERSION
-      0.1.0.0
+      ${LLVM_SPIRV_VERSION}
     LANGUAGES
       CXX
   )


### PR DESCRIPTION
Currently, LLVM_SPIRV_VERSION is not defined when building in-tree,
resulting in the pkgconfig file having an empty version.

Fixes: 7b8cc990 ("cmake: rework to be able to build outside LLVM")