### PR TITLE
Update LLVM IR metadata preprocessing

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -60,7 +60,7 @@ void initializeSPIRVLowerOCLBlocksPass(PassRegistry &);
 void initializeSPIRVLowerMemmovePass(PassRegistry &);
 void initializeSPIRVRegularizeLLVMPass(PassRegistry &);
 void initializeSPIRVToOCL20Pass(PassRegistry &);
-void initializeTransOCLMDPass(PassRegistry &);
+void initializePreprocessMetadataPass(PassRegistry &);
 } // namespace llvm
 
 #include "llvm/IR/Module.h"
@@ -163,7 +163,7 @@ ModulePass *createSPIRVToOCL20();
 
 /// Create a pass for translating SPIR 1.2/2.0 metadata to SPIR-V friendly
 /// metadata.
-ModulePass *createTransOCLMD();
+ModulePass *createPreprocessMetadata();
 
 /// Create and return a pass that writes the module to the specified
 /// ostream.

--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -21,7 +21,7 @@ add_llvm_library(LLVMSPIRVLib
   SPIRVUtil.cpp
   SPIRVWriter.cpp
   SPIRVWriterPass.cpp
-  TransOCLMD.cpp
+  PreprocessMetadata.cpp
   libSPIRV/SPIRVBasicBlock.cpp
   libSPIRV/SPIRVDebug.cpp
   libSPIRV/SPIRVDecorate.cpp

--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -143,8 +143,7 @@ void PreprocessMetadata::visit(Module *M) {
   // The rest of metadata might come not only from OpenCL
 
   // Create metadata representing (empty so far) list
-  // of OpEntryPoint and OpExecutionMode instructions
-  auto EP = B.addNamedMD(kSPIRVMD::EntryPoint);    // !spirv.EntryPoint = {}
+  // of OpExecutionMode instructions
   auto EM = B.addNamedMD(kSPIRVMD::ExecutionMode); // !spirv.ExecutionMode = {}
 
   // Add execution modes for kernels. We take it from metadata attached to
@@ -152,16 +151,6 @@ void PreprocessMetadata::visit(Module *M) {
   for (Function &Kernel : *M) {
     if (Kernel.getCallingConv() != CallingConv::SPIR_KERNEL)
       continue;
-
-    // Add EntryPoint(which actually is adding its operands) to the list of
-    // entry points:
-    // !{i32 6, void (i32 addrspace(1)*)* @kernel, !"kernel" }
-    MDNode *EPNode;
-    EP.addOp()
-        .add(spv::ExecutionModelKernel)
-        .add(&Kernel)
-        .add(Kernel.getName())
-        .done(&EPNode);
 
     // Specifing execution modes for the Kernel and adding it to the list
     // of ExecutionMode instructions.

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1910,7 +1910,7 @@ ModulePass *llvm::createLLVMToSPIRV(SPIRVModule *SMod) {
 void addPassesForSPIRV(legacy::PassManager &PassMgr) {
   if (SPIRVMemToReg)
     PassMgr.add(createPromoteMemoryToRegisterPass());
-  PassMgr.add(createTransOCLMD());
+  PassMgr.add(createPreprocessMetadata());
   PassMgr.add(createOCL21ToSPIRV());
   PassMgr.add(createSPIRVLowerSPIRBlocks());
   PassMgr.add(createOCLTypeToSPIRV());

--- a/test/preprocess-metadata.ll
+++ b/test/preprocess-metadata.ll
@@ -1,0 +1,33 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -to-text %t.spv -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+;
+; The purpose of this test is to check that some of OpenCL metadata are consumed
+; even if 'opencl.ocl.version' metadata is missed (i.e. LLVM IR was produced not
+; from OpenCL, but, for example from SYCL)
+;
+; CHECK-SPIRV: EntryPoint 6 [[TEST1:[0-9]+]] "test1"
+; CHECK-SPIRV: EntryPoint 6 [[TEST2:[0-9]+]] "test2"
+; CHECK-SPIRV: ExecutionMode [[TEST1]] 17 1 2 3
+; CHECK-SPIRV: ExecutionMode [[TEST1]] 30 6
+; CHECK-SPIRV: ExecutionMode [[TEST2]] 18 3 2 1
+; CHECK-SPIRV: ExecutionMode [[TEST2]] 35 8
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @test1() !reqd_work_group_size !1 !vec_type_hint !2  {
+entry:
+  ret void
+}
+
+define spir_kernel void @test2() !work_group_size_hint !3 !intel_reqd_sub_group_size !4 {
+entry:
+  ret void
+}
+
+!1 = !{i32 1, i32 2, i32 3}
+!2 = !{double undef, i32 1}
+!3 = !{i32 3, i32 2, i32 1}
+!4 = !{i32 8}


### PR DESCRIPTION
Main purpose of this PR is to allow SPIRV-LLVM-Translator to handle some OpenCL-specific metadata (like `reqd_work_group_size`, `intel_reqd_sub_group_size`) even if LLVM IR wasn't generated from OpenCL C (`opencl.ocl.version` metadata is missed).

Summary of changes:
* renamed `TransOCLMD` pass into `PreprocessMetadata`
* update the pass to handle some metadata unconditionally 

The first user of this PR can be found in intel/llvm#164: I've re-used existing OpenCL attribute `intel_reqd_sub_group_size` in SYCL.

I'm not particularly sure about the last commit in this PR: _Remove generating of spirv.EntryPoint metadata_ - I've removed generation of `spriv.EntryPoint` metadata since there are no uses of it. Probably it is a wrong decision. **Please speak up if you think that it is better to leave this metadata** and I will remove the commit.