### PR TITLE
Update include paths for pre-built-LLVM builds

### DIFF
--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -44,7 +44,7 @@ add_llvm_library(LLVMSPIRVLib
 
 target_include_directories(LLVMSPIRVLib
   PRIVATE
-    ${LLVM_INCLUDE_DIR}
+    ${LLVM_INCLUDE_DIRS}
     ${LLVM_SPIRV_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/libSPIRV

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -20,6 +20,6 @@ endif()
 
 target_include_directories(llvm-spirv
   PRIVATE
-    ${LLVM_INCLUDE_DIR}
+    ${LLVM_INCLUDE_DIRS}
     ${LLVM_SPIRV_INCLUDE_DIRS}
 )


### PR DESCRIPTION
Translator builds with a pre-built LLVM recently broke due to headers
in the LLVM source tree no longer being found.

Update our CMake files for LLVM commit r353924 / 95decc39b55 ("[llvm]
[cmake] Provide split include paths in LLVMConfig", 2019-02-13).