### PR TITLE
Fix build warnings

### DIFF
--- a/lib/SPIRV/Mangler/ManglingUtils.cpp
+++ b/lib/SPIRV/Mangler/ManglingUtils.cpp
@@ -279,10 +279,9 @@ const char *getSPIRVersionAsString(SPIRversion Version) {
     return "SPIR 1.2";
   case SPIR20:
     return "SPIR 2.0";
-  default:
-    assert(false && "Unknown SPIR Version");
-    return "Unknown SPIR Version";
   }
+  assert(false && "Unknown SPIR Version");
+  return "Unknown SPIR Version";
 }
 
 } // namespace SPIR

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1522,7 +1522,7 @@ protected:
     case OpTypeStruct:
       break;
     default:
-      static_assert("Invalid type", "");
+      assert(false && "Invalid type");
     }
   }
   std::vector<SPIRVId> Constituents;

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1517,6 +1517,7 @@ protected:
     case OpTypeVector:
       assert(getConstituents().size() > 1 &&
              "There must be at least two Constituent operands in vector");
+      break;
     case OpTypeArray:
     case OpTypeStruct:
       break;


### PR DESCRIPTION
Fix -Wimplicit-fallthrough warning

 * `unannotated fall-through between switch labels [-Wimplicit-fallthrough]`

Fix -Wcovered-switch-default warning

 * `default label in switch which covers all enumeration values [-Wcovered-switch-default]`