### PR TITLE
Fix Intel blocking pipe built-ins type signature

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -302,7 +302,8 @@ void SPIRVToOCL::visitCallSPIRVPipeBuiltin(CallInst *CI, Op OC) {
           Args.erase(Args.begin(), Args.begin() + 1);
 
         if (!(OC == OpReadPipe || OC == OpWritePipe ||
-              OC == OpReservedReadPipe || OC == OpReservedWritePipe))
+              OC == OpReservedReadPipe || OC == OpReservedWritePipe ||
+              OC == OpReadPipeBlockingINTEL || OC == OpWritePipeBlockingINTEL))
           return DemangledName;
 
         auto &P = Args[Args.size() - 3];

--- a/test/PipeBlocking.ll
+++ b/test/PipeBlocking.ll
@@ -19,6 +19,10 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV: 3 TypePipe [[PipeWTy:[0-9]+]] 1
 ; CHECK-SPIRV: 6 Load [[PipeRTy]] [[PipeR:[0-9]+]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: 5 ReadPipeBlockingINTEL [[PipeR]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 6 Load [[PipeRTy]] [[PipeR:[0-9]+]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 5 ReadPipeBlockingINTEL [[PipeR]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 6 Load [[PipeWTy]] [[PipeW:[0-9]+]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: 5 WritePipeBlockingINTEL [[PipeW]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: 6 Load [[PipeWTy]] [[PipeW:[0-9]+]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: 5 WritePipeBlockingINTEL [[PipeW]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 
@@ -26,6 +30,8 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-LLVM: %opencl.pipe_wo_t = type opaque
 
 ; CHECK-LLVM: call spir_func void @__read_pipe_2_bl(%opencl.pipe_ro_t addrspace(1)* %0, i8 addrspace(4)* %{{[0-9]+}}, i32 4, i32 4)
+; CHECK-LLVM: call spir_func void @__read_pipe_2_bl(%opencl.pipe_ro_t addrspace(1)* %0, i8 addrspace(4)* %{{[0-9]+}}, i32 4, i32 4)
+; CHECK-LLVM: call spir_func void @__write_pipe_2_bl(%opencl.pipe_wo_t addrspace(1)* %0, i8 addrspace(4)* %{{[0-9]+}}, i32 4, i32 4)
 ; CHECK-LLVM: call spir_func void @__write_pipe_2_bl(%opencl.pipe_wo_t addrspace(1)* %0, i8 addrspace(4)* %{{[0-9]+}}, i32 4, i32 4)
 
 ; Function Attrs: convergent noinline nounwind optnone
@@ -37,13 +43,28 @@ entry:
   store i32 addrspace(1)* %ptr, i32 addrspace(1)** %ptr.addr, align 8
   %0 = load %opencl.pipe_ro_t addrspace(1)*, %opencl.pipe_ro_t addrspace(1)** %p.addr, align 8
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %ptr.addr, align 8
-  %2 = addrspacecast i32 addrspace(1)* %1 to i8 addrspace(4)*
-  call spir_func void @_Z29__spirv_ReadPipeBlockingINTELIiEv8ocl_pipePT_ii(%opencl.pipe_ro_t addrspace(1)* %0, i8 addrspace(4)* %2, i32 4, i32 4)
+  %2 = addrspacecast i32 addrspace(1)* %1 to i32 addrspace(4)*
+  call spir_func void @_Z29__spirv_ReadPipeBlockingINTELIiEv8ocl_pipePiii(%opencl.pipe_ro_t addrspace(1)* %0, i32 addrspace(4)* %2, i32 4, i32 4)
   ret void
 }
 
-declare dso_local spir_func void @_Z29__spirv_ReadPipeBlockingINTELIiEv8ocl_pipePT_ii(%opencl.pipe_ro_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
-; CHECK-LLVM: declare spir_func void @__read_pipe_2_bl(%opencl.pipe_ro_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+declare dso_local spir_func void @_Z29__spirv_ReadPipeBlockingINTELIiEv8ocl_pipePiii(%opencl.pipe_ro_t addrspace(1)*, i32 addrspace(4)*, i32, i32)
+
+; Function Attrs: convergent noinline nounwind optnone
+define spir_func void @bar(%opencl.pipe_ro_t addrspace(1)* %p, i32 addrspace(1)* %ptr) #0 {
+entry:
+  %p.addr = alloca %opencl.pipe_ro_t addrspace(1)*, align 8
+  %ptr.addr = alloca i32 addrspace(1)*, align 8
+  store %opencl.pipe_ro_t addrspace(1)* %p, %opencl.pipe_ro_t addrspace(1)** %p.addr, align 8
+  store i32 addrspace(1)* %ptr, i32 addrspace(1)** %ptr.addr, align 8
+  %0 = load %opencl.pipe_ro_t addrspace(1)*, %opencl.pipe_ro_t addrspace(1)** %p.addr, align 8
+  %1 = load i32 addrspace(1)*, i32 addrspace(1)** %ptr.addr, align 8
+  %2 = addrspacecast i32 addrspace(1)* %1 to i8 addrspace(4)*
+  call spir_func void @_Z29__spirv_ReadPipeBlockingINTELIiEv8ocl_pipePvii(%opencl.pipe_ro_t addrspace(1)* %0, i8 addrspace(4)* %2, i32 4, i32 4)
+  ret void
+}
+
+declare dso_local spir_func void @_Z29__spirv_ReadPipeBlockingINTELIiEv8ocl_pipePvii(%opencl.pipe_ro_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
 
 ; Function Attrs: convergent noinline nounwind optnone
 define spir_func void @boo(%opencl.pipe_wo_t addrspace(1)* %p, i32 addrspace(1)* %ptr) #0 {
@@ -54,11 +75,30 @@ entry:
   store i32 addrspace(1)* %ptr, i32 addrspace(1)** %ptr.addr, align 8
   %0 = load %opencl.pipe_wo_t addrspace(1)*, %opencl.pipe_wo_t addrspace(1)** %p.addr, align 8
   %1 = load i32 addrspace(1)*, i32 addrspace(1)** %ptr.addr, align 8
-  %2 = addrspacecast i32 addrspace(1)* %1 to i8 addrspace(4)*
-  call spir_func void @_Z30__spirv_WritePipeBlockingINTELIKiEv8ocl_pipePT_ii(%opencl.pipe_wo_t addrspace(1)* %0, i8 addrspace(4)* %2, i32 4, i32 4)
+  %2 = addrspacecast i32 addrspace(1)* %1 to i32 addrspace(4)*
+  call spir_func void @_Z30__spirv_WritePipeBlockingINTELIKiEv8ocl_pipePiii(%opencl.pipe_wo_t addrspace(1)* %0, i32 addrspace(4)* %2, i32 4, i32 4)
   ret void
 }
-declare dso_local spir_func void @_Z30__spirv_WritePipeBlockingINTELIKiEv8ocl_pipePT_ii(%opencl.pipe_wo_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+
+declare dso_local spir_func void @_Z30__spirv_WritePipeBlockingINTELIKiEv8ocl_pipePiii(%opencl.pipe_wo_t addrspace(1)*, i32 addrspace(4)*, i32, i32)
+
+; Function Attrs: convergent noinline nounwind optnone
+define spir_func void @baz(%opencl.pipe_wo_t addrspace(1)* %p, i32 addrspace(1)* %ptr) #0 {
+entry:
+  %p.addr = alloca %opencl.pipe_wo_t addrspace(1)*, align 8
+  %ptr.addr = alloca i32 addrspace(1)*, align 8
+  store %opencl.pipe_wo_t addrspace(1)* %p, %opencl.pipe_wo_t addrspace(1)** %p.addr, align 8
+  store i32 addrspace(1)* %ptr, i32 addrspace(1)** %ptr.addr, align 8
+  %0 = load %opencl.pipe_wo_t addrspace(1)*, %opencl.pipe_wo_t addrspace(1)** %p.addr, align 8
+  %1 = load i32 addrspace(1)*, i32 addrspace(1)** %ptr.addr, align 8
+  %2 = addrspacecast i32 addrspace(1)* %1 to i8 addrspace(4)*
+  call spir_func void @_Z30__spirv_WritePipeBlockingINTELIKiEv8ocl_pipePvii(%opencl.pipe_wo_t addrspace(1)* %0, i8 addrspace(4)* %2, i32 4, i32 4)
+  ret void
+}
+
+declare dso_local spir_func void @_Z30__spirv_WritePipeBlockingINTELIKiEv8ocl_pipePvii(%opencl.pipe_wo_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
+
+; CHECK-LLVM: declare spir_func void @__read_pipe_2_bl(%opencl.pipe_ro_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
 ; CHECK-LLVM: declare spir_func void @__write_pipe_2_bl(%opencl.pipe_wo_t addrspace(1)*, i8 addrspace(4)*, i32, i32)
 
 attributes #0 = { convergent noinline nounwind optnone "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }


### PR DESCRIPTION
With LLVM IR consumption second argument of pipe built-in should be
void pointer. This patch fixes a bug, when Intel blocking pipes
built-ins were having second argument with the same type as data
stored in pipe. This bug could lead to a situation, when two pipe
blocking instruction were translated to LLVM IR to two functions with
different arguments types, but sharing the same name which is illegal.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>