### PR TITLE
Add support of OpDecorationGroup, OpGroupDecorate, OpGroupMemberDecorate

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -291,6 +291,8 @@ public:
   const std::string &getName() const { return Name; }
   bool hasDecorate(Decoration Kind, size_t Index = 0,
                    SPIRVWord *Result = 0) const;
+  bool hasMemberDecorate(SPIRVWord MemberIndex, Decoration Kind,
+                         size_t Index = 0, SPIRVWord *Result = 0) const;
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;
   bool hasId() const { return !(Attrib & SPIRVEA_NOID); }
   bool hasLine() const { return Line != nullptr; }
@@ -313,11 +315,11 @@ public:
     return false;
   }
 
-  void addDecorate(SPIRVDecorate *);
+  void addDecorate(const SPIRVDecorate *);
   void addDecorate(Decoration Kind);
   void addDecorate(Decoration Kind, SPIRVWord Literal);
   void eraseDecorate(Decoration);
-  void addMemberDecorate(SPIRVMemberDecorate *);
+  void addMemberDecorate(const SPIRVMemberDecorate *);
   void addMemberDecorate(SPIRVWord MemberNumber, Decoration Kind);
   void addMemberDecorate(SPIRVWord MemberNumber, Decoration Kind,
                          SPIRVWord Literal);

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -173,7 +173,8 @@ public:
   void setCurrentLine(const std::shared_ptr<const SPIRVLine> &Line) override;
   void addCapability(SPIRVCapabilityKind) override;
   void addCapabilityInternal(SPIRVCapabilityKind) override;
-  const SPIRVDecorateGeneric *addDecorate(SPIRVDecorateGeneric *) override;
+  const SPIRVDecorateGeneric *
+  addDecorate(const SPIRVDecorateGeneric *) override;
   SPIRVDecorationGroup *addDecorationGroup() override;
   SPIRVDecorationGroup *
   addDecorationGroup(SPIRVDecorationGroup *Group) override;
@@ -840,8 +841,7 @@ SPIRVBasicBlock *SPIRVModuleImpl::addBasicBlock(SPIRVFunction *Func,
 }
 
 const SPIRVDecorateGeneric *
-SPIRVModuleImpl::addDecorate(SPIRVDecorateGeneric *Dec) {
-  add(Dec);
+SPIRVModuleImpl::addDecorate(const SPIRVDecorateGeneric *Dec) {
   SPIRVId Id = Dec->getTargetId();
   bool Found = exist(Id);
   (void)Found;
@@ -1417,7 +1417,6 @@ SPIRVModuleImpl::addDecorationGroup(SPIRVDecorationGroup *Group) {
   DecGroupVec.push_back(Group);
   SPIRVDBG(spvdbgs() << "[addDecorationGroup] {" << *Group << "}\n";
            spvdbgs() << "  Remaining DecorateSet: {" << DecorateSet << "}\n");
-  assert(DecorateSet.empty());
   return Group;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -177,7 +177,7 @@ public:
                        SPIRVWord Column) = 0;
   virtual const std::shared_ptr<const SPIRVLine> &getCurrentLine() const = 0;
   virtual void setCurrentLine(const std::shared_ptr<const SPIRVLine> &) = 0;
-  virtual const SPIRVDecorateGeneric *addDecorate(SPIRVDecorateGeneric *) = 0;
+  virtual const SPIRVDecorateGeneric *addDecorate(const SPIRVDecorateGeneric *) = 0;
   virtual SPIRVDecorationGroup *addDecorationGroup() = 0;
   virtual SPIRVDecorationGroup *
   addDecorationGroup(SPIRVDecorationGroup *Group) = 0;


### PR DESCRIPTION
This change is port from AMDVLK
1. Decode GroupDecorate and GroupMemberDecorate separately
2. Add function hasMemberDecorate in SPIRVEntry, it will be used in the future.
3. Add const modifier back in the base class of SPIRVDecorateSet, and modify related functions
4. Remove incorrect assert in addDecorationGroup