### PR TITLE
Fix image type name recognition

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -1124,9 +1124,7 @@ void OCL20ToSPIRV::visitCallGetImageSize(CallInst *CI, StringRef MangledName,
   auto IsImg = isOCLImageType(CI->getArgOperand(0)->getType(), &TyName);
   (void)IsImg;
   assert(IsImg);
-  std::string ImageTyName = TyName.str();
-  if (hasAccessQualifiedName(TyName))
-    ImageTyName.erase(ImageTyName.size() - 5, 3);
+  std::string ImageTyName = getImageBaseTypeName(TyName);
   auto Desc = map<SPIRVTypeImageDescriptor>(ImageTyName);
   unsigned Dim = getImageDimension(Desc.Dim) + Desc.Arrayed;
   assert(Dim > 0 && "Invalid image dimension.");

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -839,6 +839,10 @@ Type *getSPIRVImageTypeFromOCL(Module *M, Type *T);
 Type *getLLVMTypeForSPIRVImageSampledTypePostfix(StringRef Postfix,
                                                  LLVMContext &Ctx);
 
+/// Return the unqualified and unsuffixed base name of an image type.
+/// E.g. opencl.image2d_ro_t.3 -> image2d_t
+std::string getImageBaseTypeName(StringRef Name);
+
 /// Map OpenCL opaque type name to SPIR-V type name.
 std::string mapOCLTypeNameToSPIRV(StringRef Name, StringRef Acc = "");
 

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1251,8 +1251,7 @@ std::string getImageBaseTypeName(StringRef Name) {
   Name.split(SubStrs, Delims);
   if (Name.startswith(kSPR2TypeName::OCLPrefix)) {
     ImageTyName = SubStrs[1].str();
-  }
-  else {
+  } else {
     ImageTyName = SubStrs[0].str();
   }
 

--- a/test/transcoding/image_with_suffix.ll
+++ b/test/transcoding/image_with_suffix.ll
@@ -1,0 +1,48 @@
+; Test that an image type name suffixed with .<n> does not crash the
+; translator.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: call spir_func i32 @_Z15get_image_width11ocl_image1d
+
+; ModuleID = 'foo.ll'
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image1d_ro_t.2 = type opaque
+
+; Function Attrs: convergent nounwind writeonly
+define spir_kernel void @foo(%opencl.image1d_ro_t.2 addrspace(1)* %im, i32 addrspace(1)* nocapture %res) local_unnamed_addr #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
+entry:
+  %call = tail call spir_func i32 @_Z15get_image_width14ocl_image1d_ro(%opencl.image1d_ro_t.2 addrspace(1)* %im) #2
+  store i32 %call, i32 addrspace(1)* %res, align 4, !tbaa !8
+  ret void
+}
+
+; Function Attrs: convergent nounwind readnone
+declare spir_func i32 @_Z15get_image_width14ocl_image1d_ro(%opencl.image1d_ro_t.2 addrspace(1)*) local_unnamed_addr #1
+
+attributes #0 = { convergent nounwind writeonly "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="true" "no-frame-pointer-elim-non-leaf" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind readnone }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{i32 1, i32 2}
+!3 = !{!"clang version 8.0.0"}
+!4 = !{i32 1, i32 1}
+!5 = !{!"read_only", !"none"}
+!6 = !{!"image1d_t", !"int*"}
+!7 = !{!"", !""}
+!8 = !{!9, !9, i64 0}
+!9 = !{!"int", !10, i64 0}
+!10 = !{!"omnipotent char", !11, i64 0}
+!11 = !{!"Simple C/C++ TBAA"}


### PR DESCRIPTION
Image type names may end up getting a .<n> suffix, e.g. when multiple
LLVM IR modules defining the same type name are loaded into an
LLVMContext.  The translator already has some basic handling for that,
but the included test case triggers an assert.

Improve the type name recognition handling and factor it out into a
helper function.