### PR TITLE
Fix invalid SPIRVLoopMerge cast

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1274,8 +1274,11 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto BR = static_cast<SPIRVBranch *>(BV);
     auto BI = BranchInst::Create(
         dyn_cast<BasicBlock>(transValue(BR->getTargetLabel(), F, BB)), BB);
-    if (auto LM = static_cast<SPIRVLoopMerge *>(BR->getPrevious()))
+    auto Prev = BR->getPrevious();
+    if (Prev && Prev->getOpCode() == OpLoopMerge) {
+      auto LM = static_cast<SPIRVLoopMerge *>(Prev);
       setLLVMLoopMetadata(LM, BI);
+    }
     return mapValue(BV, BI);
   }
 
@@ -1285,8 +1288,11 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         dyn_cast<BasicBlock>(transValue(BR->getTrueLabel(), F, BB)),
         dyn_cast<BasicBlock>(transValue(BR->getFalseLabel(), F, BB)),
         transValue(BR->getCondition(), F, BB), BB);
-    if (auto LM = static_cast<SPIRVLoopMerge *>(BR->getPrevious()))
+    auto Prev = BR->getPrevious();
+    if (Prev && Prev->getOpCode() == OpLoopMerge) {
+      auto LM = static_cast<SPIRVLoopMerge *>(Prev);
       setLLVMLoopMetadata(LM, BC);
+    }
     return mapValue(BV, BC);
   }
 


### PR DESCRIPTION
The previous instruction is not necessarily a SPIRVLoopMerge, but the
translator would always cast it to such and try to set loop metadata,
resulting in invalid memory accesses.

The issue was discovered using valgrind on test/selection_merge.spt .

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/6 (#6)