### PR TITLE
Add infrastructure to emit OpExtension when it is required

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -136,6 +136,16 @@ public:
   // Incomplete constructor
   SPIRVDecorate() : SPIRVDecorateGeneric(OC) {}
 
+  SPIRVExtSet getRequiredExtensions() const override {
+    switch (Dec) {
+    case DecorationNoSignedWrap:
+    case DecorationNoUnsignedWrap:
+      return getSet(SPV_KHR_no_integer_wrap_decoration);
+    default:
+      return SPIRVExtSet();
+    }
+  }
+
   _SPIRV_DCL_ENCDEC
   void setWordCount(SPIRVWord) override;
   void validate() const override {

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -288,6 +288,7 @@ public:
   Op getOpCode() const { return OpCode; }
   SPIRVModule *getModule() const { return Module; }
   virtual SPIRVCapVec getRequiredCapability() const { return SPIRVCapVec(); }
+  virtual SPIRVExtSet getRequiredExtensions() const { return SPIRVExtSet(); }
   const std::string &getName() const { return Name; }
   bool hasDecorate(Decoration Kind, size_t Index = 0,
                    SPIRVWord *Result = 0) const;

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -113,6 +113,14 @@ typedef spv::GroupOperation SPIRVGroupOperationKind;
 typedef spv::Dim SPIRVImageDimKind;
 typedef std::vector<SPIRVCapabilityKind> SPIRVCapVec;
 
+enum SPIRVExtensionKind {
+};
+
+typedef std::set<SPIRVExtensionKind> SPIRVExtSet;
+
+template <> inline void SPIRVMap<SPIRVExtensionKind, std::string>::init() {
+};
+
 template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
   add(SPIRVEIS_OpenCL, "OpenCL.std");
   add(SPIRVEIS_Debug, "SPIRV.debug");

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -114,11 +114,14 @@ typedef spv::Dim SPIRVImageDimKind;
 typedef std::vector<SPIRVCapabilityKind> SPIRVCapVec;
 
 enum SPIRVExtensionKind {
+  SPV_INTEL_device_side_avc_motion_estimation
 };
 
 typedef std::set<SPIRVExtensionKind> SPIRVExtSet;
 
 template <> inline void SPIRVMap<SPIRVExtensionKind, std::string>::init() {
+  add(SPV_INTEL_device_side_avc_motion_estimation,
+      "SPV_INTEL_device_side_avc_motion_estimation");
 };
 
 template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -114,7 +114,8 @@ typedef spv::Dim SPIRVImageDimKind;
 typedef std::vector<SPIRVCapabilityKind> SPIRVCapVec;
 
 enum SPIRVExtensionKind {
-  SPV_INTEL_device_side_avc_motion_estimation
+  SPV_INTEL_device_side_avc_motion_estimation,
+  SPV_KHR_no_integer_wrap_decoration
 };
 
 typedef std::set<SPIRVExtensionKind> SPIRVExtSet;
@@ -122,6 +123,7 @@ typedef std::set<SPIRVExtensionKind> SPIRVExtSet;
 template <> inline void SPIRVMap<SPIRVExtensionKind, std::string>::init() {
   add(SPV_INTEL_device_side_avc_motion_estimation,
       "SPV_INTEL_device_side_avc_motion_estimation");
+  add(SPV_KHR_no_integer_wrap_decoration, "SPV_KHR_no_integer_wrap_decoration");
 };
 
 template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2246,6 +2246,10 @@ protected:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
+
+  SPIRVExtSet getRequiredExtensions() const override {
+    return getSet(SPV_INTEL_device_side_avc_motion_estimation);
+  }
 };
 
 // Intel Subgroup AVC Motion Estimation Instructions

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -181,6 +181,7 @@ public:
   void setCurrentLine(const std::shared_ptr<const SPIRVLine> &Line) override;
   void addCapability(SPIRVCapabilityKind) override;
   void addCapabilityInternal(SPIRVCapabilityKind) override;
+  void addExtension(SPIRVExtensionKind) override;
   const SPIRVDecorateGeneric *addDecorate(SPIRVDecorateGeneric *) override;
   SPIRVDecorationGroup *addDecorationGroup() override;
   SPIRVDecorationGroup *
@@ -523,6 +524,12 @@ SPIRVValue *SPIRVModuleImpl::addPipeStorageConstant(SPIRVType *TheType,
       this, TheType, getId(), PacketSize, PacketAlign, Capacity));
 }
 
+void SPIRVModuleImpl::addExtension(SPIRVExtensionKind Ext) {
+  std::string ExtName;
+  SPIRVMap<SPIRVExtensionKind, std::string>::find(Ext, &ExtName);
+  SPIRVExt.insert(ExtName);
+}
+
 void SPIRVModuleImpl::addCapability(SPIRVCapabilityKind Cap) {
   addCapabilities(SPIRV::getCapability(Cap));
   SPIRVDBG(spvdbgs() << "addCapability: " << Cap << '\n');
@@ -624,6 +631,14 @@ SPIRVEntry *SPIRVModuleImpl::addEntry(SPIRVEntry *Entry) {
         Entry->getRequiredCapability().end(),
         [this](SPIRVCapabilityKind &val) { return !CapMap.count(val); }));
   }
+  if (AutoAddExtensions) {
+    // While we are reading existing SPIR-V we need to read it as-is and don't
+    // add required extensions for each entry automatically
+    for (auto &E : Entry->getRequiredExtensions()) {
+      addExtension(E);
+    }
+  }
+
   return Entry;
 }
 
@@ -1526,6 +1541,7 @@ std::istream &operator>>(std::istream &I, SPIRVModule &M) {
   SPIRVModuleImpl &MI = *static_cast<SPIRVModuleImpl *>(&M);
   // Disable automatic capability filling.
   MI.setAutoAddCapability(false);
+  MI.setAutoAddExtensions(false);
 
   SPIRVWord Magic;
   Decoder >> Magic;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -155,6 +155,7 @@ public:
   virtual void optimizeDecorates() = 0;
   virtual void setAutoAddCapability(bool E) { AutoAddCapability = E; }
   virtual void setValidateCapability(bool E) { ValidateCapability = E; }
+  virtual void setAutoAddExtensions(bool E) { AutoAddExtensions = E; }
   virtual void setGeneratorId(unsigned short) = 0;
   virtual void setGeneratorVer(unsigned short) = 0;
   virtual void resolveUnknownStructFields() = 0;
@@ -280,6 +281,7 @@ public:
     for (auto I : Caps)
       addCapability(I);
   }
+  virtual void addExtension(SPIRVExtensionKind) = 0;
   /// Used by SPIRV entries to add required capability internally.
   /// Should not be used by users directly.
   virtual void addCapabilityInternal(SPIRVCapabilityKind) = 0;
@@ -382,6 +384,7 @@ public:
 protected:
   bool AutoAddCapability;
   bool ValidateCapability;
+  bool AutoAddExtensions = true;
 
 private:
   bool IsValid;

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -779,6 +779,10 @@ public:
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
 
+  SPIRVExtSet getRequiredExtensions() const override {
+    return getSet(SPV_INTEL_device_side_avc_motion_estimation);
+  }
+
 protected:
   SPIRVTypeImage *ImgTy;
   _SPIRV_DEF_ENCDEC2(Id, ImgTy)
@@ -828,6 +832,10 @@ public:
 
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
+  }
+
+  SPIRVExtSet getRequiredExtensions() const override {
+    return getSet(SPV_INTEL_device_side_avc_motion_estimation);
   }
 
   SPIRVValue *getOperand() { return getValue(Opn); }

--- a/lib/SPIRV/libSPIRV/SPIRVUtil.h
+++ b/lib/SPIRV/libSPIRV/SPIRVUtil.h
@@ -362,6 +362,12 @@ inline std::vector<uint32_t> getVec(const std::string &Str) {
   return V;
 }
 
+template <typename T> inline std::set<T> getSet(T Op1) {
+  std::set<T> S;
+  S.insert(Op1);
+  return S;
+}
+
 template <typename T> inline std::vector<T> getVec(T Op1) {
   std::vector<T> V;
   V.push_back(Op1);

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -120,6 +120,13 @@ public:
     return Type->getRequiredCapability();
   }
 
+  SPIRVExtSet getRequiredExtensions() const override {
+    SPIRVExtSet EV;
+    if (!hasType())
+      return EV;
+    return Type->getRequiredExtensions();
+  }
+
 protected:
   void setHasNoType() { Attrib |= SPIRVEA_NOTYPE; }
   void setHasType() { Attrib &= ~SPIRVEA_NOTYPE; }

--- a/test/NoSignedUnsignedWrap.ll
+++ b/test/NoSignedUnsignedWrap.ll
@@ -12,6 +12,8 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
+; CHECK-SPIRV: Extension "SPV_KHR_no_integer_wrap_decoration"
+
 ; CHECK-SPIRV: Decorate {{[0-9]+}} NoSignedWrap
 ; CHECK-SPIRV: Decorate {{[0-9]+}} NoUnsignedWrap
 

--- a/test/transcoding/subgroup_avc_intel_generic.ll
+++ b/test/transcoding/subgroup_avc_intel_generic.ll
@@ -52,6 +52,7 @@
 ; CHECK: Capability SubgroupAvcMotionEstimationINTEL
 ; CHECK: Capability SubgroupAvcMotionEstimationIntraINTEL
 ; CHECK: Capability SubgroupAvcMotionEstimationChromaINTEL
+; CHECK: Extension "SPV_INTEL_device_side_avc_motion_estimation"
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"

--- a/test/transcoding/subgroup_avc_intel_types.ll
+++ b/test/transcoding/subgroup_avc_intel_types.ll
@@ -24,6 +24,7 @@
 
 ; CHECK: Capability Groups
 ; CHECK: Capability SubgroupAvcMotionEstimationINTEL
+; CHECK: Extension "SPV_INTEL_device_side_avc_motion_estimation"
 
 ; CHECK: TypeAvcMcePayloadINTEL
 ; CHECK: TypeAvcImePayloadINTEL [[IME_PAYLOAD:[0-9]]]

--- a/test/transcoding/subgroup_avc_intel_vme_image.ll
+++ b/test/transcoding/subgroup_avc_intel_vme_image.ll
@@ -52,6 +52,8 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"
 
+; CHECK: Extension "SPV_INTEL_device_side_avc_motion_estimation"
+
 ; CHECK: TypeImage              [[ImageTy:[0-9]+]]
 ; CHECK: TypeSampler            [[SamplerTy:[0-9]+]]
 ; CHECK: TypeAvcImePayloadINTEL [[ImePayloadTy:[0-9]+]]

--- a/test/transcoding/subgroup_avc_intel_wrappers.ll
+++ b/test/transcoding/subgroup_avc_intel_wrappers.ll
@@ -38,6 +38,8 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"
 
+; CHECK: Extension "SPV_INTEL_device_side_avc_motion_estimation"
+
 ; CHECK: TypeAvcImePayloadINTEL [[ImePayloadTy:[0-9]+]]
 ; CHECK: TypeAvcImeResultINTEL  [[ImeResultTy:[0-9]+]]
 ; CHECK: TypeAvcRefPayloadINTEL [[RefPayloadTy:[0-9]+]]


### PR DESCRIPTION
This PR introduces basic infrastructure for emitting `OpExtension`s opcodes for SPIR-V extensions similar to existing infrastructure around `OpCapability`.
It also adds generation of corresponding `OpExtension` for `SPV_INTEL_device_side_avc_motion_estimation` and `SPV_KHR_no_integer_wrap_decoration`.

We already have some infrastructure for emitting `OpExtension`s, but looks like it is related to some clang generated metadata for OpenCL extensions and SPIR. I don't know is it still actual or not, but I re-used some part of it.

