### PR TITLE
test: run spirv-val on generated spirvs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,14 @@ addons:
     sources:
     - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial main'
       key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    - sourceline: 'deb https://packages.lunarg.com/vulkan xenial main'
+      key_url: 'http://packages.lunarg.com/lunarg-signing-key-pub.asc'
     packages:
     - llvm-9-tools
     - llvm-9-dev
     - clang-format-9
     - clang-tidy-9
+    - spirv-tools
 
 compiler:
   - gcc
@@ -71,10 +74,17 @@ script:
       git clone https://git.llvm.org/git/llvm.git/ --depth 1
       mv llvm-spirv llvm/tools/llvm-spirv
     fi
+  - |
+    if [ $TRAVIS_OS_NAME == "osx" ]; then
+      wget -r --accept="*.tgz" --no-directories https://storage.googleapis.com/spirv-tools/badges/build_link_macos_clang_release.html
+      tar -xf install.tgz
+      sed -i '' -e 's|^prefix=\(.*\)|prefix='$PWD'/install|g' install/lib/pkgconfig/SPIRV-Tools.pc
+      export PKG_CONFIG_PATH=$PWD/install/lib/pkgconfig
+    fi
   - mkdir build && cd build
   - |
     if [ $BUILD_EXTERNAL == "1" ]; then
-      if [ $CHECK_FORMAT != "1" ]; then
+      if [ $CHECK_FORMAT != "1" ] && [ $CHECK_TIDY != "1" ]; then
         cmake .. \
           -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
           -DBUILD_SHARED_LIBS=${SHARED_LIBS} \

--- a/README.md
+++ b/README.md
@@ -64,11 +64,12 @@ make llvm-spirv -j`nproc`
 
 ## Test instructions
 
-All tests related to the translator are placed in the [test](test) directory.
+All tests related to the translator are placed in the [test](test) directory. Optionally the tests can make use of spirv-val (part of SPIRV-Tools) in order to validate the generated SPIR-V against the official SPIR-V specification.
+In case tests are failing due to SPIRV-Tools not supporting certain SPIR-V features, please get an updated package. The `PKG_CONFIG_PATH` environmental variable can be used to let cmake point to a custom installation.
 
-Execute the following command to run translator tests:
+Execute the following command inside the build directory to run translator tests:
 ```
-llvm-lit test
+make test
 ```
 This requires that the `-DLLVM_INCLUDE_TESTS=ON` argument was passed to CMake during the build step.
 

--- a/test/AtomicCompareExchange_cl12.ll
+++ b/test/AtomicCompareExchange_cl12.ll
@@ -1,4 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text | FileCheck %s
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"

--- a/test/AtomicCompareExchange_cl20.ll
+++ b/test/AtomicCompareExchange_cl20.ll
@@ -1,4 +1,7 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text | FileCheck %s
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,27 @@
+include(FindPkgConfig)
+
 llvm_canonicalize_cmake_booleans(SPIRV_SKIP_CLANG_BUILD)
 llvm_canonicalize_cmake_booleans(SPIRV_SKIP_DEBUG_INFO_TESTS)
 
 # required by lit.site.cfg.py.in
 get_target_property(LLVM_SPIRV_DIR llvm-spirv BINARY_DIR)
 set(LLVM_SPIRV_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# find spirv-val
+pkg_search_module(SPIRV_TOOLS SPIRV-Tools)
+if(SPIRV_TOOLS_FOUND)
+  find_program(SPIRV_TOOLS_SPIRV_VAL NAMES spirv-val PATHS ${SPIRV_TOOLS_PREFIX}/bin)
+  if(SPIRV_TOOLS_SPIRV_VAL)
+    get_filename_component(SPIRV_TOOLS_BINDIR "${SPIRV_TOOLS_SPIRV_VAL}" DIRECTORY)
+    set(SPIRV_TOOLS_SPIRV_VAL_FOUND True)
+  endif()
+endif()
+
+if(NOT SPIRV_TOOLS_SPIRV_VAL)
+  message(WARNING "spirv-val not found! SPIR-V generated for test suite will not be validated.")
+  set(SPIRV_TOOLS_SPIRV_VAL_FOUND False)
+endif()
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/test/CheckCapKernelWithoutKernel.ll
+++ b/test/CheckCapKernelWithoutKernel.ll
@@ -1,6 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
-
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; ModuleID = '../rel/CheckCapKernelWithoutKernel.bc'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -17,8 +17,11 @@
 ; clang -cc1 -x cl -emit-llvm -O2 -disable-llvm-passes -triple spir64 1.cl -o 1.ll
 ; opt -mem2reg 1.ll -S -o 1.o.ll
 
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK: EntryPoint 6 [[K1:[0-9]+]] "k1"
 ; CHECK: EntryPoint 6 [[K2:[0-9]+]] "k2"

--- a/test/EnqueueEmptyKernel.ll
+++ b/test/EnqueueEmptyKernel.ll
@@ -14,6 +14,8 @@
 ;; }
 ; RUN: llvm-as < %s > %t.bc
 ; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"

--- a/test/ExecutionMode_SPIR_to_SPIRV.ll
+++ b/test/ExecutionMode_SPIR_to_SPIRV.ll
@@ -2,6 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/FOrdGreaterThanEqual_bool.ll
+++ b/test/FOrdGreaterThanEqual_bool.ll
@@ -1,6 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: 5 FOrdGreaterThanEqual
 ; CHECK-SPIRV-NOT: Select

--- a/test/FOrdGreaterThanEqual_int.ll
+++ b/test/FOrdGreaterThanEqual_int.ll
@@ -1,6 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: 5 FOrdGreaterThanEqual {{[0-9]+}} [[result:[0-9]+]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: 6 Select {{[0-9]+}} {{[0-9]+}} [[result]] {{[0-9]+}} {{[0-9]+}}

--- a/test/InvalidAtomicBuiltins.cl
+++ b/test/InvalidAtomicBuiltins.cl
@@ -3,6 +3,8 @@
 
 // RUN: %clang_cc1 -triple spir -O1 -cl-std=cl2.0 -finclude-default-header %s -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
 
 // CHECK-LABEL: Label
 // CHECK-NOT: Atomic

--- a/test/KernelArgTypeInOpString.ll
+++ b/test/KernelArgTypeInOpString.ll
@@ -24,6 +24,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM

--- a/test/KernelArgTypeInOpString2.ll
+++ b/test/KernelArgTypeInOpString2.ll
@@ -26,6 +26,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM

--- a/test/NoSignedUnsignedWrap.ll
+++ b/test/NoSignedUnsignedWrap.ll
@@ -9,6 +9,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/OpFMod.spt
+++ b/test/OpFMod.spt
@@ -51,6 +51,7 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/OpLine.ll
+++ b/test/OpLine.ll
@@ -14,6 +14,7 @@
 ;}
 ; RUN: llvm-as < %s | llvm-spirv -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-as < %s | llvm-spirv -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o -| FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/OpLoopMergeDontUnroll.spt
+++ b/test/OpLoopMergeDontUnroll.spt
@@ -37,13 +37,13 @@
 3 FunctionParameter 14 5
 
 2 Label 20
+4 Variable 18 26 7
+4 Variable 18 27 7
 6 Load 9 21 7 2 0
 5 CompositeExtract 8 22 21 0
 5 ShiftLeftLogical 8 23 22 11
 5 ShiftRightArithmetic 8 24 23 11
 4 SConvert 14 25 24
-4 Variable 18 26 7
-4 Variable 18 27 7
 5 Store 26 15 2 4
 5 Store 27 15 2 4
 2 Branch 28
@@ -83,6 +83,7 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/OpLoopMergeDontUnroll.spt
+++ b/test/OpLoopMergeDontUnroll.spt
@@ -17,7 +17,7 @@
 11 Decorate 7 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 GroupDecorate 6 2 3
 4 TypeInt 8 64 0
-4 TypeInt 14 32 1
+4 TypeInt 14 32 0
 5 Constant 8 11 32 0
 4 Constant 14 15 0
 4 Constant 14 16 1

--- a/test/OpLoopMergeNone.spt
+++ b/test/OpLoopMergeNone.spt
@@ -37,13 +37,13 @@
 3 FunctionParameter 14 5
 
 2 Label 20
+4 Variable 18 26 7
+4 Variable 18 27 7
 6 Load 9 21 7 2 0
 5 CompositeExtract 8 22 21 0
 5 ShiftLeftLogical 8 23 22 11
 5 ShiftRightArithmetic 8 24 23 11
 4 SConvert 14 25 24
-4 Variable 18 26 7
-4 Variable 18 27 7
 5 Store 26 15 2 4
 5 Store 27 15 2 4
 2 Branch 28
@@ -80,6 +80,7 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/OpLoopMergeNone.spt
+++ b/test/OpLoopMergeNone.spt
@@ -17,7 +17,7 @@
 11 Decorate 7 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 GroupDecorate 6 2 3
 4 TypeInt 8 64 0
-4 TypeInt 14 32 1
+4 TypeInt 14 32 0
 5 Constant 8 11 32 0
 4 Constant 14 15 0
 4 Constant 14 16 1

--- a/test/OpLoopMergeUnroll.spt
+++ b/test/OpLoopMergeUnroll.spt
@@ -37,13 +37,13 @@
 3 FunctionParameter 14 5
 
 2 Label 20
+4 Variable 18 26 7
+4 Variable 18 27 7
 6 Load 9 21 7 2 0
 5 CompositeExtract 8 22 21 0
 5 ShiftLeftLogical 8 23 22 11
 5 ShiftRightArithmetic 8 24 23 11
 4 SConvert 14 25 24
-4 Variable 18 26 7
-4 Variable 18 27 7
 5 Store 26 15 2 4
 5 Store 27 15 2 4
 2 Branch 28
@@ -80,6 +80,7 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/OpLoopMergeUnroll.spt
+++ b/test/OpLoopMergeUnroll.spt
@@ -17,7 +17,7 @@
 11 Decorate 7 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 GroupDecorate 6 2 3
 4 TypeInt 8 64 0
-4 TypeInt 14 32 1
+4 TypeInt 14 32 0
 5 Constant 8 11 32 0
 4 Constant 14 15 0
 4 Constant 14 16 1

--- a/test/OpSwitch32.ll
+++ b/test/OpSwitch32.ll
@@ -18,6 +18,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/OpSwitch64.ll
+++ b/test/OpSwitch64.ll
@@ -21,6 +21,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/OpSwitchChar.ll
+++ b/test/OpSwitchChar.ll
@@ -18,6 +18,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/OpVectorInsertDynamic.ll
+++ b/test/OpVectorInsertDynamic.ll
@@ -5,6 +5,8 @@
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK: TypeInt [[TypeInt:[0-9]+]] 32
 ; CHECK: TypeVector [[TypeVector:[0-9]+]] [[TypeInt]] 8

--- a/test/SPIRVVersionAutodetect_1_0.ll
+++ b/test/SPIRVVersionAutodetect_1_0.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; check for magic number followed by version 1.0
 ; CHECK: 119734787 65536

--- a/test/SPIRVVersionAutodetect_1_1.ll
+++ b/test/SPIRVVersionAutodetect_1_1.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; check for magic number followed by version 1.1
 ; CHECK: 119734787 65792

--- a/test/SampledImage.cl
+++ b/test/SampledImage.cl
@@ -2,6 +2,7 @@
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/builtin_vars-decorate.ll
+++ b/test/builtin_vars-decorate.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; ModuleID = 'test.cl'
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/capability-Int64Atomics-store.ll
+++ b/test/capability-Int64Atomics-store.ll
@@ -6,7 +6,10 @@
 ;   atomic_store(object, desired);
 ;}
 
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o - | FileCheck %s
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK: Capability Int64Atomics
 

--- a/test/capability-Int64Atomics.ll
+++ b/test/capability-Int64Atomics.ll
@@ -6,7 +6,11 @@
 ;   atomic_fetch_xor(object, desired);
 ;}
 
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o - | FileCheck %s
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK: Capability Int64Atomics
 

--- a/test/capability-integers.ll
+++ b/test/capability-integers.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-DAG: Capability Int8
 ; CHECK-DAG: Capability Int16

--- a/test/capbility-kernel.ll
+++ b/test/capbility-kernel.ll
@@ -1,4 +1,7 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: FileCheck < %t %s
 
 ; CHECK-DAG: {{[0-9]*}} Capability Addresses

--- a/test/composite_construct_struct.spt
+++ b/test/composite_construct_struct.spt
@@ -12,8 +12,8 @@
 4 Decorate 2 FuncParamAttr 5
 11 Decorate 3 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 TypeInt 4 64 0
-4 TypeInt 8 32 1
-4 TypeInt 10 8 1
+4 TypeInt 8 32 0
+4 TypeInt 10 8 0
 5 Constant 4 15 32 0
 4 Constant 8 16 2194483696
 4 Constant 10 17 4294967168

--- a/test/composite_construct_struct.spt
+++ b/test/composite_construct_struct.spt
@@ -17,7 +17,7 @@
 4 TypeInt 10 8 0
 5 Constant 4 15 32 0
 4 Constant 8 16 2194483696
-4 Constant 10 17 4294967168
+4 Constant 10 17 128
 4 Constant 8 18 2194487296
 4 Constant 8 19 2100480000
 4 TypeVector 5 4 3
@@ -48,6 +48,7 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/composite_construct_struct.spt
+++ b/test/composite_construct_struct.spt
@@ -3,6 +3,7 @@
 2 Capability Linkage
 2 Capability Kernel
 2 Capability Int64
+2 Capability Int8
 3 MemoryModel 2 2
 10 EntryPoint 6 1 "composite_construct_struct"
 3 Source 3 102000

--- a/test/composite_construct_vector.spt
+++ b/test/composite_construct_vector.spt
@@ -12,7 +12,7 @@
 4 Decorate 2 FuncParamAttr 5
 11 Decorate 3 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 TypeInt 4 64 0
-4 TypeInt 8 32 1
+4 TypeInt 8 32 0
 5 Constant 4 12 32 0
 4 Constant 8 13 -123
 4 Constant 8 14 -122
@@ -42,6 +42,7 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/copy_object.spt
+++ b/test/copy_object.spt
@@ -12,9 +12,9 @@
 4 Decorate 2 FuncParamAttr 5
 11 Decorate 3 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 TypeInt 4 64 0
-4 TypeInt 8 8 1
+4 TypeInt 8 8 0
 5 Constant 4 11 32 0
-4 Constant 8 12 -20
+4 Constant 8 12 236
 4 TypeVector 5 4 3
 4 TypePointer 6 0 5
 2 TypeVoid 7

--- a/test/copy_object.spt
+++ b/test/copy_object.spt
@@ -3,6 +3,7 @@
 2 Capability Linkage
 2 Capability Kernel
 2 Capability Int64
+2 Capability Int8
 3 MemoryModel 2 2
 8 EntryPoint 6 1 "copy_object"
 3 Source 3 102000
@@ -41,6 +42,7 @@
 ; reading the file after first ';' symbol
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/empty.ll
+++ b/test/empty.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 

--- a/test/fmod.ll
+++ b/test/fmod.ll
@@ -5,6 +5,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/global_block.cl
+++ b/test/global_block.cl
@@ -6,6 +6,7 @@
 // RUN: %clang_cc1 -O0 -triple spir-unknown-unknown -cl-std=CL2.0 -x cl %s -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
 kernel void block_kernel(__global int* res) {

--- a/test/group-decorate.ll
+++ b/test/group-decorate.ll
@@ -1,5 +1,9 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 

--- a/test/half_extension.ll
+++ b/test/half_extension.ll
@@ -11,6 +11,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: {{[0-9]+}} Capability Float16
 

--- a/test/half_no_extension.ll
+++ b/test/half_no_extension.ll
@@ -9,6 +9,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: {{[0-9]+}} Capability Float16Buffer
 ; CHECK-SPIRV-NOT: {{[0-9]+}} Capability Float16

--- a/test/image-unoptimized.ll
+++ b/test/image-unoptimized.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 

--- a/test/image_decl_func_arg.ll
+++ b/test/image_decl_func_arg.ll
@@ -1,6 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: {{[0-9]*}} TypeImage [[TypeImage:[0-9]+]]
 ; CHECK-SPIRV-NOT: {{[0-9]*}} TypeImage

--- a/test/image_dim.ll
+++ b/test/image_dim.ll
@@ -1,6 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV-DAG: 2 Capability Sampled1D
 ; CHECK-SPIRV-DAG: 2 Capability SampledBuffer

--- a/test/image_store.ll
+++ b/test/image_store.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; Image types may be represented in two ways while translating to SPIR-V:
 ; - OpenCL form, for example, '%opencl.image2d_ro_t',

--- a/test/image_without_access_qualifier.spt
+++ b/test/image_without_access_qualifier.spt
@@ -65,6 +65,7 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/layout.ll
+++ b/test/layout.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK: 119734787 {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} 0
 ; CHECK-NEXT: {{[0-9]*}} Capability

--- a/test/lifetime.ll
+++ b/test/lifetime.ll
@@ -1,5 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-mem2reg=0 -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.spv.bc

--- a/test/link-attribute.ll
+++ b/test/link-attribute.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 

--- a/test/linkage-name.spt
+++ b/test/linkage-name.spt
@@ -27,6 +27,7 @@
 ; reading the file after first ';' symbol
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s
 

--- a/test/linked-list.ll
+++ b/test/linked-list.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t 
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -53,3 +53,9 @@ if not config.spirv_skip_debug_info_tests:
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
+if config.spirv_tools_have_spirv_val:
+    new_ld_library_path = os.path.pathsep.join((config.spirv_tools_lib_dir, config.environment['LD_LIBRARY_PATH']))
+    config.environment['LD_LIBRARY_PATH'] = new_ld_library_path
+    llvm_config.add_tool_substitutions(['spirv-val'], [config.spirv_tools_bin_dir])
+else:
+    config.substitutions.append(('spirv-val', ':'))

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -15,6 +15,9 @@ config.target_triple = "@TARGET_TRIPLE@"
 config.host_arch = "@HOST_ARCH@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
+config.spirv_tools_have_spirv_val = @SPIRV_TOOLS_SPIRV_VAL_FOUND@
+config.spirv_tools_bin_dir = "@SPIRV_TOOLS_BINDIR@"
+config.spirv_tools_lib_dir = "@SPIRV_TOOLS_LIBDIR@"
 config.spirv_skip_debug_info_tests = @SPIRV_SKIP_DEBUG_INFO_TESTS@
 
 # Support substitution of the tools and libs dirs with user parameters. This is

--- a/test/literal-struct.ll
+++ b/test/literal-struct.ll
@@ -11,8 +11,11 @@
 ;   myBlock();
 ; }
 
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK: TypeInt [[Int:[0-9]+]] 32 0
 ; CHECK: TypeInt [[Int8:[0-9]+]] 8 0

--- a/test/llvm.fmuladd.ll
+++ b/test/llvm.fmuladd.ll
@@ -1,5 +1,7 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-NOT: llvm.fmuladd
 

--- a/test/mangled_function.ll
+++ b/test/mangled_function.ll
@@ -10,6 +10,7 @@
 ; clang -cc1 /work/tmp/tmp.cl -cl-std=CL2.0 -triple spir-unknown-unknown  -finclude-default-header -emit-llvm -o test/mangled_function.ll
 
 ; RUN: llvm-as < %s | llvm-spirv -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -o - -to-text | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.spv -o - -r | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/memory_access.ll
+++ b/test/memory_access.ll
@@ -2,6 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/multi_md.ll
+++ b/test/multi_md.ll
@@ -1,8 +1,11 @@
 ; Check duplicate operands in opencl.ocl.version metadata is accepted without
 ; assertion.
 
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; ModuleID = 'clver.bc'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/no_capability_shader.ll
+++ b/test/no_capability_shader.ll
@@ -3,6 +3,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV-NOT: 2 Capability Shader
 

--- a/test/opencl.queue_t.ll
+++ b/test/opencl.queue_t.ll
@@ -1,4 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: FileCheck < %t %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: Capability DeviceEnqueue
 ; CHECK-SPIRV: 2 TypeQueue

--- a/test/opundef.spt
+++ b/test/opundef.spt
@@ -42,6 +42,7 @@
 ; reading the file after first ';' symbol
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s
 

--- a/test/redundant_word.spt
+++ b/test/redundant_word.spt
@@ -32,5 +32,6 @@
 ; reading the file after first ';' symbol
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 

--- a/test/right_shift.spt
+++ b/test/right_shift.spt
@@ -12,7 +12,7 @@
 4 Decorate 2 FuncParamAttr 5
 11 Decorate 3 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 TypeInt 4 64 0
-4 TypeInt 8 32 1
+4 TypeInt 8 32 0
 5 Constant 4 12 10 0
 5 Constant 4 25 5 0
 4 Constant 8 13 5
@@ -43,6 +43,7 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/select.ll
+++ b/test/select.ll
@@ -1,6 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: 6 Select
 

--- a/test/selection_merge.spt
+++ b/test/selection_merge.spt
@@ -16,7 +16,7 @@
 11 Decorate 6 LinkageAttributes "__spirv_GlobalInvocationId" Import
 5 GroupDecorate 5 2 3 4
 4 TypeInt 7 64 0
-4 TypeInt 12 32 1
+4 TypeInt 12 32 0
 5 Constant 7 13 32 0
 4 Constant 12 14 0
 4 TypeVector 8 7 3

--- a/test/selection_merge.spt
+++ b/test/selection_merge.spt
@@ -34,6 +34,7 @@
 3 FunctionParameter 15 4
 
 2 Label 18
+4 Variable 16 27 7
 6 Load 8 19 6 2 0
 5 CompositeExtract 7 20 19 0
 5 ShiftLeftLogical 7 21 20 13
@@ -42,7 +43,6 @@
 6 Load 12 24 23 2 4
 5 InBoundsPtrAccessChain 15 25 4 22
 6 Load 12 26 25 2 4
-4 Variable 16 27 7
 3 Store 27 14
 5 SLessThan 10 28 24 26
 3 SelectionMerge 29 2
@@ -66,6 +66,7 @@
 
 1 FunctionEnd
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/spirv.Queue.ll
+++ b/test/spirv.Queue.ll
@@ -1,4 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: FileCheck < %t %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: Capability DeviceEnqueue
 ; CHECK-SPIRV: 2 TypeQueue

--- a/test/store.ll
+++ b/test/store.ll
@@ -1,5 +1,8 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
@@ -2,6 +2,7 @@
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/transcoding/OpImageSampleExplicitLod_arg.cl
+++ b/test/transcoding/OpImageSampleExplicitLod_arg.cl
@@ -2,6 +2,7 @@
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/transcoding/block_w_struct_return.cl
+++ b/test/transcoding/block_w_struct_return.cl
@@ -2,6 +2,7 @@
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 // RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis %t.rev.bc
 // RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/pipe_builtins.cl
+++ b/test/transcoding/pipe_builtins.cl
@@ -4,6 +4,7 @@
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.bc
 // RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/unreachable.ll
+++ b/test/unreachable.ll
@@ -2,6 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/vec_type_hint.cl
+++ b/test/vec_type_hint.cl
@@ -2,6 +2,7 @@
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.bc
 // RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/vector_times_scalar.spt
+++ b/test/vector_times_scalar.spt
@@ -3,6 +3,7 @@
 2 Capability Linkage 
 2 Capability Kernel 
 2 Capability Float64 
+2 Capability Int64
 3 MemoryModel 2 2 
 8 EntryPoint 6 1 "vector_times_scalar"
 3 Source 3 102000 
@@ -52,6 +53,7 @@
 ; reading the file after first ';' symbol
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 


### PR DESCRIPTION
this mostly adds the required infrastructure in order to run spirv-val on top of generated spirvs inside tests.

Because there are no PPAs available with a recent enough spirv-tools package, we have to build it inside travis-ci which increases the time of each build by around 8-9 minutes. I think most of the time is spend on building spirv-opt. As there is no official way to disable certain binaries, we might either want to add it to spirv-tools or just use some sed commands to decrease the compilation time of spirv-tools.

Because there are quite some validation issues we can't just enable it everywhere, so I ended up enabling it only for a few tests. We should get to a point where we can add it to every test though and fix all the upcoming issues.

There were also some invalid spt files which I fixed as it is pointless to verify we translating invalid spirvs works.

Any thoughts on that?