### PR TITLE
Cherry-pick ed99fc0f92 from master

### DIFF
--- a/lib/SPIRV/Mangler/Mangler.cpp
+++ b/lib/SPIRV/Mangler/Mangler.cpp
@@ -92,11 +92,11 @@ public:
 #else
     std::string MangledPrimitive =
         std::string(mangledPrimitiveString(T->getPrimitive()));
-    // out of all enums it makes sense to substitute only
-    // memory_scope/memory_order since only they appear several times in the
-    // builtin declaration.
-    if (MangledPrimitive == "12memory_scope" ||
-        MangledPrimitive == "12memory_order") {
+    // Builtin primitives such as int are not substitution candidates, but
+    // all other primitives are.  Even though most of these do not appear
+    // repeatedly in builtin function signatures, we need to track them in
+    // the substitution map.
+    if (T->getPrimitive() >= PRIMITIVE_STRUCT_FIRST) {
       if (!mangleSubstitution(T, mangledPrimitiveString(T->getPrimitive()))) {
         size_t Index = Stream.str().size();
         Stream << mangledPrimitiveString(T->getPrimitive());

--- a/test/transcoding/OpImageSampleExplicitLod_arg.ll
+++ b/test/transcoding/OpImageSampleExplicitLod_arg.ll
@@ -51,7 +51,7 @@ entry:
 
   store <4 x float> %call1, <4 x float> addrspace(1)* %results, align 16
   %call2 = call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_fDv2_fDv2_f(%opencl.image2d_ro_t addrspace(1)* %image, %opencl.sampler_t* %imageSampler, <2 x float> %coord, <2 x float> %dx, <2 x float> %dy)
-; CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_fS_S_(%opencl.image2d_ro_t addrspace(1)* %image, %opencl.sampler_t* %imageSampler, <2 x float> %coord, <2 x float> %dx, <2 x float> %dy)
+; CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_fS1_S1_(%opencl.image2d_ro_t addrspace(1)* %image, %opencl.sampler_t* %imageSampler, <2 x float> %coord, <2 x float> %dx, <2 x float> %dy)
 
   store <4 x float> %call2, <4 x float> addrspace(1)* %results, align 16
   ret void

--- a/test/transcoding/enqueue_marker.cl
+++ b/test/transcoding/enqueue_marker.cl
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 -triple spir-unknown-unknown -finclude-default-header -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
+// RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+kernel void test_enqueue_marker(global int *out) {
+  queue_t queue = get_default_queue();
+
+  clk_event_t waitlist, evt;
+
+  // CHECK-SPIRV: EnqueueMarker
+  // CHECK-LLVM: _Z14enqueue_marker9ocl_queuejPK12ocl_clkeventPS0_
+  *out = enqueue_marker(queue, 1, &waitlist, &evt);
+}


### PR DESCRIPTION
enqueue_marker was incorrectly mangled because the `ocl_clkevent`
type was not considered for substitution.

This patch enables substitution for all primitive types (such as
queues and events) except simple builtin types (such as char or int).
This brings the mangling of enqueue_marker into alignment with clang.

This also aligns mangling for read_image-with-gradient variants with
clang, as image types are now also considered for substitution.