### PR TITLE
Cleanup Triple validation and use

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -519,6 +519,7 @@ inline size_t findFirstPtr(const std::vector<Value *> &Args) {
   return PtArg - Args.begin();
 }
 
+bool isSupportedTriple(Triple T);
 void removeFnAttr(LLVMContext *Context, CallInst *Call,
                   Attribute::AttrKind Attr);
 void addFnAttr(LLVMContext *Context, CallInst *Call, Attribute::AttrKind Attr);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -77,6 +77,8 @@ cl::opt<bool, true> EnableDbgOutput("spirv-debug",
                                     cl::location(SPIRVDbgEnable));
 #endif
 
+bool isSupportedTriple(Triple T) { return T.isSPIR(); }
+
 void addFnAttr(LLVMContext *Context, CallInst *Call, Attribute::AttrKind Attr) {
   Call->addAttribute(AttributeList::FunctionIndex, Attr);
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1386,12 +1386,11 @@ SPIRVValue *LLVMToSPIRV::transCallInst(CallInst *CI, SPIRVBasicBlock *BB) {
 
 bool LLVMToSPIRV::transAddressingMode() {
   Triple TargetTriple(M->getTargetTriple());
-  Triple::ArchType Arch = TargetTriple.getArch();
 
-  SPIRVCKRT(Arch == Triple::spir || Arch == Triple::spir64, InvalidTargetTriple,
+  SPIRVCKRT(isSupportedTriple(TargetTriple), InvalidTargetTriple,
             "Actual target triple is " + M->getTargetTriple());
 
-  if (Arch == Triple::spir)
+  if (TargetTriple.isArch32Bit())
     BM->setAddressingModel(AddressingModelPhysical32);
   else
     BM->setAddressingModel(AddressingModelPhysical64);

--- a/lib/SPIRV/TransOCLMD.cpp
+++ b/lib/SPIRV/TransOCLMD.cpp
@@ -115,12 +115,11 @@ void TransOCLMD::visit(Module *M) {
   // !spirv.MemoryModel = !{!x}
   // !{x} = !{i32 1, i32 2}
   Triple TT(M->getTargetTriple());
-  auto Arch = TT.getArch();
-  assert((Arch == Triple::spir || Arch == Triple::spir64) && "Invalid triple");
+  assert(isSupportedTriple(TT) && "Invalid triple");
   B.addNamedMD(kSPIRVMD::MemoryModel)
       .addOp()
-      .add(Arch == Triple::spir ? spv::AddressingModelPhysical32
-                                : spv::AddressingModelPhysical64)
+      .add(TT.isArch32Bit() ? spv::AddressingModelPhysical32
+                            : spv::AddressingModelPhysical64)
       .add(spv::MemoryModelOpenCL)
       .done();
 


### PR DESCRIPTION
- Centralise Triple validation
- Set the addressing model based on architecture bitness rather than
  the specific architecture.

Signed-off-by: Kevin Petit <kevin.petit@arm.com>