### PR TITLE
Fix translator crash when provided empty file

### DIFF
--- a/test/check_empty_file.ll
+++ b/test/check_empty_file.ll
@@ -1,0 +1,3 @@
+; RUN: not llvm-spirv %S/empty_file.bc -o - 2>&1 | FileCheck %s
+
+; CHECK: Can't translate, file is empty

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -177,6 +177,11 @@ static int convertLLVMToSPIRV(const SPIRV::TranslatorOpts &Opts) {
   return 0;
 }
 
+static bool isFileEmpty(const std::string &FileName) {
+  std::ifstream File(FileName);
+  return File && File.peek() == EOF;
+}
+
 static int convertSPIRVToLLVM(const SPIRV::TranslatorOpts &Opts) {
   LLVMContext Context;
   std::ifstream IFS(InputFile, std::ios::binary);
@@ -350,6 +355,11 @@ int main(int Ac, char **Av) {
   PrettyStackTraceProgram X(Ac, Av);
 
   cl::ParseCommandLineOptions(Ac, Av, "LLVM/SPIR-V translator");
+
+  if (InputFile != "-" && isFileEmpty(InputFile)) {
+    errs() << "Can't translate, file is empty\n";
+    return -1;
+  }
 
   SPIRV::TranslatorOpts::ExtensionsStatusMap ExtensionsStatus;
   // ExtensionsStatus will be properly initialized and update according to


### PR DESCRIPTION
It's checking file for emptiness before translating

Signed-off-by: Ilya Mashkov <ilya.mashkov@intel.com>