### PR TITLE
Encode and decode Input and Output Variables used in entry points

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -184,6 +184,7 @@ enum SPIRAddressSpace {
   SPIRAS_Local,
   SPIRAS_Generic,
   SPIRAS_Input,
+  SPIRAS_Output,
   SPIRAS_Count,
 };
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -128,6 +128,7 @@ LLVMToSPIRV::LLVMToSPIRV(SPIRVModule *SMod)
 
 bool LLVMToSPIRV::runOnModule(Module &Mod) {
   M = &Mod;
+  CG = make_unique<CallGraph>(Mod);
   Ctx = &M->getContext();
   DbgTran->setModule(M);
   assert(BM && "SPIR-V module not initialized");
@@ -1417,6 +1418,59 @@ bool LLVMToSPIRV::transGlobalVariables() {
   return true;
 }
 
+bool LLVMToSPIRV::isAnyFunctionReachableFromFunction(
+    const Function *FS,
+    const std::unordered_set<const Function *> Funcs) const {
+  std::unordered_set<const Function *> Done;
+  std::unordered_set<const Function *> ToDo;
+  ToDo.insert(FS);
+
+  while (!ToDo.empty()) {
+    auto It = ToDo.begin();
+    const Function *F = *It;
+
+    if (Funcs.find(F) != Funcs.end())
+      return true;
+
+    ToDo.erase(It);
+    Done.insert(F);
+
+    const CallGraphNode *FN = (*CG)[F];
+    for (unsigned I = 0; I < FN->size(); ++I) {
+      const CallGraphNode *NN = (*FN)[I];
+      const Function *NNF = NN->getFunction();
+      if (!NNF)
+        continue;
+      if (Done.find(NNF) == Done.end()) {
+        ToDo.insert(NNF);
+      }
+    }
+  }
+
+  return false;
+}
+
+void LLVMToSPIRV::collectInputOutputVariables(SPIRVFunction *SF, Function *F) {
+  for (auto &GV : M->globals()) {
+    const auto AS = GV.getAddressSpace();
+    if (AS != SPIRAS_Input && AS != SPIRAS_Output)
+      continue;
+
+    std::unordered_set<const Function *> Funcs;
+
+    for (const auto &U : GV.uses()) {
+      const Instruction *Inst = dyn_cast<Instruction>(U.getUser());
+      if (!Inst)
+        continue;
+      Funcs.insert(Inst->getFunction());
+    }
+
+    if (isAnyFunctionReachableFromFunction(F, Funcs)) {
+      SF->addVariable(ValueMap[&GV]);
+    }
+  }
+}
+
 void LLVMToSPIRV::mutateFuncArgType(
     const std::map<unsigned, Type *> &ChangedType, Function *F) {
   for (auto &I : ChangedType) {
@@ -1457,6 +1511,9 @@ void LLVMToSPIRV::transFunction(Function *I) {
       BF->shouldFPContractBeDisabled()) {
     BF->addExecutionMode(BF->getModule()->add(
         new SPIRVExecutionMode(BF, spv::ExecutionModeContractionOff)));
+  }
+  if (BF->getModule()->isEntryPoint(spv::ExecutionModelKernel, BF->getId())) {
+    collectInputOutputVariables(BF, I);
   }
 }
 

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -57,6 +57,7 @@
 #include "SPIRVUtil.h"
 #include "SPIRVValue.h"
 
+#include "llvm/Analysis/CallGraph.h"
 #include "llvm/IR/IntrinsicInst.h"
 
 #include <memory>
@@ -128,6 +129,7 @@ private:
   SPIRVWord SrcLang;
   SPIRVWord SrcLangVer;
   std::unique_ptr<LLVMToSPIRVDbgTran> DbgTran;
+  std::unique_ptr<CallGraph> CG;
 
   SPIRVType *mapType(Type *T, SPIRVType *BT);
   SPIRVValue *mapValue(Value *V, SPIRVValue *BV);
@@ -178,6 +180,11 @@ private:
   SPIRVId addInt32(int);
   void transFunction(Function *I);
   SPIRV::SPIRVLinkageTypeKind transLinkageType(const GlobalValue *GV);
+
+  bool isAnyFunctionReachableFromFunction(
+      const Function *FS,
+      const std::unordered_set<const Function *> Funcs) const;
+  void collectInputOutputVariables(SPIRVFunction *SF, Function *F);
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -438,17 +438,18 @@ std::istream &operator>>(std::istream &I, SPIRVEntry &E) {
 
 SPIRVEntryPoint::SPIRVEntryPoint(SPIRVModule *TheModule,
                                  SPIRVExecutionModelKind TheExecModel,
-                                 SPIRVId TheId, const std::string &TheName)
+                                 SPIRVId TheId, const std::string &TheName,
+                                 std::vector<SPIRVId> Variables)
     : SPIRVAnnotation(TheModule->get<SPIRVFunction>(TheId),
-                      getSizeInWords(TheName) + 3),
-      ExecModel(TheExecModel), Name(TheName) {}
+                      getSizeInWords(TheName) + Variables.size() + 3),
+      ExecModel(TheExecModel), Name(TheName), Variables(Variables) {}
 
 void SPIRVEntryPoint::encode(spv_ostream &O) const {
-  getEncoder(O) << ExecModel << Target << Name;
+  getEncoder(O) << ExecModel << Target << Name << Variables;
 }
 
 void SPIRVEntryPoint::decode(std::istream &I) {
-  getDecoder(I) >> ExecModel >> Target >> Name;
+  getDecoder(I) >> ExecModel >> Target >> Name >> Variables;
   Module->setName(getOrCreateTarget(), Name);
   Module->addEntryPoint(ExecModel, Target);
 }

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -479,12 +479,16 @@ public:
 class SPIRVEntryPoint : public SPIRVAnnotation<OpEntryPoint> {
 public:
   SPIRVEntryPoint(SPIRVModule *TheModule, SPIRVExecutionModelKind,
-                  SPIRVId TheId, const std::string &TheName);
+                  SPIRVId TheId, const std::string &TheName,
+                  std::vector<SPIRVId> Variables);
   SPIRVEntryPoint() : ExecModel(ExecutionModelKernel) {}
   _SPIRV_DCL_ENCDEC
 protected:
   SPIRVExecutionModelKind ExecModel;
   std::string Name;
+
+private:
+  std::vector<SPIRVId> Variables;
 };
 
 class SPIRVName : public SPIRVAnnotation<OpName> {

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -105,6 +105,15 @@ public:
     return getFunctionType()->getNumParameters();
   }
   SPIRVId getArgumentId(size_t I) const { return Parameters[I]->getId(); }
+  const std::vector<SPIRVId> getVariables() const {
+    std::vector<SPIRVId> Ids;
+    for (auto Variable : Variables)
+      Ids.push_back(Variable->getId());
+    return Ids;
+  }
+  void addVariable(const SPIRVValue *Variable) {
+    Variables.push_back(Variable);
+  }
   SPIRVFunctionParameter *getArgument(size_t I) const { return Parameters[I]; }
   void foreachArgument(std::function<void(SPIRVFunctionParameter *)> Func) {
     for (size_t I = 0, E = getNumArguments(); I != E; ++I)
@@ -170,6 +179,7 @@ private:
   SPIRVWord FCtrlMask;         // Function control mask
 
   std::vector<SPIRVFunctionParameter *> Parameters;
+  std::vector<const SPIRVValue *> Variables;
   typedef std::vector<SPIRVBasicBlock *> SPIRVLBasicBlockVector;
   SPIRVLBasicBlockVector BBVec;
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1435,8 +1435,8 @@ spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M) {
 
   for (auto &I : MI.EntryPointVec)
     for (auto &II : I.second)
-      O << SPIRVEntryPoint(&M, I.first, II,
-                           M.get<SPIRVFunction>(II)->getName());
+      O << SPIRVEntryPoint(&M, I.first, II, M.get<SPIRVFunction>(II)->getName(),
+                           M.get<SPIRVFunction>(II)->getVariables());
 
   for (auto &I : MI.EntryPointVec)
     for (auto &II : I.second)


### PR DESCRIPTION
spirv-val reported an error as an OpEntryPoint has to list all used input and output variables. Sorry for missing this.

With this patch all input and output variables get added to each OpEntryPointer declaration, but figuring out which entry point is used isn't exactly trivially solveable.

Add the SPIRV output storage class as well, so we don't forget to update the code if it gets added later.

Fixes: 2745e2a6ae71dba4f8948ec5cc7ee07e8f9a4a97
Fixes: #176 

We probably want to do a quick analysis to figure out which GlobalVariable is used from which entry point, but for that I didn't really came up with a acceptable way of doing that. Maybe we could do something with the LazyCallGraph pass here?