### PR TITLE
Extend TranslatorOpts to handle SPIRVGenKernelArgNameMD [llvm_release_90]

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -71,8 +71,9 @@ public:
 
   TranslatorOpts() = default;
 
-  TranslatorOpts(VersionNumber Max, const ExtensionsStatusMap &Map = {})
-      : MaxVersion(Max), ExtStatusMap(Map) {}
+  TranslatorOpts(VersionNumber Max, const ExtensionsStatusMap &Map = {},
+                 bool ArgNameMD = false)
+      : MaxVersion(Max), ExtStatusMap(Map), GenKernelArgNameMD(ArgNameMD) {}
 
   bool isAllowedToUseVersion(VersionNumber RequestedVersion) const {
     return RequestedVersion <= MaxVersion;
@@ -88,15 +89,22 @@ public:
 
   VersionNumber getMaxVersion() const { return MaxVersion; }
 
+  bool isGenArgNameMDEnabled() const { return GenKernelArgNameMD; }
+
   void enableAllExtensions() {
 #define EXT(X) ExtStatusMap[ExtensionID::X] = true;
 #include "LLVMSPIRVExtensions.inc"
 #undef EXT
   }
 
+  void enableGenArgNameMD() { GenKernelArgNameMD = true; }
+
 private:
+  // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
   ExtensionsStatusMap ExtStatusMap;
+  // SPIR-V to LLVM translation options
+  bool GenKernelArgNameMD;
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -90,11 +90,6 @@ cl::opt<bool> SPIRVEnableStepExpansion(
     "spirv-expand-step", cl::init(true),
     cl::desc("Enable expansion of OpenCL step and smoothstep function"));
 
-cl::opt<bool> SPIRVGenKernelArgNameMD(
-    "spirv-gen-kernel-arg-name-md", cl::init(false),
-    cl::desc("Enable generating OpenCL kernel argument name "
-             "metadata"));
-
 // Prefix for placeholder global variable name.
 const char *KPlaceholderPrefix = "placeholder.";
 
@@ -2761,7 +2756,7 @@ bool SPIRVToLLVM::transKernelMetadata() {
                                    return transOCLKernelArgTypeName(Arg);
                                  });
     // Generate metadata for kernel_arg_name
-    if (SPIRVGenKernelArgNameMD) {
+    if (BM->isGenArgNameMDEnabled()) {
       addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_NAME, BF, F,
                                    [=](SPIRVFunctionParameter *Arg) {
                                      return MDString::get(*Context,

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -427,6 +427,10 @@ public:
     return true;
   }
 
+  virtual bool isGenArgNameMDEnabled() const final {
+    return TranslationOpts.isGenArgNameMDEnabled();
+  }
+
   // I/O functions
   friend spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M);
   friend std::istream &operator>>(std::istream &I, SPIRVModule &M);

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -111,6 +111,11 @@ static cl::list<std::string>
            cl::value_desc("+SPV_extenstion1_name,-SPV_extension2_name"),
            cl::ValueRequired);
 
+static cl::opt<bool> SPIRVGenKernelArgNameMD(
+    "spirv-gen-kernel-arg-name-md", cl::init(false),
+    cl::desc("Enable generating OpenCL kernel argument name "
+             "metadata"));
+
 using SPIRV::ExtensionID;
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
@@ -353,7 +358,8 @@ int main(int Ac, char **Av) {
   if (0 != Ret)
     return Ret;
 
-  SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, ExtensionsStatus);
+  SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, ExtensionsStatus,
+                             SPIRVGenKernelArgNameMD);
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
   if (ToText && (ToBinary || IsReverse || IsRegularization)) {


### PR DESCRIPTION
Cherry-pick ee1fda2 form master to llvm_release_90