### PR TITLE
Set noduplicate attribute for barriers

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2508,6 +2508,7 @@ CallInst *SPIRVToLLVM::transOCLBarrier(BasicBlock *BB, SPIRVWord ExecScope,
     Func->setCallingConv(CallingConv::SPIR_FUNC);
     if (isFuncNoUnwind())
       Func->addFnAttr(Attribute::NoUnwind);
+    Func->addFnAttr(Attribute::NoDuplicate);
   }
 
   return CallInst::Create(Func, Arg, "", BB);

--- a/test/transcoding/OpControlBarrier_cl12.ll
+++ b/test/transcoding/OpControlBarrier_cl12.ll
@@ -5,12 +5,13 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: call spir_func void @_Z7barrierj(i32 2)
-; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 1)
-; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 4)
-; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 3)
-; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 5)
-; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 7)
+; CHECK-LLVM: call spir_func void @_Z7barrierj(i32 2) [[attr:#[0-9]+]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 4) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 3) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 5) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 7) [[attr]]
+; CHECK-LLVM: attributes [[attr]] = { noduplicate nounwind }
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272

--- a/test/transcoding/OpControlBarrier_cl20.ll
+++ b/test/transcoding/OpControlBarrier_cl20.ll
@@ -6,27 +6,29 @@
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; work_group_barrier with the default scope (memory_scope_work_group)
-; CHECK-LLVM: call spir_func void @_Z18work_group_barrierji(i32 2, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 3, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 5, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 7, i32 1) #{{[0-9]+}}
+; CHECK-LLVM: call spir_func void @_Z18work_group_barrierji(i32 2, i32 1) [[attr:#[0-9]+]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 3, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 5, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 7, i32 1) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 2, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 2, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 2, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 2, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 2, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 2, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 2, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 2, i32 3) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 1, i32 3) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierji(i32 4, i32 3) [[attr]]
+
+; CHECK-LLVM: attributes [[attr]] = { noduplicate nounwind }
 
 ; Both 'CrossDevice' memory scope and 'None' memory order enums have value equal to 0.
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[Null:[0-9]+]] 0

--- a/test/transcoding/OpControlBarrier_cl20_subgroup.ll
+++ b/test/transcoding/OpControlBarrier_cl20_subgroup.ll
@@ -5,27 +5,29 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 3, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 5, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 7, i32 1) #{{[0-9]+}}
+; CHECK-LLVM: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 1) [[attr:#[0-9]+]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 3, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 5, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 7, i32 1) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 3) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 3) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 3) [[attr]]
+
+; CHECK-LLVM: attributes [[attr]] = { noduplicate nounwind }
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272

--- a/test/transcoding/OpControlBarrier_cl21.ll
+++ b/test/transcoding/OpControlBarrier_cl21.ll
@@ -5,28 +5,29 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 3, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 5, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 7, i32 1) #{{[0-9]+}}
+; CHECK-LLVM: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 1) [[attr:#[0-9]+]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 3, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 5, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 7, i32 1) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 2, i32 3) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 1, i32 3) [[attr]]
 
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 0) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 1) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 2) #{{[0-9]+}}
-; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 3) #{{[0-9]+}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 0) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 1) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 2) [[attr]]
+; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierji(i32 4, i32 3) [[attr]]
 
+; CHECK-LLVM: attributes [[attr]] = { noduplicate nounwind }
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272


### PR DESCRIPTION
Without this attribute, LLVM passes such as SimplifyCFG may duplicate
barrier calls, which would cause incorrect behaviour of the compiled
program.