### PR TITLE
Make generator's magic number configurable at build time

### DIFF
--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -3,6 +3,14 @@ if(SPIRV_USE_LLVM_API)
   add_definitions(-D_SPIRV_LLVM_API)
 endif(SPIRV_USE_LLVM_API)
 
+if (SPIRVGEN_ID)
+  add_definitions(-DSPIRVGEN_ID=${SPIRVGEN_ID})
+endif(SPIRVGEN_ID)
+
+if (SPIRVGEN_VER)
+  add_definitions(-DSPIRVGEN_VER=${SPIRVGEN_VER})
+endif(SPIRVGEN_VER)
+
 add_llvm_library(LLVMSPIRVLib
   libSPIRV/SPIRVBasicBlock.cpp
   libSPIRV/SPIRVDebug.cpp

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -59,11 +59,6 @@ using namespace llvm;
 
 namespace SPIRV {
 
-/// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
-/// generator's magic number in the generated SPIR-V module.
-/// This number should be bumped up whenever the generated SPIR-V changes.
-const static unsigned short KTranslatorVer = 14;
-
 #define SPCV_TARGET_LLVM_IMAGE_TYPE_ENCODE_ACCESS_QUAL 0
 // Workaround for SPIR 2 producer bug about kernel function calling convention.
 // This workaround checks metadata to determine if a function is kernel.

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1463,8 +1463,6 @@ void LLVMToSPIRV::transFunction(Function *I) {
 }
 
 bool LLVMToSPIRV::translate() {
-  BM->setGeneratorVer(KTranslatorVer);
-
   if (!transSourceLanguage())
     return false;
   if (!transExtension())

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -71,6 +71,18 @@ enum SPIRVGeneratorKind {
   SPIRVGEN_KhronosSPIRVAssembler = 7,
 };
 
+#ifndef SPIRVGEN_ID
+#define SPIRVGEN_ID SPIRVGEN_KhronosLLVMSPIRVTranslator
+#endif
+
+/// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
+/// generator's magic number in the generated SPIR-V module.
+/// This number should be bumped up whenever format of the generated SPIR-V
+/// is changing (significantly).
+#ifndef SPIRVGEN_VER
+#define SPIRVGEN_VER 14
+#endif
+
 enum SPIRVInstructionSchemaKind {
   SPIRVISCH_Default,
 };

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -62,7 +62,7 @@ class SPIRVModuleImpl : public SPIRVModule {
 public:
   SPIRVModuleImpl()
       : SPIRVModule(), NextId(1), BoolType(NULL), SPIRVVersion(SPIRV_1_0),
-        GeneratorId(SPIRVGEN_KhronosLLVMSPIRVTranslator), GeneratorVer(0),
+        GeneratorId(SPIRVGEN_ID), GeneratorVer(SPIRVGEN_VER),
         InstSchema(SPIRVISCH_Default), SrcLang(SourceLanguageOpenCL_C),
         SrcLangVer(102000) {
     AddrModel = sizeof(size_t) == 32 ? AddressingModelPhysical32


### PR DESCRIPTION
To set high order 16 bits of generator magic number one should use
-DSPIRVGEN_ID=<ID> cmake option. And to set low order 16 bits use
-DSPIRVGEN_VER=<VER> cmake option.
Values for SPIRVGEN_ID are enumerated at
https://github.com/KhronosGroup/SPIRV-Headers/blob/master/include/spirv/spir-v.xml

By default: SPIRVGEN_ID=6("Khronos LLVM/SPIR-V Translator"), SPIRVGEN_VER=14