### PR TITLE
Do not error out when clang-tidy had no relevant inputs

### DIFF
--- a/utils/check_code_tidyness.sh
+++ b/utils/check_code_tidyness.sh
@@ -44,7 +44,10 @@ fi
 
 TIDY_DIFF=$(git diff -U0 master -- ${FILES_TO_CHECK} | python ./utils/clang-tidy-diff.py -p1 -- "${CPP_FILES}" 2> /dev/null)
 
-if [ -z "${TIDY_DIFF}" ]; then
+if [ "${TIDY_DIFF}" = "No relevant changes found." ]; then
+  echo "${TIDY_DIFF}"
+  exit 0
+elif [ -z "${TIDY_DIFF}" ]; then
   echo "All source code in PR properly tidied."
   exit 0
 else


### PR DESCRIPTION
Fixes: 72d4a32 ("Run clang-tidy on the codebase")