### PR TITLE
Updates for LLVM changes to fix travis build

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -411,6 +411,8 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool IsClassMember) {
     if (!Name.empty()) {
       if (auto OldST = M->getTypeByName(Name))
         OldST->setName("");
+    } else {
+      Name = "structtype";
     }
     auto *StructTy = StructType::create(*Context, Name);
     mapType(ST, StructTy);

--- a/test/DebugInfo/X86/live-debug-variables.ll
+++ b/test/DebugInfo/X86/live-debug-variables.ll
@@ -29,7 +29,7 @@
 ; CHECK:      .debug_loc contents:
 ; CHECK-NEXT: 0x00000000:
 ;   We currently emit an entry for the function prologue, too, which could be optimized away.
-; CHECK:              [0x0000000000000018, 0x0000000000000072): DW_OP_reg3 RBX
+; CHECK:              [0x0000000000000010, 0x0000000000000072): DW_OP_reg3 RBX
 ;   We should only have one entry inside the function.
 ; CHECK-NOT: :
 

--- a/test/composite_construct_struct.spt
+++ b/test/composite_construct_struct.spt
@@ -52,7 +52,7 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: %[[struct0_type:[0-9]+]] = type { <2 x i32>, %[[struct1_type:[0-9]+]] }
+; CHECK-LLVM: %[[struct0_type:[0-9a-z\.]+]] = type { <2 x i32>, %[[struct1_type:[0-9a-z\.]+]] }
 ; CHECK-LLVM: %[[struct1_type]] = type { i32, i8 }
 ; CHECK-LLVM: %[[struct:[0-9]+]] = getelementptr inbounds %[[struct0_type]], %[[struct0_type]] addrspace(1)* %in, i64 %{{[0-9]*}}
 ; CHECK-LLVM: store %[[struct0_type]] { <2 x i32> <i32 -2100480000, i32 2100480000>, %[[struct1_type]] { i32 -2100483600, i8 -128 } }, %[[struct0_type]] addrspace(1)* %[[struct]]

--- a/test/opundef.spt
+++ b/test/opundef.spt
@@ -48,12 +48,12 @@
 
 ; CHECK: define spir_func void @foo() #0 {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: %agg1 = insertvalue %{{[0-9]*}} undef
+; CHECK-NEXT: %agg1 = insertvalue %{{[0-9a-z\.]*}} undef
 ; CHECK-NEXT: ret void
 ; CHECK-NEXT: }
 ; CHECK: define spir_func void @bar() #0 {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: %agg2 = insertvalue %{{[0-9]*}} undef
+; CHECK-NEXT: %agg2 = insertvalue %{{[0-9a-z\.]*}} undef
 ; CHECK-NEXT: ret void
 ; CHECK-NEXT: }
 

--- a/test/transcoding/enqueue_kernel.cl
+++ b/test/transcoding/enqueue_kernel.cl
@@ -32,10 +32,10 @@
 // CHECK-SPIRV: TypeFunction [[BlockTy3:[0-9]+]] [[VoidTy]] [[Int8PtrGenTy]]
 // CHECK-SPIRV: ConstantNull [[EventPtrTy]] [[EventNull:[0-9]+]]
 
-// CHECK-LLVM: [[BlockTy1:%[0-9]+]] = type { i32, i32, i8 addrspace(4)* }
-// CHECK-LLVM: [[BlockTy2:%[0-9]+]] = type <{ i32, i32, i8 addrspace(4)*, i32 addrspace(1)*, i32, i8 }>
-// CHECK-LLVM: [[BlockTy3:%[0-9]+]] = type <{ i32, i32, i8 addrspace(4)*, i32 addrspace(1)*, i32, i32 addrspace(1)* }>
-// CHECK-LLVM: [[BlockTy4:%[0-9]+]] = type <{ i32, i32, i8 addrspace(4)* }>
+// CHECK-LLVM: [[BlockTy1:%[0-9a-z\.]+]] = type { i32, i32, i8 addrspace(4)* }
+// CHECK-LLVM: [[BlockTy2:%[0-9a-z\.]+]] = type <{ i32, i32, i8 addrspace(4)*, i32 addrspace(1)*, i32, i8 }>
+// CHECK-LLVM: [[BlockTy3:%[0-9a-z\.]+]] = type <{ i32, i32, i8 addrspace(4)*, i32 addrspace(1)*, i32, i32 addrspace(1)* }>
+// CHECK-LLVM: [[BlockTy4:%[0-9a-z\.]+]] = type <{ i32, i32, i8 addrspace(4)* }>
 
 // CHECK-LLVM: @__block_literal_global = internal addrspace(1) constant [[BlockTy1]] { i32 12, i32 4, i8 addrspace(4)* addrspacecast (i8* null to i8 addrspace(4)*) }, align 4
 // CHECK-LLVM: @__block_literal_global.1 = internal addrspace(1) constant [[BlockTy1]] { i32 12, i32 4, i8 addrspace(4)* addrspacecast (i8* null to i8 addrspace(4)*) }, align 4

--- a/test/transcoding/kernel_query.ll
+++ b/test/transcoding/kernel_query.ll
@@ -38,7 +38,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: Name [[BlockGlb3:[0-9]+]] "__block_literal_global.2"
 ; CHECK-SPIRV: Name [[BlockGlb4:[0-9]+]] "__block_literal_global.3"
 
-; CHECK-LLVM: [[BlockTy:%[0-9]+]] = type { i32, i32 }
+; CHECK-LLVM: [[BlockTy:%[0-9a-z\.]+]] = type { i32, i32 }
 %1 = type <{ i32, i32 }>
 
 ; CHECK-LLVM: @__block_literal_global = internal addrspace(1) constant [[BlockTy]] { i32 8, i32 4 }, align 4


### PR DESCRIPTION
StructTypes without a name will be numbered like %0, %1, ..., which
can be confusing for humans reading the IR who might interpret these
as Values.

If the SPIRVType has no name, fill in a dummy name "structtype", which
LLVM will unique into "structtype.0", "structtype.1", ..., if
necessary.

This fixes the current travis failure
```error: use of undefined type named 'type 0x8f0150'
define spir_func void @foo(%0* byval(%"type 0x8f0150") %f) #0 !dbg !8 {
                                     ^
error: -: The file was not recognized as a valid object file
FileCheck error: '-' is empty.
FileCheck command line:  /usr/lib/llvm-9/bin/FileCheck /home/travis/build/KhronosGroup/SPIRV-LLVM-Translator/test/DebugInfo/UnknownBaseType.ll
```

Update a test for LLVM commit 891c55ccc57 ("[DebugInfo] Incorrect
debug info record generated for loop counter.", 2019-06-06).