### PR TITLE
Translate Intel FPGA memory attributes

### DIFF
--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -259,6 +259,8 @@ private:
 
   CallInst *transOCLMemFence(BasicBlock *BB, SPIRVWord MemSema,
                              SPIRVWord MemScope);
+
+  void transIntelFPGADecorations(SPIRVValue *BV, Value *V);
 }; // class SPIRVToLLVM
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -55,6 +55,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DebugInfo.h"
@@ -1106,6 +1107,62 @@ SPIRVValue *LLVMToSPIRV::oclTransSpvcCastSampler(CallInst *CI,
   return BV;
 }
 
+std::vector<std::pair<Decoration, std::string>>
+parseAnnotations(StringRef AnnotatedCode) {
+  std::vector<std::pair<Decoration, std::string>> Decorates;
+
+  size_t OpenBracketNum = AnnotatedCode.count('{');
+  size_t CloseBracketNum = AnnotatedCode.count('}');
+  assert(OpenBracketNum == CloseBracketNum);
+
+  for (size_t I = 0; I < OpenBracketNum; ++I) {
+    size_t From = AnnotatedCode.find('{');
+    size_t To = AnnotatedCode.find('}', From);
+    StringRef AnnotatedDecoration = AnnotatedCode.substr(From + 1, To - 1);
+    std::pair<StringRef, StringRef> D = AnnotatedDecoration.split(':');
+
+    StringRef F = D.first;
+    Decoration Dec = llvm::StringSwitch<Decoration>(F)
+                         .Case("memory", DecorationMemoryINTEL)
+                         .Case("register", DecorationRegisterINTEL)
+                         .Case("numbanks", DecorationNumbanksINTEL)
+                         .Case("bankwidth", DecorationBankwidthINTEL);
+
+    Decorates.push_back({Dec, D.second});
+    AnnotatedCode = AnnotatedCode.drop_front(To + 1);
+  }
+  return Decorates;
+}
+
+void addIntelFPGADecorations(
+    SPIRVEntry *E,
+    std::vector<std::pair<Decoration, std::string>> &Decorations) {
+  for (const auto &I : Decorations) {
+    if (I.first == DecorationMemoryINTEL)
+      E->addDecorate(new SPIRVDecorateMemoryINTELAttr(E, I.second));
+    else {
+      SPIRVWord Result = 0;
+      StringRef(I.second).getAsInteger(10, Result);
+      E->addDecorate(I.first, Result);
+    }
+  }
+}
+
+void addIntelFPGADecorationsForStructMember(
+    SPIRVEntry *E, SPIRVWord MemberNumber,
+    std::vector<std::pair<Decoration, std::string>> &Decorations) {
+  for (const auto &I : Decorations) {
+    if (I.first == DecorationMemoryINTEL)
+      E->addMemberDecorate(
+          new SPIRVMemberDecorateMemoryINTELAttr(E, MemberNumber, I.second));
+    else {
+      SPIRVWord Result = 0;
+      StringRef(I.second).getAsInteger(10, Result);
+      E->addMemberDecorate(MemberNumber, I.first, Result);
+    }
+  }
+}
+
 SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
                                             SPIRVBasicBlock *BB) {
   auto GetMemoryAccess = [](MemIntrinsic *MI) -> std::vector<SPIRVWord> {
@@ -1192,6 +1249,42 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
     return DbgTran->createDebugDeclarePlaceholder(cast<DbgDeclareInst>(II), BB);
   case Intrinsic::dbg_value:
     return DbgTran->createDebugValuePlaceholder(cast<DbgValueInst>(II), BB);
+  case Intrinsic::var_annotation: {
+    BitCastInst *BI = cast<BitCastInst>(II->getArgOperand(0));
+    SPIRVValue *SV = transValue(BI->getOperand(0), BB);
+
+    GetElementPtrInst *GEP = cast<GetElementPtrInst>(II->getArgOperand(1));
+    Constant *C = cast<Constant>(GEP->getOperand(0));
+    StringRef AnnotationString =
+        cast<ConstantDataArray>(C->getOperand(0))->getAsString();
+
+    std::vector<std::pair<Decoration, std::string>> Decorations =
+        parseAnnotations(AnnotationString);
+
+    addIntelFPGADecorations(SV, Decorations);
+    return SV;
+  }
+  case Intrinsic::ptr_annotation: {
+    BitCastInst *BI = dyn_cast<BitCastInst>(II->getArgOperand(0));
+    GetElementPtrInst *GI = dyn_cast<GetElementPtrInst>(BI->getOperand(0));
+    SPIRVType *Ty = transType(GI->getSourceElementType());
+
+    SPIRVWord MemberNumber =
+        dyn_cast<ConstantInt>(GI->getOperand(2))->getZExtValue();
+
+    GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(II->getArgOperand(1));
+    Constant *C = dyn_cast<Constant>(GEP->getOperand(0));
+    StringRef AnnotationString =
+        dyn_cast<ConstantDataArray>(C->getOperand(0))->getAsString();
+
+    std::vector<std::pair<Decoration, std::string>> Decorations =
+        parseAnnotations(AnnotationString);
+
+    addIntelFPGADecorationsForStructMember(Ty, MemberNumber, Decorations);
+
+    II->replaceAllUsesWith(BI);
+    return 0;
+  }
   default:
     // LLVM intrinsic functions shouldn't get to SPIRV, because they
     // would have no definition there.

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -89,6 +89,8 @@ void SPIRVDecorate::encode(spv_ostream &O) const {
   Encoder << Target << Dec;
   if (Dec == DecorationLinkageAttributes)
     SPIRVDecorateLinkageAttr::encodeLiterals(Encoder, Literals);
+  else if (Dec == DecorationMemoryINTEL)
+    SPIRVDecorateMemoryINTELAttr::encodeLiterals(Encoder, Literals);
   else
     Encoder << Literals;
 }
@@ -103,13 +105,20 @@ void SPIRVDecorate::decode(std::istream &I) {
   Decoder >> Target >> Dec;
   if (Dec == DecorationLinkageAttributes)
     SPIRVDecorateLinkageAttr::decodeLiterals(Decoder, Literals);
+  else if (Dec == DecorationMemoryINTEL)
+    SPIRVDecorateMemoryINTELAttr::decodeLiterals(Decoder, Literals);
   else
     Decoder >> Literals;
   getOrCreateTarget()->addDecorate(this);
 }
 
 void SPIRVMemberDecorate::encode(spv_ostream &O) const {
-  getEncoder(O) << Target << MemberNumber << Dec << Literals;
+  SPIRVEncoder Encoder = getEncoder(O);
+  Encoder << Target << MemberNumber << Dec;
+  if (Dec == DecorationMemoryINTEL)
+    SPIRVDecorateMemoryINTELAttr::encodeLiterals(Encoder, Literals);
+  else
+    Encoder << Literals;
 }
 
 void SPIRVMemberDecorate::setWordCount(SPIRVWord Count) {
@@ -118,7 +127,12 @@ void SPIRVMemberDecorate::setWordCount(SPIRVWord Count) {
 }
 
 void SPIRVMemberDecorate::decode(std::istream &I) {
-  getDecoder(I) >> Target >> MemberNumber >> Dec >> Literals;
+  SPIRVDecoder Decoder = getDecoder(I);
+  Decoder >> Target >> MemberNumber >> Dec;
+  if (Dec == DecorationMemoryINTEL)
+    SPIRVDecorateMemoryINTELAttr::decodeLiterals(Decoder, Literals);
+  else
+    Decoder >> Literals;
   getOrCreateTarget()->addMemberDecorate(this);
 }
 
@@ -197,6 +211,12 @@ bool operator==(const SPIRVDecorateGeneric &A, const SPIRVDecorateGeneric &B) {
     return false;
   if (A.getOpCode() != B.getOpCode())
     return false;
+  if (B.isMemberDecorate()) {
+    auto &MDA = static_cast<SPIRVMemberDecorate const &>(A);
+    auto &MDB = static_cast<SPIRVMemberDecorate const &>(B);
+    if (MDA.getMemberNumber() != MDB.getMemberNumber())
+      return false;
+  }
   if (A.getDecorateKind() != B.getDecorateKind())
     return false;
   if (A.getLiteralCount() != B.getLiteralCount())

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -310,6 +310,58 @@ public:
   void decorateTargets() override;
 };
 
+class SPIRVDecorateMemoryINTELAttr : public SPIRVDecorate {
+public:
+  // Complete constructor for MemoryINTEL decoration
+  SPIRVDecorateMemoryINTELAttr(SPIRVEntry *TheTarget,
+                               const std::string &MemoryType)
+      : SPIRVDecorate(DecorationMemoryINTEL, TheTarget) {
+    for (auto &I : getVec(MemoryType))
+      Literals.push_back(I);
+    WordCount += Literals.size();
+  }
+  // Incomplete constructor
+  SPIRVDecorateMemoryINTELAttr() : SPIRVDecorate() {}
+
+  static void encodeLiterals(SPIRVEncoder &Encoder,
+                             const std::vector<SPIRVWord> &Literals) {
+#ifdef _SPIRV_SUPPORT_TEXT_FMT
+    if (SPIRVUseTextFormat) {
+      Encoder << getString(Literals.cbegin(), Literals.cend());
+    } else
+#endif
+      Encoder << Literals;
+  }
+
+  static void decodeLiterals(SPIRVDecoder &Decoder,
+                             std::vector<SPIRVWord> &Literals) {
+#ifdef _SPIRV_SUPPORT_TEXT_FMT
+    if (SPIRVUseTextFormat) {
+      std::string MemoryType;
+      Decoder >> MemoryType;
+      std::copy_n(getVec(MemoryType).begin(), Literals.size(),
+                  Literals.begin());
+    } else
+#endif
+      Decoder >> Literals;
+  }
+};
+
+class SPIRVMemberDecorateMemoryINTELAttr : public SPIRVMemberDecorate {
+public:
+  // Complete constructor for MemoryINTEL decoration
+  SPIRVMemberDecorateMemoryINTELAttr(SPIRVEntry *TheTarget,
+                                     SPIRVWord MemberNumber,
+                                     const std::string &MemoryType)
+      : SPIRVMemberDecorate(DecorationMemoryINTEL, MemberNumber, TheTarget) {
+    for (auto &I : getVec(MemoryType))
+      Literals.push_back(I);
+    WordCount += Literals.size();
+  }
+  // Incomplete constructor
+  SPIRVMemberDecorateMemoryINTELAttr() : SPIRVMemberDecorate() {}
+};
+
 } // namespace SPIRV
 
 #endif // SPIRV_LIBSPIRV_SPIRVDECORATE_H

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -322,6 +322,45 @@ bool SPIRVEntry::hasDecorate(Decoration Kind, size_t Index,
   return true;
 }
 
+// Check if an entry member has Kind of decoration and get the literal of the
+// first decoration of such kind at Index.
+bool SPIRVEntry::hasMemberDecorate(Decoration Kind, size_t Index,
+                                   SPIRVWord MemberNumber,
+                                   SPIRVWord *Result) const {
+  auto Loc = MemberDecorates.find({MemberNumber, Kind});
+  if (Loc == MemberDecorates.end())
+    return false;
+  if (Result)
+    *Result = Loc->second->getLiteral(Index);
+  return true;
+}
+
+std::string SPIRVEntry::getDecorationStringLiteral(Decoration Kind) const {
+  std::vector<SPIRVWord> Literals;
+  auto Loc = Decorates.find(Kind);
+  if (Loc == Decorates.end())
+    return std::string();
+
+  for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
+    Literals.push_back(Loc->second->getLiteral(I));
+
+  return getString(Literals.cbegin(), Literals.cend());
+}
+
+std::string
+SPIRVEntry::getMemberDecorationStringLiteral(Decoration Kind,
+                                             SPIRVWord MemberNumber) const {
+  std::vector<SPIRVWord> Literals;
+  auto Loc = MemberDecorates.find({MemberNumber, Kind});
+  if (Loc == MemberDecorates.end())
+    return std::string();
+
+  for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
+    Literals.push_back(Loc->second->getLiteral(I));
+
+  return getString(Literals.cbegin(), Literals.cend());
+}
+
 // Get literals of all decorations of Kind at Index.
 std::set<SPIRVWord> SPIRVEntry::getDecorate(Decoration Kind,
                                             size_t Index) const {

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -291,6 +291,12 @@ public:
   const std::string &getName() const { return Name; }
   bool hasDecorate(Decoration Kind, size_t Index = 0,
                    SPIRVWord *Result = 0) const;
+  bool hasMemberDecorate(Decoration Kind, size_t Index = 0,
+                         SPIRVWord MemberNumber = 0,
+                         SPIRVWord *Result = 0) const;
+  std::string getDecorationStringLiteral(Decoration Kind) const;
+  std::string getMemberDecorationStringLiteral(Decoration Kind,
+                                               SPIRVWord MemberNumber) const;
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;
   bool hasId() const { return !(Attrib & SPIRVEA_NOID); }
   bool hasLine() const { return Line != nullptr; }

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -338,6 +338,10 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationNoContraction, {CapabilityShader});
   ADD_VEC_INIT(DecorationInputAttachmentIndex, {CapabilityInputAttachment});
   ADD_VEC_INIT(DecorationAlignment, {CapabilityKernel});
+  ADD_VEC_INIT(DecorationRegisterINTEL, {CapabilityFPGAMemoryAttributesINTEL});
+  ADD_VEC_INIT(DecorationMemoryINTEL, {CapabilityFPGAMemoryAttributesINTEL});
+  ADD_VEC_INIT(DecorationNumbanksINTEL, {CapabilityFPGAMemoryAttributesINTEL});
+  ADD_VEC_INIT(DecorationBankwidthINTEL, {CapabilityFPGAMemoryAttributesINTEL});
 }
 
 template <> inline void SPIRVMap<BuiltIn, SPIRVCapVec>::init() {

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -397,6 +397,10 @@ inline bool isValid(spv::Decoration V) {
   case DecorationInputAttachmentIndex:
   case DecorationAlignment:
   case DecorationMaxByteOffset:
+  case DecorationRegisterINTEL:
+  case DecorationMemoryINTEL:
+  case DecorationNumbanksINTEL:
+  case DecorationBankwidthINTEL:
     return true;
   default:
     return false;
@@ -548,6 +552,7 @@ inline bool isValid(spv::Capability V) {
   case CapabilitySubgroupDispatch:
   case CapabilityNamedBarrier:
   case CapabilityPipeStorage:
+  case CapabilityFPGAMemoryAttributesINTEL:
     return true;
   default:
     return false;

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -331,6 +331,10 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationMaxByteOffset, "MaxByteOffset");
   add(DecorationNoSignedWrap, "NoSignedWrap");
   add(DecorationNoUnsignedWrap, "NoUnsignedWrap");
+  add(DecorationRegisterINTEL, "RegisterINTEL");
+  add(DecorationMemoryINTEL, "MemoryINTEL");
+  add(DecorationNumbanksINTEL, "NumbanksINTEL");
+  add(DecorationBankwidthINTEL, "BankwidthINTEL");
 }
 SPIRV_DEF_NAMEMAP(Decoration, SPIRVDecorationNameMap)
 
@@ -476,6 +480,7 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
       "SubgroupAvcMotionEstimationIntraINTEL");
   add(CapabilitySubgroupAvcMotionEstimationChromaINTEL,
       "SubgroupAvcMotionEstimationChromaINTEL");
+  add(CapabilityFPGAMemoryAttributesINTEL, "FPGAMemoryAttributesINTEL");
 }
 SPIRV_DEF_NAMEMAP(Capability, SPIRVCapabilityNameMap)
 

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -388,6 +388,10 @@ enum Decoration {
     DecorationPassthroughNV = 5250,
     DecorationViewportRelativeNV = 5252,
     DecorationSecondaryViewportRelativeNV = 5256,
+    DecorationRegisterINTEL = 5825,
+    DecorationMemoryINTEL = 5826,
+    DecorationNumbanksINTEL = 5827,
+    DecorationBankwidthINTEL = 5828,
     DecorationMax = 0x7fffffff,
 };
 
@@ -656,6 +660,7 @@ enum Capability {
   CapabilitySubgroupAvcMotionEstimationINTEL = 5696,
   CapabilitySubgroupAvcMotionEstimationIntraINTEL = 5697,
   CapabilitySubgroupAvcMotionEstimationChromaINTEL = 5698,
+  CapabilityFPGAMemoryAttributesINTEL = 5824,
   CapabilityMax = 0x7fffffff,
 };
 

--- a/test/IntelFPGAMemoryAttributes.ll
+++ b/test/IntelFPGAMemoryAttributes.ll
@@ -1,0 +1,117 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: Decorate {{[0-9]+}} MemoryINTEL "DEFAULT"
+; CHECK-SPIRV: Decorate {{[0-9]+}} RegisterINTEL 1
+; CHECK-SPIRV: Decorate {{[0-9]+}} MemoryINTEL "BLOCK_RAM"
+; CHECK-SPIRV: Decorate {{[0-9]+}} NumbanksINTEL 4
+; CHECK-SPIRV: Decorate {{[0-9]+}} BankwidthINTEL 8
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-linux"
+
+%class.anon = type { i8 }
+
+; CHECK-LLVM: [[STR1:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:4}
+; CHECK-LLVM: [[STR2:@[a-zA-Z0-9_.]+]] = {{.*}}{register:1}
+; CHECK-LLVM: [[STR3:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:BLOCK_RAM}
+; CHECK-LLVM: [[STR4:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:8}
+@.str = private unnamed_addr constant [29 x i8] c"{memory:DEFAULT}{numbanks:4}\00", section "llvm.metadata"
+@.str.1 = private unnamed_addr constant [13 x i8] c"test_var.cpp\00", section "llvm.metadata"
+@.str.2 = private unnamed_addr constant [13 x i8] c"{register:1}\00", section "llvm.metadata"
+@.str.3 = private unnamed_addr constant [19 x i8] c"{memory:BLOCK_RAM}\00", section "llvm.metadata"
+@.str.4 = private unnamed_addr constant [30 x i8] c"{memory:DEFAULT}{bankwidth:8}\00", section "llvm.metadata"
+
+; Function Attrs: nounwind
+define spir_kernel void @_ZTSZ4mainE15kernel_function() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
+entry:
+  %0 = alloca %class.anon, align 1
+  %1 = bitcast %class.anon* %0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %1) #4
+  call spir_func void @"_ZZ4mainENK3$_0clEv"(%class.anon* %0)
+  %2 = bitcast %class.anon* %0 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %2) #4
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: inlinehint nounwind
+define internal spir_func void @"_ZZ4mainENK3$_0clEv"(%class.anon* %this) #2 align 2 {
+entry:
+  %this.addr = alloca %class.anon*, align 8
+  store %class.anon* %this, %class.anon** %this.addr, align 8, !tbaa !5
+  %this1 = load %class.anon*, %class.anon** %this.addr, align 8
+  call spir_func void @_Z3foov()
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: nounwind
+define spir_func void @_Z3foov() #3 {
+entry:
+  %var_one = alloca i32, align 4
+  %var_two = alloca i32, align 4
+  %var_three = alloca i32, align 4
+  %var_four = alloca i32, align 4
+  %0 = bitcast i32* %var_one to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #4
+  %var_one1 = bitcast i32* %var_one to i8*
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %[[VAR1:[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([29 x i8], [29 x i8]* [[STR1]], i32 0, i32 0), i8* undef, i32 undef)
+  call void @llvm.var.annotation(i8* %var_one1, i8* getelementptr inbounds ([29 x i8], [29 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.1, i32 0, i32 0), i32 2)
+  %1 = bitcast i32* %var_two to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #4
+  %var_two2 = bitcast i32* %var_two to i8*
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* [[VAR2:%[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([13 x i8], [13 x i8]* [[STR2]], i32 0, i32 0), i8* undef, i32 undef)
+  call void @llvm.var.annotation(i8* %var_two2, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.2, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.1, i32 0, i32 0), i32 3)
+  %2 = bitcast i32* %var_three to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %2) #4
+  %var_three3 = bitcast i32* %var_three to i8*
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* [[VAR3:%[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([19 x i8], [19 x i8]* [[STR3]], i32 0, i32 0), i8* undef, i32 undef)
+  call void @llvm.var.annotation(i8* %var_three3, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.3, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.1, i32 0, i32 0), i32 4)
+  %3 = bitcast i32* %var_four to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %3) #4
+  %var_four4 = bitcast i32* %var_four to i8*
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* [[VAR4:%[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([30 x i8], [30 x i8]* [[STR4]], i32 0, i32 0), i8* undef, i32 undef)
+  call void @llvm.var.annotation(i8* %var_four4, i8* getelementptr inbounds ([30 x i8], [30 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.1, i32 0, i32 0), i32 5)
+  %4 = bitcast i32* %var_four to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %4) #4
+  %5 = bitcast i32* %var_three to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %5) #4
+  %6 = bitcast i32* %var_two to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %6) #4
+  %7 = bitcast i32* %var_one to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %7) #4
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @llvm.var.annotation(i8*, i8*, i8*, i32) #4
+
+attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind }
+attributes #2 = { inlinehint nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind optnone noinline "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.spir.version = !{!1}
+!spirv.Source = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{i32 4, i32 100000}
+!3 = !{!"clang version 9.0.0"}
+!4 = !{}
+!5 = !{!6, !6, i64 0}
+!6 = !{!"any pointer", !7, i64 0}
+!7 = !{!"omnipotent char", !8, i64 0}
+!8 = !{!"Simple C++ TBAA"}

--- a/test/IntelFPGAMemoryAttributesForStruct.ll
+++ b/test/IntelFPGAMemoryAttributesForStruct.ll
@@ -1,0 +1,130 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 1 RegisterINTEL 1
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 0 MemoryINTEL "DEFAULT"
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 3 MemoryINTEL "DEFAULT"
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 2 MemoryINTEL "MLAB"
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 0 NumbanksINTEL 4
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 3 BankwidthINTEL 8
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-linux"
+
+%class.anon = type { i8 }
+%struct.foo = type { i32, i32, i32, i32 }
+
+; CHECK-LLVM: [[STR1:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:4}
+; CHECK-LLVM: [[STR2:@[a-zA-Z0-9_.]+]] = {{.*}}{register:1}
+; CHECK-LLVM: [[STR3:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:MLAB}
+; CHECK-LLVM: [[STR4:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:8}
+@.str = private unnamed_addr constant [29 x i8] c"{memory:DEFAULT}{numbanks:4}\00", section "llvm.metadata"
+@.str.1 = private unnamed_addr constant [16 x i8] c"test_struct.cpp\00", section "llvm.metadata"
+@.str.2 = private unnamed_addr constant [13 x i8] c"{register:1}\00", section "llvm.metadata"
+@.str.3 = private unnamed_addr constant [14 x i8] c"{memory:MLAB}\00", section "llvm.metadata"
+@.str.4 = private unnamed_addr constant [30 x i8] c"{memory:DEFAULT}{bankwidth:8}\00", section "llvm.metadata"
+
+; Function Attrs: nounwind
+define spir_kernel void @_ZTSZ4mainE15kernel_function() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
+entry:
+  %0 = alloca %class.anon, align 1
+  %1 = bitcast %class.anon* %0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %1) #4
+  call spir_func void @"_ZZ4mainENK3$_0clEv"(%class.anon* %0)
+  %2 = bitcast %class.anon* %0 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %2) #4
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: inlinehint nounwind
+define internal spir_func void @"_ZZ4mainENK3$_0clEv"(%class.anon* %this) #2 align 2 {
+entry:
+  %this.addr = alloca %class.anon*, align 8
+  store %class.anon* %this, %class.anon** %this.addr, align 8, !tbaa !5
+  %this1 = load %class.anon*, %class.anon** %this.addr, align 8
+  call spir_func void @_Z3barv()
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: nounwind
+define spir_func void @_Z3barv() #3 {
+entry:
+  %s1 = alloca %struct.foo, align 4
+  %0 = bitcast %struct.foo* %s1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 16, i8* %0) #4
+  ; CHECK-LLVM: %[[FIELD1:.*]] = getelementptr inbounds %struct.foo, %struct.foo* %{{[a-zA-Z0-9]+}}, i32 0, i32 0
+  ; CHECK-LLVM: %[[CAST1:.*]] = bitcast{{.*}}%[[FIELD1]]
+  ; CHECK-LLVM: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST1]]{{.*}}[[STR1]]
+  %f1 = getelementptr inbounds %struct.foo, %struct.foo* %s1, i32 0, i32 0
+  %1 = bitcast i32* %f1 to i8*
+  %2 = call i8* @llvm.ptr.annotation.p0i8(i8* %1, i8* getelementptr inbounds ([29 x i8], [29 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @.str.1, i32 0, i32 0), i32 2)
+  %3 = bitcast i8* %2 to i32*
+  store i32 0, i32* %3, align 4, !tbaa !9
+  ; CHECK-LLVM: %[[FIELD2:.*]] = getelementptr inbounds %struct.foo, %struct.foo* %{{[a-zA-Z0-9]+}}, i32 0, i32 1
+  ; CHECK-LLVM: %[[CAST2:.*]] = bitcast{{.*}}%[[FIELD2]]
+  ; CHECK-LLVM: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST2]]{{.*}}[[STR2]]
+  %f2 = getelementptr inbounds %struct.foo, %struct.foo* %s1, i32 0, i32 1
+  %4 = bitcast i32* %f2 to i8*
+  %5 = call i8* @llvm.ptr.annotation.p0i8(i8* %4, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.2, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @.str.1, i32 0, i32 0), i32 3)
+  %6 = bitcast i8* %5 to i32*
+  store i32 0, i32* %6, align 4, !tbaa !12
+  ; CHECK-LLVM: %[[FIELD3:.*]] = getelementptr inbounds %struct.foo, %struct.foo* %{{[a-zA-Z0-9]+}}, i32 0, i32 2
+  ; CHECK-LLVM: %[[CAST3:.*]] = bitcast{{.*}}%[[FIELD3]]
+  ; CHECK-LLVM: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST3]]{{.*}}[[STR3]]
+  %f3 = getelementptr inbounds %struct.foo, %struct.foo* %s1, i32 0, i32 2
+  %7 = bitcast i32* %f3 to i8*
+  %8 = call i8* @llvm.ptr.annotation.p0i8(i8* %7, i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str.3, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @.str.1, i32 0, i32 0), i32 4)
+  %9 = bitcast i8* %8 to i32*
+  store i32 0, i32* %9, align 4, !tbaa !13
+  ; CHECK-LLVM: %[[FIELD4:.*]] = getelementptr inbounds %struct.foo, %struct.foo* %{{[a-zA-Z0-9]+}}, i32 0, i32 3
+  ; CHECK-LLVM: %[[CAST4:.*]] = bitcast{{.*}}%[[FIELD4]]
+  ; CHECK-LLVM: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[CAST4]]{{.*}}[[STR4]]
+  %f4 = getelementptr inbounds %struct.foo, %struct.foo* %s1, i32 0, i32 3
+  %10 = bitcast i32* %f4 to i8*
+  %11 = call i8* @llvm.ptr.annotation.p0i8(i8* %10, i8* getelementptr inbounds ([30 x i8], [30 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @.str.1, i32 0, i32 0), i32 5)
+  %12 = bitcast i8* %11 to i32*
+  store i32 0, i32* %12, align 4, !tbaa !14
+  %13 = bitcast %struct.foo* %s1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 16, i8* %13) #4
+  ret void
+}
+
+; Function Attrs: nounwind
+declare i8* @llvm.ptr.annotation.p0i8(i8*, i8*, i8*, i32) #4
+
+attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind }
+attributes #2 = { inlinehint nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind optnone noinline "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.spir.version = !{!1}
+!spirv.Source = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{i32 4, i32 100000}
+!3 = !{!"clang version 9.0.0"}
+!4 = !{}
+!5 = !{!6, !6, i64 0}
+!6 = !{!"any pointer", !7, i64 0}
+!7 = !{!"omnipotent char", !8, i64 0}
+!8 = !{!"Simple C++ TBAA"}
+!9 = !{!10, !11, i64 0}
+!10 = !{!"_ZTS3foo", !11, i64 0, !11, i64 4, !11, i64 8, !11, i64 12}
+!11 = !{!"int", !7, i64 0}
+!12 = !{!10, !11, i64 4}
+!13 = !{!10, !11, i64 8}
+!14 = !{!10, !11, i64 12}


### PR DESCRIPTION
This patch introduces translation of the following FPGA memory attributes:
* register
* memory
* numbanks
* bankwidth

Link to the SPIR-V Specification:
http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/
           blob/master/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.html