### PR TITLE
Avoid double linking of LLVM/SPIR-V libraries.

### DIFF
--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -14,7 +14,9 @@ add_llvm_tool(llvm-spirv
   NO_INSTALL_RPATH
 )
 
-target_link_libraries(llvm-spirv PRIVATE LLVMSPIRVLib)
+if (BUILD_EXTERNAL)
+  target_link_libraries(llvm-spirv PRIVATE LLVMSPIRVLib)
+endif()
 
 target_include_directories(llvm-spirv
   PRIVATE


### PR DESCRIPTION
When llvm-spirv is built out of LLVM tree there might be two cases:
- SPIR-V library linked statically. This this case linker and loader are
  able to handle LLVM symbols correctly.
- SPIR-V library linked dynamically. LLVM_LINK_COMPONENTS is ignored as
  all LLVM components is supposed to be linked into libLLVM.so and we
  should explicitly link with SPIR-V library.

If we build llvm-spirv tool in LLVM tree explicit link with SPIR-V
library might lead to multiple symbol definition (e.g. SPIR-V library
linked with libLLVM.so as LLVM component and with llmv-spirv tool via
explicit target_link_library command).