### PR TITLE
Changing deploy mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ git:
 branches:
   only:
     - llvm_release_80
+# From https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches
+# "Note that safelisting also prevents tagged commits from being built.
+#  If you consistently tag your builds in the format v1.3 you can safelist them
+#  all with regular expressions, for example /^v\d+\.\d+(\.\d+)?(-\S*)?$/."
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 
 addons:
   apt:
@@ -109,30 +114,16 @@ script:
       make $MAKE_TARGETS && make $MAKE_TEST_TARGET && if [ $BUILD_EXTERNAL == "1" ]; then make install; fi
     fi
 
-
-after_success:
-  # Create tarball for deployment
-  - if [[ "${BUILD_EXTERNAL}" == "1" && "${SHARED_LIBS}" == "ON" && "${repo_token}" != "" ]]; then
-      export TAG=v8.0.1-1;
-      export TARBALL=SPIRV-LLVM-Translator-${TAG}-${TRAVIS_OS_NAME}-${BUILD_TYPE}.zip;
-      cd ../install && find . -print | zip -@ ${TARBALL};
-    fi
-
 before_deploy:
-  # Travis CI relies on the tag name to push to the correct release.
-  - git config --global user.name "Travis CI"
-  - git config --global user.email "builds@travis-ci.org"
-  - git tag -f ${TAG}
-  - git push -f https://${repo_token}@github.com/${TRAVIS_REPO_SLUG} --tags
+  - export TARBALL=SPIRV-LLVM-Translator-${TRAVIS_TAG}-${TRAVIS_OS_NAME}-${BUILD_TYPE}.zip;
+  - cd ../install && find . -print | zip -@ ${TARBALL};
 
 deploy:
   provider: releases
   api_key: ${repo_token}
   on:
-    branch: llvm_release_80
+    tags: true
     condition: ${BUILD_EXTERNAL} == 1 && ${SHARED_LIBS} == ON && ${repo_token}
   file: ${TARBALL}
-  name: Binaries linked against LLVM 8.0.1
   skip_cleanup: true
-  overwrite: true
-  prerelease: false
+  overwrite: false


### PR DESCRIPTION
Currently every commit on a release branch can overwrite published release
on github. New approach in this patch presumes that releases will be done
manually via web interface on github. This will trigger another build in
travis, which in turn will deploy build aritfacts on github.