### PR TITLE
Improve test coverage

### DIFF
--- a/test/transcoding/atomic_flag.cl
+++ b/test/transcoding/atomic_flag.cl
@@ -1,0 +1,33 @@
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+kernel void testAtomicFlag(global int *res) {
+  atomic_flag f;
+
+  *res = atomic_flag_test_and_set(&f);
+  *res += atomic_flag_test_and_set_explicit(&f, memory_order_seq_cst);
+  *res += atomic_flag_test_and_set_explicit(&f, memory_order_seq_cst, memory_scope_work_group);
+
+  atomic_flag_clear(&f);
+  atomic_flag_clear_explicit(&f, memory_order_seq_cst);
+  atomic_flag_clear_explicit(&f, memory_order_seq_cst, memory_scope_work_group);
+}
+
+// CHECK-SPIRV: AtomicFlagTestAndSet
+// CHECK-SPIRV: AtomicFlagTestAndSet
+// CHECK-SPIRV: AtomicFlagTestAndSet
+// CHECK-SPIRV: AtomicFlagClear
+// CHECK-SPIRV: AtomicFlagClear
+// CHECK-SPIRV: AtomicFlagClear
+
+// CHECK-LLVM-LABEL: @testAtomicFlag
+// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
+// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
+// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
+// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
+// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
+// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope

--- a/test/transcoding/atomic_load_store.ll
+++ b/test/transcoding/atomic_load_store.ll
@@ -6,14 +6,33 @@ target triple = "spir-unknown-unknown"
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; Check 'LLVM ==> SPIR-V ==> LLVM' conversion of atomic_store.
+; Check 'LLVM ==> SPIR-V ==> LLVM' conversion of atomic_load and atomic_store.
+
 
 ; Function Attrs: nounwind
 
-; CHECK-LLVM:         define spir_func void @test
+; CHECK-LLVM:         define spir_func i32 @test_load
+; CHECK-LLVM-LABEL:   entry
+; CHECK-LLVM:         call spir_func i32 @_Z20atomic_load_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(i32 addrspace(4)* %object, i32 5, i32 2)
+
+; CHECK-SPIRV-LABEL:  5 Function
+; CHECK-SPIRV-NEXT:   FunctionParameter {{[0-9]+}} [[object:[0-9]+]]
+; CHECK-SPIRV:        AtomicLoad {{[0-9]+}} [[ret:[0-9]+]] [[object]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV:        ReturnValue [[ret]]
+; CHECK-SPIRV-LABEL:  1 FunctionEnd
+
+; Function Attrs: nounwind
+define spir_func i32 @test_load(i32 addrspace(4)* %object) #0 {
+entry:
+  %0 = call spir_func i32 @_Z11atomic_loadPVU3AS4U7_Atomici(i32 addrspace(4)* %object) #2
+  ret i32 %0
+}
+
+; CHECK-LLVM:         define spir_func void @test_store
 ; CHECK-LLVM-LABEL:   entry
 ; CHECK-LLVM:         call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %object, i32 %desired, i32 5, i32 2)
 
@@ -25,11 +44,13 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV-LABEL:  1 FunctionEnd
 
 ; Function Attrs: nounwind
-define spir_func void @test(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #0 {
+define spir_func void @test_store(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #0 {
 entry:
   call spir_func void @_Z12atomic_storePVU3AS4U7_Atomicii(i32 addrspace(4)* %object, i32 %desired) #2
   ret void
 }
+
+declare spir_func i32 @_Z11atomic_loadPVU3AS4U7_Atomici(i32 addrspace(4)*) #1
 
 declare spir_func void @_Z12atomic_storePVU3AS4U7_Atomicii(i32 addrspace(4)*, i32) #1
 

--- a/test/transcoding/bit_ops.cl
+++ b/test/transcoding/bit_ops.cl
@@ -1,0 +1,19 @@
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+kernel void testBitOperations(int a, int b, int c, global int *res) {
+  *res = (a & b) | (0x6F ^ c);
+}
+
+// CHECK-SPIRV: BitwiseAnd
+// CHECK-SPIRV: BitwiseXor
+// CHECK-SPIRV: BitwiseOr
+
+// CHECK-LLVM-LABEL: @testBitOperations
+// CHECK-LLVM: and i32
+// CHECK-LLVM: xor i32
+// CHECK-LLVM: or i32

--- a/test/transcoding/clk_event_t.cl
+++ b/test/transcoding/clk_event_t.cl
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+// CHECK-SPIRV: TypeDeviceEvent
+// CHECK-SPIRV: 5 Function
+// CHECK-SPIRV: CreateUserEvent
+// CHECK-SPIRV: IsValidEvent
+// CHECK-SPIRV: RetainEvent
+// CHECK-SPIRV: SetUserEventStatus
+// CHECK-SPIRV: CaptureEventProfilingInfo
+// CHECK-SPIRV: ReleaseEvent
+// CHECK-SPIRV: FunctionEnd
+
+// CHECK-LLVM-LABEL: @clk_event_t_test
+// CHECK-LLVM: call spir_func %opencl.clk_event_t* @_Z17create_user_eventv()
+// CHECK-LLVM: call spir_func i1 @_Z14is_valid_event12ocl_clkevent
+// CHECK-LLVM: call spir_func void @_Z12retain_event12ocl_clkevent
+// CHECK-LLVM: call spir_func void @_Z21set_user_event_status12ocl_clkeventi(%opencl.clk_event_t* %{{[a-z]+}}, i32 -42)
+// CHECK-LLVM: call spir_func void @_Z28capture_event_profiling_info12ocl_clkeventiPU3AS1v(%opencl.clk_event_t* %{{[a-z]+}}, i32 1, i8 addrspace(1)* %prof)
+// CHECK-LLVM: call spir_func void @_Z13release_event12ocl_clkevent
+// CHECK-LLVM: ret
+
+kernel void clk_event_t_test(global int *res, global void *prof) {
+  clk_event_t e1 = create_user_event();
+  *res = is_valid_event(e1);
+  retain_event(e1);
+  set_user_event_status(e1, -42);
+  capture_event_profiling_info(e1, CLK_PROFILING_COMMAND_EXEC_TIME, prof);
+  release_event(e1);
+}

--- a/test/transcoding/relationals.ll
+++ b/test/transcoding/relationals.ll
@@ -10,6 +10,8 @@
 ; CHECK-LLVM: call spir_func i32 @_Z5isinff(
 ; CHECK-LLVM: call spir_func i32 @_Z8isnormalf(
 ; CHECK-LLVM: call spir_func i32 @_Z7signbitf(
+; CHECK-LLVM: call spir_func i32 @_Z9isorderedff(
+; CHECK-LLVM: call spir_func i32 @_Z11isunorderedff(
 
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z8isfiniteDv2_f(
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z5isnanDv2_f(
@@ -24,6 +26,8 @@
 ; CHECK-SPIRV: 4 IsInf [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolTypeID]]
 ; CHECK-SPIRV: 4 SignBitSet [[BoolTypeID]]
+; CHECK-SPIRV: 5 Ordered [[BoolTypeID]]
+; CHECK-SPIRV: 5 Unordered [[BoolTypeID]]
 
 ; CHECK-SPIRV: 4 IsFinite [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
@@ -45,7 +49,11 @@ entry:
   %add5 = add nsw i32 %add3, %call4
   %call6 = tail call spir_func i32 @_Z7signbitf(float %f) #2
   %add7 = add nsw i32 %add5, %call6
-  store i32 %add7, i32 addrspace(1)* %out, align 4
+  %call8 = tail call spir_func i32 @_Z9isorderedff(float %f, float %f) #2
+  %add9 = add nsw i32 %add7, %call8
+  %call10 = tail call spir_func i32 @_Z11isunorderedff(float %f, float %f) #2
+  %add11 = add nsw i32 %add9, %call10
+  store i32 %add11, i32 addrspace(1)* %out, align 4
   ret void
 }
 
@@ -56,6 +64,10 @@ declare spir_func i32 @_Z5isnanf(float) #1
 declare spir_func i32 @_Z5isinff(float) #1
 
 declare spir_func i32 @_Z8isnormalf(float) #1
+
+declare spir_func i32 @_Z9isorderedff(float, float) #1
+
+declare spir_func i32 @_Z11isunorderedff(float, float) #1
 
 declare spir_func i32 @_Z7signbitf(float) #1
 


### PR DESCRIPTION
Add or extend tests to improve testing coverage of:

 - the atomic_flag type,
 - bitwise operators,
 - clk_event_t builtins,
 - OpAtomicLoad,
 - OpDot