### PR TITLE
Update tests after changes in the FileCheck tool

### DIFF
--- a/test/transcoding/check_ro_qualifier.ll
+++ b/test/transcoding/check_ro_qualifier.ll
@@ -7,7 +7,7 @@
 ; CHECK-LLVM: define spir_kernel void @sample_kernel(%opencl.image2d_array_ro_t addrspace(1)
 ; CHECK-LLVM-SAME: !kernel_arg_access_qual [[AQ:![0-9]+]]
 ; CHECK-LLVM-SAME: !kernel_arg_type [[TYPE:![0-9]+]]
-; CHECK-LLVM-SAME: !kernel_arg_base_type [[BT:![0-9]+]]
+; CHECK-LLVM-SAME: !kernel_arg_base_type [[TYPE]]
 
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z13get_image_dimPU3AS125opencl.image2d_array_ro_t(%opencl.image2d_array_ro_t addrspace(1)
 ; CHECK-LLVM: call spir_func i64 @_Z20get_image_array_sizePU3AS125opencl.image2d_array_ro_t(%opencl.image2d_array_ro_t addrspace(1)
@@ -16,7 +16,6 @@
 
 ; CHECK-LLVM-DAG: [[AQ]] = !{!"read_only"}
 ; CHECK-LLVM-DAG: [[TYPE]] = !{!"image2d_array_ro_t"}
-; CHECK-LLVM-DAG: [[BT]] = !{!"image2d_array_ro_t"}
 
 ; ModuleID = 'out.ll'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/transcoding/check_wo_qualifier.ll
+++ b/test/transcoding/check_wo_qualifier.ll
@@ -7,7 +7,7 @@
 ; CHECK-LLVM: define spir_kernel void @sample_kernel(%opencl.image2d_array_wo_t addrspace(1)
 ; CHECK-LLVM-SAME: !kernel_arg_access_qual [[AQ:![0-9]+]]
 ; CHECK-LLVM-SAME: !kernel_arg_type [[TYPE:![0-9]+]]
-; CHECK-LLVM-SAME: !kernel_arg_base_type [[BT:![0-9]+]]
+; CHECK-LLVM-SAME: !kernel_arg_base_type [[TYPE]]
 
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z13get_image_dimPU3AS125opencl.image2d_array_wo_t(%opencl.image2d_array_wo_t addrspace(1)
 ; CHECK-LLVM: call spir_func i64 @_Z20get_image_array_sizePU3AS125opencl.image2d_array_wo_t(%opencl.image2d_array_wo_t addrspace(1)
@@ -15,7 +15,6 @@
 ; CHECK-LLVM: declare spir_func i64 @_Z20get_image_array_sizePU3AS125opencl.image2d_array_wo_t(%opencl.image2d_array_wo_t addrspace(1)
 ; CHECK-LLVM-DAG: [[AQ]] = !{!"write_only"}
 ; CHECK-LLVM-DAG: [[TYPE]] = !{!"image2d_array_wo_t"}
-; CHECK-LLVM-DAG: [[BT]] = !{!"image2d_array_wo_t"}
 
 ; ModuleID = 'out.ll'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/transcoding/cl-types.ll
+++ b/test/transcoding/cl-types.ll
@@ -87,7 +87,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-LLVM-SAME:   !kernel_arg_access_qual [[AQ:![0-9]+]]
 ; CHECK-LLVM-SAME:   !kernel_arg_type [[TYPE:![0-9]+]]
 ; CHECK-LLVM-SAME:   !kernel_arg_type_qual [[TQ:![0-9]+]]
-; CHECK-LLVM-SAME:   !kernel_arg_base_type [[BT:![0-9]+]]
+; CHECK-LLVM-SAME:   !kernel_arg_base_type [[TYPE]]
 
 ; Function Attrs: nounwind readnone
 define spir_kernel void @foo(
@@ -130,7 +130,6 @@ attributes #0 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-point
 ; CHECK-LLVM-DAG: [[AS]] = !{i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 0}
 ; CHECK-LLVM-DAG: [[AQ]] = !{!"read_only", !"write_only", !"read_only", !"read_only", !"read_only", !"read_only", !"read_only", !"write_only", !"read_write", !"none"}
 ; CHECK-LLVM-DAG: [[TYPE]] = !{!"pipe", !"pipe", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t", !"sampler_t"}
-; CHECK-LLVM-DAG: [[BT]] = !{!"pipe", !"pipe", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t", !"sampler_t"}
 ; CHECK-LLVM-DAG: [[TQ]] = !{!"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !"", !""}
 
 !0 = !{void (%opencl.pipe_t addrspace(1)*, %opencl.pipe_t addrspace(1)*, %opencl.image1d_t addrspace(1)*, %opencl.image2d_t addrspace(1)*, %opencl.image3d_t addrspace(1)*, %opencl.image2d_array_t addrspace(1)*, %opencl.image1d_buffer_t addrspace(1)*, %opencl.image1d_t addrspace(1)*, %opencl.image2d_t addrspace(1)*, i32)* @foo, !1, !2, !3, !4, !5}

--- a/test/transcoding/spirv-types.ll
+++ b/test/transcoding/spirv-types.ll
@@ -96,7 +96,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-LLVM-SAME:     !kernel_arg_access_qual [[AQ:![0-9]+]]
 ; CHECK-LLVM-SAME:     !kernel_arg_type [[TYPE:![0-9]+]]
 ; CHECK-LLVM-SAME:     !kernel_arg_type_qual [[TQ:![0-9]+]]
-; CHECK-LLVM-SAME:     !kernel_arg_base_type [[BT:![0-9]+]]
+; CHECK-LLVM-SAME:     !kernel_arg_base_type [[TYPE]]
 
 ; Function Attrs: nounwind readnone
 define spir_kernel void @foo(
@@ -169,7 +169,6 @@ attributes #0 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-point
 ; CHECK-LLVM-DAG: [[AS]] = !{i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1}
 ; CHECK-LLVM-DAG: [[AQ]] = !{!"read_only", !"write_only", !"read_only", !"read_only", !"read_only", !"read_only", !"read_only", !"write_only", !"read_write"}
 ; CHECK-LLVM-DAG: [[TYPE]] = !{!"pipe", !"pipe", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
-; CHECK-LLVM-DAG: [[BT]] = !{!"pipe", !"pipe", !"image1d_t", !"image2d_t", !"image3d_t", !"image2d_array_t", !"image1d_buffer_t", !"image1d_t", !"image2d_t"}
 ; CHECK-LLVM-DAG: [[TQ]] = !{!"pipe", !"pipe", !"", !"", !"", !"", !"", !"", !""}
 
 !0 = !{void (%spirv.Pipe._0 addrspace(1)*, %spirv.Pipe._1 addrspace(1)*, %spirv.Image._void_0_0_0_0_0_0_0 addrspace(1)*, %spirv.Image._int_1_0_0_0_0_0_0 addrspace(1)*, %spirv.Image._uint_2_0_0_0_0_0_0 addrspace(1)*, %spirv.Image._half_1_0_1_0_0_0_0 addrspace(1)*, %spirv.Image._float_5_0_0_0_0_0_0 addrspace(1)*, %spirv.Image._void_0_0_0_0_0_0_1 addrspace(1)*, %spirv.Image._void_1_0_0_0_0_0_2 addrspace(1)*)* @foo, !1, !2, !3, !4, !5}


### PR DESCRIPTION
This is to reflect changes introduced in https://reviews.llvm.org/D47106
[FileCheck] Make CHECK-DAG non-overlapping

Now CHECK-DAG skips repeating matches by default. We have such cases when we
check kernel_arg_type and kernel_arg_base_type with CHECK-DAG and they happen
to be the same.