### PR TITLE
Replace hardcoded address space for clk_event_t

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1881,7 +1881,8 @@ Instruction *SPIRVToLLVM::transEnqueueKernelBI(SPIRVInstruction *BI,
   Function *F = M->getFunction(FName);
   if (!F) {
     Type *EventTy = PointerType::get(
-        getOrCreateOpaquePtrType(M, SPIR_TYPE_NAME_CLK_EVENT_T, SPIRAS_Private),
+        getOrCreateOpaquePtrType(M, SPIR_TYPE_NAME_CLK_EVENT_T,
+                                 getOCLOpaqueTypeAddrSpace(OpTypeDeviceEvent)),
         SPIRAS_Generic);
 
     SmallVector<Type *, 8> Tys = {


### PR DESCRIPTION
Set the address space through `getOCLOpaqueTypeAddrSpace`, which is
build-time configurable through the `SPIRV_CLK_EVENT_T_ADDR_SPACE`
preprocessor macro.

There is no easy way to test this functionality using the llvm-lit test suite currently.