### PR TITLE
Rename the installed header and install it in a prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.3)
 
-set(LLVM_SPIRV_VERSION 0.2.0.0)
+set(LLVM_SPIRV_VERSION 0.2.1.0)
 
 # check if we build inside llvm or not
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
@@ -53,9 +53,9 @@ endif(LLVM_INCLUDE_TESTS)
 
 install(
   FILES
-    ${LLVM_SPIRV_INCLUDE_DIRS}/SPIRV.h
+    ${LLVM_SPIRV_INCLUDE_DIRS}/LLVMSPIRVLib.h
   DESTINATION
-    include
+    ${CMAKE_INSTALL_PREFIX}/include/LLVMSPIRVLib
 )
 
 get_target_property(LLVMSPIRVlib_LIBDIR LLVMSPIRVLib BINARY_DIR)

--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -1,4 +1,4 @@
-//===- SPIRV.h - Read and write SPIR-V binary -------------------*- C++ -*-===//
+//===- LLVMSPIRVLib.h - Read and write SPIR-V binary ------------*- C++ -*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //
@@ -31,7 +31,7 @@
 // THE SOFTWARE.
 //
 //===----------------------------------------------------------------------===//
-/// \file SPIRV.h
+/// \file LLVMSPIRVLib.h
 ///
 /// This files declares functions and passes for translating between LLVM and
 /// SPIR-V.

--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -42,7 +42,7 @@
 #ifndef SPIRV_OCLTYPETOSPIRV_H
 #define SPIRV_OCLTYPETOSPIRV_H
 
-#include "SPIRV.h"
+#include "LLVMSPIRVLib.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Pass.h"

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -46,7 +46,7 @@
 #include "libSPIRV/SPIRVType.h"
 #include "libSPIRV/SPIRVUtil.h"
 
-#include "SPIRV.h"
+#include "LLVMSPIRVLib.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"

--- a/lib/SPIRV/SPIRVWriterPass.cpp
+++ b/lib/SPIRV/SPIRVWriterPass.cpp
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SPIRVWriterPass.h"
-#include "SPIRV.h"
+#include "LLVMSPIRVLib.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -64,7 +64,7 @@
 #define _SPIRV_SUPPORT_TEXT_FMT
 #endif
 
-#include "SPIRV.h"
+#include "LLVMSPIRVLib.h"
 
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Also, the version was bumped to 0.2.1 (from 0.2.0) due to the changes.

Fix: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/15