### PR TITLE
Extend TranslatorOpts to handle SPIRVGenKernelArgNameMD [llvm_release_80]

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -60,7 +60,8 @@ class TranslatorOpts {
 public:
   TranslatorOpts() = default;
 
-  TranslatorOpts(VersionNumber Max) : MaxVersion(Max) {}
+  TranslatorOpts(VersionNumber Max, bool ArgNameMD = false)
+      : MaxVersion(Max), GenKernelArgNameMD(ArgNameMD) {}
 
   bool isAllowedToUseVersion(VersionNumber RequestedVersion) const {
     return RequestedVersion <= MaxVersion;
@@ -68,8 +69,15 @@ public:
 
   VersionNumber getMaxVersion() const { return MaxVersion; }
 
+  bool isGenArgNameMDEnabled() const { return GenKernelArgNameMD; }
+
+  void enableGenArgNameMD() { GenKernelArgNameMD = true; }
+
 private:
+  // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
+  // SPIR-V to LLVM translation options
+  bool GenKernelArgNameMD;
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -90,11 +90,6 @@ cl::opt<bool> SPIRVEnableStepExpansion(
     "spirv-expand-step", cl::init(true),
     cl::desc("Enable expansion of OpenCL step and smoothstep function"));
 
-cl::opt<bool> SPIRVGenKernelArgNameMD(
-    "spirv-gen-kernel-arg-name-md", cl::init(false),
-    cl::desc("Enable generating OpenCL kernel argument name "
-             "metadata"));
-
 // Prefix for placeholder global variable name.
 const char *KPlaceholderPrefix = "placeholder.";
 
@@ -2511,7 +2506,7 @@ bool SPIRVToLLVM::transKernelMetadata() {
                                    return transOCLKernelArgTypeName(Arg);
                                  });
     // Generate metadata for kernel_arg_name
-    if (SPIRVGenKernelArgNameMD) {
+    if (BM->isGenArgNameMDEnabled()) {
       addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_NAME, BF, F,
                                    [=](SPIRVFunctionParameter *Arg) {
                                      return MDString::get(*Context,

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -396,6 +396,10 @@ public:
     return TranslationOpts.getMaxVersion();
   }
 
+  virtual bool isGenArgNameMDEnabled() const final {
+    return TranslationOpts.isGenArgNameMDEnabled();
+  }
+
   // I/O functions
   friend spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M);
   friend std::istream &operator>>(std::istream &I, SPIRVModule &M);

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -101,6 +101,11 @@ static cl::opt<VersionNumber> MaxSPIRVVersion(
     cl::values(clEnumValN(VersionNumber::SPIRV_1_0, "1.0", "SPIR-V 1.0"),
                clEnumValN(VersionNumber::SPIRV_1_1, "1.1", "SPIR-V 1.1")),
     cl::init(VersionNumber::MaximumVersion));
+static cl::opt<bool> SPIRVGenKernelArgNameMD(
+    "spirv-gen-kernel-arg-name-md", cl::init(false),
+    cl::desc("Enable generating OpenCL kernel argument name "
+             "metadata"));
+
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
 namespace SPIRV {
@@ -275,7 +280,7 @@ int main(int Ac, char **Av) {
 
   cl::ParseCommandLineOptions(Ac, Av, "LLVM/SPIR-V translator");
 
-  SPIRV::TranslatorOpts Opts(MaxSPIRVVersion);
+  SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, SPIRVGenKernelArgNameMD);
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
   if (ToText && (ToBinary || IsReverse || IsRegularization)) {


### PR DESCRIPTION
Cherry-pick ee1fda2 from master to llvm_release_80