### PR TITLE
Fix atomic functions pointers SPIRV -> LLVM

### DIFF
--- a/test/transcoding/AtomicCompareExchange_cl12.ll
+++ b/test/transcoding/AtomicCompareExchange_cl12.ll
@@ -15,8 +15,9 @@ target triple = "spir-unknown-unknown"
 ; CHECK-LABEL:   entry
 ; CHECK:         [[PTR:%expected[0-9]*]] = alloca i32, align 4
 ; CHECK:         store i32 {{.*}}, i32* [[PTR]]
+; CHECK:         %object.as = addrspacecast i32 addrspace(1)* %object to i32 addrspace(4)*
 ; CHECK:         [[PTR]].as = addrspacecast i32* [[PTR]] to i32 addrspace(4)*
-; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}%object, i32 addrspace(4)* [[PTR]].as, i32 %desired, i32 5, i32 5, i32 2)
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %object.as, i32 addrspace(4)* [[PTR]].as, i32 %desired, i32 5, i32 5, i32 2)
 ; CHECK-NEXT;         load i32* [[PTR]]
 define spir_func i32 @test(i32 addrspace(1)* %object, i32 %expected, i32 %desired) #0 {
 entry:

--- a/test/transcoding/atomics_1.2.ll
+++ b/test/transcoding/atomics_1.2.ll
@@ -17,63 +17,65 @@ target triple = "spir64-unknown-unknown"
 define spir_kernel void @test_atomic_global(i32 addrspace(1)* %dst) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
   ; atomic_inc
   %inc_ig = tail call spir_func i32 @_Z10atomic_incPVU3AS1i(i32 addrspace(1)* %dst) #0
-  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope(i32 addrspace(1)* {{.*}}, i32 1
+  ; CHECK: %dst.as = addrspacecast i32 addrspace(1)* %dst to i32 addrspace(4)*
+  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %dst.as, i32 1
   %dec_jg = tail call spir_func i32 @_Z10atomic_decPVU3AS1j(i32 addrspace(1)* %dst) #0
-  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope(i32 addrspace(1)* {{.*}}, i32 1
+  ; CHECK: %dst.as1 = addrspacecast i32 addrspace(1)* %dst to i32 addrspace(4)*
+  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %dst.as1, i32 1
 
   ; atomic_max
   %max_ig = tail call spir_func i32 @_Z10atomic_maxPVU3AS1ii(i32 addrspace(1)* %dst, i32 0) #0
-  ; CHECK: _Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_max_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %max_jg = tail call spir_func i32 @_Z10atomic_maxPVU3AS1jj(i32 addrspace(1)* %dst, i32 0) #0
-  ; CHECK: _Z25atomic_fetch_max_explicitPU3AS1VU7_Atomicjj12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_max_explicitPU3AS4VU7_Atomicjj12memory_order12memory_scope
 
   ; atomic_min
   %min_ig = tail call spir_func i32 @_Z10atomic_minPVU3AS1ii(i32 addrspace(1)* %dst, i32 0) #0
-  ; CHECK: _Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_min_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %min_jg = tail call spir_func i32 @_Z10atomic_minPVU3AS1jj(i32 addrspace(1)* %dst, i32 0) #0
-  ; CHECK: _Z25atomic_fetch_min_explicitPU3AS1VU7_Atomicjj12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_min_explicitPU3AS4VU7_Atomicjj12memory_order12memory_scope
 
   ; atomic_add
   %add_ig = tail call spir_func i32 @_Z10atomic_addPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %add_jg = tail call spir_func i32 @_Z10atomic_addPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_sub
   %sub_ig = tail call spir_func i32 @_Z10atomic_subPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %sub_jg = tail call spir_func i32 @_Z10atomic_subPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_or
   %or_ig = tail call spir_func i32 @_Z9atomic_orPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z24atomic_fetch_or_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z24atomic_fetch_or_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %or_jg = tail call spir_func i32 @_Z9atomic_orPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z24atomic_fetch_or_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z24atomic_fetch_or_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_xor
   %xor_ig = tail call spir_func i32 @_Z10atomic_xorPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_xor_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_xor_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %xor_jg = tail call spir_func i32 @_Z10atomic_xorPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_xor_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_xor_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_and
   %and_ig = tail call spir_func i32 @_Z10atomic_andPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_and_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_and_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %and_jg = tail call spir_func i32 @_Z10atomic_andPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_and_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_and_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_cmpxchg
   %cmpxchg_ig = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS1iii(i32 addrspace(1)* %dst, i32 0, i32 1) #0
-  ; CHECK: _Z39atomic_compare_exchange_strong_explicitPU3AS1VU7
+  ; CHECK: _Z39atomic_compare_exchange_strong_explicitPU3AS4VU7
   %cmpxchg_jg = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS1jjj(i32 addrspace(1)* %dst, i32 0, i32 1) #0
-  ; CHECK: _Z39atomic_compare_exchange_strong_explicitPU3AS1VU7
+  ; CHECK: _Z39atomic_compare_exchange_strong_explicitPU3AS4VU7
   
   ; atomic_xchg
   %xchg_ig = call spir_func i32 @_Z11atomic_xchgPVU3AS1ii(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z24atomic_exchange_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z24atomic_exchange_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %xchg_jg = call spir_func i32 @_Z11atomic_xchgPVU3AS1jj(i32 addrspace(1)* %dst, i32 1) #0
-  ; CHECK: _Z24atomic_exchange_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z24atomic_exchange_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   ret void
 }
 
@@ -81,65 +83,67 @@ define spir_kernel void @test_atomic_global(i32 addrspace(1)* %dst) #0 !kernel_a
 define spir_kernel void @test_atomic_local(i32 addrspace(3)* %dst) #0 !kernel_arg_addr_space !11 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
   ; atomic_inc
   %inc_il = tail call spir_func i32 @_Z10atomic_incPVU3AS3i(i32 addrspace(3)* %dst) #0
-  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope(i32 addrspace(3)* {{.*}}, i32 1
+  ; CHECK: %dst.as = addrspacecast i32 addrspace(3)* %dst to i32 addrspace(4)*
+  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %dst.as, i32 1
 
   ; atomic dec
   %dec_jl = tail call spir_func i32 @_Z10atomic_decPVU3AS3j(i32 addrspace(3)* %dst) #0
-  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope(i32 addrspace(3)* {{.*}}, i32 1
+  ; CHECK: %dst.as1 = addrspacecast i32 addrspace(3)* %dst to i32 addrspace(4)*
+  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %dst.as1, i32 1
 
   ; atomic_max
   %max_il = tail call spir_func i32 @_Z10atomic_maxPVU3AS3ii(i32 addrspace(3)* %dst, i32 0) #0
-  ; CHECK: _Z25atomic_fetch_max_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_max_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %max_jl = tail call spir_func i32 @_Z10atomic_maxPVU3AS3jj(i32 addrspace(3)* %dst, i32 0) #0
-  ; CHECK: _Z25atomic_fetch_max_explicitPU3AS3VU7_Atomicjj12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_max_explicitPU3AS4VU7_Atomicjj12memory_order12memory_scope
 
   ; atomic_min
   %min_il = tail call spir_func i32 @_Z10atomic_minPVU3AS3ii(i32 addrspace(3)* %dst, i32 0) #0
-  ; CHECK: _Z25atomic_fetch_min_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_min_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %min_jl = tail call spir_func i32 @_Z10atomic_minPVU3AS3jj(i32 addrspace(3)* %dst, i32 0) #0
-  ; CHECK: _Z25atomic_fetch_min_explicitPU3AS3VU7_Atomicjj12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_min_explicitPU3AS4VU7_Atomicjj12memory_order12memory_scope
 
   ; atomic_add
   %add_il = tail call spir_func i32 @_Z10atomic_addPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %add_jl = tail call spir_func i32 @_Z10atomic_addPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_sub
   %sub_il = tail call spir_func i32 @_Z10atomic_subPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %sub_jl = tail call spir_func i32 @_Z10atomic_subPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_or
   %or_il = tail call spir_func i32 @_Z9atomic_orPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z24atomic_fetch_or_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z24atomic_fetch_or_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %or_jl = tail call spir_func i32 @_Z9atomic_orPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z24atomic_fetch_or_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z24atomic_fetch_or_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_xor
   %xor_il = tail call spir_func i32 @_Z10atomic_xorPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_xor_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_xor_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %xor_jl = tail call spir_func i32 @_Z10atomic_xorPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_xor_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_xor_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_and
   %and_il = tail call spir_func i32 @_Z10atomic_andPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_and_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_and_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %and_jl = tail call spir_func i32 @_Z10atomic_andPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z25atomic_fetch_and_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z25atomic_fetch_and_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ; atomic_cmpxchg
   %cmpxchg_il = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS3iii(i32 addrspace(3)* %dst, i32 0, i32 1) #0
-  ; CHECK: _Z39atomic_compare_exchange_strong_explicitPU3AS3V
+  ; CHECK: _Z39atomic_compare_exchange_strong_explicitPU3AS4V
   %cmpxchg_jl = call spir_func i32 @_Z14atomic_cmpxchgPVU3AS3jjj(i32 addrspace(3)* %dst, i32 0, i32 1) #0
-  ; CHECK: _Z39atomic_compare_exchange_strong_explicitPU3AS3VU7
+  ; CHECK: _Z39atomic_compare_exchange_strong_explicitPU3AS4VU7
 
   ; atomic_xchg
   %xchg_il = call spir_func i32 @_Z11atomic_xchgPVU3AS3ii(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z24atomic_exchange_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z24atomic_exchange_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
   %xchg_jl = call spir_func i32 @_Z11atomic_xchgPVU3AS3jj(i32 addrspace(3)* %dst, i32 1) #0
-  ; CHECK: _Z24atomic_exchange_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope
+  ; CHECK: _Z24atomic_exchange_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope
 
   ret void
 }


### PR DESCRIPTION
OpenCL 1.2 allows to specify local and global address spaces for pointer
arguments in atomic function. OpenCL 2.0 uses generic address space for
all of them.