### PR TITLE
Fix length for debug operations 'plus' and 'minus'

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -431,8 +431,8 @@ enum {
 };
 static std::map<ExpressionOpCode, unsigned> OpCountMap {
   { Deref,      1 },
-  { Plus,       2 },
-  { Minus,      2 },
+  { Plus,       1 },
+  { Minus,      1 },
   { PlusUconst, 2 },
   { BitPiece,   3 },
   { Swap,       1 },


### PR DESCRIPTION
Operations 'plus' and 'minus' should have length 1 word instead of two