### PR TITLE
Move target triple check before translation

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1454,9 +1454,6 @@ SPIRVValue *LLVMToSPIRV::transCallInst(CallInst *CI, SPIRVBasicBlock *BB) {
 bool LLVMToSPIRV::transAddressingMode() {
   Triple TargetTriple(M->getTargetTriple());
 
-  SPIRVCKRT(isSupportedTriple(TargetTriple), InvalidTargetTriple,
-            "Actual target triple is " + M->getTargetTriple());
-
   if (TargetTriple.isArch32Bit())
     BM->setAddressingModel(AddressingModelPhysical32);
   else
@@ -1949,8 +1946,23 @@ void addPassesForSPIRV(legacy::PassManager &PassMgr) {
   PassMgr.add(createSPIRVLowerMemmove());
 }
 
+bool isValidLLVMModule(Module *M, SPIRVErrorLog &ErrorLog) {
+  if (!M)
+    return false;
+
+  Triple TT(M->getTargetTriple());
+  if (!ErrorLog.checkError(isSupportedTriple(TT), SPIRVEC_InvalidTargetTriple,
+                           "Actual target triple is " + M->getTargetTriple()))
+    return false;
+
+  return true;
+}
+
 bool llvm::writeSpirv(Module *M, std::ostream &OS, std::string &ErrMsg) {
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
+  if (!isValidLLVMModule(M, BM->getErrorLog()))
+    return false;
+
   legacy::PassManager PassMgr;
   addPassesForSPIRV(PassMgr);
   if (hasLoopUnrollMetadata(M))
@@ -1966,6 +1978,9 @@ bool llvm::writeSpirv(Module *M, std::ostream &OS, std::string &ErrMsg) {
 
 bool llvm::regularizeLlvmForSpirv(Module *M, std::string &ErrMsg) {
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
+  if (!isValidLLVMModule(M, BM->getErrorLog()))
+    return false;
+
   legacy::PassManager PassMgr;
   addPassesForSPIRV(PassMgr);
   PassMgr.run(*M);

--- a/test/negative/unsupported-triple.ll
+++ b/test/negative/unsupported-triple.ll
@@ -1,0 +1,20 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+
+; CHECK: InvalidTargetTriple: Expects spir-unknown-unknown or spir64-unknown-unknown. Actual target triple is aarch64
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "aarch64"
+
+; Function Attrs: convergent noinline nounwind optnone
+define spir_func void @_Z3foov() {
+entry:
+  ret void
+}
+
+!llvm.module.flags = !{!0}
+!opencl.spir.version = !{!1}
+!opencl.ocl.version = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}


### PR DESCRIPTION
Check that the target triple is supported before LLVM to SPIR-V
translation, rather than during translation.  This allows us to
gracefully report InvalidTargetTriple instead of failing the target
triple assertion in PreprocessMetadata.cpp.