### PR TITLE
Ignore .n suffix for all OpenCL types

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1030,9 +1030,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
     } else if (auto StructTy = dyn_cast<StructType>(ET)) {
       LLVM_DEBUG(dbgs() << "ptr to struct: " << *Ty << '\n');
       auto TyName = StructTy->getStructName();
-      if (TyName.startswith(kSPR2TypeName::ImagePrefix) ||
-          TyName.startswith(kSPR2TypeName::PipeRO) ||
-          TyName.startswith(kSPR2TypeName::PipeWO)) {
+      if (TyName.startswith(kSPR2TypeName::OCLPrefix)) {
         auto DelimPos = TyName.find_first_of(kSPR2TypeName::Delimiter,
                                              strlen(kSPR2TypeName::OCLPrefix));
         if (DelimPos != StringRef::npos)


### PR DESCRIPTION
LLVM type names may end up getting a .<n> suffix, e.g. when multiple
LLVM modules defining the same type name are loaded into a single
LLVMContext.  transTypeDesc was already ignoring such suffixes for
image and pipe types, but other OpenCL types could be affected by the
same issue, resulting in incorrect mangling of builtin function
arguments.

Strip the suffix for any type whose name starts with "opencl.".