### PR TITLE
Add #include <cctype> required for std::isspace() used in SPIRVStream.h

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -44,6 +44,7 @@
 #include "SPIRVExtInst.h"
 #include "SPIRVModule.h"
 #include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <iostream>
 #include <iterator>


### PR DESCRIPTION
Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>