### PR TITLE
Add SPIR-V assembly tests and fix translation of OpLogicalNot

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ make llvm-spirv -j`nproc`
 
 ## Test instructions
 
-All tests related to the translator are placed in the [test](test) directory. Optionally the tests can make use of spirv-val (part of SPIRV-Tools) in order to validate the generated SPIR-V against the official SPIR-V specification.
+All tests related to the translator are placed in the [test](test) directory. A number of the tests require spirv-as (part of SPIR-V Tools) to run, but the remainder of the tests can still be run without this. Optionally the tests can make use of spirv-val (part of SPIRV-Tools) in order to validate the generated SPIR-V against the official SPIR-V specification.
+
 In case tests are failing due to SPIRV-Tools not supporting certain SPIR-V features, please get an updated package. The `PKG_CONFIG_PATH` environmental variable can be used to let cmake point to a custom installation.
 
 Execute the following command inside the build directory to run translator tests:

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1744,7 +1744,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
                                        BV->getName(), BB));
   }
 
-  case OpNot: {
+  case OpNot:
+  case OpLogicalNot: {
     SPIRVUnary *BC = static_cast<SPIRVUnary *>(BV);
     return mapValue(
         BV, BinaryOperator::CreateNot(transValue(BC->getOperand(0), F, BB),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,11 +10,22 @@ set(LLVM_SPIRV_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # find spirv-val
 pkg_search_module(SPIRV_TOOLS SPIRV-Tools)
 if(SPIRV_TOOLS_FOUND)
+  find_program(SPIRV_TOOLS_SPIRV_AS NAMES spirv-as PATHS ${SPIRV_TOOLS_PREFIX}/bin)
+  if(SPIRV_TOOLS_SPIRV_AS)
+    set(SPIRV_TOOLS_SPIRV_AS_FOUND True)
+  endif()
+
   find_program(SPIRV_TOOLS_SPIRV_VAL NAMES spirv-val PATHS ${SPIRV_TOOLS_PREFIX}/bin)
   if(SPIRV_TOOLS_SPIRV_VAL)
-    get_filename_component(SPIRV_TOOLS_BINDIR "${SPIRV_TOOLS_SPIRV_VAL}" DIRECTORY)
     set(SPIRV_TOOLS_SPIRV_VAL_FOUND True)
   endif()
+
+  set(SPIRV_TOOLS_BINDIR "${SPIRV_TOOLS_PREFIX}/bin")
+endif()
+
+if(NOT SPIRV_TOOLS_SPIRV_AS)
+  message(WARNING "spirv-as not found! SPIR-V assembly tests will not be run.")
+  set(SPIRV_TOOLS_SPIRV_AS_FOUND False)
 endif()
 
 if(NOT SPIRV_TOOLS_SPIRV_VAL)

--- a/test/OpFNegate.spvasm
+++ b/test/OpFNegate.spvasm
@@ -1,0 +1,19 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testFNegate"
+               OpName %a "a"
+       %void = OpTypeVoid
+      %float = OpTypeFloat 32
+          %5 = OpTypeFunction %void %float
+          %1 = OpFunction %void None %5
+          %a = OpFunctionParameter %float
+          %6 = OpLabel
+          %7 = OpFNegate %float %a
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: fsub float -0.000000e+00, %a

--- a/test/OpFRem.spvasm
+++ b/test/OpFRem.spvasm
@@ -1,0 +1,21 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testFRem"
+               OpName %a "a"
+               OpName %b "b"
+       %void = OpTypeVoid
+      %float = OpTypeFloat 32
+          %5 = OpTypeFunction %void %float %float
+          %1 = OpFunction %void None %5
+          %a = OpFunctionParameter %float
+          %b = OpFunctionParameter %float
+          %6 = OpLabel
+          %7 = OpFRem %float %a %b
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: frem float %a, %b

--- a/test/OpLogicalAnd.spvasm
+++ b/test/OpLogicalAnd.spvasm
@@ -1,0 +1,24 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testLogicalAnd"
+               OpName %a "a"
+               OpName %b "b"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+%_ptr_CrossWorkgroup_bool = OpTypePointer CrossWorkgroup %bool
+          %7 = OpTypeFunction %void %_ptr_CrossWorkgroup_bool %_ptr_CrossWorkgroup_bool
+          %1 = OpFunction %void None %7
+          %8 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+          %9 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+         %10 = OpLabel
+          %a = OpLoad %bool %8 Aligned 8
+          %b = OpLoad %bool %9 Aligned 8
+         %11 = OpLogicalAnd %bool %a %b
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: and i1 {{%a, %b|%b, %a}}

--- a/test/OpLogicalEqual.spvasm
+++ b/test/OpLogicalEqual.spvasm
@@ -1,0 +1,24 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testLogicalEqual"
+               OpName %a "a"
+               OpName %b "b"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+%_ptr_CrossWorkgroup_bool = OpTypePointer CrossWorkgroup %bool
+          %7 = OpTypeFunction %void %_ptr_CrossWorkgroup_bool %_ptr_CrossWorkgroup_bool
+          %1 = OpFunction %void None %7
+          %8 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+          %9 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+         %10 = OpLabel
+          %a = OpLoad %bool %8 Aligned 8
+          %b = OpLoad %bool %9 Aligned 8
+         %11 = OpLogicalEqual %bool %a %b
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: icmp eq i1 {{%a, %b|%b, %a}}

--- a/test/OpLogicalNot.spvasm
+++ b/test/OpLogicalNot.spvasm
@@ -1,6 +1,4 @@
 ; REQUIRES: spirv-as
-; TODO: OpLogicalNot cannot currently be translated
-; XFAIL: *
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
                OpCapability Addresses

--- a/test/OpLogicalNot.spvasm
+++ b/test/OpLogicalNot.spvasm
@@ -1,0 +1,23 @@
+; REQUIRES: spirv-as
+; TODO: OpLogicalNot cannot currently be translated
+; XFAIL: *
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testLogicalNot"
+               OpName %a "a"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+%_ptr_CrossWorkgroup_bool = OpTypePointer CrossWorkgroup %bool
+          %7 = OpTypeFunction %void %_ptr_CrossWorkgroup_bool
+          %1 = OpFunction %void None %7
+          %8 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+          %9 = OpLabel
+          %a = OpLoad %bool %8 Aligned 8
+         %10 = OpLogicalNot %bool %a
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: xor i1 {{%a, true|true, %a}}

--- a/test/OpLogicalNotEqual.spvasm
+++ b/test/OpLogicalNotEqual.spvasm
@@ -1,0 +1,24 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testLogicalNotEqual"
+               OpName %a "a"
+               OpName %b "b"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+%_ptr_CrossWorkgroup_bool = OpTypePointer CrossWorkgroup %bool
+          %7 = OpTypeFunction %void %_ptr_CrossWorkgroup_bool %_ptr_CrossWorkgroup_bool
+          %1 = OpFunction %void None %7
+          %8 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+          %9 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+         %10 = OpLabel
+          %a = OpLoad %bool %8 Aligned 8
+          %b = OpLoad %bool %9 Aligned 8
+         %11 = OpLogicalNotEqual %bool %a %b
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: icmp ne i1 {{%a, %b|%b, %a}}

--- a/test/OpLogicalOr.spvasm
+++ b/test/OpLogicalOr.spvasm
@@ -1,0 +1,24 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testLogicalOr"
+               OpName %a "a"
+               OpName %b "b"
+       %void = OpTypeVoid
+       %bool = OpTypeBool
+%_ptr_CrossWorkgroup_bool = OpTypePointer CrossWorkgroup %bool
+          %7 = OpTypeFunction %void %_ptr_CrossWorkgroup_bool %_ptr_CrossWorkgroup_bool
+          %1 = OpFunction %void None %7
+          %8 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+          %9 = OpFunctionParameter %_ptr_CrossWorkgroup_bool
+         %10 = OpLabel
+          %a = OpLoad %bool %8 Aligned 8
+          %b = OpLoad %bool %9 Aligned 8
+         %11 = OpLogicalOr %bool %a %b
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: or i1 {{%a, %b|%b, %a}}

--- a/test/OpNop.spvasm
+++ b/test/OpNop.spvasm
@@ -1,0 +1,20 @@
+; REQUIRES: spirv-as
+; TODO: OpNop cannot currently be decoded
+; XFAIL: *
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testNop"
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+          %5 = OpTypeFunction %void
+          %1 = OpFunction %void None %5
+          %6 = OpLabel
+               OpNop
+               OpReturn
+               OpFunctionEnd
+
+; CHECK-LABEL: @testNop
+; CHECK-NEXT: ret

--- a/test/OpNot.spvasm
+++ b/test/OpNot.spvasm
@@ -1,0 +1,19 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testNot"
+               OpName %a "a"
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+          %5 = OpTypeFunction %void %uint
+          %1 = OpFunction %void None %5
+          %a = OpFunctionParameter %uint
+          %6 = OpLabel
+          %7 = OpNot %uint %a
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: xor i32 {{%a, -1|-1, %a}}

--- a/test/OpSNegate.spvasm
+++ b/test/OpSNegate.spvasm
@@ -1,0 +1,19 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testSNegate"
+               OpName %a "a"
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+          %5 = OpTypeFunction %void %uint
+          %1 = OpFunction %void None %5
+          %a = OpFunctionParameter %uint
+          %6 = OpLabel
+          %7 = OpSNegate %uint %a
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: sub nsw i32 0, %a

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -16,7 +16,7 @@ config.name = 'LLVM_SPIRV'
 config.test_format = lit.formats.ShTest(True)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.cl', '.ll', '.spt']
+config.suffixes = ['.cl', '.ll', '.spt', '.spvasm']
 
 # excludes: A list of directories  and fles to exclude from the testsuite.
 config.excludes = ['CMakeLists.txt']
@@ -53,9 +53,19 @@ if not config.spirv_skip_debug_info_tests:
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
+using_spirv_tools = False
+
+if config.spirv_tools_have_spirv_as:
+    llvm_config.add_tool_substitutions(['spirv-as'], [config.spirv_tools_bin_dir])
+    config.available_features.add('spirv-as')
+    using_spirv_tools = True
+
 if config.spirv_tools_have_spirv_val:
-    new_ld_library_path = os.path.pathsep.join((config.spirv_tools_lib_dir, config.environment['LD_LIBRARY_PATH']))
-    config.environment['LD_LIBRARY_PATH'] = new_ld_library_path
     llvm_config.add_tool_substitutions(['spirv-val'], [config.spirv_tools_bin_dir])
+    using_spirv_tools = True
 else:
     config.substitutions.append(('spirv-val', ':'))
+
+if using_spirv_tools:
+    new_ld_library_path = os.path.pathsep.join((config.spirv_tools_lib_dir, config.environment['LD_LIBRARY_PATH']))
+    config.environment['LD_LIBRARY_PATH'] = new_ld_library_path

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -15,6 +15,7 @@ config.target_triple = "@TARGET_TRIPLE@"
 config.host_arch = "@HOST_ARCH@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
+config.spirv_tools_have_spirv_as = @SPIRV_TOOLS_SPIRV_AS_FOUND@
 config.spirv_tools_have_spirv_val = @SPIRV_TOOLS_SPIRV_VAL_FOUND@
 config.spirv_tools_bin_dir = "@SPIRV_TOOLS_BINDIR@"
 config.spirv_tools_lib_dir = "@SPIRV_TOOLS_LIBDIR@"


### PR DESCRIPTION
This change adds SPIR-V assembly tests for OpFNegate, OpSNegate, OpFRem, OpNot, OpLogicalAnd, OpLogicalOr, OpLogicalEqual, OpLogicalNotEqual, OpLogicalNot and OpNop, and fixes translation of the OpLogicalNot instruction to LLVM IR.

As the OpNop instruction cannot currently be decoded, the test for this is an XFAIL test.

This adds a dependency on SPIR-V Tools, which provides the `spirv-as` program needed to assemble the tests. These tests are added in the SPIR-V assembly format with the intent that other tests will be converted away from the internal SPIR-V text format in future, as per issue #211.