### PR TITLE
Fix Line debug info contradicting control flow semantics

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -191,10 +191,15 @@ void LLVMToSPIRVDbgTran::transLocationInfo() {
           LineNo = DL.getLine();
           Col = DL.getCol();
           V = SPIRVWriter->getTranslatedValue(&I);
-          // TODO: Resolve issue with OpLine being inserted between
-          // branch merge instruction and branch instruction.
           // According to the spec, OpLine for an OpBranch/OpBranchConditional
           // must precede the merge instruction and not the branch instruction
+          auto *VPrev = static_cast<SPIRVInstruction *>(V)->getPrevious();
+          if (VPrev->getOpCode() == OpLoopMerge ||
+              VPrev->getOpCode() == OpLoopControlINTEL) {
+            assert(V->getOpCode() == OpBranch ||
+                   V->getOpCode() == OpBranchConditional);
+            V = VPrev;
+          }
           BM->addLine(V, File ? File->getId() : getDebugInfoNone()->getId(),
                       LineNo, Col);
         }

--- a/test/DebugInfo/DebugControlFlow.cl
+++ b/test/DebugInfo/DebugControlFlow.cl
@@ -24,13 +24,19 @@ void sample() {
   } while (j++ < 10);
 }
 
+// Check that all Line items are retained
+// CHECK-SPIRV: Line [[File:[0-9]+]] 18 0
+// Control flow
 // CHECK-SPIRV: {{[0-9]+}} LoopMerge [[MergeBlock:[0-9]+]] [[ContinueTarget:[0-9]+]] 1
-// CHECK-SPIRV-NOT: ExtInst
-// TODO: Check-not for Line (can only precede LoopMerge)
-// CHECK-SPIRV: BranchConditional
+// CHECK-SPIRV-NEXT: BranchConditional
+
+// Check that all Line items are retained
+// CHECK-SPIRV: Line [[File]] 23 0
+// CHECK-SPIRV: Line [[File]] 24 0
+// Control flow
 // CHECK-SPIRV: {{[0-9]+}} LoopMerge [[MergeBlock:[0-9]+]] [[ContinueTarget:[0-9]+]] 1
-// CHECK-SPIRV-NOT: ExtInst
-// CHECK-SPIRV: Branch
+// CHECK-SPIRV-NEXT: Branch
+
 // CHECK-LLVM: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}, !dbg !{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 // CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
 // CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.enable"}

--- a/test/DebugInfo/DebugUnstructuredControlFlow.cl
+++ b/test/DebugInfo/DebugUnstructuredControlFlow.cl
@@ -15,11 +15,12 @@ void sample() {
   for(;;);
 }
 
+// Check that all Line items are retained
+// CHECK-SPIRV: Line [[File:[0-9]+]] 15 0
+// Loop control
 // CHECK-SPIRV: 2 LoopControlINTEL 1
-// CHECK-SPIRV-NOT: ExtInst
-// TODO: Check-not for Line (can only precede LoopControl)
-// CHECK-SPIRV: {{[0-9]+}} Line {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-// CHECK-SPIRV: Branch
+// CHECK-SPIRV-NEXT: Branch
+
 // CHECK-LLVM: br label %{{.*}}, !dbg !{{[0-9]+}}, !llvm.loop ![[MD:[0-9]+]]
 // CHECK-LLVM: ![[MD]] = distinct !{![[MD]], ![[MD_unroll:[0-9]+]]}
 // CHECK-LLVM: ![[MD_unroll]] = !{!"llvm.loop.unroll.enable"}


### PR DESCRIPTION
This fixes 'OpLine's being inserted between branch merge
instructions and branch instructions. Although this has no
functional effect, SPIR-V specification clearly states that
Line instructions must precede branch merge instructions

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>