### PR TITLE
Fix translation of undef initializers of LLVM structures

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -746,7 +746,7 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
       // Undef initializer for LLVM structure be can translated to
       // OpConstantComposite with OpUndef constituents.
       auto I = ValueMap.find(Init);
-      if (ValueMap.find(Init) == ValueMap.end()) {
+      if (I == ValueMap.end()) {
         std::vector<SPIRVValue *> Elements;
         for (Type *E : ST->elements())
           Elements.push_back(transValue(UndefValue::get(E), nullptr));

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -728,6 +728,7 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
     llvm::Value *Init = GV->hasInitializer() && !GV->hasCommonLinkage()
                             ? GV->getInitializer()
                             : nullptr;
+    SPIRVValue *BVarInit = nullptr;
     StructType *ST = Init ? dyn_cast<StructType>(Init->getType()) : nullptr;
     if (ST && ST->hasName() && isSPIRVConstantName(ST->getName())) {
       auto BV = transConstant(Init);
@@ -740,10 +741,22 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
         Ty = static_cast<PointerType *>(Init->getType());
       }
       Inst->dropAllReferences();
+      BVarInit = transValue(Init, nullptr);
+    } else if (ST && isa<UndefValue>(Init)) {
+      // Undef initializer for LLVM structure be can translated to
+      // OpConstantComposite with OpUndef constituents.
+      auto I = ValueMap.find(Init);
+      if (ValueMap.find(Init) == ValueMap.end()) {
+        std::vector<SPIRVValue *> Elements;
+        for (Type *E : ST->elements())
+          Elements.push_back(transValue(UndefValue::get(E), nullptr));
+        BVarInit = BM->addCompositeConstant(transType(ST), Elements);
+        ValueMap[Init] = BVarInit;
+      } else
+        BVarInit = I->second;
+    } else if (Init && !isa<UndefValue>(Init)) {
+      BVarInit = transValue(Init, nullptr);
     }
-    // Translate initializer first.
-    SPIRVValue *BVarInit =
-        (Init && !isa<UndefValue>(Init)) ? transValue(Init, nullptr) : nullptr;
 
     auto BVar = static_cast<SPIRVVariable *>(BM->addVariable(
         transType(Ty), GV->isConstant(), transLinkageType(GV), BVarInit,

--- a/test/undef_initializer.cpp
+++ b/test/undef_initializer.cpp
@@ -1,0 +1,26 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+
+%"struct.my_struct" = type { i8 }
+
+@__const.struct = private unnamed_addr addrspace(2) constant %"struct.my_struct" undef, align 1
+
+; CHECK-SPIRV: {{[0-9]+}} Undef {{[0-9]+}} [[UNDEF_ID:[0-9]+]]
+; CHECK-SPIRV: {{[0-9]+}} ConstantComposite {{[0-9]+}} [[CC_ID:[0-9]+]] [[UNDEF_ID]]
+; CHECK-SPIRV: {{[0-9]+}} Variable {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[CC_ID]]
+; CHECK-LLVM: @__const.struct = internal addrspace(2) constant %struct.my_struct undef, align 1
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{i32 1, i32 2}


### PR DESCRIPTION
Now if internal global constant has undef initializer SPIRV translator
will drop this initializer. It produces errors in translation back to
LLVM IR because internal global variables must have initializers.
Undef initializer for LLVM structure be can translated to OpConstantComposite
with OpUndef constituents.