### PR TITLE
Add separate functions for reading and translating SPIR-V

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -89,6 +89,11 @@ bool convertSpirv(std::string &Input, std::string &Out, std::string &ErrMsg,
 bool isSpirvText(std::string &Img);
 #endif
 
+/// \brief Load SPIR-V from istream as a SPIRVModule.
+/// \returns null on failure.
+std::unique_ptr<SPIRVModule> readSpirvModule(std::istream &IS,
+                                             std::string &ErrMsg);
+
 } // End namespace SPIRV
 
 namespace llvm {
@@ -101,6 +106,11 @@ bool writeSpirv(Module *M, std::ostream &OS, std::string &ErrMsg);
 /// \returns true if succeeds.
 bool readSpirv(LLVMContext &C, std::istream &IS, Module *&M,
                std::string &ErrMsg);
+
+/// \brief Convert a SPIRVModule into LLVM IR.
+/// \returns null on failure.
+std::unique_ptr<Module>
+convertSpirvToLLVM(LLVMContext &C, SPIRV::SPIRVModule &BM, std::string &ErrMsg);
 
 /// \brief Regularize LLVM module by removing entities not representable by
 /// SPIRV.

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2904,36 +2904,52 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
              &Attrs)));
 }
 
-} // namespace SPIRV
-
-bool llvm::readSpirv(LLVMContext &C, std::istream &IS, Module *&M,
-                     std::string &ErrMsg) {
+std::unique_ptr<SPIRVModule> readSpirvModule(std::istream &IS,
+                                             std::string &ErrMsg) {
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
 
   IS >> *BM;
   if (!BM->isModuleValid()) {
     BM->getError(ErrMsg);
-    M = nullptr;
-    return false;
+    return nullptr;
+  }
+  return BM;
+}
+
+} // namespace SPIRV
+
+std::unique_ptr<Module>
+llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM, std::string &ErrMsg) {
+  std::unique_ptr<Module> M(new Module("", C));
+  SPIRVToLLVM BTL(M.get(), &BM);
+
+  if (!BTL.translate()) {
+    BM.getError(ErrMsg);
+    return nullptr;
   }
 
-  M = new Module("", C);
-  SPIRVToLLVM BTL(M, BM.get());
-  bool Succeed = true;
-  if (!BTL.translate()) {
-    BM->getError(ErrMsg);
-    Succeed = false;
-  }
   llvm::legacy::PassManager PassMgr;
   PassMgr.add(createSPIRVToOCL20());
   PassMgr.add(createOCL20To12());
   PassMgr.run(*M);
 
+  return M;
+}
+
+bool llvm::readSpirv(LLVMContext &C, std::istream &IS, Module *&M,
+                     std::string &ErrMsg) {
+  std::unique_ptr<SPIRVModule> BM(readSpirvModule(IS, ErrMsg));
+
+  if (!BM)
+    return false;
+
+  M = convertSpirvToLLVM(C, *BM, ErrMsg).release();
+
+  if (!M)
+    return false;
+
   if (DbgSaveTmpLLVM)
     dumpLLVM(M, DbgTmpLLVMFileName);
-  if (!Succeed) {
-    delete M;
-    M = nullptr;
-  }
-  return Succeed;
+
+  return true;
 }


### PR DESCRIPTION
The OpenCL runtime API requires that IL be loaded and compiled with
separate function calls:

 1. clCreateProgramWithIL(), which must check that the IL is well-formed
    and return CL_INVALID_VALUE if it is not.

 2. clBuildProgram() or clCompileProgram(), which allow build options to
    be specified.

To facilitate the above, this change adds two new API functions:

 1. readSpirvModule(), which reads an istream to produce a SPIRVModule.

 2. convertSpirvToLLVM(), which converts a SPIRVModule to LLVM IR.

The existing readSpirv() function is refactored in terms of these calls,
but is kept in the API for the convenience of tools such as llvm-spirv.

Fixes issue #20.