### PR TITLE
Move Pass ID out of SPIRVToOCL base class

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -56,8 +56,6 @@ static cl::opt<std::string>
                        cl::desc("Specify version of OCL builtins to translate "
                                 "to (CL1.2, CL2.0, CL2.1)"));
 
-char SPIRVToOCL::ID = 0;
-
 void SPIRVToOCL::visitCallInst(CallInst &CI) {
   LLVM_DEBUG(dbgs() << "[visistCallInst] " << CI << '\n');
   auto F = CI.getCalledFunction();

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -49,7 +49,7 @@
 namespace SPIRV {
 class SPIRVToOCL : public ModulePass, public InstVisitor<SPIRVToOCL> {
 protected:
-  SPIRVToOCL() : ModulePass(ID), M(nullptr), Ctx(nullptr) {}
+  SPIRVToOCL(char ID) : ModulePass(ID), M(nullptr), Ctx(nullptr) {}
 
 public:
   virtual bool runOnModule(Module &M) = 0;
@@ -132,8 +132,6 @@ public:
   /// Transform __spirv_Opcode to ocl-version specific builtin name
   /// using separate maps for OpenCL 1.2 and OpenCL 2.0
   virtual Instruction *mutateAtomicName(CallInst *CI, Op OC) = 0;
-
-  static char ID;
 
 protected:
   Module *M;

--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -45,7 +45,7 @@ namespace SPIRV {
 
 class SPIRVToOCL12 : public SPIRVToOCL {
 public:
-  SPIRVToOCL12() {
+  SPIRVToOCL12() : SPIRVToOCL(ID) {
     initializeSPIRVToOCL12Pass(*PassRegistry::getPassRegistry());
   }
   bool runOnModule(Module &M) override;
@@ -103,7 +103,11 @@ public:
   /// types or with "atom_" for 64-bit types, as specified by
   /// cl_khr_int64_base_atomics and cl_khr_int64_extended_atomics extensions.
   std::string mapAtomicName(Op OC, Type *Ty);
+
+  static char ID;
 };
+
+char SPIRVToOCL12::ID = 0;
 
 bool SPIRVToOCL12::runOnModule(Module &Module) {
   M = &Module;

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -44,7 +44,7 @@ namespace SPIRV {
 
 class SPIRVToOCL20 : public SPIRVToOCL {
 public:
-  SPIRVToOCL20() {
+  SPIRVToOCL20() : SPIRVToOCL(ID) {
     initializeSPIRVToOCL20Pass(*PassRegistry::getPassRegistry());
   }
   bool runOnModule(Module &M) override;
@@ -81,7 +81,11 @@ public:
   /// Transform __spirv_OpAtomicCompareExchange/Weak into
   /// compare_exchange_strong/weak_explicit
   Instruction *visitCallSPIRVAtomicCmpExchg(CallInst *CI, Op OC) override;
+
+  static char ID;
 };
+
+char SPIRVToOCL20::ID = 0;
 
 bool SPIRVToOCL20::runOnModule(Module &Module) {
   M = &Module;


### PR DESCRIPTION
Having the SPIRVToOCL12 and SPIRVToOCL20 passes share the base class
Pass ID could cause the LLVM PassRegistry to believe it would register
the same pass twice.

Move the ID member down the class hierarchy such that each pass has
its own ID.