### PR TITLE
Support addrspacecast on SPIR-V built-in variables

### DIFF
--- a/test/builtin_vars.ll
+++ b/test/builtin_vars.ll
@@ -1,0 +1,22 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.out.bc
+; RUN: llvm-dis %t.out.bc -o - | FileCheck %s
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+@__spirv_BuiltInGlobalLinearId = external addrspace(1) global i32
+
+; Function Attrs: nounwind readnone
+define spir_kernel void @f() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
+entry:
+  %0 = load i32, i32 addrspace(4)* addrspacecast (i32 addrspace(1)* @__spirv_BuiltInGlobalLinearId to i32 addrspace(4)*), align 4
+  ; CHECK: %0 = call spir_func i32 @_Z20get_global_linear_idv() #1
+  ret void
+}
+
+attributes #0 = { alwaysinline nounwind readonly "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!0 = !{}


### PR DESCRIPTION
Before this patch, SPIR-V Translator assumed that a builtin global
variable can only be used by a load instruction (since all globals are
pointers). This patch adds support for addrspacecast instruction that
is followed by a load instruction.