### PR TITLE
Fix disabling of fp-contract

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -698,11 +698,8 @@ void checkFpContract(BinaryOperator *B, SPIRVBasicBlock *BB) {
     if (auto *I = dyn_cast<Instruction>(Op)) {
       if (I->getOpcode() == Instruction::FMul) {
         SPIRVFunction *BF = BB->getParent();
-        if (BB->getModule()->isEntryPoint(ExecutionModelKernel, BF->getId())) {
-          BF->addExecutionMode(BB->getModule()->add(
-              new SPIRVExecutionMode(BF, spv::ExecutionModeContractionOff)));
-          break;
-        }
+        BF->setUncontractedFMulAddFound();
+        break;
       }
     }
   }

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -135,6 +135,22 @@ public:
     assert(FuncType && "Invalid func type");
   }
 
+  bool shouldFPContractBeDisabled() const {
+    // We could find some instructions in LLVM IR which look exactly like an
+    // unfused fmuladd. So, we assume that FP_CONTRACT was disabled only if
+    // there are something that looks like uncointracted fmul + fadd, but there
+    // no calls to @llvm.fmuladd.*
+    return FoundUncontractedFMulAdd && !FoundContractedFMulAdd;
+  }
+
+  void setUncontractedFMulAddFound(bool Value = true) {
+    FoundUncontractedFMulAdd = Value;
+  }
+
+  void setContractedFMulAddFound(bool Value = true) {
+    FoundContractedFMulAdd = Value;
+  }
+
 private:
   SPIRVFunctionParameter *addArgument(unsigned TheArgNo, SPIRVId TheId) {
     SPIRVFunctionParameter *Arg = new SPIRVFunctionParameter(
@@ -156,6 +172,9 @@ private:
   std::vector<SPIRVFunctionParameter *> Parameters;
   typedef std::vector<SPIRVBasicBlock *> SPIRVLBasicBlockVector;
   SPIRVLBasicBlockVector BBVec;
+
+  bool FoundUncontractedFMulAdd = false;
+  bool FoundContractedFMulAdd = false;
 };
 
 typedef SPIRVEntryOpCodeOnly<OpFunctionEnd> SPIRVFunctionEnd;

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -7,19 +7,28 @@
 ; void kernel k2 (float a, float b, float c) {
 ;   float d = a * b + c;
 ; }
+;
+; void kernel k3 (float a, float b, float c) {
+;   float d = a * b; // a * b together with -d in the next statement look
+;   float e = a * c - d; // exactly like an unfused fmuladd in LLVM IR
+; }
+;
+; IR generated using the following commands:
+; clang -cc1 -x cl -emit-llvm -O2 -disable-llvm-passes -triple spir64 1.cl -o 1.ll
+; opt -mem2reg 1.ll -S -o 1.o.ll
 
 ; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 
 ; CHECK: EntryPoint 6 [[K1:[0-9]+]] "k1"
 ; CHECK: EntryPoint 6 [[K2:[0-9]+]] "k2"
+; CHECK: EntryPoint 6 [[K3:[0-9]+]] "k3"
 ; CHECK: ExecutionMode [[K1]] 31
 ; CHECK-NOT: ExecutionMode [[K2]] 31
+; CHECK-NOT: ExecutionMode [[K3]] 31
 
-;ModuleID = '<stdin>'
-source_filename = "/tmp/tmp.cl"
-target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
-target triple = "spir"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
 
 ; Function Attrs: convergent nounwind
 define spir_kernel void @k1(float %a, float %b, float %c) #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
@@ -39,7 +48,16 @@ entry:
 ; Function Attrs: nounwind readnone speculatable
 declare float @llvm.fmuladd.f32(float, float, float) #2
 
-attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+; Function Attrs: convergent nounwind
+define spir_kernel void @k3(float %a, float %b, float %c) #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
+entry:
+  %mul = fmul float %a, %b
+  %neg = fsub float -0.000000e+00, %mul
+  %0 = call float @llvm.fmuladd.f32(float %a, float %c, float %neg)
+  ret void
+}
+
+attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { argmemonly nounwind }
 attributes #2 = { nounwind readnone speculatable }
 
@@ -51,7 +69,7 @@ attributes #2 = { nounwind readnone speculatable }
 !0 = !{i32 1, !"wchar_size", i32 4}
 !1 = !{i32 1, i32 0}
 !2 = !{i32 1, i32 2}
-!3 = !{!"clang version 8.0.0"}
+!3 = !{!"clang version 7.0.1"}
 !4 = !{i32 0, i32 0, i32 0}
 !5 = !{!"none", !"none", !"none"}
 !6 = !{!"float", !"float", !"float"}


### PR DESCRIPTION
6197c7d5901a0bd5638b1b464cdbff7e9ccdb210 introduced some very primitive heuristic to detect when fp-contraction is disabled to set ContractionOff execution mode.

There were test cases where contraction was enabled, but SPIR-V Translator set it to off.

The root cause is in poor algorithm of 'disabled fp-contract' detection.
This patch doesn't bring the good and reliable algorithm and only provides a workaround.