### PR TITLE
Fix SPIRVToOCL pass ID argument to be a reference

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -49,7 +49,7 @@
 namespace SPIRV {
 class SPIRVToOCL : public ModulePass, public InstVisitor<SPIRVToOCL> {
 protected:
-  SPIRVToOCL(char ID) : ModulePass(ID), M(nullptr), Ctx(nullptr) {}
+  SPIRVToOCL(char &ID) : ModulePass(ID), M(nullptr), Ctx(nullptr) {}
 
 public:
   virtual bool runOnModule(Module &M) = 0;


### PR DESCRIPTION
The ModulePass constructor takes a reference so we should forward the
reference given to the SPIRVToOCL constructor.

Reported-by: Stuart Brady