### PR TITLE
Update tests after change in LLVM

### DIFF
--- a/test/DebugInfo/Generic/2010-04-19-FramePtr.ll
+++ b/test/DebugInfo/Generic/2010-04-19-FramePtr.ll
@@ -4,7 +4,7 @@
 
 ; RUN: llc -mtriple=%triple -debugger-tune=lldb -asm-verbose -O1 -o - < %t.ll | FileCheck %s
 ; RUN: llc -mtriple=%triple -debugger-tune=gdb -asm-verbose -O1 -o - < %t.ll | FileCheck %s --check-prefix=DISABLE
-; RUN: llc -mtriple=%triple -disable-fp-elim -debugger-tune=lldb -asm-verbose -O1 -o - < %t.ll | FileCheck %s --check-prefix=DISABLE
+; RUN: llc -mtriple=%triple -frame-pointer=all -debugger-tune=lldb -asm-verbose -O1 -o - < %t.ll | FileCheck %s --check-prefix=DISABLE
 
 ; CHECK: DW_AT_APPLE_omit_frame_ptr
 ; DISABLE-NOT: DW_AT_APPLE_omit_frame_ptr


### PR DESCRIPTION
This is to catch up with LLVM master branch. We need to update tests after
changes introduced the following commit in LLVM:

commit 08223c34d49c74300b25ceafa9ef3ba9c3c790e7
Author: Francis Visoiu Mistrih <francisvm@yahoo.com>
Date:   Mon Jan 14 10:55:55 2019 +0000

    Replace "no-frame-pointer-*" function attributes with "frame-pointer"

    Part of the effort to refactoring frame pointer code generation. We used
    to use two function attributes "no-frame-pointer-elim" and
    "no-frame-pointer-elim-non-leaf" to represent three kinds of frame
    pointer usage: (all) frames use frame pointer, (non-leaf) frames use
    frame pointer, (none) frame use frame pointer. This CL makes the idea
    explicit by using only one enum function attribute "frame-pointer"

    Option "-frame-pointer=" replaces "-disable-fp-elim" for tools such as
    llc.

    "no-frame-pointer-elim" and "no-frame-pointer-elim-non-leaf" are still
    supported for easy migration to "frame-pointer".

    tests are mostly updated with

    // replace command line args �<80><98>-disable-fp-elim=false�<80><99> with �<80><98>-frame-pointer=none�<80><99>
    grep -iIrnl '\-disable-fp-elim=false' * | xargs sed -i '' -e "s/-disable-fp-elim=false/-frame-pointer=none/g"

    // replace command line args �<80><98>-disable-fp-elim�<80><99> with �<80><98>-frame-pointer=all�<80><99>
    grep -iIrnl '\-disable-fp-elim' * | xargs sed -i '' -e "s/-disable-fp-elim/-frame-pointer=all/g"

    Patch by Yuanfang Chen (tabloid.adroit)!

    Differential Revision: https://reviews.llvm.org/D56351

    git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@351049 91177308-0d34-0410-b5e6-96231b3b80d8