### PR TITLE
lit: Fix DebugInfo test tools warnings

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -47,7 +47,9 @@ config.substitutions.append(('%PATH%', config.environment['PATH']))
 
 tool_dirs = [config.llvm_tools_dir, config.llvm_spirv_dir]
 
-tools = ['llc', 'llvm-as', 'llvm-dis', 'llvm-dwarfdump', 'llvm-objdump', 'llvm-readelf', 'llvm-readobj',  'llvm-spirv', 'not']
+tools = ['llvm-as', 'llvm-dis', 'llvm-spirv', 'not']
+if not config.skip_spirv_debug_info_tests:
+    tools.extend(['llc', 'llvm-dwarfdump', 'llvm-objdump', 'llvm-readelf', 'llvm-readobj'])
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 


### PR DESCRIPTION
Only substitute DebugInfo-test-specific tools such as llvm-readelf
when running the DebugInfo tests.  Otherwise these tools may not be
available, causing llvm-lit to warn about being unable to find the
tools.

See e.g. https://travis-ci.org/KhronosGroup/SPIRV-LLVM-Translator/jobs/505139401#L1538