### PR TITLE
Remove the _SPIRV_LLVM_API switch

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -76,7 +76,7 @@ bool isSpirvBinary(std::string &Img);
 /// This function is not thread safe and should not be used in multi-thread
 /// applications unless guarded by a critical section.
 /// \returns true if succeeds.
-bool convertSpirv(std::istream &IS, llvm::raw_ostream &OS, std::string &ErrMsg,
+bool convertSpirv(std::istream &IS, std::ostream &OS, std::string &ErrMsg,
                   bool FromText, bool ToText);
 
 /// \brief Convert SPIR-V between binary and internel text formats.
@@ -95,7 +95,7 @@ namespace llvm {
 
 /// \brief Translate LLVM module to SPIRV and write to ostream.
 /// \returns true if succeeds.
-bool writeSpirv(Module *M, raw_ostream &OS, std::string &ErrMsg);
+bool writeSpirv(Module *M, std::ostream &OS, std::string &ErrMsg);
 
 /// \brief Load SPIRV from istream and translate to LLVM module.
 /// \returns true if succeeds.
@@ -157,7 +157,7 @@ ModulePass *createTransOCLMD();
 
 /// Create and return a pass that writes the module to the specified
 /// ostream.
-ModulePass *createSPIRVWriterPass(raw_ostream &Str);
+ModulePass *createSPIRVWriterPass(std::ostream &Str);
 
 } // namespace llvm
 

--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -1,8 +1,3 @@
-option(SPIRV_USE_LLVM_API "Enable usage of LLVM API for libSPIRV." ON)
-if(SPIRV_USE_LLVM_API)
-  add_definitions(-D_SPIRV_LLVM_API)
-endif(SPIRV_USE_LLVM_API)
-
 add_llvm_library(LLVMSPIRVLib
   LLVMToSPIRVDbgTran.cpp
   Mangler/FunctionDescriptor.cpp

--- a/lib/SPIRV/OCL20To12.cpp
+++ b/lib/SPIRV/OCL20To12.cpp
@@ -48,7 +48,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -51,7 +51,6 @@
 #include "llvm/Pass.h"
 #include "llvm/PassSupport.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
 #include <set>

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -47,7 +47,6 @@
 #include "llvm/Pass.h"
 #include "llvm/PassSupport.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <set>
 

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -47,7 +47,6 @@
 #include "llvm/Pass.h"
 #include "llvm/PassSupport.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <iterator>
 #include <set>

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -51,7 +51,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -46,7 +46,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -52,7 +52,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <list>
 #include <set>

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -47,7 +47,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
@@ -57,7 +57,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/GlobalStatus.h"
 #include <iostream>

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -65,7 +65,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
 #include <cstdlib>

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -52,7 +52,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <set>
 

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -48,7 +48,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <cstring>
 

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -56,7 +56,6 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/ToolOutputFile.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <functional>
 #include <sstream>

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -73,7 +73,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ToolOutputFile.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils.h" // loop-simplify pass
 
 #include <cstdlib>
@@ -1693,7 +1692,7 @@ void addPassesForSPIRV(legacy::PassManager &PassMgr) {
   PassMgr.add(createSPIRVLowerMemmove());
 }
 
-bool llvm::writeSpirv(Module *M, llvm::raw_ostream &OS, std::string &ErrMsg) {
+bool llvm::writeSpirv(Module *M, std::ostream &OS, std::string &ErrMsg) {
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
   legacy::PassManager PassMgr;
   addPassesForSPIRV(PassMgr);

--- a/lib/SPIRV/SPIRVWriterPass.cpp
+++ b/lib/SPIRV/SPIRVWriterPass.cpp
@@ -27,10 +27,10 @@ PreservedAnalyses SPIRVWriterPass::run(Module &M) {
 
 namespace {
 class WriteSPIRVPass : public ModulePass {
-  raw_ostream &OS; // raw_ostream to print on
+  std::ostream &OS; // std::ostream to print on
 public:
   static char ID; // Pass identification, replacement for typeid
-  explicit WriteSPIRVPass(raw_ostream &O) : ModulePass(ID), OS(O) {}
+  explicit WriteSPIRVPass(std::ostream &O) : ModulePass(ID), OS(O) {}
 
   StringRef getPassName() const override { return "SPIRV Writer"; }
 
@@ -45,6 +45,6 @@ public:
 
 char WriteSPIRVPass::ID = 0;
 
-ModulePass *llvm::createSPIRVWriterPass(raw_ostream &Str) {
+ModulePass *llvm::createSPIRVWriterPass(std::ostream &Str) {
   return new WriteSPIRVPass(Str);
 }

--- a/lib/SPIRV/SPIRVWriterPass.h
+++ b/lib/SPIRV/SPIRVWriterPass.h
@@ -20,24 +20,23 @@
 namespace llvm {
 class Module;
 class ModulePass;
-class raw_ostream;
 class PreservedAnalyses;
 
 /// \brief Create and return a pass that writes the module to the specified
 /// ostream. Note that this pass is designed for use with the legacy pass
 /// manager.
-ModulePass *createSPIRVWriterPass(raw_ostream &Str);
+ModulePass *createSPIRVWriterPass(std::ostream &Str);
 
 /// \brief Pass for writing a module of IR out to a SPIRV file.
 ///
 /// Note that this is intended for use with the new pass manager. To construct
 /// a pass for the legacy pass manager, use the function above.
 class SPIRVWriterPass {
-  raw_ostream &OS;
+  std::ostream &OS;
 
 public:
   /// \brief Construct a SPIRV writer pass around a particular output stream.
-  explicit SPIRVWriterPass(raw_ostream &OS) : OS(OS) {}
+  explicit SPIRVWriterPass(std::ostream &OS) : OS(OS) {}
 
   /// \brief Run the SPIRV writer pass, and output the module to the selected
   /// output stream.

--- a/lib/SPIRV/TransOCLMD.cpp
+++ b/lib/SPIRV/TransOCLMD.cpp
@@ -50,7 +50,6 @@
 #include "llvm/PassSupport.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -41,9 +41,6 @@
 #define SPIRV_LIBSPIRV_SPIRVDEBUG_H
 
 #include "SPIRVUtil.h"
-#ifdef _SPIRV_LLVM_API
-#include "llvm/Support/Debug.h"
-#endif
 #include <iostream>
 
 namespace SPIRV {
@@ -67,11 +64,7 @@ extern bool SPIRVDbgAssertOnError;
 
 // Output stream for SPIRV debug information.
 inline spv_ostream &spvdbgs() {
-#ifdef _SPIRV_LLVM_API
-  return llvm::dbgs();
-#else
   return std::cerr;
-#endif
 }
 
 #else

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1635,7 +1635,7 @@ bool isSpirvBinary(const std::string &Img) {
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
 
-bool convertSpirv(std::istream &IS, spv_ostream &OS, std::string &ErrMsg,
+bool convertSpirv(std::istream &IS, std::ostream &OS, std::string &ErrMsg,
                   bool FromText, bool ToText) {
   auto SaveOpt = SPIRVUseTextFormat;
   SPIRVUseTextFormat = FromText;
@@ -1672,11 +1672,7 @@ bool convertSpirv(std::string &Input, std::string &Out, std::string &ErrMsg,
     return true;
   }
   std::istringstream IS(Input);
-#ifdef _SPIRV_LLVM_API
-  llvm::raw_string_ostream OS(Out);
-#else
   std::ostringstream OS;
-#endif
   if (!convertSpirv(IS, OS, ErrMsg, FromText, ToText))
     return false;
   Out = OS.str();

--- a/lib/SPIRV/libSPIRV/SPIRVUtil.h
+++ b/lib/SPIRV/libSPIRV/SPIRVUtil.h
@@ -40,13 +40,8 @@
 #ifndef SPIRV_LIBSPIRV_SPIRVUTIL_H
 #define SPIRV_LIBSPIRV_SPIRVUTIL_H
 
-#ifdef _SPIRV_LLVM_API
-#include "llvm/Support/raw_ostream.h"
-#define spv_ostream llvm::raw_ostream
-#else
 #include <ostream>
 #define spv_ostream std::ostream
-#endif
 
 #include <algorithm>
 #include <cassert>


### PR DESCRIPTION
The default remains the same, i.e. using the LLVM API, but removes the
option of using the std API, as it was untested and failed to compile.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/9