### PR TITLE
Fix translation of OpGenericCastToPtrExplicit and add pointer cast tests

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -777,7 +777,7 @@ bool isSamplerTy(Type *Ty) {
   return STy && STy->hasName() && STy->getName() == kSPR2TypeName::Sampler;
 }
 
-bool isPipeBI(const StringRef MangledName) {
+bool isPipeOrAddressSpaceCastBI(const StringRef MangledName) {
   return MangledName == "write_pipe_2" || MangledName == "read_pipe_2" ||
          MangledName == "write_pipe_2_bl" || MangledName == "read_pipe_2_bl" ||
          MangledName == "write_pipe_4" || MangledName == "read_pipe_4" ||
@@ -796,7 +796,9 @@ bool isPipeBI(const StringRef MangledName) {
          MangledName == "sub_group_reserve_write_pipe" ||
          MangledName == "sub_group_reserve_read_pipe" ||
          MangledName == "sub_group_commit_write_pipe" ||
-         MangledName == "sub_group_commit_read_pipe";
+         MangledName == "sub_group_commit_read_pipe" ||
+         MangledName == "to_global" || MangledName == "to_local" ||
+         MangledName == "to_private";
 }
 
 bool isEnqueueKernelBI(const StringRef MangledName) {

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -416,7 +416,7 @@ bool isPipeStorageInitializer(Instruction *Inst);
 /// Check (isSamplerInitializer || isPipeStorageInitializer)
 bool isSpecialTypeInitializer(Instruction *Inst);
 
-bool isPipeBI(const StringRef MangledName);
+bool isPipeOrAddressSpaceCastBI(const StringRef MangledName);
 bool isEnqueueKernelBI(const StringRef MangledName);
 bool isKernelQueryBI(const StringRef MangledName);
 

--- a/test/OpConvertPtrToU_narrowing.spvasm
+++ b/test/OpConvertPtrToU_narrowing.spvasm
@@ -1,0 +1,27 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int16
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testNarrowingPtrToU"
+               OpName %a "a"
+               OpName %res "res"
+               OpName %entry "entry"
+       %uint = OpTypeInt 32 0
+     %ushort = OpTypeInt 16 0
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+%_ptr_CrossWorkgroup_ushort = OpTypePointer CrossWorkgroup %ushort
+         %17 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_ushort
+          %1 = OpFunction %void None %17
+          %a = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+        %res = OpFunctionParameter %_ptr_CrossWorkgroup_ushort
+      %entry = OpLabel
+         %18 = OpConvertPtrToU %ushort %a
+               OpStore %res %18 Aligned 2
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: ptrtoint i32 addrspace(1)* %a to i16

--- a/test/OpConvertPtrToU_widening.spvasm
+++ b/test/OpConvertPtrToU_widening.spvasm
@@ -1,0 +1,27 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int64
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testWideningPtrToU"
+               OpName %a "a"
+               OpName %res "res"
+               OpName %entry "entry"
+       %uint = OpTypeInt 32 0
+      %ulong = OpTypeInt 64 0
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+%_ptr_CrossWorkgroup_ulong = OpTypePointer CrossWorkgroup %ulong
+         %17 = OpTypeFunction %void %_ptr_CrossWorkgroup_uint %_ptr_CrossWorkgroup_ulong
+          %1 = OpFunction %void None %17
+          %a = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+        %res = OpFunctionParameter %_ptr_CrossWorkgroup_ulong
+      %entry = OpLabel
+         %18 = OpConvertPtrToU %ulong %a
+               OpStore %res %18 Aligned 8
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: ptrtoint i32 addrspace(1)* %a to i64

--- a/test/OpConvertUToPtr_narrowing.spvasm
+++ b/test/OpConvertUToPtr_narrowing.spvasm
@@ -1,0 +1,25 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int64
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testNarrowingUToPtr"
+               OpName %a "a"
+               OpName %entry "entry"
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+      %ulong = OpTypeInt 64 0
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+          %9 = OpTypeFunction %void %ulong
+          %1 = OpFunction %void None %9
+          %a = OpFunctionParameter %ulong
+      %entry = OpLabel
+         %10 = OpConvertUToPtr %_ptr_CrossWorkgroup_uint %a
+               OpStore %10 %uint_0 Aligned 4
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: inttoptr i64 %a to i32 addrspace(1)*

--- a/test/OpConvertUToPtr_widening.spvasm
+++ b/test/OpConvertUToPtr_widening.spvasm
@@ -1,0 +1,25 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int16
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testWideningUToPtr"
+               OpName %a "a"
+               OpName %entry "entry"
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %ushort = OpTypeInt 16 0
+       %void = OpTypeVoid
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+          %9 = OpTypeFunction %void %ushort
+          %1 = OpFunction %void None %9
+          %a = OpFunctionParameter %ushort
+      %entry = OpLabel
+         %10 = OpConvertUToPtr %_ptr_CrossWorkgroup_uint %a
+               OpStore %10 %uint_0 Aligned 4
+               OpReturn
+               OpFunctionEnd
+
+; CHECK: inttoptr i16 %a to i32 addrspace(1)*

--- a/test/transcoding/ConvertPtr.cl
+++ b/test/transcoding/ConvertPtr.cl
@@ -5,12 +5,23 @@
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-kernel void test(global int *a, global unsigned long *res) {
+kernel void testConvertPtrToU(global int *a, global unsigned long *res) {
   res[0] = (unsigned long)&a[0];
 }
 
-// CHECK-SPIRV: ConvertPtrToU
+// CHECK-SPIRV: 4 ConvertPtrToU
 
-// CHECK-LLVM-LABEL: @test
+// CHECK-LLVM-LABEL: @testConvertPtrToU
 // CHECK-LLVM: %0 = ptrtoint i32 addrspace(1)* %a to i32
 // CHECK-LLVM: zext i32 %0 to i64
+
+kernel void testConvertUToPtr(unsigned long a) {
+  global unsigned int *res = (global unsigned int *)a;
+  res[0] = 0;
+}
+
+// CHECK-SPIRV: 4 ConvertUToPtr
+
+// CHECK-LLVM-LABEL: @testConvertUToPtr
+// CHECK-LLVM: %[[Conv:[a-z]+]] = trunc i64 %a to i32
+// CHECK-LLVM: inttoptr i32 %[[Conv]] to i32 addrspace(1)*

--- a/test/transcoding/GenericCastToPtr.cl
+++ b/test/transcoding/GenericCastToPtr.cl
@@ -1,0 +1,69 @@
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -emit-llvm-bc -finclude-default-header %s -o %t.bc
+// RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+// CHECK-SPIRV: 4 GenericCastToPtr
+
+// CHECK-LLVM-LABEL: @testGenericCastToPtrGlobal
+// CHECK-LLVM: %0 = addrspacecast <2 x i16> addrspace(4)* %a to <2 x i16> addrspace(1)*
+
+global short2 *testGenericCastToPtrGlobal(generic short2 *a) {
+  return (global short2 *)a;
+}
+
+// CHECK-SPIRV: 4 GenericCastToPtr
+
+// CHECK-LLVM-LABEL: @testGenericCastToPtrLocal
+// CHECK-LLVM: %0 = addrspacecast <2 x i16> addrspace(4)* %a to <2 x i16> addrspace(3)*
+
+local short2 *testGenericCastToPtrLocal(generic short2 *a) {
+  return (local short2 *)a;
+}
+
+// CHECK-SPIRV: 4 GenericCastToPtr
+
+// CHECK-LLVM-LABEL: @testGenericCastToPtrPrivate
+// CHECK-LLVM: %0 = addrspacecast <2 x i16> addrspace(4)* %a to <2 x i16>*
+
+private short2 *testGenericCastToPtrPrivate(generic short2 *a) {
+  return (private short2 *)a;
+}
+
+// CHECK-SPIRV: 5 GenericCastToPtrExplicit
+
+// CHECK-LLVM-LABEL: @testGenericCastToPtrExplicitGlobal
+// CHECK-LLVM: %[[VoidPtrCast:[0-9]+]] = bitcast <2 x i16> addrspace(4)* %a to i8 addrspace(4)*
+// CHECK-LLVM-NEXT: %[[AddrSpaceCast:[0-9]+]] = bitcast i8 addrspace(4)* %[[VoidPtrCast]] to i8 addrspace(4)*
+// CHECK-LLVM-NEXT: %.tmp = call spir_func i8 addrspace(1)* @__to_global(i8 addrspace(4)* %[[AddrSpaceCast]])
+// CHECK-LLVM: bitcast i8 addrspace(1)* %{{[0-9]+}} to <2 x i16> addrspace(1)*
+
+global short2 *testGenericCastToPtrExplicitGlobal(generic short2 *a) {
+  return to_global(a);
+}
+
+// CHECK-SPIRV: 5 GenericCastToPtrExplicit
+
+// CHECK-LLVM-LABEL: @testGenericCastToPtrExplicitLocal
+// CHECK-LLVM: %[[VoidPtrCast:[0-9]+]] = bitcast <2 x i16> addrspace(4)* %a to i8 addrspace(4)*
+// CHECK-LLVM-NEXT: %[[AddrSpaceCast:[0-9]+]] = bitcast i8 addrspace(4)* %[[VoidPtrCast]] to i8 addrspace(4)*
+// CHECK-LLVM-NEXT: %.tmp = call spir_func i8 addrspace(3)* @__to_local(i8 addrspace(4)* %[[AddrSpaceCast]])
+// CHECK-LLVM: bitcast i8 addrspace(3)* %{{[0-9]+}} to <2 x i16> addrspace(3)*
+
+local short2 *testGenericCastToPtrExplicitLocal(generic short2 *a) {
+  return to_local(a);
+}
+
+// CHECK-SPIRV: 5 GenericCastToPtrExplicit
+
+// CHECK-LLVM-LABEL: @testGenericCastToPtrExplicitPrivate
+// CHECK-LLVM: %[[VoidPtrCast:[0-9]+]] = bitcast <2 x i16> addrspace(4)* %a to i8 addrspace(4)*
+// CHECK-LLVM-NEXT: %[[AddrSpaceCast:[0-9]+]] = bitcast i8 addrspace(4)* %[[VoidPtrCast]] to i8 addrspace(4)*
+// CHECK-LLVM-NEXT: %.tmp = call spir_func i8* @__to_private(i8 addrspace(4)* %[[AddrSpaceCast]])
+// CHECK-LLVM: bitcast i8* %{{[0-9]+}} to <2 x i16>*
+
+private short2 *testGenericCastToPtrExplicitPrivate(generic short2 *a) {
+  return to_private(a);
+}


### PR DESCRIPTION
`OpGenericCastToPtrExplicit` should be translated to `__to_global()`, `__to_local()` or `__to_private()` as appropriate, without name mangling, as this is what Clang generates.

Fix this to remove name mangling for these builtins, and add transcoding tests for both `OpGenericCastToPtrExplicit` and `OpGenericCastToPtr`.

Also add SPIR-V assembly tests for widening/narrowing `OpConvertUToPtr` and `OpConvertPtrToU` conversions, and add a transcoding test for same-width `OpConvertUToPtr` conversions.