### PR TITLE
Fix the build after changes in LLVM

### DIFF
--- a/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
@@ -53,6 +53,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/Verifier.h"
+#include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 #include "llvm/PassSupport.h"
 #include "llvm/Support/Casting.h"

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -43,6 +43,7 @@
 
 #include "SPIRVToOCL.h"
 #include "llvm/IR/Verifier.h"
+#include "llvm/Support/CommandLine.h"
 
 namespace SPIRV {
 

--- a/test/DebugInfo/X86/dw_op_minus_direct.ll
+++ b/test/DebugInfo/X86/dw_op_minus_direct.ll
@@ -21,7 +21,7 @@
 
 ; CHECK: .debug_loc contents:
 ; CHECK: 0x00000000:
-; CHECK-NEXT:   [0x0000000000000003, 0x0000000000000004): DW_OP_breg0 RAX+0, DW_OP_constu 0xffffffff, DW_OP_and, DW_OP_lit1, DW_OP_minus, DW_OP_stack_value
+; CHECK-NEXT:   (0x0000000000000003, 0x0000000000000004): DW_OP_breg0 RAX+0, DW_OP_constu 0xffffffff, DW_OP_and, DW_OP_lit1, DW_OP_minus, DW_OP_stack_value
 ;        rax+0, constu 0xffffffff, and, constu 0x00000001, minus, stack-value
 
 source_filename = "minus.c"

--- a/test/DebugInfo/X86/live-debug-variables.ll
+++ b/test/DebugInfo/X86/live-debug-variables.ll
@@ -29,7 +29,7 @@
 ; CHECK:      .debug_loc contents:
 ; CHECK-NEXT: 0x00000000:
 ;   We currently emit an entry for the function prologue, too, which could be optimized away.
-; CHECK:              [0x0000000000000010, 0x0000000000000072): DW_OP_reg3 RBX
+; CHECK:              (0x0000000000000010, 0x0000000000000072): DW_OP_reg3 RBX
 ;   We should only have one entry inside the function.
 ; CHECK-NOT: :
 


### PR DESCRIPTION
The following commits broke the build:
https://github.com/llvm/llvm-project/commit/05da2fe52162c80dfa18aedf70cf73cb11201811
https://github.com/llvm/llvm-project/commit/631be5c0d41161057d02fe08a7aeb4fbde1a91d6
https://github.com/llvm/llvm-project/commit/0908093977b2b80d00baa12f0b2f1424dde096fb

Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>