### PR TITLE
Support partial unrolling

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -547,6 +547,18 @@ void SPIRVToLLVM::setName(llvm::Value *V, SPIRVValue *BV) {
     V->setName(Name);
 }
 
+inline llvm::Metadata *SPIRVToLLVM::getMetadataFromName(std::string Name) {
+  return llvm::MDNode::get(*Context, llvm::MDString::get(*Context, Name));
+}
+
+inline std::vector<llvm::Metadata *>
+SPIRVToLLVM::getMetadataFromNameAndParameter(std::string Name,
+                                             SPIRVWord Parameter) {
+  return {MDString::get(*Context, Name),
+          ConstantAsMetadata::get(
+              ConstantInt::get(Type::getInt32Ty(*Context), Parameter))};
+}
+
 void SPIRVToLLVM::setLLVMLoopMetadata(SPIRVLoopMerge *LM, BranchInst *BI) {
   if (!LM)
     return;
@@ -559,54 +571,90 @@ void SPIRVToLLVM::setLLVMLoopMetadata(SPIRVLoopMerge *LM, BranchInst *BI) {
     return;
   }
 
+  unsigned NumParam = 0;
   std::vector<llvm::Metadata *> Metadata;
+  std::vector<SPIRVWord> LoopControlParameters = LM->getLoopControlParameters();
   Metadata.push_back(llvm::MDNode::get(*Context, Self));
-  std::vector<SPIRVWord> LoopControlParameters;
+
+  // To correctly decode loop control parameters, order of checks for loop
+  // control masks must match with the order given in the spec (see 3.23),
+  // i.e. check smaller-numbered bits first.
+  // Unroll and UnrollCount loop controls can't be applied simultaneously with
+  // DontUnroll loop control.
   if (LC & LoopControlUnrollMask)
-    Metadata.push_back(llvm::MDNode::get(
-        *Context, llvm::MDString::get(*Context, "llvm.loop.unroll.full")));
+    Metadata.push_back(getMetadataFromName("llvm.loop.unroll.enable"));
   else if (LC & LoopControlDontUnrollMask)
-    Metadata.push_back(llvm::MDNode::get(
-        *Context, llvm::MDString::get(*Context, "llvm.loop.unroll.disable")));
+    Metadata.push_back(getMetadataFromName("llvm.loop.unroll.disable"));
   if (LC & LoopControlDependencyInfiniteMask)
-    Metadata.push_back(llvm::MDNode::get(
-        *Context, llvm::MDString::get(*Context, "llvm.loop.ivdep.enable")));
+    Metadata.push_back(getMetadataFromName("llvm.loop.ivdep.enable"));
   if (LC & LoopControlDependencyLengthMask) {
-    LoopControlParameters = LM->getLoopControlParameters();
     if (!LoopControlParameters.empty()) {
-      llvm::Metadata *OpValues[] = {
-          MDString::get(*Context, "llvm.loop.ivdep.safelen"),
-          ConstantAsMetadata::get(ConstantInt::get(Type::getInt32Ty(*Context),
-                                                   LoopControlParameters[0]))};
-      Metadata.push_back(llvm::MDNode::get(*Context, OpValues));
+      Metadata.push_back(llvm::MDNode::get(
+          *Context,
+          getMetadataFromNameAndParameter("llvm.loop.ivdep.safelen",
+                                          LoopControlParameters[NumParam])));
+      ++NumParam;
+      assert(NumParam <= LoopControlParameters.size() &&
+             "Missing loop control parameter!");
     }
   }
+  // Placeholder for LoopControls added in SPIR-V 1.4 spec (see 3.23)
+  if (LC & LoopControlMinIterationsMask) {
+    ++NumParam;
+    assert(NumParam <= LoopControlParameters.size() &&
+           "Missing loop control parameter!");
+  }
+  if (LC & LoopControlMaxIterationsMask) {
+    ++NumParam;
+    assert(NumParam <= LoopControlParameters.size() &&
+           "Missing loop control parameter!");
+  }
+  if (LC & LoopControlIterationMultipleMask) {
+    ++NumParam;
+    assert(NumParam <= LoopControlParameters.size() &&
+           "Missing loop control parameter!");
+  }
+  if (LC & LoopControlPeelCountMask) {
+    ++NumParam;
+    assert(NumParam <= LoopControlParameters.size() &&
+           "Missing loop control parameter!");
+  }
+  if (LC & LoopControlPartialCountMask && !(LC & LoopControlDontUnrollMask)) {
+    // If unroll factor is set as '1' - disable loop unrolling
+    if (1 == LoopControlParameters[NumParam])
+      Metadata.push_back(getMetadataFromName("llvm.loop.unroll.disable"));
+    else
+      Metadata.push_back(llvm::MDNode::get(
+          *Context,
+          getMetadataFromNameAndParameter("llvm.loop.unroll.count",
+                                          LoopControlParameters[NumParam])));
+    ++NumParam;
+    assert(NumParam <= LoopControlParameters.size() &&
+           "Missing loop control parameter!");
+  }
   if (LC & LoopControlExtendedControlsMask) {
-    LoopControlParameters = LM->getLoopControlParameters();
-    for (auto LCP = LoopControlParameters.begin();
-         LCP != LoopControlParameters.end(); ++LCP) {
-      switch (*LCP) {
+    while (NumParam < LoopControlParameters.size()) {
+      switch (LoopControlParameters[NumParam]) {
       case InitiationIntervalINTEL: {
         // To generate a correct integer part of metadata we skip a parameter
         // that encodes name of the metadata and take the next one
-        llvm::Metadata *OpValues[] = {
-            MDString::get(*Context, "llvm.loop.ii.count"),
-            ConstantAsMetadata::get(
-                ConstantInt::get(Type::getInt32Ty(*Context), *(++LCP)))};
-        Metadata.push_back(llvm::MDNode::get(*Context, OpValues));
+        Metadata.push_back(llvm::MDNode::get(
+            *Context,
+            getMetadataFromNameAndParameter(
+                "llvm.loop.ii.count", LoopControlParameters[++NumParam])));
         break;
       }
       case MaxConcurrencyINTEL: {
-        llvm::Metadata *OpValues[] = {
-            MDString::get(*Context, "llvm.loop.max_concurrency.count"),
-            ConstantAsMetadata::get(
-                ConstantInt::get(Type::getInt32Ty(*Context), *(++LCP)))};
-        Metadata.push_back(llvm::MDNode::get(*Context, OpValues));
+        Metadata.push_back(llvm::MDNode::get(
+            *Context, getMetadataFromNameAndParameter(
+                          "llvm.loop.max_concurrency.count",
+                          LoopControlParameters[++NumParam])));
         break;
       }
       default:
         break;
       }
+      ++NumParam;
     }
   }
   llvm::MDNode *Node = llvm::MDNode::get(*Context, Metadata);

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -45,6 +45,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
+#include "llvm/IR/Metadata.h"    // llvm::Metadata
 
 namespace llvm {
 class Module;
@@ -246,6 +247,9 @@ private:
   Value *oclTransConstantPipeStorage(SPIRV::SPIRVConstantPipeStorage *BCPS);
   void setName(llvm::Value *V, SPIRVValue *BV);
   void setLLVMLoopMetadata(SPIRVLoopMerge *LM, BranchInst *BI);
+  inline llvm::Metadata *getMetadataFromName(std::string Name);
+  inline std::vector<llvm::Metadata *>
+  getMetadataFromNameAndParameter(std::string Name, SPIRVWord Parameter);
   void insertImageNameAccessQualifier(SPIRV::SPIRVTypeImage *ST,
                                       std::string &Name);
   template <class Source, class Func> bool foreachFuncCtlMask(Source, Func);

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -1041,6 +1041,7 @@ inline bool isValidLoopControlMask(SPIRVWord Mask) {
   SPIRVWord ValidMask = 0u;
   ValidMask |= LoopControlUnrollMask;
   ValidMask |= LoopControlDontUnrollMask;
+  ValidMask |= LoopControlPartialCountMask;
   ValidMask |= LoopControlDependencyInfiniteMask;
   ValidMask |= LoopControlDependencyLengthMask;
   ValidMask |= LoopControlExtendedControlsMask;

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -484,6 +484,11 @@ enum LoopControlMask {
     LoopControlDontUnrollMask = 0x00000002,
     LoopControlDependencyInfiniteMask = 0x00000004,
     LoopControlDependencyLengthMask = 0x00000008,
+    LoopControlMinIterationsMask = 0x00000010,
+    LoopControlMaxIterationsMask = 0x00000020,
+    LoopControlIterationMultipleMask = 0x00000040,
+    LoopControlPeelCountMask = 0x00000080,
+    LoopControlPartialCountMask = 0x00000100,
     LoopControlExtendedControlsMask = 0x80000000,
 };
 

--- a/test/OpLoopMergeDontUnrollHint1.spt
+++ b/test/OpLoopMergeDontUnrollHint1.spt
@@ -17,7 +17,7 @@
 11 Decorate 7 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 GroupDecorate 6 2 3
 4 TypeInt 8 64 0
-4 TypeInt 14 32 0
+4 TypeInt 14 32 1
 5 Constant 8 11 32 0
 4 Constant 14 15 0
 4 Constant 14 16 1
@@ -37,13 +37,13 @@
 3 FunctionParameter 14 5
 
 2 Label 20
-4 Variable 18 26 7
-4 Variable 18 27 7
 6 Load 9 21 7 2 0
 5 CompositeExtract 8 22 21 0
 5 ShiftLeftLogical 8 23 22 11
 5 ShiftRightArithmetic 8 24 23 11
 4 SConvert 14 25 24
+4 Variable 18 26 7
+4 Variable 18 27 7
 5 Store 26 15 2 4
 5 Store 27 15 2 4
 2 Branch 28
@@ -51,7 +51,7 @@
 2 Label 28
 4 Load 14 29 27
 5 SLessThan 12 30 29 4
-4 LoopMerge 31 32 1
+5 LoopMerge 31 32 256 1
 4 BranchConditional 30 33 31
 
 2 Label 33
@@ -80,10 +80,9 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
-; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 ; CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
-; CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.enable"}
+; CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.disable"}

--- a/test/OpLoopMergePartialUnroll.spt
+++ b/test/OpLoopMergePartialUnroll.spt
@@ -17,7 +17,7 @@
 11 Decorate 7 LinkageAttributes "__spirv_GlobalInvocationId" Import
 4 GroupDecorate 6 2 3
 4 TypeInt 8 64 0
-4 TypeInt 14 32 0
+4 TypeInt 14 32 1
 5 Constant 8 11 32 0
 4 Constant 14 15 0
 4 Constant 14 16 1
@@ -37,13 +37,13 @@
 3 FunctionParameter 14 5
 
 2 Label 20
-4 Variable 18 26 7
-4 Variable 18 27 7
 6 Load 9 21 7 2 0
 5 CompositeExtract 8 22 21 0
 5 ShiftLeftLogical 8 23 22 11
 5 ShiftRightArithmetic 8 24 23 11
 4 SConvert 14 25 24
+4 Variable 18 26 7
+4 Variable 18 27 7
 5 Store 26 15 2 4
 5 Store 27 15 2 4
 2 Branch 28
@@ -51,7 +51,7 @@
 2 Label 28
 4 Load 14 29 27
 5 SLessThan 12 30 29 4
-4 LoopMerge 31 32 1
+5 LoopMerge 31 32 256 4
 4 BranchConditional 30 33 31
 
 2 Label 33
@@ -80,10 +80,9 @@
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
-; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: br i1 %{{[0-9]+}}, label %{{[0-9]+}}, label %{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 ; CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
-; CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.enable"}
+; CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.count", i32 4}

--- a/test/transcoding/LoopUnroll.ll
+++ b/test/transcoding/LoopUnroll.ll
@@ -105,7 +105,7 @@ while.cond:                                       ; preds = %if.end, %if.then, %
   store i32 %dec, i32* %i, align 4
   %cmp = icmp sgt i32 %0, 0
 ; Per SPIRV spec p3.23 "Unroll" loop control = 0x1
-; CHECK-SPIRV: 4 LoopMerge [[MergeBlock:[0-9]+]] [[ContinueTarget:[0-9]+]] 1
+; CHECK-SPIRV: 5 LoopMerge [[MergeBlock:[0-9]+]] [[ContinueTarget:[0-9]+]] 256 8
 ; CHECK-SPIRV: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MergeBlock]]
   br i1 %cmp, label %while.body, label %while.end
 
@@ -201,4 +201,4 @@ attributes #0 = { noinline nounwind optnone "correctly-rounded-divide-sqrt-fp-ma
 !7 = distinct !{!7, !8}
 !8 = !{!"llvm.loop.unroll.count", i32 8}
 !9 = distinct !{!9, !10}
-!10 = !{!"llvm.loop.unroll.full"}
+!10 = !{!"llvm.loop.unroll.enable"}


### PR DESCRIPTION
Possible use cases:
1. unroll [N]
   going to be translated into:
   SPIR-V: 5 LoopMerge [X] [Y] 256 [N]
   LLVM-IR: !{!"llvm.loop.unroll.count", i32 [N]}

2. unroll 1
   in this case loop unrolling should be disabled,
   going to be translated into:
   LLVM-IR:  !{!"llvm.loop.unroll.disable"}

unroll default (without hint) behaviour was changed as well, see:
LLVM-IR: !{!"llvm.loop.unroll.full"} -> !{!"llvm.loop.unroll.enable"}