### PR TITLE
Add default mask for getOrCreateSwitchFunc

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -481,7 +481,7 @@ Instruction *
 getOrCreateSwitchFunc(StringRef MapName, Value *V,
                       const SPIRVMap<KeyTy, ValTy, Identifier> &Map,
                       bool IsReverse, Optional<int> DefaultCase,
-                      Instruction *InsertPoint, Module *M) {
+                      Instruction *InsertPoint, Module *M, int KeyMask = 0) {
   static_assert(std::is_convertible<KeyTy, int>::value &&
                     std::is_convertible<ValTy, int>::value,
                 "Can map only integer values");
@@ -496,8 +496,17 @@ getOrCreateSwitchFunc(StringRef MapName, Value *V,
   LLVMContext &Ctx = M->getContext();
   BasicBlock *BB = BasicBlock::Create(Ctx, "entry", F);
   IRBuilder<> IRB(BB);
+  SwitchInst *SI;
   F->arg_begin()->setName("key");
-  SwitchInst *SI = IRB.CreateSwitch(F->arg_begin(), BB);
+  if (KeyMask) {
+    Value *MaskV = ConstantInt::get(Type::getInt32Ty(Ctx), KeyMask);
+    Value *NewKey = IRB.CreateAnd(MaskV, F->arg_begin());
+    NewKey->setName("key.masked");
+    SI = IRB.CreateSwitch(NewKey, BB);
+  } else {
+    SI = IRB.CreateSwitch(F->arg_begin(), BB);
+  }
+
   if (!DefaultCase) {
     BasicBlock *DefaultBB = BasicBlock::Create(Ctx, "default", F);
     IRBuilder<> DefaultIRB(DefaultBB);

--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -133,10 +133,13 @@ void SPIRVToOCL12::visitCallSPIRVMemoryBarrier(CallInst *CI) {
           if (F && F->getName().equals(kSPIRVName::TranslateOCLMemScope)) {
             Args[0] = TransCall->getArgOperand(0);
           } else {
-            Args[0] = getOrCreateSwitchFunc(kSPIRVName::TranslateSPIRVMemFence,
-                                            Args[1],
-                                            OCLMemFenceExtendedMap::getRMap(),
-                                            true /*IsReverse*/, None, CI, M);
+            int ClMemFenceMask = MemorySemanticsWorkgroupMemoryMask |
+                                 MemorySemanticsCrossWorkgroupMemoryMask |
+                                 MemorySemanticsImageMemoryMask;
+            Args[0] = getOrCreateSwitchFunc(
+                kSPIRVName::TranslateSPIRVMemFence, Args[1],
+                OCLMemFenceExtendedMap::getRMap(), true /*IsReverse*/, None, CI,
+                M, ClMemFenceMask);
           }
           Args.resize(1);
         }
@@ -162,10 +165,13 @@ void SPIRVToOCL12::visitCallSPIRVControlBarrier(CallInst *CI) {
           if (F && F->getName().equals(kSPIRVName::TranslateOCLMemScope)) {
             Args[0] = TransCall->getArgOperand(0);
           } else {
-            Args[0] = getOrCreateSwitchFunc(kSPIRVName::TranslateSPIRVMemFence,
-                                            Args[2],
-                                            OCLMemFenceExtendedMap::getRMap(),
-                                            true /*IsReverse*/, None, CI, M);
+            int ClMemFenceMask = MemorySemanticsWorkgroupMemoryMask |
+                                 MemorySemanticsCrossWorkgroupMemoryMask |
+                                 MemorySemanticsImageMemoryMask;
+            Args[0] = getOrCreateSwitchFunc(
+                kSPIRVName::TranslateSPIRVMemFence, Args[2],
+                OCLMemFenceExtendedMap::getRMap(), true /*IsReverse*/, None, CI,
+                M, ClMemFenceMask);
           }
           Args.resize(1);
         }

--- a/test/barrier_explicit_arguments.spt
+++ b/test/barrier_explicit_arguments.spt
@@ -33,7 +33,8 @@
 ; CHECK: call spir_func void @_Z7barrierj(i32 %call)
 ; CHECK: define private spir_func i32 @__translate_spirv_memory_fence(i32 %key)
 ; CHECK: entry:
-; CHECK:   switch i32 %key, label %default [
+; CHECK:   %key.masked = and i32 2816, %key
+; CHECK:   switch i32 %key.masked, label %default [
 ; CHECK:     i32 256, label %case.256
 ; CHECK:     i32 512, label %case.512
 ; CHECK:     i32 768, label %case.768

--- a/test/mem_fence_explicit_arguments.spt
+++ b/test/mem_fence_explicit_arguments.spt
@@ -33,7 +33,8 @@
 ; CHECK: call spir_func void @_Z9mem_fencej(i32 %call)
 ; CHECK: define private spir_func i32 @__translate_spirv_memory_fence(i32 %key)
 ; CHECK: entry:
-; CHECK:   switch i32 %key, label %default [
+; CHECK:   %key.masked = and i32 2816, %key
+; CHECK:   switch i32 %key.masked, label %default [
 ; CHECK:     i32 256, label %case.256
 ; CHECK:     i32 512, label %case.512
 ; CHECK:     i32 768, label %case.768


### PR DESCRIPTION
It fixes a wrong switch generation with translation of
ControlBarrier and MemoryBarrier instructions back to
LLVM IR.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>