### PR TITLE
Set convergent attribute for barriers

### DIFF
--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -151,7 +151,7 @@ void SPIRVToOCL12::visitCallSPIRVMemoryBarrier(CallInst *CI) {
 void SPIRVToOCL12::visitCallSPIRVControlBarrier(CallInst *CI) {
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   Attrs = Attrs.addAttribute(CI->getContext(), AttributeList::FunctionIndex,
-                             Attribute::NoDuplicate);
+                             Attribute::Convergent);
   mutateCallInstOCL(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -123,7 +123,7 @@ void SPIRVToOCL20::visitCallSPIRVMemoryBarrier(CallInst *CI) {
 void SPIRVToOCL20::visitCallSPIRVControlBarrier(CallInst *CI) {
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   Attrs = Attrs.addAttribute(CI->getContext(), AttributeList::FunctionIndex,
-                             Attribute::NoDuplicate);
+                             Attribute::Convergent);
   mutateCallInstOCL(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {

--- a/test/spirv-ocl-builtins-version.spt
+++ b/test/spirv-ocl-builtins-version.spt
@@ -41,7 +41,7 @@
 ; CHECK-LLVM-12: call spir_func void @_Z7barrierj(i32 3) [[attr]]
 ; CHECK-LLVM-12: call spir_func void @_Z7barrierj(i32 5) [[attr]]
 ; CHECK-LLVM-12: call spir_func void @_Z7barrierj(i32 7) [[attr]]
-; CHECK-LLVM-12: attributes [[attr]] = { noduplicate nounwind }
+; CHECK-LLVM-12: attributes [[attr]] = { convergent nounwind }
 
 ; RUN: llvm-spirv %s -to-binary -o %t2.spv
 ; RUN: spirv-val %t2.spv
@@ -54,4 +54,4 @@
 ; CHECK-LLVM-20: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 3, i32 1) [[attr]]
 ; CHECK-LLVM-20: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 5, i32 1) [[attr]]
 ; CHECK-LLVM-20: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 7, i32 1) [[attr]]
-; CHECK-LLVM-20: attributes [[attr]] = { noduplicate nounwind }
+; CHECK-LLVM-20: attributes [[attr]] = { convergent nounwind }

--- a/test/transcoding/OpControlBarrier_cl12.ll
+++ b/test/transcoding/OpControlBarrier_cl12.ll
@@ -11,7 +11,7 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 3) [[attr]]
 ; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 5) [[attr]]
 ; CHECK-LLVM-NEXT: call spir_func void @_Z7barrierj(i32 7) [[attr]]
-; CHECK-LLVM: attributes [[attr]] = { noduplicate nounwind }
+; CHECK-LLVM: attributes [[attr]] = { convergent nounwind }
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272

--- a/test/transcoding/OpControlBarrier_cl20.ll
+++ b/test/transcoding/OpControlBarrier_cl20.ll
@@ -28,7 +28,7 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 4, i32 2) [[attr]]
 ; CHECK-LLVM-NEXT: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 4, i32 3) [[attr]]
 
-; CHECK-LLVM: attributes [[attr]] = { noduplicate nounwind }
+; CHECK-LLVM: attributes [[attr]] = { convergent nounwind }
 
 ; Both 'CrossDevice' memory scope and 'None' memory order enums have value equal to 0.
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[Null:[0-9]+]] 0

--- a/test/transcoding/OpControlBarrier_cl20_subgroup.ll
+++ b/test/transcoding/OpControlBarrier_cl20_subgroup.ll
@@ -27,7 +27,7 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 4, i32 2) [[attr]]
 ; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 4, i32 3) [[attr]]
 
-; CHECK-LLVM: attributes [[attr]] = { noduplicate nounwind }
+; CHECK-LLVM: attributes [[attr]] = { convergent nounwind }
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272

--- a/test/transcoding/OpControlBarrier_cl21.ll
+++ b/test/transcoding/OpControlBarrier_cl21.ll
@@ -27,7 +27,7 @@
 ; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 4, i32 2) [[attr]]
 ; CHECK-LLVM-NEXT: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 4, i32 3) [[attr]]
 
-; CHECK-LLVM: attributes [[attr]] = { noduplicate nounwind }
+; CHECK-LLVM: attributes [[attr]] = { convergent nounwind }
 
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema1:[0-9]+]] 528
 ; CHECK-SPIRV-DAG: 4 Constant {{[0-9]+}} [[MemSema2:[0-9]+]] 272


### PR DESCRIPTION
The `noduplicate` attribute is unnecessarily restrictive.  Align with
clang by setting the `convergent` attribute instead of `noduplicate`.

Followup from https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/109