### PR TITLE
Explicit initialization of "memory_order_*" constants in SPIRV genera…

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -70,12 +70,17 @@ enum OCLScopeKind {
   OCLMS_sub_group,
 };
 
+// The enum below declares constants corresponding to memory synchronization
+// operations constants defined in
+// https://www.khronos.org/registry/OpenCL/sdk/2.1/docs/man/xhtml/memory_order.html
+// To avoid any inconsistence here, constants are explicitly initialized with
+// the corresponding constants from 'std::memory_order' enum.
 enum OCLMemOrderKind {
-  OCLMO_relaxed,
-  OCLMO_acquire,
-  OCLMO_release,
-  OCLMO_acq_rel,
-  OCLMO_seq_cst
+  OCLMO_relaxed = std::memory_order::memory_order_relaxed,
+  OCLMO_acquire = std::memory_order::memory_order_acquire,
+  OCLMO_release = std::memory_order::memory_order_release,
+  OCLMO_acq_rel = std::memory_order::memory_order_acq_rel,
+  OCLMO_seq_cst = std::memory_order::memory_order_seq_cst
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.ll
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.ll
@@ -5,20 +5,20 @@
 ;;{
 ;;  // Values of memory order and memory scope arguments correspond to SPIR-2.0 spec.
 ;;  atomic_compare_exchange_strong_explicit(object, expected, desired,
-;;                                          memory_order_release, // 2
+;;                                          memory_order_release, // 3
 ;;                                          memory_order_relaxed  // 0
 ;;                                         ); // by default, assume device scope = 2
 ;;  atomic_compare_exchange_strong_explicit(object, expected, desired,
-;;                                          memory_order_acq_rel,   // 3
+;;                                          memory_order_acq_rel,   // 4
 ;;                                          memory_order_relaxed,   // 0
 ;;                                          memory_scope_work_group // 1
 ;;                                         );
 ;;  atomic_compare_exchange_weak_explicit(object, expected, desired,
-;;                                        memory_order_release, // 2
+;;                                        memory_order_release, // 3
 ;;                                        memory_order_relaxed  // 0
 ;;                                         ); // by default, assume device scope = 2
 ;;  atomic_compare_exchange_weak_explicit(object, expected, desired,
-;;                                        memory_order_acq_rel,   // 3
+;;                                        memory_order_acq_rel,   // 4
 ;;                                        memory_order_relaxed,   // 0
 ;;                                        memory_scope_work_group // 1
 ;;                                       );
@@ -44,10 +44,10 @@
 ;CHECK-SPIRV: AtomicCompareExchangeWeak {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
 ;CHECK-SPIRV: AtomicCompareExchangeWeak {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
 
-;CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope(i32 addrspace(4)* %0, i32* %expected1, i32 %desired, i32 2, i32 0, i32 2)
-;CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope(i32 addrspace(4)* %0, i32* %expected2, i32 %desired, i32 3, i32 0, i32 1)
-;CHECK-LLVM: call spir_func i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope(i32 addrspace(4)* %0, i32* %expected3, i32 %desired, i32 2, i32 0, i32 2)
-;CHECK-LLVM: call spir_func i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope(i32 addrspace(4)* %0, i32* %expected4, i32 %desired, i32 3, i32 0, i32 1)
+;CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope(i32 addrspace(4)* %0, i32* %expected1, i32 %desired, i32 3, i32 0, i32 2)
+;CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope(i32 addrspace(4)* %0, i32* %expected2, i32 %desired, i32 4, i32 0, i32 1)
+;CHECK-LLVM: call spir_func i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope(i32 addrspace(4)* %0, i32* %expected3, i32 %desired, i32 3, i32 0, i32 2)
+;CHECK-LLVM: call spir_func i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope(i32 addrspace(4)* %0, i32* %expected4, i32 %desired, i32 4, i32 0, i32 1)
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"
@@ -57,10 +57,10 @@ define spir_kernel void @testAtomicCompareExchangeExplicit_cl20(i32 addrspace(1)
 entry:
   %0 = addrspacecast i32 addrspace(1)* %object to i32 addrspace(4)*
   %1 = addrspacecast i32 addrspace(1)* %expected to i32 addrspace(4)*
-  %call = tail call spir_func zeroext i1 @_Z39atomic_compare_exchange_strong_explicitPVU3AS4U7_AtomiciPU3AS4ii12memory_orderS4_(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %desired, i32 2, i32 0) #2
-  %call1 = tail call spir_func zeroext i1 @_Z39atomic_compare_exchange_strong_explicitPVU3AS4U7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %desired, i32 3, i32 0, i32 1) #2
-  %call2 = tail call spir_func zeroext i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPU3AS4ii12memory_orderS4_(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %desired, i32 2, i32 0) #2
-  %call3 = tail call spir_func zeroext i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %desired, i32 3, i32 0, i32 1) #2
+  %call = tail call spir_func zeroext i1 @_Z39atomic_compare_exchange_strong_explicitPVU3AS4U7_AtomiciPU3AS4ii12memory_orderS4_(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %desired, i32 3, i32 0) #2
+  %call1 = tail call spir_func zeroext i1 @_Z39atomic_compare_exchange_strong_explicitPVU3AS4U7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %desired, i32 4, i32 0, i32 1) #2
+  %call2 = tail call spir_func zeroext i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPU3AS4ii12memory_orderS4_(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %desired, i32 3, i32 0) #2
+  %call3 = tail call spir_func zeroext i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %desired, i32 4, i32 0, i32 1) #2
   ret void
 }
 

--- a/test/transcoding/AtomicCompareExchange_cl12.ll
+++ b/test/transcoding/AtomicCompareExchange_cl12.ll
@@ -15,7 +15,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-LABEL:   entry
 ; CHECK:         [[PTR:%expected[0-9]*]] = alloca i32, align 4
 ; CHECK:         store i32 {{.*}}, i32* [[PTR]]
-; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}%object, i32* [[PTR]], i32 %desired, i32 4, i32 4, i32 2)
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}%object, i32* [[PTR]], i32 %desired, i32 5, i32 5, i32 2)
 ; CHECK-NEXT;         load i32* [[PTR]]
 define spir_func i32 @test(i32 addrspace(1)* %object, i32 %expected, i32 %desired) #0 {
 entry:

--- a/test/transcoding/AtomicCompareExchange_cl20.ll
+++ b/test/transcoding/AtomicCompareExchange_cl20.ll
@@ -15,14 +15,14 @@ target triple = "spir-unknown-unknown"
 ; CHECK-NEXT:    entry:
 ; CHECK:         [[PTR_STRONG:%expected[0-9]*]] = alloca i32, align 4
 ; CHECK:         store i32 {{.*}}, i32* [[PTR_STRONG]]
-; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}(i32 {{.*}}* %object, i32* [[PTR_STRONG]], i32 %desired, i32 4, i32 4, i32 2)
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}(i32 {{.*}}* %object, i32* [[PTR_STRONG]], i32 %desired, i32 5, i32 5, i32 2)
 ; CHECK:         load i32, i32* [[PTR_STRONG]]
 
 ; CHECK-LABEL:   define spir_func void @test_weak
 ; CHECK-NEXT:    entry:
 ; CHECK:         [[PTR_WEAK:%expected[0-9]*]] = alloca i32, align 4
 ; CHECK:         store i32 {{.*}}, i32* [[PTR_WEAK]]
-; CHECK:         call spir_func i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope{{.*}}(i32 {{.*}}* %object, i32* [[PTR_WEAK]], i32 %desired, i32 4, i32 4, i32 2)
+; CHECK:         call spir_func i1 @_Z37atomic_compare_exchange_weak_explicitPVU3AS4U7_AtomiciPii12memory_orderS3_12memory_scope{{.*}}(i32 {{.*}}* %object, i32* [[PTR_WEAK]], i32 %desired, i32 5, i32 5, i32 2)
 ; CHECK:         load i32, i32* [[PTR_WEAK]]
 
 ; Check that alloca for atomic_compare_exchange is being created in the entry block.
@@ -32,7 +32,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK:         %expected{{[0-9]*}} = alloca i32
 ; CHECK-LABEL:   for.body:
 ; CHECK-NOT:     %expected{{[0-9]*}} = alloca i32
-; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}(i32 {{.*}}* {{.*}}, i32* {{.*}}, i32 {{.*}}, i32 4, i32 4, i32 2)
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}(i32 {{.*}}* {{.*}}, i32* {{.*}}, i32 {{.*}}, i32 5, i32 5, i32 2)
 
 ; Function Attrs: nounwind
 define spir_func void @test_strong(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #0 {

--- a/test/transcoding/OpMemoryBarrier_cl20.ll
+++ b/test/transcoding/OpMemoryBarrier_cl20.ll
@@ -21,11 +21,11 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 4, i32 3, i32 3)
 
 ; global | acquire_release
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 520
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 516
 ; local | acquire_release
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 264
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 260
 ; image | acquire_release
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2056
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2052
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkItem:[0-9]+]] 4
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkGroup:[0-9]+]] 2

--- a/test/transcoding/atomic_store.ll
+++ b/test/transcoding/atomic_store.ll
@@ -15,7 +15,7 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK-LLVM:         define spir_func void @test
 ; CHECK-LLVM-LABEL:   entry
-; CHECK-LLVM:         call spir_func void @_Z21atomic_store_explicitPVU3AS4U7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %object, i32 %desired, i32 4, i32 2)
+; CHECK-LLVM:         call spir_func void @_Z21atomic_store_explicitPVU3AS4U7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %object, i32 %desired, i32 5, i32 2)
 
 ; CHECK-SPIRV-LABEL:  5 Function
 ; CHECK-SPIRV-NEXT:   FunctionParameter {{[0-9]+}} [[object:[0-9]+]]


### PR DESCRIPTION
…tor.

Instead of default enum initialization of "memory_order_*" constants
in SPIRV generator I declared them with specific values. It makes
declaration of these constants in SPIRV generator consistent with
corresponding constants produced by Clang avoiding any inconsistence.