### PR TITLE
Set SequentiallyConsistent bit in translation of barrier builtins

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -847,10 +847,18 @@ void OCL20ToSPIRV::visitCallBarrier(CallInst *CI) {
   mutateCallInstSPIRV(M, CI,
                       [=](CallInst *, std::vector<Value *> &Args) {
                         Args.resize(3);
+                        // Execution scope
                         Args[0] = addInt32(map<Scope>(std::get<2>(Lit)));
+                        // Memory scope
                         Args[1] = addInt32(map<Scope>(std::get<1>(Lit)));
-                        Args[2] = addInt32(
-                            mapOCLMemFenceFlagToSPIRV(std::get<0>(Lit)));
+                        // Use sequential consistent memory order by default.
+                        // But if the flags argument is set to 0, we use
+                        // None(Relaxed) memory order.
+                        unsigned MemFenceFlag = std::get<0>(Lit);
+                        OCLMemOrderKind MemOrder =
+                            MemFenceFlag ? OCLMO_seq_cst : OCLMO_relaxed;
+                        Args[2] = addInt32(mapOCLMemSemanticToSPIRV(
+                            MemFenceFlag, MemOrder)); // Memory semantics
                         return getSPIRVFuncName(OpControlBarrier);
                       },
                       &Attrs);

--- a/test/transcoding/OpControlBarrier_cl12.ll
+++ b/test/transcoding/OpControlBarrier_cl12.ll
@@ -12,12 +12,12 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 5)
 ; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 7)
 
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 512
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 256
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2048
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema4:[0-9]+]] 768
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema5:[0-9]+]] 2304
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema6:[0-9]+]] 2816
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2064
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema4:[0-9]+]] 784
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema5:[0-9]+]] 2320
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema6:[0-9]+]] 2832
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkGroup:[0-9]+]] 2
 
 ; CHECK-SPIRV: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema1]]

--- a/test/transcoding/OpControlBarrier_cl20.ll
+++ b/test/transcoding/OpControlBarrier_cl20.ll
@@ -28,20 +28,21 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 2) #{{[0-9]+}}
 ; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 3) #{{[0-9]+}}
 
-
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 512
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 256
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2048
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema4:[0-9]+]] 768
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema5:[0-9]+]] 2304
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema6:[0-9]+]] 2816
+; Both 'CrossDevice' memory scope and 'None' memory order enums have value equal to 0.
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[Null:[0-9]+]] 0
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2064
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema4:[0-9]+]] 784
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema5:[0-9]+]] 2320
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema6:[0-9]+]] 2832
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkItem:[0-9]+]] 4
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkGroup:[0-9]+]] 2
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeDevice:[0-9]+]] 1
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeCrossDevice:[0-9]+]] 0
 
-; CHECK-SPIRV: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema1]]
+; CHECK-SPIRV: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[Null]]
+; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema1]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema2]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema3]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema4]]
@@ -51,17 +52,17 @@
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkItem]] [[MemSema1]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema1]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeDevice]] [[MemSema1]]
-; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeCrossDevice]] [[MemSema1]]
+; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[Null]] [[MemSema1]]
 
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkItem]] [[MemSema2]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema2]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeDevice]] [[MemSema2]]
-; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeCrossDevice]] [[MemSema2]]
+; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[Null]] [[MemSema2]]
 
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkItem]] [[MemSema3]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeWorkGroup]] [[MemSema3]]
 ; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeDevice]] [[MemSema3]]
-; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[ScopeCrossDevice]] [[MemSema3]]
+; CHECK-SPIRV-NEXT: 4 ControlBarrier [[ScopeWorkGroup]] [[Null]] [[MemSema3]]
 
 
 ; ModuleID = 'work_group_barrier.cl'
@@ -71,6 +72,7 @@ target triple = "spir-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test() #0 {
 entry:
+  call spir_func void @_Z18work_group_barrierj(i32 0) ; no mem fence
   call spir_func void @_Z18work_group_barrierj(i32 2) ; global mem fence
   call spir_func void @_Z18work_group_barrierj(i32 1) ; local mem fence
   call spir_func void @_Z18work_group_barrierj(i32 4) ; image mem fence

--- a/test/transcoding/OpControlBarrier_cl20_subgroup.ll
+++ b/test/transcoding/OpControlBarrier_cl20_subgroup.ll
@@ -27,13 +27,12 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 2) #{{[0-9]+}}
 ; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 3) #{{[0-9]+}}
 
-
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 512
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 256
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2048
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema4:[0-9]+]] 768
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema5:[0-9]+]] 2304
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema6:[0-9]+]] 2816
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2064
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema4:[0-9]+]] 784
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema5:[0-9]+]] 2320
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema6:[0-9]+]] 2832
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkItem:[0-9]+]] 4
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkGroup:[0-9]+]] 2

--- a/test/transcoding/OpControlBarrier_cl21.ll
+++ b/test/transcoding/OpControlBarrier_cl21.ll
@@ -28,12 +28,12 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 3) #{{[0-9]+}}
 
 
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 512
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 256
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2048
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema4:[0-9]+]] 768
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema5:[0-9]+]] 2304
-; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema6:[0-9]+]] 2816
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema3:[0-9]+]] 2064
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema4:[0-9]+]] 784
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema5:[0-9]+]] 2320
+; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema6:[0-9]+]] 2832
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkItem:[0-9]+]] 4
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[ScopeWorkGroup:[0-9]+]] 2


### PR DESCRIPTION
According to the description in the OpenCL specification, barrier,
work_group_barrier and sub_group_barrier builtins imply acquire-release
memory-order semantics.
Resolves #70