### PR TITLE
Open SPIR-V output file as a binary file

### DIFF
--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -139,7 +139,7 @@ static int convertLLVMToSPIRV() {
   std::string Err;
   bool Success = false;
   if (OutputFile != "-") {
-    std::ofstream OutFile(OutputFile);
+    std::ofstream OutFile(OutputFile, std::ios::binary);
     Success = writeSpirv(M.get(), OutFile, Err);
   } else {
     Success = writeSpirv(M.get(), std::cout, Err);


### PR DESCRIPTION
I'm using the SPIRV-LLVM-Translator on Windows.  On Windows, "text" files replace a newline (character '\n') with two characters representing a carriage return and line feed ("\r\n").  Unfortunately, if the newline actually represents a SPIR-V ID, the replacement corrupts the SPIR-V file.

Fix is to use a "binary" file instead, which only writes the single byte '\n'.  With this change I am able to use the SPIRV-LLVM-Translator on Windows.