### PR TITLE
Translate initializer of global variables before its type.

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -734,9 +734,12 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
       }
       Inst->dropAllReferences();
     }
+    // Translate initializer first.
+    SPIRVValue *BVarInit =
+        (Init && !isa<UndefValue>(Init)) ? transValue(Init, nullptr) : nullptr;
+
     auto BVar = static_cast<SPIRVVariable *>(BM->addVariable(
-        transType(Ty), GV->isConstant(), transLinkageType(GV),
-        (Init && !isa<UndefValue>(Init)) ? transValue(Init, nullptr) : nullptr,
+        transType(Ty), GV->isConstant(), transLinkageType(GV), BVarInit,
         GV->getName(),
         SPIRSPIRVAddrSpaceMap::map(
             static_cast<SPIRAddressSpace>(Ty->getAddressSpace())),


### PR DESCRIPTION
Order of evaluation of functions arguments is unspecified in C++. Therefore
having translation of the initializer and the type as arguments of
SPIRVModule::addVariable results in slightly different SPIR-V depending on
whether we use GCC or Clang to build the translator.