### PR TITLE
Fix loss of loop metadata during reverse translation

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -725,10 +725,9 @@ void SPIRVToLLVM::transLLVMLoopMetadata(const Function *F) {
         const auto *LCI = static_cast<const SPIRVLoopControlINTEL *>(LMD);
         setLLVMLoopMetadata<SPIRVLoopControlINTEL>(LCI, BI);
       }
-    }
 
-    // Loop metadata map should be re-filled during each function translation.
-    FuncLoopMetadataMap.clear();
+      FuncLoopMetadataMap.erase(LMDItr);
+    }
   }
 }
 

--- a/test/InfiniteLoopMetadataPlacement.ll
+++ b/test/InfiniteLoopMetadataPlacement.ll
@@ -45,6 +45,7 @@ while.body:                                       ; preds = %while.cond
   br i1 %cmp, label %if.then, label %if.else
 
 if.then:                                          ; preds = %while.body
+  call spir_func void @_Z1fv() #0
   br label %while.end
 
 if.else:                                          ; preds = %while.body
@@ -71,6 +72,12 @@ while.end:                                        ; preds = %if.then
   call void @llvm.lifetime.end.p0i8(i64 4, i8* %6) #2
   %7 = bitcast i32* %i to i8*
   call void @llvm.lifetime.end.p0i8(i64 4, i8* %7) #2
+  ret void
+}
+
+; Function Attrs: nounwind
+define spir_func void @_Z1fv() #0 {
+entry:
   ret void
 }
 


### PR DESCRIPTION
A loop's attribute information may be lost during reverse translation
from SPIR-V in case if a function, which contains the loop, also have
a call to another function that is defined after the function with
the loop.
Fix this loss of loop's metadata.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>