### PR TITLE
[DO NOT COMMIT] This patch shows lack of testing

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -110,7 +110,7 @@ bool SPIRVRegularizeLLVM::regularize() {
   LLVMContext *Context = &M->getContext();
 
   eraseUselessFunctions(M);
-  lowerFuncPtr(M);
+  //lowerFuncPtr(M);
   // lowerConstantExpressions();
 
   for (auto I = M->begin(), E = M->end(); I != E;) {


### PR DESCRIPTION
I've commented out lowerFuncPtr step from SPIRVRegularizeLLVM. I
expected to see some failed LIT tests, but everthing is okay.