### PR TITLE
Fix build after LLVM API update

### DIFF
--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -95,7 +95,7 @@ public:
 
     auto *Alloca =
         Builder.CreateAlloca(SrcTy->getPointerElementType(), NumElements);
-    Alloca->setAlignment(Align);
+    Alloca->setAlignment(MaybeAlign(Align));
     Builder.CreateLifetimeStart(Alloca);
     Builder.CreateMemCpy(Alloca, Align, Src, Align, Length, Volatile);
     auto *SecondCpy = Builder.CreateMemCpy(Dest, I.getDestAlignment(), Alloca,

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2907,13 +2907,13 @@ bool SPIRVToLLVM::transAlign(SPIRVValue *BV, Value *V) {
   if (auto AL = dyn_cast<AllocaInst>(V)) {
     SPIRVWord Align = 0;
     if (BV->hasAlignment(&Align))
-      AL->setAlignment(Align);
+      AL->setAlignment(MaybeAlign(Align));
     return true;
   }
   if (auto GV = dyn_cast<GlobalVariable>(V)) {
     SPIRVWord Align = 0;
     if (BV->hasAlignment(&Align))
-      GV->setAlignment(Align);
+      GV->setAlignment(MaybeAlign(Align));
     return true;
   }
   return true;

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -287,7 +287,8 @@ Instruction *SPIRVToOCL20::visitCallSPIRVAtomicCmpExchg(CallInst *CI, Op OC) {
                                                       ->getParent()
                                                       ->getEntryBlock()
                                                       .getFirstInsertionPt()));
-        PExpected->setAlignment(CI->getType()->getScalarSizeInBits() / 8);
+        PExpected->setAlignment(
+            MaybeAlign(CI->getType()->getScalarSizeInBits() / 8));
         new StoreInst(Args[1], PExpected, PInsertBefore);
         unsigned AddrSpc = SPIRAS_Generic;
         Type *PtrTyAS =


### PR DESCRIPTION

commit ab11b9188d75a9cc24faa1e76592e4a1903a6e20
Author: Guillaume Chatelet <gchatelet@google.com>
Date:   Mon Sep 30 13:34:44 2019 +0000

    [Alignment][NFC] Remove AllocaInst::setAlignment(unsigned)

    Summary:
    This is patch is part of a series to introduce an Alignment type.
    See this thread for context: http://lists.llvm.org/pipermail/llvm-dev/2019-July/133851.html
    See this patch for the introduction of the type: https://reviews.llvm.org/D64790

    Reviewers: courbet

    Subscribers: jholewinski, arsenm, jvesely, nhaehnle, eraman, hiraditya, cfe-commits, llvm-commits

    Tags: #clang, #llvm

    Differential Revision: https://reviews.llvm.org/D68141

    llvm-svn: 373207
