### PR TITLE
Fix range of TemplateTemplateParameter

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -283,7 +283,7 @@ enum {
   SourceIdx       = 2,
   LineIdx         = 3,
   ColumnIdx       = 4,
-  OperandCount    = 4
+  OperandCount    = 5
 };
 }
 


### PR DESCRIPTION
According to SPIR-V Registry DebugTypeTemplateTemplateParameter should have 5 operands, not 4. In function LLVMToSPIRVDbgTran::transDbgTemplateTemplateParameter it also takes 5 operands.

Signed-off-by: Ilya Mashkov ilya.mashkov@intel.com