### PR TITLE
Fix lifetime intrinsics translation.

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -261,8 +261,6 @@ private:
 
   SPIRVInstruction *transBinaryInst(BinaryOperator *B, SPIRVBasicBlock *BB);
   SPIRVInstruction *transCmpInst(CmpInst *Cmp, SPIRVBasicBlock *BB);
-  SPIRVInstruction *transLifetimeIntrinsicInst(Op OC, IntrinsicInst *Intrinsic,
-                                               SPIRVBasicBlock *BB);
 
   void dumpUsers(Value *V);
 
@@ -821,44 +819,6 @@ SPIRVInstruction *LLVMToSPIRV::transCmpInst(CmpInst *Cmp, SPIRVBasicBlock *BB) {
   return BI;
 }
 
-SPIRVInstruction *LLVMToSPIRV::transLifetimeIntrinsicInst(Op OC,
-                                                          IntrinsicInst *II,
-                                                          SPIRVBasicBlock *BB) {
-  int64_t Size = dyn_cast<ConstantInt>(II->getOperand(0))->getSExtValue();
-  if (Size == -1)
-    Size = 0;
-  auto Op1 = II->getOperand(1);
-
-  if (auto AI = dyn_cast<AllocaInst>(Op1)) {
-    (void)AI;
-    assert((!Size || M->getDataLayout().getTypeSizeInBits(
-                         AI->getAllocatedType()) == (uint64_t)(Size * 8)) &&
-           "Size of the argument should match the allocated memory");
-    return BM->addLifetimeInst(OC, transValue(Op1, BB), Size, BB);
-  }
-  // Bitcast might be inserted during translation of OpLifetimeStart
-  assert(isa<BitCastInst>(Op1));
-  for (const auto &U : Op1->users()) {
-    auto BCU = dyn_cast<IntrinsicInst>(U);
-    (void)BCU;
-    assert(
-        BCU &&
-        (BCU->getIntrinsicID() == Intrinsic::lifetime_start ||
-         BCU->getIntrinsicID() == Intrinsic::lifetime_end) &&
-        "The only users of this bitcast instruction are lifetime intrinsics");
-  }
-  auto AI = dyn_cast<AllocaInst>(dyn_cast<BitCastInst>(Op1)->getOperand(0));
-  assert(AI &&
-         (!Size || M->getDataLayout().getTypeSizeInBits(
-                       AI->getAllocatedType()) == (uint64_t)(Size * 8)) &&
-         "Size of the argument should match the allocated memory");
-  auto LT = BM->addLifetimeInst(OC, transValue(AI, BB), Size, BB);
-  auto BC = LT->getPrevious();
-  if (BC && BC->getOpCode() == OpBitcast)
-    BM->eraseInstruction(BC, BB);
-  return LT;
-}
-
 SPIRV::SPIRVInstruction *LLVMToSPIRV::transUnaryInst(UnaryInstruction *U,
                                                      SPIRVBasicBlock *BB) {
   Op BOC = OpNop;
@@ -1299,9 +1259,15 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
         transValue(II->getOperand(2), BB),
         GetMemoryAccess(cast<MemIntrinsic>(II)), BB);
   case Intrinsic::lifetime_start:
-    return transLifetimeIntrinsicInst(OpLifetimeStart, II, BB);
-  case Intrinsic::lifetime_end:
-    return transLifetimeIntrinsicInst(OpLifetimeStop, II, BB);
+  case Intrinsic::lifetime_end: {
+    Op OC = (II->getIntrinsicID() == Intrinsic::lifetime_start)
+                ? OpLifetimeStart
+                : OpLifetimeStop;
+    int64_t Size = dyn_cast<ConstantInt>(II->getOperand(0))->getSExtValue();
+    if (Size == -1)
+      Size = 0;
+    return BM->addLifetimeInst(OC, transValue(II->getOperand(1), BB), Size, BB);
+  }
   default:
     // LLVM intrinsic functions shouldn't get to SPIRV, because they
     // would have no definition there.

--- a/test/lifetime.ll
+++ b/test/lifetime.ll
@@ -5,7 +5,6 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.spv.bc
 ; RUN: llvm-dis < %t.spv.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-SPIRV-NOT: Bitcast
 ; CHECK-SPIRV: 3 LifetimeStart [[tmp:[0-9]+]] 0
 ; CHECK-SPIRV: 3 LifetimeStop [[tmp]] 0
 

--- a/test/transcoding/lifetime-sized.ll
+++ b/test/transcoding/lifetime-sized.ll
@@ -1,0 +1,68 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: Variable {{[0-9]+}} [[mem:[0-9]+]] 7
+; CHECK-SPIRV: Bitcast [[i8Ty:[0-9]+]] [[tmp0:[0-9]+]] [[mem]]
+; CHECK-SPIRV: LifetimeStart [[tmp0]] [[size:[0-9]+]]
+; CHECK-SPIRV: FunctionCall
+; CHECK-SPIRV: Bitcast [[i8Ty]] [[tmp1:[0-9]+]] [[mem]]
+; CHECK-SPIRV: LifetimeStop [[tmp1]] [[size]]
+
+; CHECK-LLVM-LABEL:  kernel_function
+; CHECK-LLVM: [[local:%[0-9]+]] = alloca %class.anon
+; CHECK-LLVM: [[tmp1:%[0-9]+]] = bitcast %class.anon* [[local]] to [[type:i[0-9]+\*]]
+; CHECK-LLVM: call void @llvm.lifetime.start.p0i8(i64 1, i8* [[tmp1]])
+; CHECK-LLVM: [[tmp2:%[0-9]+]] = bitcast %class.anon* [[local]] to [[type]]
+; CHECK-LLVM: call void @llvm.lifetime.end.p0i8(i64 1, i8* [[tmp2]])
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+%class.anon = type { i8 }
+
+define spir_kernel void @kernel_function() #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !3 {
+entry:
+  %0 = alloca %class.anon, align 1
+  %1 = bitcast %class.anon* %0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %1) #3
+  call spir_func void @foo(%class.anon* %0)
+  %2 = bitcast %class.anon* %0 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %2) #3
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: inlinehint nounwind
+define internal spir_func void @foo(%class.anon* %this) #2 align 2 {
+entry:
+  %this.addr = alloca %class.anon*, align 8
+  store %class.anon* %this, %class.anon** %this.addr, align 8
+  %this1 = load %class.anon*, %class.anon** %this.addr, align 8
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false
+" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind }
+attributes #2 = { inlinehint nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no
+-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.spir.version = !{!1}
+!spirv.Source = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{i32 4, i32 100000}
+!3 = !{}
+

--- a/test/transcoding/llvm.memmove.ll
+++ b/test/transcoding/llvm.memmove.ll
@@ -8,13 +8,14 @@
 ; CHECK-SPIRV-NOT: llvm.memmove
 
 ; CHECK-SPIRV: Variable {{[0-9]+}} [[mem:[0-9]+]] 7
-
-; CHECK-SPIRV: LifetimeStart [[mem]] [[size:[0-9]+]]
-; CHECK-SPIRV: Bitcast [[i8Ty:[0-9]+]] [[tmp1:[0-9]+]] [[mem]]
+; CHECK-SPIRV: Bitcast [[i8Ty:[0-9]+]] [[tmp0:[0-9]+]] [[mem]]
+; CHECK-SPIRV: LifetimeStart [[tmp0]] [[size:[0-9]+]]
+; CHECK-SPIRV: Bitcast [[i8Ty]] [[tmp1:[0-9]+]] [[mem]]
 ; CHECK-SPIRV: CopyMemorySized [[tmp1]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: Bitcast [[i8Ty]] [[tmp2:[0-9]+]] [[mem]]
 ; CHECK-SPIRV: CopyMemorySized {{[0-9]+}} [[tmp2]] {{[0-9]+}}
-; CHECK-SPIRV: LifetimeStop [[mem]] [[size]]
+; CHECK-SPIRV: Bitcast [[i8Ty]] [[tmp3:[0-9]+]] [[mem]]
+; CHECK-SPIRV: LifetimeStop [[tmp3]] [[size]]
 
 ; CHECK-LLVM-NOT: llvm.memmove
 
@@ -28,7 +29,8 @@
 ; CHECK-LLVM: [[tmp3:%[0-9]+]] = bitcast %struct.SomeStruct* [[local]] to [[type]]
 ; CHECK-LLVM: call void @llvm.memcpy
 ; CHECK-LLVM:  , [[type]] align 64 [[tmp3]], {{i[0-9]+}} [[size]]
-; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{i[0-9]+}} {{-?[0-9]+}}, [[type]] [[tmp1]])
+; CHECK-LLVM: [[tmp4:%[0-9]+]] = bitcast %struct.SomeStruct* [[local]] to [[type]]
+; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{i[0-9]+}} {{-?[0-9]+}}, [[type]] [[tmp4]])
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir-unknown-unknown"


### PR DESCRIPTION
LLVM lifetime intrinsics accept only i8* pointers + size as object
descriptors, so typical pattern for local variables is
alloca+bitcast+lifetime instructions.
SPIR-V translator tries store original type into lifetime instruction
looking though bitcast. It also removes bitcast from the SPIR-V file and
tries to recover it during SPIR-V conversion.
This patch simplifies the translation by keeping bitcast instruction and
fixes assertion of lifetime intrinsics for 8-bit objects.