### PR TITLE
[NFC] Refactoring to fix issues found by a static analysis tool.

### DIFF
--- a/lib/SPIRV/OCL20To12.cpp
+++ b/lib/SPIRV/OCL20To12.cpp
@@ -120,6 +120,7 @@ void OCL20To12::visitCallAtomicWorkItemFence(CallInst *CI) {
     report_fatal_error("OCL 2.0 builtin atomic_work_item_fence used in 1.2",
                        false);
 
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstOCL(M, CI,
                     [=](CallInst *, std::vector<Value *> &Args) {

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -573,6 +573,7 @@ void OCL20ToSPIRV::visitCallNDRange(CallInst *CI,
 
 void OCL20ToSPIRV::visitCallAsyncWorkGroupCopy(
     CallInst *CI, const std::string &DemangledName) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstSPIRV(M, CI,
                       [=](CallInst *, std::vector<Value *> &Args) {
@@ -623,6 +624,7 @@ void OCL20ToSPIRV::visitCallAtomicInit(CallInst *CI) {
 }
 
 void OCL20ToSPIRV::visitCallAllAny(spv::Op OC, CallInst *CI) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
 
   auto Args = getArguments(CI);
@@ -669,6 +671,7 @@ void OCL20ToSPIRV::visitCallMemFence(CallInst *CI) {
 
 void OCL20ToSPIRV::transMemoryBarrier(CallInst *CI,
                                       AtomicWorkItemFenceLiterals Lit) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstSPIRV(M, CI,
                       [=](CallInst *, std::vector<Value *> &Args) {
@@ -872,6 +875,7 @@ void OCL20ToSPIRV::visitCallConvert(CallInst *CI, StringRef MangledName,
   if (Loc != std::string::npos && !(isa<IntegerType>(SrcTy) && IsTargetInt)) {
     Rounding = DemangledName.substr(Loc, 4);
   }
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstSPIRV(M, CI,
                       [=](CallInst *, std::vector<Value *> &Args) {
@@ -1027,6 +1031,7 @@ void OCL20ToSPIRV::visitCallReadImageMSAA(CallInst *CI, StringRef MangledName,
 void OCL20ToSPIRV::visitCallReadImageWithSampler(
     CallInst *CI, StringRef MangledName, const std::string &DemangledName) {
   assert(MangledName.find(kMangledName::Sampler) != StringRef::npos);
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   bool IsRetScalar = !CI->getType()->isVectorTy();
   mutateCallInstSPIRV(
@@ -1265,6 +1270,7 @@ void OCL20ToSPIRV::visitCallToAddr(CallInst *CI, StringRef MangledName,
 
 void OCL20ToSPIRV::visitCallRelational(CallInst *CI,
                                        const std::string &DemangledName) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   Op OC = OpNop;
   OCLSPIRVBuiltinMap::find(DemangledName, &OC);
@@ -1435,6 +1441,7 @@ void OCL20ToSPIRV::visitCallScalToVec(CallInst *CI, StringRef MangledName,
 void OCL20ToSPIRV::visitCallGetImageChannel(CallInst *CI, StringRef MangledName,
                                             const std::string &DemangledName,
                                             unsigned int Offset) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   Op OC = OpNop;
   OCLSPIRVBuiltinMap::find(DemangledName, &OC);
@@ -1480,6 +1487,7 @@ void OCL20ToSPIRV::visitSubgroupBlockReadINTEL(
     Info.Postfix += "_us";
   else
     Info.Postfix += "_ui";
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstSPIRV(M, CI,
                       [=](CallInst *, std::vector<Value *> &Args) {
@@ -1517,6 +1525,7 @@ void OCL20ToSPIRV::visitSubgroupBlockWriteINTEL(
       break;
     }
   }
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstSPIRV(M, CI,
                       [=](CallInst *, std::vector<Value *> &Args) {
@@ -1525,7 +1534,6 @@ void OCL20ToSPIRV::visitSubgroupBlockWriteINTEL(
                       },
                       &Attrs);
 }
-
 } // namespace SPIRV
 
 INITIALIZE_PASS_BEGIN(OCL20ToSPIRV, "cl20tospv", "Transform OCL 2.0 to SPIR-V",

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -174,6 +174,7 @@ void OCL21ToSPIRV::visitCallInst(CallInst &CI) {
 
 void OCL21ToSPIRV::visitCallConvert(CallInst *CI, StringRef MangledName,
                                     Op OC) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstSPIRV(
       M, CI,
@@ -192,6 +193,7 @@ void OCL21ToSPIRV::visitCallConvert(CallInst *CI, StringRef MangledName,
 
 void OCL21ToSPIRV::visitCallDecorate(CallInst *CI, StringRef MangledName) {
   auto Target = cast<CallInst>(CI->getArgOperand(0));
+  assert(Target->getCalledFunction() && "Unexpected indirect call");
   auto F = Target->getCalledFunction();
   auto Name = F->getName().str();
   std::string DemangledName;
@@ -223,6 +225,7 @@ void OCL21ToSPIRV::visitCallSubGroupBarrier(CallInst *CI) {
 }
 
 void OCL21ToSPIRV::transBuiltin(CallInst *CI, Op OC) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   assert(OC != OpExtInst && "not supported");
   mutateCallInstSPIRV(M, CI,

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -115,6 +115,7 @@ static unsigned getArgIndex(CallInst *CI, Value *V) {
       return AI;
   }
   llvm_unreachable("Not argument of function call");
+  return ~0U;
 }
 
 /// Find index of \param V as argument of function call \param CI.
@@ -125,6 +126,7 @@ static unsigned getArgIndex(Function *F, Value *V) {
       return I;
   }
   llvm_unreachable("Not argument of function");
+  return ~0U;
 }
 
 /// Get i-th argument of a function.

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -112,6 +112,7 @@ BarrierLiterals getBarrierLiterals(CallInst *CI) {
   assert(N == 1 || N == 2);
 
   std::string DemangledName;
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   if (!oclIsBuiltin(CI->getCalledFunction()->getName(), &DemangledName)) {
     assert(0 &&
            "call must a builtin (work_group_barrier or sub_group_barrier)");
@@ -247,6 +248,7 @@ unsigned encodeVecTypeHint(Type *Ty) {
     return Size << 16 | encodeVecTypeHint(EleTy);
   }
   llvm_unreachable("invalid type");
+  return ~0U;
 }
 
 Type *decodeVecTypeHint(LLVMContext &C, unsigned Code) {
@@ -271,6 +273,7 @@ Type *decodeVecTypeHint(LLVMContext &C, unsigned Code) {
     break;
   default:
     llvm_unreachable("Invalid vec type hint");
+    return nullptr;
   }
   if (VecWidth < 1)
     return ST;
@@ -318,6 +321,7 @@ static SPIR::TypeAttributeEnum mapAddrSpaceEnums(SPIRAddressSpace Addrspace) {
   default:
     llvm_unreachable("Invalid addrspace enum member");
   }
+  return SPIR::ATTR_NONE;
 }
 
 SPIR::TypeAttributeEnum
@@ -349,6 +353,7 @@ getOCLOpaqueTypeAddrSpace(SPIR::TypePrimitiveEnum Prim) {
   default:
     llvm_unreachable("No address space is determined for a SPIR primitive");
   }
+  return SPIR::ATTR_NONE;
 }
 
 // Fetch type of invoke function passed to device execution built-ins

--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -88,6 +88,7 @@ public:
       auto Ty = I.getType();
       auto Zero = getScalarOrVectorConstantInt(Ty, 0, false);
       auto One = getScalarOrVectorConstantInt(Ty, 1, false);
+      assert(Zero && One && "Couldn't create constant int");
       auto Sel = SelectInst::Create(Op, One, Zero, "", &I);
       replace(&I, Sel);
     }
@@ -98,6 +99,7 @@ public:
       auto Ty = I.getType();
       auto Zero = getScalarOrVectorConstantInt(Ty, 0, false);
       auto One = getScalarOrVectorConstantInt(Ty, ~0, false);
+      assert(Zero && One && "Couldn't create constant int");
       auto Sel = SelectInst::Create(Op, One, Zero, "", &I);
       replace(&I, Sel);
     }

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -333,6 +333,7 @@ void SPIRVToOCL20::visitCallSPRIVImageQuerySize(CallInst *CI) {
 }
 
 void SPIRVToOCL20::visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   Instruction *PInsertBefore = CI;
 
@@ -435,6 +436,7 @@ void SPIRVToOCL20::visitCallSPIRVGroupBuiltin(CallInst *CI, Op OC) {
     DemangledName = Prefix + kSPIRVName::GroupPrefix +
                     SPIRSPIRVGroupOperationMap::rmap(GO) + '_' + Op.str();
   }
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstOCL(M, CI,
                     [=](CallInst *, std::vector<Value *> &Args) {
@@ -465,6 +467,7 @@ void SPIRVToOCL20::visitCallSPIRVPipeBuiltin(CallInst *CI, Op OC) {
   if (HasScope)
     DemangledName = getGroupBuiltinPrefix(CI) + DemangledName;
 
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstOCL(
       M, CI,

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1192,6 +1192,7 @@ std::string getSPIRVImageSampledTypeName(SPIRVType *Ty) {
     break;
   }
   llvm_unreachable("Invalid sampled type for image");
+  return std::string();
 }
 
 // ToDo: Find a way to represent uint sampled type in LLVM, maybe an
@@ -1208,6 +1209,7 @@ Type *getLLVMTypeForSPIRVImageSampledTypePostfix(StringRef Postfix,
       Postfix == kSPIRVImageSampledTypeName::UInt)
     return Type::getInt32Ty(Ctx);
   llvm_unreachable("Invalid sampled type postfix");
+  return nullptr;
 }
 
 std::string mapOCLTypeNameToSPIRV(StringRef Name, StringRef Acc) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1197,6 +1197,7 @@ bool LLVMToSPIRV::transBuiltinSet() {
 ///   arg = load from sampler -> look through load
 SPIRVValue *LLVMToSPIRV::oclTransSpvcCastSampler(CallInst *CI,
                                                  SPIRVBasicBlock *BB) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
   llvm::Function *F = CI->getCalledFunction();
   auto FT = F->getFunctionType();
   auto RT = FT->getReturnType();


### PR DESCRIPTION
* Adding asserts to prevent possible dereference of a null pointer
* Adding return statements after llvm_unreachable