### PR TITLE
Fix error path in transValueWithoutDecoration

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1680,10 +1680,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return mapValue(
         BV, transSPIRVBuiltinFromInst(static_cast<SPIRVInstruction *>(BV), BB));
   }
-
-    SPIRVDBG(spvdbgs() << "Cannot translate " << *BV << '\n';)
-    llvm_unreachable("Translation of SPIRV instruction not implemented");
-    return NULL;
   }
 }
 


### PR DESCRIPTION
The error path in transValueWithoutDecoration was inside the default
case of a switch statement.  Move it to the correct place, i.e., after
the switch statement.

Reported-by: Pedro Olsen Ferreira