### PR TITLE
Fix translation of llvm.global.annotation

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -725,11 +725,6 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
     return transFunctionDecl(F);
 
   if (auto GV = dyn_cast<GlobalVariable>(V)) {
-    if (GV->getName() == "llvm.global.annotations") {
-      transGlobalAnnotation(GV);
-      return nullptr;
-    }
-
     llvm::PointerType *Ty = GV->getType();
     // Though variables with common linkage type are initialized by 0,
     // they can be represented in SPIR-V as uninitialized variables with
@@ -1663,7 +1658,9 @@ void LLVMToSPIRV::transGlobalAnnotation(GlobalVariable *V) {
 
 bool LLVMToSPIRV::transGlobalVariables() {
   for (auto I = M->global_begin(), E = M->global_end(); I != E; ++I) {
-    if (!transValue(&(*I), nullptr))
+    if ((&(*I))->getName() == "llvm.global.annotations")
+      transGlobalAnnotation(&(*I));
+    else if (!transValue(&(*I), nullptr))
       return false;
   }
   return true;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1658,7 +1658,7 @@ void LLVMToSPIRV::transGlobalAnnotation(GlobalVariable *V) {
 
 bool LLVMToSPIRV::transGlobalVariables() {
   for (auto I = M->global_begin(), E = M->global_end(); I != E; ++I) {
-    if ((&(*I))->getName() == "llvm.global.annotations")
+    if ((*I).getName() == "llvm.global.annotations")
       transGlobalAnnotation(&(*I));
     else if (!transValue(&(*I), nullptr))
       return false;

--- a/test/IntelFPGAMemoryAttributesForStaticVar.ll
+++ b/test/IntelFPGAMemoryAttributesForStaticVar.ll
@@ -92,6 +92,7 @@ entry:
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
 
+; CHECK-LLVM: void @_Z3fooi(i32 %a)
 ; Function Attrs: nounwind
 define spir_func void @_Z3fooi(i32 %a) #3 {
 entry:
@@ -104,6 +105,7 @@ entry:
   ret void
 }
 
+; CHECK-LLVM: void @_Z3barc(i8 signext %b)
 ; Function Attrs: nounwind
 define spir_func void @_Z3barc(i8 signext %b) #3 {
 entry:
@@ -119,6 +121,7 @@ entry:
   ret void
 }
 
+; CHECK-LLVM: void @_Z3bazi(i32 %c)
 ; Function Attrs: nounwind
 define spir_func void @_Z3bazi(i32 %c) #3 {
 entry:


### PR DESCRIPTION
This patch fixes the problem that if LLVM IR contains llvm.global.annotation,
translator drops all the rest code except this variable.