### PR TITLE
Fix invalid .spv->.bc translation of Intel FPGA merge attribute

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2465,9 +2465,15 @@ void generateIntelFPGAAnnotation(const SPIRVEntry *E,
     Out << "{max_replicates:" << Result << '}';
   if (E->hasDecorate(DecorationSimpleDualPortINTEL))
     Out << "{simple_dual_port:1}";
-  if (E->hasDecorate(DecorationMergeINTEL))
-    Out << "{merge:" << E->getDecorationStringLiteral(DecorationMergeINTEL)
-        << '}';
+  if (E->hasDecorate(DecorationMergeINTEL)) {
+    std::vector<std::string> Buf =
+        E->getDecorationStringLiterals(DecorationMergeINTEL);
+    Out << "{merge";
+    for (auto I : Buf) {
+      Out << ":" << I;
+    }
+    Out << '}';
+  }
   if (E->hasDecorate(DecorationUserSemantic))
     Out << E->getDecorationStringLiteral(DecorationUserSemantic);
 }
@@ -2501,11 +2507,16 @@ void generateIntelFPGAAnnotationForStructMember(
     Out << "{max_replicates:" << Result << '}';
   if (E->hasMemberDecorate(DecorationSimpleDualPortINTEL, 0, MemberNumber))
     Out << "{simple_dual_port:1}";
-  if (E->hasMemberDecorate(DecorationMergeINTEL, 0, MemberNumber))
-    Out << "{merge:"
-        << E->getMemberDecorationStringLiteral(DecorationMergeINTEL,
-                                               MemberNumber)
-        << '}';
+  if (E->hasMemberDecorate(DecorationMergeINTEL, 0, MemberNumber)) {
+    std::vector<std::string> Buf = E->getMemberDecorationStringLiterals(
+        DecorationMergeINTEL, MemberNumber);
+    Out << "{merge";
+    for (auto I : Buf) {
+      Out << ":" << I;
+    }
+    Out << '}';
+  }
+
   if (E->hasMemberDecorate(DecorationUserSemantic, 0, MemberNumber))
     Out << E->getMemberDecorationStringLiteral(DecorationUserSemantic,
                                                MemberNumber);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2447,10 +2447,9 @@ void generateIntelFPGAAnnotation(const SPIRVEntry *E,
     Out << "{register:1}";
 
   SPIRVWord Result = 0;
-  if (E->hasDecorate(DecorationMemoryINTEL)) {
-    Out << "{memory:" << E->getDecorationStringLiteral(DecorationMemoryINTEL)
-        << '}';
-  }
+  if (E->hasDecorate(DecorationMemoryINTEL))
+    Out << "{memory:"
+        << E->getDecorationStringLiteral(DecorationMemoryINTEL).front() << '}';
   if (E->hasDecorate(DecorationBankwidthINTEL, 0, &Result))
     Out << "{bankwidth:" << Result << '}';
   if (E->hasDecorate(DecorationNumbanksINTEL, 0, &Result))
@@ -2466,16 +2465,13 @@ void generateIntelFPGAAnnotation(const SPIRVEntry *E,
   if (E->hasDecorate(DecorationSimpleDualPortINTEL))
     Out << "{simple_dual_port:1}";
   if (E->hasDecorate(DecorationMergeINTEL)) {
-    std::vector<std::string> Buf =
-        E->getDecorationStringLiterals(DecorationMergeINTEL);
     Out << "{merge";
-    for (auto I : Buf) {
-      Out << ":" << I;
-    }
+    for (auto Str : E->getDecorationStringLiteral(DecorationMergeINTEL))
+      Out << ":" << Str;
     Out << '}';
   }
   if (E->hasDecorate(DecorationUserSemantic))
-    Out << E->getDecorationStringLiteral(DecorationUserSemantic);
+    Out << E->getDecorationStringLiteral(DecorationUserSemantic).front();
 }
 
 void generateIntelFPGAAnnotationForStructMember(
@@ -2490,6 +2486,7 @@ void generateIntelFPGAAnnotationForStructMember(
     Out << "{memory:"
         << E->getMemberDecorationStringLiteral(DecorationMemoryINTEL,
                                                MemberNumber)
+               .front()
         << '}';
   if (E->hasMemberDecorate(DecorationBankwidthINTEL, 0, MemberNumber, &Result))
     Out << "{bankwidth:" << Result << '}';
@@ -2508,18 +2505,17 @@ void generateIntelFPGAAnnotationForStructMember(
   if (E->hasMemberDecorate(DecorationSimpleDualPortINTEL, 0, MemberNumber))
     Out << "{simple_dual_port:1}";
   if (E->hasMemberDecorate(DecorationMergeINTEL, 0, MemberNumber)) {
-    std::vector<std::string> Buf = E->getMemberDecorationStringLiterals(
-        DecorationMergeINTEL, MemberNumber);
     Out << "{merge";
-    for (auto I : Buf) {
-      Out << ":" << I;
-    }
+    for (auto Str : E->getMemberDecorationStringLiteral(DecorationMergeINTEL,
+                                                        MemberNumber))
+      Out << ":" << Str;
     Out << '}';
   }
 
   if (E->hasMemberDecorate(DecorationUserSemantic, 0, MemberNumber))
     Out << E->getMemberDecorationStringLiteral(DecorationUserSemantic,
-                                               MemberNumber);
+                                               MemberNumber)
+               .front();
 }
 
 void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -82,6 +82,10 @@ SPIRVWord SPIRVDecorateGeneric::getLiteral(size_t I) const {
   return Literals[I];
 }
 
+std::vector<SPIRVWord> SPIRVDecorateGeneric::getVecLiteral() const {
+  return Literals;
+}
+
 size_t SPIRVDecorateGeneric::getLiteralCount() const { return Literals.size(); }
 
 void SPIRVDecorate::encode(spv_ostream &O) const {

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -61,6 +61,7 @@ public:
   SPIRVDecorateGeneric(Op OC);
 
   SPIRVWord getLiteral(size_t) const;
+  std::vector<SPIRVWord> getVecLiteral() const;
   Decoration getDecorateKind() const;
   size_t getLiteralCount() const;
   /// Compare for kind and literal only.

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -335,57 +335,23 @@ bool SPIRVEntry::hasMemberDecorate(Decoration Kind, size_t Index,
   return true;
 }
 
-std::string SPIRVEntry::getDecorationStringLiteral(Decoration Kind) const {
-  std::vector<SPIRVWord> Literals;
-  auto Loc = Decorates.find(Kind);
-  if (Loc == Decorates.end())
-    return std::string();
-
-  for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
-    Literals.push_back(Loc->second->getLiteral(I));
-
-  return getString(Literals);
-}
-
 std::vector<std::string>
-SPIRVEntry::getDecorationStringLiterals(Decoration Kind) const {
-  std::vector<SPIRVWord> Literals;
+SPIRVEntry::getDecorationStringLiteral(Decoration Kind) const {
   auto Loc = Decorates.find(Kind);
   if (Loc == Decorates.end())
     return {};
 
-  for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
-    Literals.push_back(Loc->second->getLiteral(I));
-
-  return getStrings(Literals);
+  return getVecString(Loc->second->getVecLiteral());
 }
 
-std::string
+std::vector<std::string>
 SPIRVEntry::getMemberDecorationStringLiteral(Decoration Kind,
                                              SPIRVWord MemberNumber) const {
-  std::vector<SPIRVWord> Literals;
-  auto Loc = MemberDecorates.find({MemberNumber, Kind});
-  if (Loc == MemberDecorates.end())
-    return std::string();
-
-  for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
-    Literals.push_back(Loc->second->getLiteral(I));
-
-  return getString(Literals);
-}
-
-std::vector<std::string>
-SPIRVEntry::getMemberDecorationStringLiterals(Decoration Kind,
-                                              SPIRVWord MemberNumber) const {
-  std::vector<SPIRVWord> Literals;
   auto Loc = MemberDecorates.find({MemberNumber, Kind});
   if (Loc == MemberDecorates.end())
     return {};
 
-  for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
-    Literals.push_back(Loc->second->getLiteral(I));
-
-  return getStrings(Literals);
+  return getVecString(Loc->second->getVecLiteral());
 }
 
 // Get literals of all decorations of Kind at Index.

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -344,7 +344,20 @@ std::string SPIRVEntry::getDecorationStringLiteral(Decoration Kind) const {
   for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
     Literals.push_back(Loc->second->getLiteral(I));
 
-  return getString(Literals.cbegin(), Literals.cend());
+  return getString(Literals);
+}
+
+std::vector<std::string>
+SPIRVEntry::getDecorationStringLiterals(Decoration Kind) const {
+  std::vector<SPIRVWord> Literals;
+  auto Loc = Decorates.find(Kind);
+  if (Loc == Decorates.end())
+    return {};
+
+  for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
+    Literals.push_back(Loc->second->getLiteral(I));
+
+  return getStrings(Literals);
 }
 
 std::string
@@ -358,7 +371,21 @@ SPIRVEntry::getMemberDecorationStringLiteral(Decoration Kind,
   for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
     Literals.push_back(Loc->second->getLiteral(I));
 
-  return getString(Literals.cbegin(), Literals.cend());
+  return getString(Literals);
+}
+
+std::vector<std::string>
+SPIRVEntry::getMemberDecorationStringLiterals(Decoration Kind,
+                                              SPIRVWord MemberNumber) const {
+  std::vector<SPIRVWord> Literals;
+  auto Loc = MemberDecorates.find({MemberNumber, Kind});
+  if (Loc == MemberDecorates.end())
+    return {};
+
+  for (SPIRVWord I = 0; I < Loc->second->getLiteralCount(); ++I)
+    Literals.push_back(Loc->second->getLiteral(I));
+
+  return getStrings(Literals);
 }
 
 // Get literals of all decorations of Kind at Index.

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -297,8 +297,12 @@ public:
                          SPIRVWord MemberNumber = 0,
                          SPIRVWord *Result = 0) const;
   std::string getDecorationStringLiteral(Decoration Kind) const;
+  std::vector<std::string> getDecorationStringLiterals(Decoration Kind) const;
   std::string getMemberDecorationStringLiteral(Decoration Kind,
                                                SPIRVWord MemberNumber) const;
+  std::vector<std::string>
+  getMemberDecorationStringLiterals(Decoration Kind,
+                                    SPIRVWord MemberNumber) const;
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;
   bool hasId() const { return !(Attrib & SPIRVEA_NOID); }
   bool hasLine() const { return Line != nullptr; }

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -296,13 +296,10 @@ public:
   bool hasMemberDecorate(Decoration Kind, size_t Index = 0,
                          SPIRVWord MemberNumber = 0,
                          SPIRVWord *Result = 0) const;
-  std::string getDecorationStringLiteral(Decoration Kind) const;
-  std::vector<std::string> getDecorationStringLiterals(Decoration Kind) const;
-  std::string getMemberDecorationStringLiteral(Decoration Kind,
-                                               SPIRVWord MemberNumber) const;
+  std::vector<std::string> getDecorationStringLiteral(Decoration Kind) const;
   std::vector<std::string>
-  getMemberDecorationStringLiterals(Decoration Kind,
-                                    SPIRVWord MemberNumber) const;
+  getMemberDecorationStringLiteral(Decoration Kind,
+                                   SPIRVWord MemberNumber) const;
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;
   bool hasId() const { return !(Attrib & SPIRVEA_NOID); }
   bool hasLine() const { return Line != nullptr; }

--- a/lib/SPIRV/libSPIRV/SPIRVUtil.h
+++ b/lib/SPIRV/libSPIRV/SPIRVUtil.h
@@ -344,20 +344,13 @@ inline std::string getString(const std::vector<uint32_t> &V) {
 }
 
 // if vector of Literals is expected to contain more than one Literal String
-inline std::vector<std::string> getStrings(const std::vector<uint32_t> &V) {
-  std::vector<std::string> Result = {};
-  std::string Str = std::string();
-  for (auto I = V.cbegin(); I != V.cend(); ++I) {
-    uint32_t Word = *I;
-    for (unsigned J = 0u; J < 32u; J += 8u) {
-      char Char = (char)((Word >> J) & 0xff);
-      if (Char == '\0') {
-        Result.push_back(Str);
-        Str = std::string();
-        break;
-      }
-      Str += Char;
-    }
+inline std::vector<std::string> getVecString(const std::vector<uint32_t> &V) {
+  std::vector<std::string> Result;
+  std::string Str;
+  for (auto It = V.cbegin(); It < V.cend(); It += getSizeInWords(Str)) {
+    Str.clear();
+    Str = getString(It, V.cend());
+    Result.push_back(Str);
   }
   return Result;
 }

--- a/lib/SPIRV/libSPIRV/SPIRVUtil.h
+++ b/lib/SPIRV/libSPIRV/SPIRVUtil.h
@@ -343,6 +343,25 @@ inline std::string getString(const std::vector<uint32_t> &V) {
   return getString(V.cbegin(), V.cend());
 }
 
+// if vector of Literals is expected to contain more than one Literal String
+inline std::vector<std::string> getStrings(const std::vector<uint32_t> &V) {
+  std::vector<std::string> Result = {};
+  std::string Str = std::string();
+  for (auto I = V.cbegin(); I != V.cend(); ++I) {
+    uint32_t Word = *I;
+    for (unsigned J = 0u; J < 32u; J += 8u) {
+      char Char = (char)((Word >> J) & 0xff);
+      if (Char == '\0') {
+        Result.push_back(Str);
+        Str = std::string();
+        break;
+      }
+      Str += Char;
+    }
+  }
+  return Result;
+}
+
 inline std::vector<uint32_t> getVec(const std::string &Str) {
   std::vector<uint32_t> V;
   auto StrSize = Str.size();

--- a/test/IntelFPGAMemoryAttributes.ll
+++ b/test/IntelFPGAMemoryAttributes.ll
@@ -1,9 +1,12 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -spirv-text -o %t.spt
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -o %t.spv
+; RUN: llvm-spirv %t.spv --spirv-ext=+SPV_INTEL_fpga_memory_attributes -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; FIXME: use proper SPIR-V binary format instead of text representation
-; RUN: llvm-spirv -r %t.spt -spirv-text -o %t.rev.bc
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; RUN: llvm-spirv -spirv-text -r %t.spt -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ;
 ; TODO: add a bunch of different tests for --spirv-ext option

--- a/test/IntelFPGAMemoryAttributesForStruct.ll
+++ b/test/IntelFPGAMemoryAttributesForStruct.ll
@@ -1,9 +1,12 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -spirv-text -o %t.spt
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -o %t.spv
+; RUN: llvm-spirv %t.spv --spirv-ext=+SPV_INTEL_fpga_memory_attributes -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; FIXME: use proper SPIR-V binary format instead of text representation
-; RUN: llvm-spirv -r %t.spt -spirv-text -o %t.rev.bc
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; RUN: llvm-spirv -spirv-text -r %t.spt -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ;
 ; TODO: add a bunch of different tests for --spirv-ext option


### PR DESCRIPTION
This patch introduces fix for the problem related to translation of SPIR-V decoration with two (or more) Literal Strings to LLVM IR. The processing of getting Literal Strings from the related decoration was limited to the first Literal String (first '\0' symbol).
In particular, the merge attribute has two Literal String according to the specification.