### PR TITLE
Fix Travis CI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ matrix:
 
 script:
   - |
+    pyenv global 3.7
+  - |
     if [ $BUILD_EXTERNAL == "0" ]; then
       mkdir llvm-spirv
       mv * llvm-spirv


### PR DESCRIPTION
Fixes #250 

Looks like something has changed in the Travis CI environment:
Before:
> Found PythonInterp: /opt/pyenv/shims/python2.7 (found version "2.7.12")

Now:
> Found PythonInterp: /opt/pyenv/shims/python3.7 (found version "1.4")

Due to some reason different python interpreter is being found and cmake
failed to identify it correctly

This PR tries to explicitly set python version