### PR TITLE
Refactor the way of atomics builtins mutations

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -101,6 +101,18 @@ public:
   /// workgroup/subgroup scope enums.
   std::string getGroupBuiltinPrefix(CallInst *CI);
 
+  /// Transform atomic common arguments like sema, scope to order(sema),
+  /// map(scope).
+  CallInst *mutateCommonAtomicArguments(CallInst *CI, Op OC);
+
+  /// Transform __spirv_OpAtomicCompareExchange and
+  /// __spirv_OpAtomicCompareExchangeWeak
+  Instruction *visitCallSPIRVAtomicCmpExchg(CallInst *CI, Op OC);
+
+  /// Transform __spirv_OpAtomicIIncrement/OpAtomicIDecrement to
+  /// atomic_fetch_add_explicit/atomic_fetch_sub_explicit
+  Instruction *visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC);
+
   /// Transform __spirv_Atomic* to atomic_*.
   ///   __spirv_Atomic*(atomic_op, scope, sema, ops, ...) =>
   ///      atomic_*(atomic_op, ops, ..., order(sema), map(scope))

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -90,7 +90,7 @@ public:
 
   /// Transform __spirv_* builtins to OCL 2.0 builtins.
   /// No change with arguments.
-  void visitCallSPIRVBuiltin(CallInst *CI, Op OC);
+  Instruction *visitCallSPIRVBuiltin(CallInst *CI, Op OC);
 
   /// Translate mangled atomic type name: "atomic_" =>
   ///   MangledAtomicTypeNamePrefix
@@ -111,7 +111,7 @@ public:
 
   /// Transform __spirv_OpAtomicIIncrement/OpAtomicIDecrement to
   /// atomic_fetch_add_explicit/atomic_fetch_sub_explicit
-  Instruction *visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC);
+  virtual Instruction *visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) = 0;
 
   /// Transform __spirv_Atomic* to atomic_*.
   ///   __spirv_Atomic*(atomic_op, scope, sema, ops, ...) =>

--- a/test/atomic_explicit_arguments.spt
+++ b/test/atomic_explicit_arguments.spt
@@ -38,8 +38,8 @@
 ; CHECK: entry:
 ; CHECK:   %call1 = call spir_func i32 @__translate_spirv_memory_scope(i32 %scope)
 ; CHECK:   %call2 = call spir_func i32 @__translate_spirv_memory_order(i32 %order)
-; CHECK:   %call.old = call spir_func i32 @_Z20atomic_load_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(i32 addrspace(4)* %obj, i32 %call2, i32 %call1)
-; CHECK:   ret i32 %call.old
+; CHECK:   %call = call spir_func i32 @_Z20atomic_load_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(i32 addrspace(4)* %obj, i32 %call2, i32 %call1)
+; CHECK:   ret i32 %call
 ; CHECK: }
 
 ; CHECK: define private spir_func i32 @__translate_spirv_memory_scope(i32 %key) {

--- a/test/transcoding/atomics_1.2.ll
+++ b/test/transcoding/atomics_1.2.ll
@@ -16,10 +16,10 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind
 define spir_kernel void @test_atomic_global(i32 addrspace(1)* %dst) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
   ; atomic_inc
-  %inc_ig = tail call spir_func i32 @_Z10atomic_incPVU3AS1i(i32 addrspace(1)* %dst) #0
-  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope(i32 addrspace(1)* {{.*}}, i32 1
-  %dec_jg = tail call spir_func i32 @_Z10atomic_decPVU3AS1j(i32 addrspace(1)* %dst) #0
-  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS1VU7_Atomicii12memory_order12memory_scope(i32 addrspace(1)* {{.*}}, i32 1
+  %inc_ig = tail call spir_func i32 @_Z10atomic_incPU3AS1Vi(i32 addrspace(1)* %dst) #0
+  ; CHECK: _Z10atomic_incPU3AS1Vi(i32 addrspace(1)* %dst) #0
+  %dec_jg = tail call spir_func i32 @_Z10atomic_decPU3AS1Vj(i32 addrspace(1)* %dst) #0
+  ; CHECK: _Z10atomic_decPU3AS1Vi(i32 addrspace(1)* %dst) #0
 
   ; atomic_max
   %max_ig = tail call spir_func i32 @_Z10atomic_maxPVU3AS1ii(i32 addrspace(1)* %dst, i32 0) #0
@@ -80,12 +80,12 @@ define spir_kernel void @test_atomic_global(i32 addrspace(1)* %dst) #0 !kernel_a
 ; Function Attrs: nounwind
 define spir_kernel void @test_atomic_local(i32 addrspace(3)* %dst) #0 !kernel_arg_addr_space !11 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
   ; atomic_inc
-  %inc_il = tail call spir_func i32 @_Z10atomic_incPVU3AS3i(i32 addrspace(3)* %dst) #0
-  ; CHECK: _Z25atomic_fetch_add_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope(i32 addrspace(3)* {{.*}}, i32 1
+  %inc_il = tail call spir_func i32 @_Z10atomic_incPU3AS3Vi(i32 addrspace(3)* %dst) #0
+  ; CHECK: _Z10atomic_incPU3AS3Vi(i32 addrspace(3)* %dst) #0
 
   ; atomic dec
-  %dec_jl = tail call spir_func i32 @_Z10atomic_decPVU3AS3j(i32 addrspace(3)* %dst) #0
-  ; CHECK: _Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicii12memory_order12memory_scope(i32 addrspace(3)* {{.*}}, i32 1
+  %dec_jl = tail call spir_func i32 @_Z10atomic_decPU3AS3Vj(i32 addrspace(3)* %dst) #0
+  ; CHECK: _Z10atomic_decPU3AS3Vi(i32 addrspace(3)* %dst) #0
 
   ; atomic_max
   %max_il = tail call spir_func i32 @_Z10atomic_maxPVU3AS3ii(i32 addrspace(3)* %dst, i32 0) #0
@@ -145,8 +145,8 @@ define spir_kernel void @test_atomic_local(i32 addrspace(3)* %dst) #0 !kernel_ar
 }
 
 ; Function Attrs: nounwind readnone
-declare spir_func i32 @_Z10atomic_incPVU3AS1i(i32 addrspace(1)*)
-declare spir_func i32 @_Z10atomic_decPVU3AS1j(i32 addrspace(1)*)
+declare spir_func i32 @_Z10atomic_incPU3AS1Vi(i32 addrspace(1)*)
+declare spir_func i32 @_Z10atomic_decPU3AS1Vj(i32 addrspace(1)*)
 declare spir_func i32 @_Z10atomic_maxPVU3AS1ii(i32 addrspace(1)*, i32)
 declare spir_func i32 @_Z10atomic_maxPVU3AS1jj(i32 addrspace(1)*, i32)
 declare spir_func i32 @_Z10atomic_minPVU3AS1ii(i32 addrspace(1)*, i32)
@@ -166,8 +166,8 @@ declare spir_func i32 @_Z14atomic_cmpxchgPVU3AS1jjj(i32 addrspace(1)*, i32, i32)
 declare spir_func i32 @_Z11atomic_xchgPVU3AS1ii(i32 addrspace(1)*, i32)
 declare spir_func i32 @_Z11atomic_xchgPVU3AS1jj(i32 addrspace(1)*, i32)
 
-declare spir_func i32 @_Z10atomic_incPVU3AS3i(i32 addrspace(3)*)
-declare spir_func i32 @_Z10atomic_decPVU3AS3j(i32 addrspace(3)*)
+declare spir_func i32 @_Z10atomic_incPU3AS3Vi(i32 addrspace(3)*)
+declare spir_func i32 @_Z10atomic_decPU3AS3Vj(i32 addrspace(3)*)
 declare spir_func i32 @_Z10atomic_maxPVU3AS3ii(i32 addrspace(3)*, i32)
 declare spir_func i32 @_Z10atomic_maxPVU3AS3jj(i32 addrspace(3)*, i32)
 declare spir_func i32 @_Z10atomic_minPVU3AS3ii(i32 addrspace(3)*, i32)


### PR DESCRIPTION
This PR contains the following changes:

- 5a8e4e9 : Our target is to seperate the code responsible for ocl-specific mutations into SPIRVToOCL-specific passes. With this change it's easier to introduce different logic for OpenCL 2.0 and OpenCL1.2 mutations.
- 6c91d56 : Fix translation of OpAtomicIIncrement and OpAtomicIDecrement opcodes for OpenCL 1.2. Those builtins were translated into OpenCL 2.0 version (even if target version was 1.2), but with wrong pointer address space (not generic). So the output for 1.2 kernel was incorrect 2.0 version of builtin.
This patch introduces translation to atomic_inc and atomic_dec builtins for OpenCL1.2.