### PR TITLE
travis: Switch to LLVM GitHub monorepo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
       mkdir llvm-spirv
       mv * llvm-spirv
       git clone https://github.com/llvm/llvm-project --depth 1
-      mv llvm-spirv llvm-project/llvm/tools/llvm-spirv
+      mv llvm-spirv llvm-project/llvm-spirv
     fi
   - |
     if [ $TRAVIS_OS_NAME == "osx" ]; then
@@ -99,6 +99,7 @@ script:
           -G "Unix Makefiles"
       fi
     else
+      BUILDDIR=$(pwd)
       cmake ../llvm-project/llvm/ \
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DBUILD_SHARED_LIBS=${SHARED_LIBS} \
@@ -108,6 +109,9 @@ script:
         -DSPIRV_SKIP_CLANG_BUILD=ON \
         -DSPIRV_SKIP_DEBUG_INFO_TESTS=ON \
         -DLLVM_LIT_ARGS="-sv --no-progress-bar" \
+        -DLLVM_EXTERNAL_PROJECTS="llvm-spirv" \
+        -DLLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR=${BUILDDIR}/../llvm-project/llvm-spirv \
+        -DLLVM_ENABLE_PROJECTS="llvm-spirv" \
         -G "Unix Makefiles"
       ln -s /usr/lib/llvm-9/bin/clang bin/
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,8 +74,8 @@ script:
     if [ $BUILD_EXTERNAL == "0" ]; then
       mkdir llvm-spirv
       mv * llvm-spirv
-      git clone https://git.llvm.org/git/llvm.git/ --depth 1
-      mv llvm-spirv llvm/tools/llvm-spirv
+      git clone https://github.com/llvm/llvm-project --depth 1
+      mv llvm-spirv llvm-project/llvm/tools/llvm-spirv
     fi
   - |
     if [ $TRAVIS_OS_NAME == "osx" ]; then
@@ -99,7 +99,7 @@ script:
           -G "Unix Makefiles"
       fi
     else
-      cmake ../llvm/ \
+      cmake ../llvm-project/llvm/ \
         -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
         -DBUILD_SHARED_LIBS=${SHARED_LIBS} \
         -DLLVM_BUILD_TOOLS=ON \


### PR DESCRIPTION
The community is now advising that all workflows and CI systems
migrate to the GitHub monorepo, see [1] and [2].

[1] http://lists.llvm.org/pipermail/llvm-dev/2019-July/133840.html
[2] http://llvm.org/GitHubMigrationStatus.html