### PR TITLE
Fix Intel FPGA decorations for structure variables

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2503,21 +2503,21 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
             Builder.CreateCall(AnnotationFn, Args);
           }
         }
-      } else {
-        SmallString<256> AnnotStr;
-        generateIntelFPGAAnnotation(BV, AnnotStr);
-        if (!AnnotStr.empty()) {
-          auto *GS = Builder.CreateGlobalStringPtr(AnnotStr);
+      }
 
-          auto AnnotationFn =
-              llvm::Intrinsic::getDeclaration(M, Intrinsic::var_annotation);
+      SmallString<256> AnnotStr;
+      generateIntelFPGAAnnotation(BV, AnnotStr);
+      if (!AnnotStr.empty()) {
+        auto *GS = Builder.CreateGlobalStringPtr(AnnotStr);
 
-          llvm::Value *Args[] = {
-              Builder.CreateBitCast(V, Int8PtrTyPrivate, V->getName()),
-              Builder.CreateBitCast(GS, Int8PtrTyPrivate), UndefInt8Ptr,
-              UndefInt32};
-          Builder.CreateCall(AnnotationFn, Args);
-        }
+        auto AnnotationFn =
+            llvm::Intrinsic::getDeclaration(M, Intrinsic::var_annotation);
+
+        llvm::Value *Args[] = {
+            Builder.CreateBitCast(V, Int8PtrTyPrivate, V->getName()),
+            Builder.CreateBitCast(GS, Int8PtrTyPrivate), UndefInt8Ptr,
+            UndefInt32};
+        Builder.CreateCall(AnnotationFn, Args);
       }
     }
   }


### PR DESCRIPTION
After consumption back to LLVM IR, if a variable that had Intel FPGA
decoration attached was a type of struct - the needed
@llvm.var.annotation wasn't generated.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>