### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1505,9 +1505,7 @@ bool hasLoopMetadata(const Module *M) {
   for (const Function &F : *M)
     for (const BasicBlock &BB : F) {
       const Instruction *Term = BB.getTerminator();
-      if (!Term)
-        continue;
-      if (const MDNode *MD = Term->getMetadata("llvm.loop"))
+      if (Term && Term->getMetadata("llvm.loop"))
         return true;
     }
   return false;


### PR DESCRIPTION
Fix unused variable warning after bc9fa54 ("Enable loop simplify pass
for all llvm.loop attributes", 2019-11-05).