### PR TITLE
Fix build after r375436

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -63,6 +63,8 @@ void initializeSPIRVRegularizeLLVMPass(PassRegistry &);
 void initializeSPIRVToOCL12Pass(PassRegistry &);
 void initializeSPIRVToOCL20Pass(PassRegistry &);
 void initializePreprocessMetadataPass(PassRegistry &);
+
+class ModulePass;
 } // namespace llvm
 
 #include "llvm/IR/Module.h"


### PR DESCRIPTION
LLVM change that caused build failure:

> Prune Pass.h include from DataLayout.h. NFCI
>
> Summary:
> Reduce include dependencies by no longer including Pass.h from
> DataLayout.h. That include seemed irrelevant to DataLayout, as
> well as being irrelevant to several users of DataLayout.
>
> Reviewers: rnk
>
> Reviewed By: rnk
>
> Subscribers: mehdi_amini, hiraditya, cfe-commits, llvm-commits
>
> Tags: #clang, #llvm
>
> Differential Revision: https://reviews.llvm.org/D69261
>
> llvm-svn: 375436

Signed-off-by: Alexey Sachkov <alexey.sachkov@intel.com>