### PR TITLE
cmake: Add LLVM_SPIRV_INCLUDE_TESTS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.3)
 
 set(LLVM_SPIRV_VERSION 0.2.1.0)
 
+option(LLVM_SPIRV_INCLUDE_TESTS
+  "Generate build targets for the llvm-spirv lit tests."
+  ${LLVM_INCLUDE_TESTS})
+
 # check if we build inside llvm or not
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(BUILD_EXTERNAL YES)
@@ -15,12 +19,12 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   set(CMAKE_CXX_STANDARD 14)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-  if(LLVM_INCLUDE_TESTS)
+  if(LLVM_SPIRV_INCLUDE_TESTS)
     set(LLVM_TEST_COMPONENTS
       llvm-as
       llvm-dis
     )
-  endif(LLVM_INCLUDE_TESTS)
+  endif(LLVM_SPIRV_INCLUDE_TESTS)
 
   find_package(LLVM 10.0.0 REQUIRED
     COMPONENTS
@@ -56,9 +60,9 @@ set(LLVM_SPIRV_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 add_subdirectory(lib/SPIRV)
 add_subdirectory(tools/llvm-spirv)
-if(LLVM_INCLUDE_TESTS)
+if(LLVM_SPIRV_INCLUDE_TESTS)
   add_subdirectory(test)
-endif(LLVM_INCLUDE_TESTS)
+endif(LLVM_SPIRV_INCLUDE_TESTS)
 
 install(
   FILES

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ This requires that the `-DLLVM_INCLUDE_TESTS=ON` and
 `-DLLVM_EXTERNAL_LIT="/usr/lib/llvm-10/build/utils/lit/lit.py"` arguments were
 passed to CMake during the build step.
 
+The translator test suite can be disabled by passing
+`-DLLVM_SPIRV_INCLUDE_TESTS=OFF` to cmake.
+
 ## Run Instructions for `llvm-spirv`
 
 


### PR DESCRIPTION
Make it possible to disable the llvm-spirv test suite while still
allowing LLVM_INCLUDE_TESTS to be set to true.