### PR TITLE
travis: Add libclang-9-dev package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
     - llvm-9-dev
     - clang-format-9
     - clang-tidy-9
+    - libclang-9-dev
     - spirv-tools
 
 compiler:


### PR DESCRIPTION
Looks like package dependencies are broken.
Adding libclang-9-dev manually to fix travis build.