### PR TITLE
Update deploy mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ git:
 branches:
   only:
     - master
+    - /llvm_release_\d+$/
+# From https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches
+# "Note that safelisting also prevents tagged commits from being built.
+#  If you consistently tag your builds in the format v1.3 you can safelist them
+#  all with regular expressions, for example /^v\d+\.\d+(\.\d+)?(-\S*)?$/."
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 
 addons:
   apt:
@@ -127,32 +133,40 @@ script:
       make $MAKE_TARGETS && make $MAKE_TEST_TARGET && if [ $BUILD_EXTERNAL == "1" ]; then make install; fi
     fi
 
-after_success:
-  # Create tarball for deployment
-  - if [[ "${BUILD_EXTERNAL}" == "1" && "${SHARED_LIBS}" == "ON" && "${repo_token}" != "" ]]; then
-      export TAG=dev-build;
-      export TARBALL=SPIRV-LLVM-Translator-${TAG}-${TRAVIS_OS_NAME}-${BUILD_TYPE}.zip;
-      cd ../install;
-      echo ${TRAVIS_COMMIT} > version.txt;
-      find . -print | zip -@ ${TARBALL};
-    fi
-
 before_deploy:
-  # Tag the current master top of the tree as "latest".
   # Travis CI relies on the tag name to push to the correct release.
-  - git config --global user.name "Travis CI"
-  - git config --global user.email "builds@travis-ci.org"
-  - git tag -f ${TAG}
-  - git push -f https://${repo_token}@github.com/${TRAVIS_REPO_SLUG} --tags
+  # Tag the current master top of the tree as "dev-build".
+  # We must be very careful with "git push -f" and allow it ONLY
+  # for the "dev-build" tag!
+  - if [[ "${TRAVIS_BRANCH}" == "master" && -z "${TRAVIS_TAG}" ]]; then
+      export TRAVIS_TAG=dev-build;
+      git config --global user.name "Travis CI";
+      git config --global user.email "builds@travis-ci.org";
+      git tag -f ${TRAVIS_TAG};
+      git push -f https://${repo_token}@github.com/${TRAVIS_REPO_SLUG} --tags;
+    fi
+  # Create tarball for deployment
+  - echo ${TRAVIS_COMMIT} > ../install/version.txt;
+  - export TARBALL=SPIRV-LLVM-Translator-${TRAVIS_TAG}-${TRAVIS_OS_NAME}-${BUILD_TYPE}.zip;
+  - cd ../install && find . -print | zip -@ ${TARBALL};
 
 deploy:
-  provider: releases
-  api_key: ${repo_token}
-  on:
-    branch: master
-    condition: ${BUILD_EXTERNAL} == 1 && ${SHARED_LIBS} == ON && ${repo_token}
-  file: ${TARBALL}
-  name: Latest development build $(date -u +'%F %R %Z')
-  skip_cleanup: true
-  overwrite: true
-  prerelease: true
+  - provider: releases
+    api_key: ${repo_token}
+    on:
+      tags: true
+      condition: ${BUILD_EXTERNAL} == 1 && ${SHARED_LIBS} == ON && ${repo_token}
+    file: ${TARBALL}
+    skip_cleanup: true
+    overwrite: false
+  - provider: releases
+    api_key: ${repo_token}
+    on:
+      tags: false
+      branch: master
+      condition: ${BUILD_EXTERNAL} == 1 && ${SHARED_LIBS} == ON && ${repo_token}
+    file: ${TARBALL}
+    name: Latest development build $(date -u +'%F %R %Z')
+    skip_cleanup: true
+    overwrite: true
+    prerelease: true


### PR DESCRIPTION
Updated travis config should support 2 use cases:
1. Ongoing development - after commit to the master branch build artifacts
   should be published as a pre-release. For this purpose we maintain the
   "dev-build" tag which is always pointing to the tip of master branch.
2. Creating a release - when we are ready to make a release from a release
   branch we push a tag via command line or github web interface(preferred).
   This triggers a travis build and deploy of binaries.