### PR TITLE
Add the input storage class and use it for builtins instead of Uniform

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -1229,9 +1229,9 @@ void OCL20ToSPIRV::transWorkItemBuiltinsToVariables() {
     bool IsVec = I.getFunctionType()->getNumParams() > 0;
     Type *GVType =
         IsVec ? VectorType::get(I.getReturnType(), 3) : I.getReturnType();
-    auto BV = new GlobalVariable(
-        *M, GVType, true, GlobalValue::ExternalLinkage, nullptr, BuiltinVarName,
-        0, GlobalVariable::NotThreadLocal, SPIRAS_Constant);
+    auto BV = new GlobalVariable(*M, GVType, true, GlobalValue::ExternalLinkage,
+                                 nullptr, BuiltinVarName, 0,
+                                 GlobalVariable::NotThreadLocal, SPIRAS_Input);
     std::vector<Instruction *> InstList;
     for (auto UI = I.user_begin(), UE = I.user_end(); UI != UE; ++UI) {
       auto CI = dyn_cast<CallInst>(*UI);

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -183,6 +183,7 @@ enum SPIRAddressSpace {
   SPIRAS_Constant,
   SPIRAS_Local,
   SPIRAS_Generic,
+  SPIRAS_Input,
   SPIRAS_Count,
 };
 
@@ -192,6 +193,7 @@ template <> inline void SPIRVMap<SPIRAddressSpace, std::string>::init() {
   add(SPIRAS_Constant, "Constant");
   add(SPIRAS_Local, "Local");
   add(SPIRAS_Generic, "Generic");
+  add(SPIRAS_Input, "Input");
 }
 typedef SPIRVMap<SPIRAddressSpace, SPIRVStorageClassKind>
     SPIRAddrSpaceCapitalizedNameMap;
@@ -203,6 +205,7 @@ inline void SPIRVMap<SPIRAddressSpace, SPIRVStorageClassKind>::init() {
   add(SPIRAS_Constant, StorageClassUniformConstant);
   add(SPIRAS_Local, StorageClassWorkgroup);
   add(SPIRAS_Generic, StorageClassGeneric);
+  add(SPIRAS_Input, StorageClassInput);
 }
 typedef SPIRVMap<SPIRAddressSpace, SPIRVStorageClassKind> SPIRSPIRVAddrSpaceMap;
 


### PR DESCRIPTION
builtins are generally not uniformly constant, so using the UniformConstant
storage class is missleading and might confuse the consumer of the spir-v

Sadly there is no perfect fit, but Input is what comes the closest