### PR TITLE
Rename Maxconcurrency decoration to MaxPrivateCopies to align with spec

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2292,8 +2292,8 @@ void generateIntelFPGAAnnotation(const SPIRVEntry *E,
     Out << "{bankwidth:" << Result << '}';
   if (E->hasDecorate(DecorationNumbanksINTEL, 0, &Result))
     Out << "{numbanks:" << Result << '}';
-  if (E->hasDecorate(DecorationMaxconcurrencyINTEL, 0, &Result))
-    Out << "{max_concurrency:" << Result << '}';
+  if (E->hasDecorate(DecorationMaxPrivateCopiesINTEL, 0, &Result))
+    Out << "{max_private_copies:" << Result << '}';
   if (E->hasDecorate(DecorationSinglepumpINTEL))
     Out << "{pump:1}";
   if (E->hasDecorate(DecorationDoublepumpINTEL))
@@ -2319,9 +2319,9 @@ void generateIntelFPGAAnnotationForStructMember(
     Out << "{bankwidth:" << Result << '}';
   if (E->hasMemberDecorate(DecorationNumbanksINTEL, 0, MemberNumber, &Result))
     Out << "{numbanks:" << Result << '}';
-  if (E->hasMemberDecorate(DecorationMaxconcurrencyINTEL, 0, MemberNumber,
+  if (E->hasMemberDecorate(DecorationMaxPrivateCopiesINTEL, 0, MemberNumber,
                            &Result))
-    Out << "{max_concurrency:" << Result << '}';
+    Out << "{max_private_copies:" << Result << '}';
   if (E->hasMemberDecorate(DecorationSinglepumpINTEL, 0, MemberNumber))
     Out << "{pump:1}";
   if (E->hasMemberDecorate(DecorationDoublepumpINTEL, 0, MemberNumber))

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1142,7 +1142,7 @@ parseAnnotations(StringRef AnnotatedCode) {
                 .Case("memory", DecorationMemoryINTEL)
                 .Case("numbanks", DecorationNumbanksINTEL)
                 .Case("bankwidth", DecorationBankwidthINTEL)
-                .Case("max_concurrency", DecorationMaxconcurrencyINTEL)
+                .Case("max_private_copies", DecorationMaxPrivateCopiesINTEL)
                 .Default(DecorationUserSemantic);
       if (Dec == DecorationUserSemantic)
         Value = AnnotatedCode.substr(From, To + 1);
@@ -1176,7 +1176,7 @@ void addIntelFPGADecorations(
     // The rest of IntelFPGA decorations:
     // DecorationNumbanksINTEL
     // DecorationBankwidthINTEL
-    // DecorationMaxconcurrencyINTEL
+    // DecorationMaxPrivateCopiesINTEL
     default:
       SPIRVWord Result = 0;
       StringRef(I.second).getAsInteger(10, Result);
@@ -1208,7 +1208,7 @@ void addIntelFPGADecorationsForStructMember(
     // The rest of IntelFPGA decorations:
     // DecorationNumbanksINTEL
     // DecorationBankwidthINTEL
-    // DecorationMaxconcurrencyINTEL
+    // DecorationMaxPrivateCopiesINTEL
     default:
       SPIRVWord Result = 0;
       StringRef(I.second).getAsInteger(10, Result);

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -355,7 +355,7 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationMemoryINTEL, {CapabilityFPGAMemoryAttributesINTEL});
   ADD_VEC_INIT(DecorationNumbanksINTEL, {CapabilityFPGAMemoryAttributesINTEL});
   ADD_VEC_INIT(DecorationBankwidthINTEL, {CapabilityFPGAMemoryAttributesINTEL});
-  ADD_VEC_INIT(DecorationMaxconcurrencyINTEL,
+  ADD_VEC_INIT(DecorationMaxPrivateCopiesINTEL,
                {CapabilityFPGAMemoryAttributesINTEL});
   ADD_VEC_INIT(DecorationSinglepumpINTEL,
                {CapabilityFPGAMemoryAttributesINTEL});

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -402,7 +402,7 @@ inline bool isValid(spv::Decoration V) {
   case DecorationMemoryINTEL:
   case DecorationNumbanksINTEL:
   case DecorationBankwidthINTEL:
-  case DecorationMaxconcurrencyINTEL:
+  case DecorationMaxPrivateCopiesINTEL:
   case DecorationSinglepumpINTEL:
   case DecorationDoublepumpINTEL:
     return true;

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -336,7 +336,7 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationMemoryINTEL, "MemoryINTEL");
   add(DecorationNumbanksINTEL, "NumbanksINTEL");
   add(DecorationBankwidthINTEL, "BankwidthINTEL");
-  add(DecorationMaxconcurrencyINTEL, "MaxconcurrencyINTEL");
+  add(DecorationMaxPrivateCopiesINTEL, "MaxPrivateCopiesINTEL");
   add(DecorationSinglepumpINTEL, "SinglepumpINTEL");
   add(DecorationDoublepumpINTEL, "DoublepumpINTEL");
 }

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -393,7 +393,7 @@ enum Decoration {
     DecorationMemoryINTEL = 5826,
     DecorationNumbanksINTEL = 5827,
     DecorationBankwidthINTEL = 5828,
-    DecorationMaxconcurrencyINTEL = 5829,
+    DecorationMaxPrivateCopiesINTEL = 5829,
     DecorationSinglepumpINTEL = 5830,
     DecorationDoublepumpINTEL = 5831,
     DecorationMax = 0x7fffffff,

--- a/test/IntelFPGAMemoryAttributes.ll
+++ b/test/IntelFPGAMemoryAttributes.ll
@@ -10,7 +10,7 @@
 ; CHECK-SPIRV: Decorate {{[0-9]+}} MemoryINTEL "BLOCK_RAM"
 ; CHECK-SPIRV: Decorate {{[0-9]+}} NumbanksINTEL 4
 ; CHECK-SPIRV: Decorate {{[0-9]+}} BankwidthINTEL 8
-; CHECK-SPIRV: Decorate {{[0-9]+}} MaxconcurrencyINTEL 4
+; CHECK-SPIRV: Decorate {{[0-9]+}} MaxPrivateCopiesINTEL 4
 ; CHECK-SPIRV: Decorate {{[0-9]+}} SinglepumpINTEL
 ; CHECK-SPIRV: Decorate {{[0-9]+}} DoublepumpINTEL
 
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-linux"
 ; CHECK-LLVM: [[STR2:@[a-zA-Z0-9_.]+]] = {{.*}}{register:1}
 ; CHECK-LLVM: [[STR3:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:BLOCK_RAM}
 ; CHECK-LLVM: [[STR4:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:8}
-; CHECK-LLVM: [[STR5:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{max_concurrency:4}
+; CHECK-LLVM: [[STR5:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{max_private_copies:4}
 ; CHECK-LLVM: [[STR6:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{pump:1}
 ; CHECK-LLVM: [[STR7:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{pump:2}
 @.str = private unnamed_addr constant [29 x i8] c"{memory:DEFAULT}{numbanks:4}\00", section "llvm.metadata"
@@ -31,7 +31,7 @@ target triple = "spir64-unknown-linux"
 @.str.2 = private unnamed_addr constant [13 x i8] c"{register:1}\00", section "llvm.metadata"
 @.str.3 = private unnamed_addr constant [19 x i8] c"{memory:BLOCK_RAM}\00", section "llvm.metadata"
 @.str.4 = private unnamed_addr constant [30 x i8] c"{memory:DEFAULT}{bankwidth:8}\00", section "llvm.metadata"
-@.str.5 = private unnamed_addr constant [36 x i8] c"{memory:DEFAULT}{max_concurrency:4}\00", section "llvm.metadata"
+@.str.5 = private unnamed_addr constant [39 x i8] c"{memory:DEFAULT}{max_private_copies:4}\00", section "llvm.metadata"
 @.str.6 = private unnamed_addr constant [25 x i8] c"{memory:DEFAULT}{pump:1}\00", section "llvm.metadata"
 @.str.7 = private unnamed_addr constant [25 x i8] c"{memory:DEFAULT}{pump:2}\00", section "llvm.metadata"
 
@@ -94,8 +94,8 @@ entry:
   ; CHECK-LLVM: call void @llvm.var.annotation(i8* [[VAR4:%[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([30 x i8], [30 x i8]* [[STR4]], i32 0, i32 0), i8* undef, i32 undef)
   call void @llvm.var.annotation(i8* %var_four4, i8* getelementptr inbounds ([30 x i8], [30 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.1, i32 0, i32 0), i32 5)
   call void @llvm.lifetime.start.p0i8(i64 1, i8* %var_five) #4
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* [[VAR5:%[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([36 x i8], [36 x i8]* [[STR5]], i32 0, i32 0), i8* undef, i32 undef)
-  call void @llvm.var.annotation(i8* %var_five, i8* getelementptr inbounds ([36 x i8], [36 x i8]* @.str.5, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.1, i32 0, i32 0), i32 6)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* [[VAR5:%[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([39 x i8], [39 x i8]* [[STR5]], i32 0, i32 0), i8* undef, i32 undef)
+  call void @llvm.var.annotation(i8* %var_five, i8* getelementptr inbounds ([39 x i8], [39 x i8]* @.str.5, i32 0, i32 0), i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.1, i32 0, i32 0), i32 6)
   %4 = bitcast i32* %var_six to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %4) #4
   %var_six6 = bitcast i32* %var_six to i8*

--- a/test/IntelFPGAMemoryAttributesForStruct.ll
+++ b/test/IntelFPGAMemoryAttributesForStruct.ll
@@ -11,7 +11,7 @@
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 2 MemoryINTEL "MLAB"
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 0 NumbanksINTEL 4
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 3 BankwidthINTEL 8
-; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 4 MaxconcurrencyINTEL 4
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 4 MaxPrivateCopiesINTEL 4
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 5 SinglepumpINTEL
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 6 DoublepumpINTEL
 
@@ -25,7 +25,7 @@ target triple = "spir64-unknown-linux"
 ; CHECK-LLVM: [[STR2:@[a-zA-Z0-9_.]+]] = {{.*}}{register:1}
 ; CHECK-LLVM: [[STR3:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:MLAB}
 ; CHECK-LLVM: [[STR4:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:8}
-; CHECK-LLVM: [[STR5:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{max_concurrency:4}
+; CHECK-LLVM: [[STR5:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{max_private_copies:4}
 ; CHECK-LLVM: [[STR6:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{pump:1}
 ; CHECK-LLVM: [[STR7:@[a-zA-Z0-9_.]+]] = {{.*}}{memory:DEFAULT}{pump:2}
 @.str = private unnamed_addr constant [29 x i8] c"{memory:DEFAULT}{numbanks:4}\00", section "llvm.metadata"
@@ -33,7 +33,7 @@ target triple = "spir64-unknown-linux"
 @.str.2 = private unnamed_addr constant [13 x i8] c"{register:1}\00", section "llvm.metadata"
 @.str.3 = private unnamed_addr constant [14 x i8] c"{memory:MLAB}\00", section "llvm.metadata"
 @.str.4 = private unnamed_addr constant [30 x i8] c"{memory:DEFAULT}{bankwidth:8}\00", section "llvm.metadata"
-@.str.5 = private unnamed_addr constant [36 x i8] c"{memory:DEFAULT}{max_concurrency:4}\00", section "llvm.metadata"
+@.str.5 = private unnamed_addr constant [39 x i8] c"{memory:DEFAULT}{max_private_copies:4}\00", section "llvm.metadata"
 @.str.6 = private unnamed_addr constant [25 x i8] c"{memory:DEFAULT}{pump:1}\00", section "llvm.metadata"
 @.str.7 = private unnamed_addr constant [25 x i8] c"{memory:DEFAULT}{pump:2}\00", section "llvm.metadata"
 
@@ -106,7 +106,7 @@ entry:
   ; CHECK-LLVM: %[[FIELD5:.*]] = getelementptr inbounds %struct.foo, %struct.foo* %{{[a-zA-Z0-9]+}}, i32 0, i32 4
   ; CHECK-LLVM: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[FIELD5]]{{.*}}[[STR5]]
   %f5 = getelementptr inbounds %struct.foo, %struct.foo* %s1, i32 0, i32 4
-  %13 = call i8* @llvm.ptr.annotation.p0i8(i8* %f5, i8* getelementptr inbounds ([36 x i8], [36 x i8]* @.str.5, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @.str.1, i32 0, i32 0), i32 6)
+  %13 = call i8* @llvm.ptr.annotation.p0i8(i8* %f5, i8* getelementptr inbounds ([39 x i8], [39 x i8]* @.str.5, i32 0, i32 0), i8* getelementptr inbounds ([16 x i8], [16 x i8]* @.str.1, i32 0, i32 0), i32 6)
   store i8 0, i8* %13, align 4, !tbaa !15
   ; CHECK-LLVM: %[[FIELD6:.*]] = getelementptr inbounds %struct.foo, %struct.foo* %{{[a-zA-Z0-9]+}}, i32 0, i32 5
   ; CHECK-LLVM: %[[CAST6:.*]] = bitcast{{.*}}%[[FIELD6]]


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-Registry/pull/34