### PR TITLE
Enable unsupported debug information tests

### DIFF
--- a/test/DebugInfo/Generic/incorrect-variable-debugloc1.ll
+++ b/test/DebugInfo/Generic/incorrect-variable-debugloc1.ll
@@ -15,6 +15,7 @@
 ; This is a test for PR21176.
 ; DW_OP_const <const> doesn't describe a constant value, but a value at a constant address. 
 ; The proper way to describe a constant value is DW_OP_constu <const>, DW_OP_stack_value.
+; For values < 32 we emit the canonical DW_OP_lit<const>.
 
 ; Generated with clang -S -emit-llvm -g -O2 test.cpp
 
@@ -30,8 +31,8 @@
 ; CHECK: DW_TAG_variable
 ; CHECK: DW_AT_location
 ; CHECK-NOT: DW_AT
-; DWARF23: DW_OP_constu 0xd{{$}}
-; DWARF4: DW_OP_constu 0xd, DW_OP_stack_value{{$}}
+; DWARF23: DW_OP_lit13{{$}}
+; DWARF4: DW_OP_lit13, DW_OP_stack_value{{$}}
 
 ; Function Attrs: uwtable
 define i32 @main() #0 !dbg !4 {

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -21,6 +21,18 @@ config.suffixes = ['.ll', '.spt']
 # excludes: A list of directories  and fles to exclude from the testsuite.
 config.excludes = ['CMakeLists.txt']
 
+if not config.skip_spirv_debug_info_tests:
+    # Direct object generation.
+    config.available_features.add('object-emission')
+    
+    # LLVM can be configured with an empty default triple.
+    # Some tests are "generic" and require a valid default triple.
+    if config.target_triple:
+        config.available_features.add('default_triple')
+    
+    # Ask llvm-config about asserts.
+    llvm_config.feature_config([('--assertion-mode', {'ON': 'asserts'})])
+
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)
 


### PR DESCRIPTION
This commit adds dependencies for currently unsupported debug information tests and updates one of the outdated ones in accordance with https://reviews.llvm.org/D51640 .