### PR TITLE
Translate the new representation of Intel FPGA IVDep loop attribute

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -777,6 +777,9 @@ int getMDOperandAsInt(MDNode *N, unsigned I);
 /// Get metadata operand as string.
 std::string getMDOperandAsString(MDNode *N, unsigned I);
 
+/// Get metadata operand as another metadata node
+MDNode *getMDOperandAsMDNode(MDNode *N, unsigned I);
+
 /// Get metadata operand as type.
 Type *getMDOperandAsType(MDNode *N, unsigned I);
 
@@ -935,10 +938,6 @@ template <> inline void SPIRVMap<std::string, Op, SPIRVOpaqueType>::init() {
 // Check if the module contains llvm.loop.* metadata
 bool hasLoopMetadata(const Module *M);
 
-// If the branch instruction has !llvm.loop metadata, go through its operands
-// and find Loop Control mask and possible parameters.
-spv::LoopControlMask getLoopControl(const BranchInst *Branch,
-                                    std::vector<SPIRVWord> &Parameters);
 } // namespace SPIRV
 
 #endif // SPIRV_SPIRVINTERNAL_H

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -51,10 +51,11 @@
 #include "SPIRVValue.h"
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/Analysis/CFG.h"
+#include "llvm/Analysis/LoopInfo.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicInst.h"
@@ -590,18 +591,17 @@ SPIRVToLLVM::getMetadataFromNameAndParameter(std::string Name,
 }
 
 template <typename LoopInstType>
-void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM, Instruction *BI) {
+void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
+                                      const Loop *LoopObj) {
   if (!LM)
     return;
-
-  assert(BI && isa<BranchInst>(BI));
 
   auto Temp = MDNode::getTemporary(*Context, None);
   auto Self = MDNode::get(*Context, Temp.get());
   Self->replaceOperandWith(0, Self);
   SPIRVWord LC = LM->getLoopControl();
   if (LC == LoopControlMaskNone) {
-    BI->setMetadata("llvm.loop", Self);
+    LoopObj->setLoopID(Self);
     return;
   }
 
@@ -685,8 +685,96 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM, Instruction *BI) {
                           LoopControlParameters[++NumParam])));
         break;
       }
-      default:
+      case DependencyArrayINTEL: {
+        // Collect array variable <-> safelen information
+        std::map<Value *, unsigned> ArraySflnMap;
+        unsigned NumOperandPairs = LoopControlParameters[++NumParam];
+        unsigned OperandsEndIndex = NumParam + NumOperandPairs * 2;
+        assert(OperandsEndIndex <= LoopControlParameters.size() &&
+               "Missing loop control parameter!");
+        SPIRVModule *M = LM->getModule();
+        while (NumParam < OperandsEndIndex) {
+          SPIRVId ArraySPIRVId = LoopControlParameters[++NumParam];
+          Value *ArrayVar = ValueMap[M->getValue(ArraySPIRVId)];
+          unsigned Safelen = LoopControlParameters[++NumParam];
+          ArraySflnMap.emplace(ArrayVar, Safelen);
+        }
+
+        // A single run over the loop to retrieve all GetElementPtr instructions
+        // that access relevant array variables
+        std::map<Value *, std::vector<GetElementPtrInst *>> ArrayGEPMap;
+        for (auto &BB : LoopObj->blocks()) {
+          for (Instruction &I : *BB) {
+            auto *GEP = dyn_cast<GetElementPtrInst>(&I);
+            if (!GEP)
+              continue;
+
+            Value *AccessedArray = GEP->getPointerOperand();
+            auto ArraySflnIt = ArraySflnMap.find(AccessedArray);
+            if (ArraySflnIt != ArraySflnMap.end())
+              ArrayGEPMap[AccessedArray].push_back(GEP);
+          }
+        }
+
+        // Create index group metadata nodes specific - one per each array
+        // variables. Mark each GEP accessing a particular array variable
+        // into a corresponding index group
+        std::map<unsigned, std::vector<MDNode *>> SafelenIdxGroupMap;
+        for (auto &ArrayGEPIt : ArrayGEPMap) {
+          // Emit a distinct index group that will be referenced from
+          // llvm.loop.parallel_access_indices metadata
+          auto *CurrentDepthIdxGroup =
+              llvm::MDNode::getDistinct(*Context, None);
+          unsigned Safelen = ArraySflnMap.find(ArrayGEPIt.first)->second;
+          SafelenIdxGroupMap[Safelen].push_back(CurrentDepthIdxGroup);
+
+          for (auto *GEP : ArrayGEPIt.second) {
+            StringRef IdxGroupMDName("llvm.index.group");
+            llvm::MDNode *PreviousIdxGroup = GEP->getMetadata(IdxGroupMDName);
+            if (!PreviousIdxGroup) {
+              GEP->setMetadata(IdxGroupMDName, CurrentDepthIdxGroup);
+              continue;
+            }
+
+            // If we're dealing with an embedded loop, it may be the case
+            // that GEP instructions for some of the arrays were already
+            // marked by the algorithm when it went over the outer level loops.
+            // In order to retain the IVDep information for each "loop
+            // dimension", we will mark such GEP's into a separate joined node
+            // that will refer to the previous levels' index groups AND to the
+            // index group specific to the current loop.
+            std::vector<llvm::Metadata *> CurrentDepthOperands;
+            for (auto &Op : PreviousIdxGroup->operands())
+              CurrentDepthOperands.push_back(Op);
+            if (CurrentDepthOperands.size() == 0)
+              CurrentDepthOperands.push_back(PreviousIdxGroup);
+            CurrentDepthOperands.push_back(CurrentDepthIdxGroup);
+            auto *JointIdxGroup =
+                llvm::MDNode::get(*Context, CurrentDepthOperands);
+            GEP->setMetadata(IdxGroupMDName, JointIdxGroup);
+          }
+        }
+
+        for (auto &SflnIdxGroupIt : SafelenIdxGroupMap) {
+          auto *Name =
+              MDString::get(*Context, "llvm.loop.parallel_access_indices");
+          unsigned SflnValue = SflnIdxGroupIt.first;
+          llvm::Metadata *SafelenMDOp =
+              SflnValue ? ConstantAsMetadata::get(ConstantInt::get(
+                              Type::getInt32Ty(*Context), SflnValue))
+                        : nullptr;
+          std::vector<llvm::Metadata *> Parameters{Name};
+          for (auto *Node : SflnIdxGroupIt.second)
+            Parameters.push_back(Node);
+          if (SafelenMDOp)
+            Parameters.push_back(SafelenMDOp);
+          Metadata.push_back(llvm::MDNode::get(*Context, Parameters));
+        }
         break;
+      }
+      default:
+        llvm_unreachable(
+            "Unexpected token in LoopControlExtendedConstrolsMask");
       }
       ++NumParam;
     }
@@ -695,39 +783,39 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM, Instruction *BI) {
 
   // Set the first operand to refer itself
   Node->replaceOperandWith(0, Node);
-  BI->setMetadata("llvm.loop", Node);
+  LoopObj->setLoopID(Node);
 }
 
 void SPIRVToLLVM::transLLVMLoopMetadata(const Function *F) {
   assert(F);
 
-  if (!FuncLoopMetadataMap.empty()) {
-    // In SPIRV loop metadata is linked to a header basic block of a loop
-    // whilst in LLVM IR it is linked to a latch basic block (the one
-    // whose back edge goes to a header basic block) of the loop.
+  if (FuncLoopMetadataMap.empty())
+    return;
 
-    using Edge = std::pair<const BasicBlock *, const BasicBlock *>;
-    SmallVector<Edge, 32> Edges;
-    FindFunctionBackedges(*F, Edges);
+  DominatorTree DomTree(*(const_cast<Function *>(F)));
+  LoopInfo LI(DomTree);
 
-    for (const auto &BkEdge : Edges) {
-      // Check that loop header BB contains loop metadata.
-      const auto LMDItr = FuncLoopMetadataMap.find(BkEdge.second);
-      if (LMDItr == FuncLoopMetadataMap.end())
-        continue;
+  // In SPIRV loop metadata is linked to a header basic block of a loop
+  // whilst in LLVM IR it is linked to a latch basic block (the one
+  // whose back edge goes to a header basic block) of the loop.
+  // To ensure consistent behaviour, we can rely on the `llvm::Loop`
+  // class to handle the metadata placement
+  for (const auto *LoopObj : LI.getLoopsInPreorder()) {
+    // Check that loop header BB contains loop metadata.
+    const auto LMDItr = FuncLoopMetadataMap.find(LoopObj->getHeader());
+    if (LMDItr == FuncLoopMetadataMap.end())
+      continue;
 
-      auto *BI = const_cast<Instruction *>(BkEdge.first->getTerminator());
-      const auto *LMD = LMDItr->second;
-      if (LMD->getOpCode() == OpLoopMerge) {
-        const auto *LM = static_cast<const SPIRVLoopMerge *>(LMD);
-        setLLVMLoopMetadata<SPIRVLoopMerge>(LM, BI);
-      } else if (LMD->getOpCode() == OpLoopControlINTEL) {
-        const auto *LCI = static_cast<const SPIRVLoopControlINTEL *>(LMD);
-        setLLVMLoopMetadata<SPIRVLoopControlINTEL>(LCI, BI);
-      }
-
-      FuncLoopMetadataMap.erase(LMDItr);
+    const auto *LMD = LMDItr->second;
+    if (LMD->getOpCode() == OpLoopMerge) {
+      const auto *LM = static_cast<const SPIRVLoopMerge *>(LMD);
+      setLLVMLoopMetadata<SPIRVLoopMerge>(LM, LoopObj);
+    } else if (LMD->getOpCode() == OpLoopControlINTEL) {
+      const auto *LCI = static_cast<const SPIRVLoopControlINTEL *>(LMD);
+      setLLVMLoopMetadata<SPIRVLoopControlINTEL>(LCI, LoopObj);
     }
+
+    FuncLoopMetadataMap.erase(LMDItr);
   }
 }
 

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -50,10 +50,10 @@
 namespace llvm {
 class Module;
 class Type;
-class Value;
 class Instruction;
 class CallInst;
 class BasicBlock;
+class Loop;
 class Function;
 class GlobalVariable;
 class LLVMContext;
@@ -255,7 +255,7 @@ private:
   Value *oclTransConstantPipeStorage(SPIRV::SPIRVConstantPipeStorage *BCPS);
   void setName(llvm::Value *V, SPIRVValue *BV);
   template <typename LoopInstType>
-  void setLLVMLoopMetadata(const LoopInstType *LM, Instruction *BI);
+  void setLLVMLoopMetadata(const LoopInstType *LM, const Loop *LoopObj);
   void transLLVMLoopMetadata(const Function *F);
   inline llvm::Metadata *getMetadataFromName(std::string Name);
   inline std::vector<llvm::Metadata *>

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -705,11 +705,74 @@ SPIRV::SPIRVInstruction *LLVMToSPIRV::transUnaryInst(UnaryInstruction *U,
                           BB);
 }
 
+/// This helper class encapsulates information extraction from
+/// "llvm.loop.parallel_access_indices" metadata hints. Initialize
+/// with a pointer to an MDNode with the following structure:
+/// !<Node> = !{!"llvm.loop.parallel_access_indices", !<Node>, !<Node>, ...}
+/// OR:
+/// !<Node> = !{!"llvm.loop.parallel_access_indices", !<Nodes...>, i32 <value>}
+///
+/// All of the MDNode-type operands mark the index groups for particular
+/// array variables. An optional i32 value indicates the safelen (safe
+/// number of iterations) for the optimization application to these
+/// array variables. If the safelen value is absent, an infinite
+/// number of iterations is implied.
+class LLVMParallelAccessIndices {
+public:
+  LLVMParallelAccessIndices(
+      MDNode *Node, LLVMToSPIRV::LLVMToSPIRVMetadataMap &IndexGroupArrayMap)
+      : Node(Node), IndexGroupArrayMap(IndexGroupArrayMap) {}
+
+  void initialize() {
+    assert(isValid() &&
+           "LLVMParallelAccessIndices initialized from an invalid MDNode");
+
+    unsigned NumOperands = Node->getNumOperands();
+    auto *SafeLenExpression = mdconst::dyn_extract_or_null<ConstantInt>(
+        Node->getOperand(NumOperands - 1));
+    // If no safelen value is specified and the last operand
+    // casts to an MDNode* rather than an int, 0 will be stored
+    SafeLen = SafeLenExpression ? SafeLenExpression->getZExtValue() : 0;
+
+    // Count MDNode operands that refer to index groups:
+    // - operand [0] is a string literal and should be ignored;
+    // - depending on whether a particular safelen is specified as the
+    //   last operand, we may or may not want to extract the latter
+    //   as an index group
+    unsigned NumIdxGroups = SafeLen ? NumOperands - 2 : NumOperands - 1;
+    for (unsigned I = 1; I <= NumIdxGroups; ++I) {
+      MDNode *IdxGroupNode = getMDOperandAsMDNode(Node, I);
+      assert(IdxGroupNode &&
+             "Invalid operand in the MDNode for LLVMParallelAccessIndices");
+      auto IdxGroupArrayPairIt = IndexGroupArrayMap.find(IdxGroupNode);
+      assert(IdxGroupArrayPairIt != IndexGroupArrayMap.end() &&
+             "Absent entry for this index group node");
+      ArrayVariablesVec.push_back(IdxGroupArrayPairIt->second);
+    }
+  }
+
+  bool isValid() {
+    bool IsNamedCorrectly = getMDOperandAsString(Node, 0) == ExpectedName;
+    return Node && IsNamedCorrectly;
+  }
+
+  unsigned getSafeLen() { return SafeLen; }
+  const std::vector<SPIRVId> &getArrayVariables() { return ArrayVariablesVec; }
+
+private:
+  MDNode *Node;
+  LLVMToSPIRV::LLVMToSPIRVMetadataMap &IndexGroupArrayMap;
+  const std::string ExpectedName = "llvm.loop.parallel_access_indices";
+  std::vector<SPIRVId> ArrayVariablesVec;
+  unsigned SafeLen;
+};
+
 /// Go through the operands !llvm.loop metadata attached to the branch
 /// instruction, fill the Loop Control mask and possible parameters for its
 /// fields.
-static spv::LoopControlMask getLoopControl(const BranchInst *Branch,
-                                           std::vector<SPIRVWord> &Parameters) {
+static spv::LoopControlMask
+getLoopControl(const BranchInst *Branch, std::vector<SPIRVWord> &Parameters,
+               LLVMToSPIRV::LLVMToSPIRVMetadataMap &IndexGroupArrayMap) {
   if (!Branch)
     return spv::LoopControlMaskNone;
   MDNode *LoopMD = Branch->getMetadata("llvm.loop");
@@ -717,6 +780,12 @@ static spv::LoopControlMask getLoopControl(const BranchInst *Branch,
     return spv::LoopControlMaskNone;
 
   size_t LoopControl = spv::LoopControlMaskNone;
+
+  // Unlike with most of the cases, some loop metadata specifications
+  // can occur multiple times - for these, all correspondent tokens
+  // need to be collected first, and only then added to SPIR-V loop
+  // parameters in a separate routine
+  std::vector<std::pair<SPIRVWord, SPIRVWord>> DependencyArrayParameters;
 
   for (const MDOperand &MDOp : LoopMD->operands()) {
     if (MDNode *Node = dyn_cast<MDNode>(MDOp)) {
@@ -753,8 +822,34 @@ static spv::LoopControlMask getLoopControl(const BranchInst *Branch,
         size_t I = getMDOperandAsInt(Node, 1);
         Parameters.push_back(I);
         LoopControl |= spv::LoopControlExtendedControlsMask;
+      } else if (S == "llvm.loop.parallel_access_indices") {
+        // Intel FPGA IVDep loop attribute
+        LLVMParallelAccessIndices IVDep(Node, IndexGroupArrayMap);
+        IVDep.initialize();
+        // Store IVDep-specific parameters into an intermediate
+        // container to address the case when there're multiple
+        // IVDep metadata nodes and this condition gets entered multiple
+        // times. The update of the main parameters vector & the loop control
+        // mask will be done later, in the main scope of the function
+        unsigned SafeLen = IVDep.getSafeLen();
+        for (auto &ArrayId : IVDep.getArrayVariables())
+          DependencyArrayParameters.emplace_back(ArrayId, SafeLen);
       }
     }
+  }
+
+  // If any loop control parameters were held back until fully collected,
+  // now is the time to move the information to the main parameters collection
+  if (!DependencyArrayParameters.empty()) {
+    Parameters.push_back(DependencyArrayINTEL);
+    // The first parameter states the number of <array, safelen> pairs to be
+    // listed
+    Parameters.push_back(DependencyArrayParameters.size());
+    for (auto &ArraySflnPair : DependencyArrayParameters) {
+      Parameters.push_back(ArraySflnPair.first);
+      Parameters.push_back(ArraySflnPair.second);
+    }
+    LoopControl |= spv::LoopControlExtendedControlsMask;
   }
 
   return static_cast<spv::LoopControlMask>(LoopControl);
@@ -965,7 +1060,8 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
     /// with true edge going to the header and the false edge going out of
     /// the loop, which corresponds to a "Merge Block" per the SPIR-V spec.
     std::vector<SPIRVWord> Parameters;
-    spv::LoopControlMask LoopControl = getLoopControl(Branch, Parameters);
+    spv::LoopControlMask LoopControl =
+        getLoopControl(Branch, Parameters, IndexGroupArrayMap);
 
     if (Branch->isUnconditional()) {
       // For "for" and "while" loops llvm.loop metadata is attached to
@@ -1050,10 +1146,36 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
     std::vector<SPIRVValue *> Indices;
     for (unsigned I = 0, E = GEP->getNumIndices(); I != E; ++I)
       Indices.push_back(transValue(GEP->getOperand(I + 1), BB));
-    return mapValue(
-        V, BM->addPtrAccessChainInst(transType(GEP->getType()),
-                                     transValue(GEP->getPointerOperand(), BB),
-                                     Indices, BB, GEP->isInBounds()));
+    auto *TransPointerOperand = transValue(GEP->getPointerOperand(), BB);
+
+    // Certain array-related optimization hints can be expressed via
+    // LLVM metadata. For the purpose of linking this metadata with
+    // the accessed array variables, our GEP may have been marked into
+    // a so-called index group, an MDNode by itself.
+    if (MDNode *IndexGroup = GEP->getMetadata("llvm.index.group")) {
+      // When where we work with embedded loops, it's natural that
+      // the outer loop's hints apply to all code contained within.
+      // The inner loop's specific hints, however, should stay private
+      // to the inner loop's scope.
+      // Consequently, the following division of the index group metadata
+      // nodes emerges:
+      // 1) The metadata node has no operands. It will be directly referenced
+      //    from within the optimization hint metadata.
+      // 2) The metadata node has several operands. It serves to link an index
+      //    group specific to some embedded loop with other index groups that
+      //    mark the same array variable for the outer loop(s).
+      unsigned NumOperands = IndexGroup->getNumOperands();
+      if (NumOperands > 0)
+        // The index group for this particular "embedded loop depth" is always
+        // signalled by the last variable. We'll want to associate this loop's
+        // control parameters with this inner-loop-specific index group
+        IndexGroup = getMDOperandAsMDNode(IndexGroup, NumOperands - 1);
+      IndexGroupArrayMap[IndexGroup] = TransPointerOperand->getId();
+    }
+
+    return mapValue(V, BM->addPtrAccessChainInst(transType(GEP->getType()),
+                                                 TransPointerOperand, Indices,
+                                                 BB, GEP->isInBounds()));
   }
 
   if (auto Ext = dyn_cast<ExtractElementInst>(V)) {

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -116,6 +116,7 @@ public:
 
   typedef DenseMap<Type *, SPIRVType *> LLVMToSPIRVTypeMap;
   typedef DenseMap<Value *, SPIRVValue *> LLVMToSPIRVValueMap;
+  typedef DenseMap<MDNode *, SPIRVId> LLVMToSPIRVMetadataMap;
 
 private:
   Module *M;
@@ -123,6 +124,7 @@ private:
   SPIRVModule *BM;
   LLVMToSPIRVTypeMap TypeMap;
   LLVMToSPIRVValueMap ValueMap;
+  LLVMToSPIRVMetadataMap IndexGroupArrayMap;
   SPIRVWord SrcLang;
   SPIRVWord SrcLangVer;
   std::unique_ptr<LLVMToSPIRVDbgTran> DbgTran;

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -501,9 +501,13 @@ enum LoopControlMask {
     LoopControlExtendedControlsMask = 0x80000000,
 };
 
+// TODO: Align the controls handling with the latest revision
+// of the SPIR-V specification for FPGA Loop Controls by removing
+// the extended controls token and using the control bits directly
 enum ExtendedControls {
     InitiationIntervalINTEL = 5889,
     MaxConcurrencyINTEL = 5890,
+    DependencyArrayINTEL = 5891,
 };
 
 enum FunctionControlShift {

--- a/test/InfiniteLoopMetadataPlacement.ll
+++ b/test/InfiniteLoopMetadataPlacement.ll
@@ -8,7 +8,7 @@
 ; ModuleID = 'llvm_loop_test.cpp'
 source_filename = "llvm_loop_test.cpp"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
-target triple = "spir64-unknown-linux-sycldevice"
+target triple = "spir64-unknown-unknown-sycldevice"
 
 $_ZTS12WhileOneTest = comdat any
 
@@ -32,7 +32,7 @@ entry:
 
 while.cond:                                       ; preds = %if.end, %entry
 ; CHECK-SPV:      {{[0-9]+}} Label [[WH_COND]]
-; CHECK-SPV-NEXT: {{[0-9]+}} LoopControlINTEL 4
+; CHECK-SPV-NEXT: {{[0-9]+}} LoopControlINTEL 1
 ; CHECK-SPV-NEXT: {{[0-9]+}} Branch
   br label %while.body
 
@@ -63,7 +63,7 @@ if.end:                                           ; preds = %if.else
   %inc = add nsw i32 %5, 1
   store i32 %inc, i32* %i, align 4, !tbaa !7
   br label %while.cond, !llvm.loop !9
-; CHECK-REV-LLVM: br label %while.cond, !llvm.loop ![[MD_IVDEP:[0-9]+]]
+; CHECK-REV-LLVM: br label %while.cond, !llvm.loop ![[MD_UNROLL:[0-9]+]]
 
 ; CHECK-REV-LLVM-NOT: br {{.*}}, !llvm.loop
 
@@ -106,7 +106,7 @@ attributes #2 = { nounwind }
 !7 = !{!8, !8, i64 0}
 !8 = !{!"int", !5, i64 0}
 !9 = distinct !{!9, !10}
-!10 = !{!"llvm.loop.ivdep.enable"}
+!10 = !{!"llvm.loop.unroll.enable"}
 
-; CHECK-REV-LLVM: ![[MD_IVDEP]] = distinct !{![[MD_IVDEP]], ![[MD_ivdep_enable:[0-9]+]]}
-; CHECK-REV-LLVM: ![[MD_ivdep_enable]] = !{!"llvm.loop.ivdep.enable"}
+; CHECK-REV-LLVM: ![[MD_UNROLL]] = distinct !{![[MD_UNROLL]], ![[MD_unroll_enable:[0-9]+]]}
+; CHECK-REV-LLVM: ![[MD_unroll_enable]] = !{!"llvm.loop.unroll.enable"}

--- a/test/transcoding/FPGAIVDepLoopAttr.ll
+++ b/test/transcoding/FPGAIVDepLoopAttr.ll
@@ -1,0 +1,416 @@
+; This LLVM IR was generated using Intel SYCL Clang compiler (https://github.com/intel/llvm)
+;
+; SYCL source code of this program can be found below.
+;
+; void ivdep_embedded_multiple_dimensions() {
+;   int a[10];
+;   int b[10];
+;   [[intelfpga::ivdep]]
+;   for (int i = 0; i != 10; ++i) {
+;     a[i] = i;
+;     b[i] = i;
+;     [[intelfpga::ivdep]]
+;     for (int j = 0; j != 10; ++j) {
+;       a[j] += j;
+;       b[j] += j;
+;       [[intelfpga::ivdep]]
+;       for (int k = 0; k != 10; ++k) {
+;         a[k] += k;
+;         b[k] += k;
+;       }
+;     }
+;   }
+; }
+;
+; void ivdep_mul_arrays_and_global() {
+;   int a[10];
+;   int b[10];
+;   int c[10];
+;   int d[10];
+;   [[intelfpga::ivdep(5)]]
+;   [[intelfpga::ivdep(b, 6)]]
+;   [[intelfpga::ivdep(c)]]
+;   for (int i = 0; i != 10; ++i) {
+;     a[i] = 0;
+;     b[i] = 0;
+;     c[i] = 0;
+;     d[i] = 0;
+;   }
+; }
+;
+; template <typename name, typename Func>
+; __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+;   kernelFunc();
+; }
+;
+; int main() {
+;   kernel_single_task<class kernel_function>([]() {
+;     ivdep_embedded_multiple_dimensions();
+;     ivdep_mul_arrays_and_global();
+;   });
+;   return 0;
+; }
+
+; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -to-text %t.spv -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown-sycldevice"
+
+%"class._ZTSZ4mainE3$_0.anon" = type { i8 }
+
+; CHECK-SPIRV: TypeInt [[TYPE_INT_64:[0-9]+]] 64 0
+; CHECK-SPIRV: TypeInt [[TYPE_INT_32:[0-9]+]] 32 0
+; CHECK-SPIRV: Constant [[TYPE_INT_64]] [[SIZE:[0-9]+]] 10 0
+; CHECK-SPIRV: TypeArray [[TYPE_ARRAY:[0-9]+]] [[TYPE_INT_32]] [[SIZE]]
+; CHECK-SPIRV: TypePointer [[TYPE_PTR:[0-9]+]] {{[0-9]+}} [[TYPE_ARRAY]]
+
+; CHECK-SPIRV: Function
+define dso_local spir_kernel void @_ZTSZ4mainE15kernel_function() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
+  %1 = alloca %"class._ZTSZ4mainE3$_0.anon", align 1
+  %2 = bitcast %"class._ZTSZ4mainE3$_0.anon"* %1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %2) #4
+  %3 = addrspacecast %"class._ZTSZ4mainE3$_0.anon"* %1 to %"class._ZTSZ4mainE3$_0.anon" addrspace(4)*
+  call spir_func void @"_ZZ4mainENK3$_0clEv"(%"class._ZTSZ4mainE3$_0.anon" addrspace(4)* %3)
+  %4 = bitcast %"class._ZTSZ4mainE3$_0.anon"* %1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %4) #4
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: inlinehint nounwind
+define internal spir_func void @"_ZZ4mainENK3$_0clEv"(%"class._ZTSZ4mainE3$_0.anon" addrspace(4)* %0) #2 align 2 {
+  %2 = alloca %"class._ZTSZ4mainE3$_0.anon" addrspace(4)*, align 8
+  store %"class._ZTSZ4mainE3$_0.anon" addrspace(4)* %0, %"class._ZTSZ4mainE3$_0.anon" addrspace(4)** %2, align 8, !tbaa !5
+  call spir_func void @_Z34ivdep_embedded_multiple_dimensionsv()
+  call spir_func void @_Z27ivdep_mul_arrays_and_globalv()
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+; CHECK-SPIRV: Function
+; Function Attrs: nounwind
+define dso_local spir_func void @_Z34ivdep_embedded_multiple_dimensionsv() #3 {
+  ; CHECK-SPIRV: Variable [[TYPE_PTR]] [[ARRAY_A:[0-9]+]]
+  ; CHECK-LLVM: %[[EMB_ARRAY_A:[0-9]+]] = alloca [10 x i32]
+  %1 = alloca [10 x i32], align 4
+  ; CHECK-SPIRV: Variable [[TYPE_PTR]] [[ARRAY_B:[0-9]+]]
+  ; CHECK-LLVM: %[[EMB_ARRAY_B:[0-9]+]] = alloca [10 x i32]
+  %2 = alloca [10 x i32], align 4
+  %3 = alloca i32, align 4
+  %4 = alloca i32, align 4
+  %5 = alloca i32, align 4
+  %6 = alloca i32, align 4
+  %7 = bitcast [10 x i32]* %1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* %7) #4
+  %8 = bitcast [10 x i32]* %2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* %8) #4
+  %9 = bitcast i32* %3 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %9) #4
+  store i32 0, i32* %3, align 4, !tbaa !9
+  br label %10
+
+10:                                               ; preds = %70, %0
+  %11 = load i32, i32* %3, align 4, !tbaa !9
+  %12 = icmp ne i32 %11, 10
+  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 2147483648 5891 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
+  ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
+  br i1 %12, label %15, label %13
+
+13:                                               ; preds = %10
+  store i32 2, i32* %4, align 4
+  %14 = bitcast i32* %3 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %14) #4
+  br label %73
+
+15:                                               ; preds = %10
+  %16 = load i32, i32* %3, align 4, !tbaa !9
+  %17 = load i32, i32* %3, align 4, !tbaa !9
+  %18 = sext i32 %17 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[EMB_ARRAY_A]], {{.*}}, !llvm.index.group ![[EMB_A_IDX_GR_DIM_1:[0-9]+]]
+  %19 = getelementptr inbounds [10 x i32], [10 x i32]* %1, i64 0, i64 %18, !llvm.index.group !11
+  store i32 %16, i32* %19, align 4, !tbaa !9
+  %20 = load i32, i32* %3, align 4, !tbaa !9
+  %21 = load i32, i32* %3, align 4, !tbaa !9
+  %22 = sext i32 %21 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[EMB_ARRAY_B]], {{.*}}, !llvm.index.group ![[EMB_B_IDX_GR_DIM_1:[0-9]+]]
+  %23 = getelementptr inbounds [10 x i32], [10 x i32]* %2, i64 0, i64 %22, !llvm.index.group !12
+  store i32 %20, i32* %23, align 4, !tbaa !9
+  %24 = bitcast i32* %5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %24) #4
+  store i32 0, i32* %5, align 4, !tbaa !9
+  br label %25
+
+25:                                               ; preds = %66, %15
+  %26 = load i32, i32* %5, align 4, !tbaa !9
+  %27 = icmp ne i32 %26, 10
+  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 2147483648 5891 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
+  ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
+  br i1 %27, label %30, label %28
+
+28:                                               ; preds = %25
+  store i32 5, i32* %4, align 4
+  %29 = bitcast i32* %5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %29) #4
+  br label %69
+
+30:                                               ; preds = %25
+  %31 = load i32, i32* %5, align 4, !tbaa !9
+  %32 = load i32, i32* %5, align 4, !tbaa !9
+  %33 = sext i32 %32 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[EMB_ARRAY_A]], {{.*}}, !llvm.index.group ![[EMB_A_IDX_GR_DIM_2:[0-9]+]]
+  %34 = getelementptr inbounds [10 x i32], [10 x i32]* %1, i64 0, i64 %33, !llvm.index.group !13
+  %35 = load i32, i32* %34, align 4, !tbaa !9
+  %36 = add nsw i32 %35, %31
+  store i32 %36, i32* %34, align 4, !tbaa !9
+  %37 = load i32, i32* %5, align 4, !tbaa !9
+  %38 = load i32, i32* %5, align 4, !tbaa !9
+  %39 = sext i32 %38 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[EMB_ARRAY_B]], {{.*}}, !llvm.index.group ![[EMB_B_IDX_GR_DIM_2:[0-9]+]]
+  %40 = getelementptr inbounds [10 x i32], [10 x i32]* %2, i64 0, i64 %39, !llvm.index.group !15
+  %41 = load i32, i32* %40, align 4, !tbaa !9
+  %42 = add nsw i32 %41, %37
+  store i32 %42, i32* %40, align 4, !tbaa !9
+  %43 = bitcast i32* %6 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %43) #4
+  store i32 0, i32* %6, align 4, !tbaa !9
+  br label %44
+
+44:                                               ; preds = %62, %30
+  %45 = load i32, i32* %6, align 4, !tbaa !9
+  %46 = icmp ne i32 %45, 10
+  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 2147483648 5891 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
+  ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
+  br i1 %46, label %49, label %47
+
+47:                                               ; preds = %44
+  store i32 8, i32* %4, align 4
+  %48 = bitcast i32* %6 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %48) #4
+  br label %65
+
+49:                                               ; preds = %44
+  %50 = load i32, i32* %6, align 4, !tbaa !9
+  %51 = load i32, i32* %6, align 4, !tbaa !9
+  %52 = sext i32 %51 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[EMB_ARRAY_A]], {{.*}}, !llvm.index.group ![[EMB_A_IDX_GR_DIM_3:[0-9]+]]
+  %53 = getelementptr inbounds [10 x i32], [10 x i32]* %1, i64 0, i64 %52, !llvm.index.group !17
+  %54 = load i32, i32* %53, align 4, !tbaa !9
+  %55 = add nsw i32 %54, %50
+  store i32 %55, i32* %53, align 4, !tbaa !9
+  %56 = load i32, i32* %6, align 4, !tbaa !9
+  %57 = load i32, i32* %6, align 4, !tbaa !9
+  %58 = sext i32 %57 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[EMB_ARRAY_B]], {{.*}}, !llvm.index.group ![[EMB_B_IDX_GR_DIM_3:[0-9]+]]
+  %59 = getelementptr inbounds [10 x i32], [10 x i32]* %2, i64 0, i64 %58, !llvm.index.group !19
+  %60 = load i32, i32* %59, align 4, !tbaa !9
+  %61 = add nsw i32 %60, %56
+  store i32 %61, i32* %59, align 4, !tbaa !9
+  br label %62
+
+62:                                               ; preds = %49
+  %63 = load i32, i32* %6, align 4, !tbaa !9
+  %64 = add nsw i32 %63, 1
+  store i32 %64, i32* %6, align 4, !tbaa !9
+  ; CHECK-LLVM: br label %{{.*}}, !llvm.loop ![[EMB_MD_LOOP_DIM_3:[0-9]+]]
+  br label %44, !llvm.loop !21
+
+65:                                               ; preds = %47
+  br label %66
+
+66:                                               ; preds = %65
+  %67 = load i32, i32* %5, align 4, !tbaa !9
+  %68 = add nsw i32 %67, 1
+  store i32 %68, i32* %5, align 4, !tbaa !9
+  ; CHECK-LLVM: br label %{{.*}}, !llvm.loop ![[EMB_MD_LOOP_DIM_2:[0-9]+]]
+  br label %25, !llvm.loop !23
+
+69:                                               ; preds = %28
+  br label %70
+
+70:                                               ; preds = %69
+  %71 = load i32, i32* %3, align 4, !tbaa !9
+  %72 = add nsw i32 %71, 1
+  store i32 %72, i32* %3, align 4, !tbaa !9
+  ; CHECK-LLVM: br label %{{.*}}, !llvm.loop ![[EMB_MD_LOOP_DIM_1:[0-9]+]]
+  br label %10, !llvm.loop !25
+
+73:                                               ; preds = %13
+  %74 = bitcast [10 x i32]* %2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* %74) #4
+  %75 = bitcast [10 x i32]* %1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* %75) #4
+  ret void
+}
+
+; CHECK-SPIRV: Function
+; Function Attrs: nounwind
+define dso_local spir_func void @_Z27ivdep_mul_arrays_and_globalv() #3 {
+  ; CHECK-SPIRV: Variable [[TYPE_PTR]] [[ARRAY_A:[0-9]+]]
+  ; CHECK-LLVM: %[[SIMPLE_ARRAY_A:[0-9]+]] = alloca [10 x i32]
+  %1 = alloca [10 x i32], align 4
+  ; CHECK-SPIRV: Variable [[TYPE_PTR]] [[ARRAY_B:[0-9]+]]
+  ; CHECK-LLVM: %[[SIMPLE_ARRAY_B:[0-9]+]] = alloca [10 x i32]
+  %2 = alloca [10 x i32], align 4
+  ; CHECK-SPIRV: Variable [[TYPE_PTR]] [[ARRAY_C:[0-9]+]]
+  ; CHECK-LLVM: %[[SIMPLE_ARRAY_C:[0-9]+]] = alloca [10 x i32]
+  %3 = alloca [10 x i32], align 4
+  ; CHECK-SPIRV: Variable [[TYPE_PTR]] [[ARRAY_D:[0-9]+]]
+  ; CHECK-LLVM: %[[SIMPLE_ARRAY_D:[0-9]+]] = alloca [10 x i32]
+  %4 = alloca [10 x i32], align 4
+  %5 = alloca i32, align 4
+  %6 = bitcast [10 x i32]* %1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* %6) #4
+  %7 = bitcast [10 x i32]* %2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* %7) #4
+  %8 = bitcast [10 x i32]* %3 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* %8) #4
+  %9 = bitcast [10 x i32]* %4 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 40, i8* %9) #4
+  %10 = bitcast i32* %5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 4, i8* %10) #4
+  store i32 0, i32* %5, align 4, !tbaa !9
+  br label %11
+
+11:                                               ; preds = %29, %0
+  %12 = load i32, i32* %5, align 4, !tbaa !9
+  %13 = icmp ne i32 %12, 10
+  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 2147483648 5891 4 [[ARRAY_A]] 5 [[ARRAY_D]] 5 [[ARRAY_B]] 6 [[ARRAY_C]] 0
+  ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
+  br i1 %13, label %16, label %14
+
+14:                                               ; preds = %11
+  %15 = bitcast i32* %5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 4, i8* %15) #4
+  br label %32
+
+16:                                               ; preds = %11
+  %17 = load i32, i32* %5, align 4, !tbaa !9
+  %18 = sext i32 %17 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[SIMPLE_ARRAY_A]], {{.*}}, !llvm.index.group ![[SIMPLE_A_IDX_GR:[0-9]+]]
+  %19 = getelementptr inbounds [10 x i32], [10 x i32]* %1, i64 0, i64 %18, !llvm.index.group !27
+  store i32 0, i32* %19, align 4, !tbaa !9
+  %20 = load i32, i32* %5, align 4, !tbaa !9
+  %21 = sext i32 %20 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[SIMPLE_ARRAY_B]], {{.*}}, !llvm.index.group ![[SIMPLE_B_IDX_GR:[0-9]+]]
+  %22 = getelementptr inbounds [10 x i32], [10 x i32]* %2, i64 0, i64 %21, !llvm.index.group !28
+  store i32 0, i32* %22, align 4, !tbaa !9
+  %23 = load i32, i32* %5, align 4, !tbaa !9
+  %24 = sext i32 %23 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[SIMPLE_ARRAY_C]], {{.*}}, !llvm.index.group ![[SIMPLE_C_IDX_GR:[0-9]+]]
+  %25 = getelementptr inbounds [10 x i32], [10 x i32]* %3, i64 0, i64 %24, !llvm.index.group !29
+  store i32 0, i32* %25, align 4, !tbaa !9
+  %26 = load i32, i32* %5, align 4, !tbaa !9
+  %27 = sext i32 %26 to i64
+  ; CHECK-LLVM: getelementptr inbounds [10 x i32], [10 x i32]* %[[SIMPLE_ARRAY_D]], {{.*}}, !llvm.index.group ![[SIMPLE_D_IDX_GR:[0-9]+]]
+  %28 = getelementptr inbounds [10 x i32], [10 x i32]* %4, i64 0, i64 %27, !llvm.index.group !30
+  store i32 0, i32* %28, align 4, !tbaa !9
+  br label %29
+
+29:                                               ; preds = %16
+  %30 = load i32, i32* %5, align 4, !tbaa !9
+  %31 = add nsw i32 %30, 1
+  store i32 %31, i32* %5, align 4, !tbaa !9
+  ; CHECK-LLVM: br label %{{.*}}, !llvm.loop ![[SIMPLE_MD_LOOP:[0-9]+]]
+  br label %11, !llvm.loop !31
+
+32:                                               ; preds = %14
+  %33 = bitcast [10 x i32]* %4 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* %33) #4
+  %34 = bitcast [10 x i32]* %3 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* %34) #4
+  %35 = bitcast [10 x i32]* %2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* %35) #4
+  %36 = bitcast [10 x i32]* %1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 40, i8* %36) #4
+  ret void
+}
+
+attributes #0 = { "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "sycl-module-id"="ivdep-spirv.cpp" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { argmemonly nounwind willreturn }
+attributes #2 = { inlinehint nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #3 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.spir.version = !{!1}
+!spirv.Source = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 2}
+!2 = !{i32 4, i32 100000}
+!3 = !{!"clang version 10.0.0"}
+!4 = !{}
+!5 = !{!6, !6, i64 0}
+!6 = !{!"any pointer", !7, i64 0}
+!7 = !{!"omnipotent char", !8, i64 0}
+!8 = !{!"Simple C++ TBAA"}
+!9 = !{!10, !10, i64 0}
+!10 = !{!"int", !7, i64 0}
+; Accesses within each dimension of a multi-dimensional (n > 2) loop
+; Index group(s) of each inner loop should have a subnode that points to the containing loop's index group subnode
+; (in case the containing loop is the outermost, to the index group itself)
+;
+; Loop dimension 3 (the innermost loop)
+; CHECK-LLVM-DAG: ![[EMB_A_IDX_GR_DIM_3]] = !{![[EMB_A_IDX_GR_DIM_1]], ![[EMB_A_IDX_NODE_DIM_2:[0-9]+]], ![[EMB_A_IDX_NODE_DIM_3:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[EMB_A_IDX_NODE_DIM_3]] = distinct !{}
+; CHECK-LLVM-DAG: ![[EMB_B_IDX_GR_DIM_3]] = !{![[EMB_B_IDX_GR_DIM_1]], ![[EMB_B_IDX_NODE_DIM_2:[0-9]+]], ![[EMB_B_IDX_NODE_DIM_3:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[EMB_B_IDX_NODE_DIM_3]] = distinct !{}
+; CHECK-LLVM-DAG: ![[EMB_MD_LOOP_DIM_3]] = distinct !{![[EMB_MD_LOOP_DIM_3]], ![[EMB_IVDEP_DIM_3:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[EMB_IVDEP_DIM_3]] = !{!"llvm.loop.parallel_access_indices", ![[EMB_A_IDX_NODE_DIM_3]], ![[EMB_B_IDX_NODE_DIM_3]]}
+;
+; Loop dimension 2
+; CHECK-LLVM-DAG: ![[EMB_A_IDX_GR_DIM_2]] = !{![[EMB_A_IDX_GR_DIM_1]], ![[EMB_A_IDX_NODE_DIM_2]]}
+; CHECK-LLVM-DAG: ![[EMB_A_IDX_NODE_DIM_2]] = distinct !{}
+; CHECK-LLVM-DAG: ![[EMB_B_IDX_GR_DIM_2]] = !{![[EMB_B_IDX_GR_DIM_1]], ![[EMB_B_IDX_NODE_DIM_2]]}
+; CHECK-LLVM-DAG: ![[EMB_B_IDX_NODE_DIM_2]] = distinct !{}
+; CHECK-LLVM-DAG: ![[EMB_MD_LOOP_DIM_2]] = distinct !{![[EMB_MD_LOOP_DIM_2]], ![[EMB_IVDEP_DIM_2:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[EMB_IVDEP_DIM_2]] = !{!"llvm.loop.parallel_access_indices", ![[EMB_A_IDX_NODE_DIM_2]], ![[EMB_B_IDX_NODE_DIM_2]]}
+;
+; Loop dimension 1 (the outermost loop)
+; CHECK-LLVM-DAG: ![[EMB_A_IDX_GR_DIM_1]] = distinct !{}
+; CHECK-LLVM-DAG: ![[EMB_MD_LOOP_DIM_1]] = distinct !{![[EMB_MD_LOOP_DIM_1]], ![[EMB_IVDEP_DIM_1:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[EMB_IVDEP_DIM_1]] = !{!"llvm.loop.parallel_access_indices", ![[EMB_A_IDX_GR_DIM_1]], ![[EMB_B_IDX_GR_DIM_1]]}
+!11 = distinct !{}
+!12 = distinct !{}
+!13 = !{!11, !14}
+!14 = distinct !{}
+!15 = !{!12, !16}
+!16 = distinct !{}
+!17 = !{!11, !14, !18}
+!18 = distinct !{}
+!19 = !{!12, !16, !20}
+!20 = distinct !{}
+!21 = distinct !{!21, !22}
+!22 = !{!"llvm.loop.parallel_access_indices", !18, !20}
+!23 = distinct !{!23, !24}
+!24 = !{!"llvm.loop.parallel_access_indices", !14, !16}
+!25 = distinct !{!25, !26}
+!26 = !{!"llvm.loop.parallel_access_indices", !11, !12}
+; Multiple arrays with specific safelens in a simple one-dimensional loop
+; CHECK-LLVM-DAG: ![[SIMPLE_A_IDX_GR]] = distinct !{}
+; CHECK-LLVM-DAG: ![[SIMPLE_B_IDX_GR]] = distinct !{}
+; CHECK-LLVM-DAG: ![[SIMPLE_C_IDX_GR]] = distinct !{}
+; CHECK-LLVM-DAG: ![[SIMPLE_D_IDX_GR]] = distinct !{}
+!27 = distinct !{}
+!28 = distinct !{}
+!29 = distinct !{}
+!30 = distinct !{}
+; CHECK-LLVM-DAG: ![[SIMPLE_MD_LOOP]] = distinct !{![[SIMPLE_MD_LOOP]], ![[SIMPLE_IVDEP_C:[0-9]+]], ![[SIMPLE_IVDEP_A_D:[0-9]+]], ![[SIMPLE_IVDEP_B:[0-9]+]]}
+!31 = distinct !{!31, !32, !33, !34}
+; CHECK-LLVM-DAG: ![[SIMPLE_IVDEP_A_D]] = !{!"llvm.loop.parallel_access_indices", ![[SIMPLE_A_IDX_GR]], ![[SIMPLE_D_IDX_GR]], i32 5}
+!32 = !{!"llvm.loop.parallel_access_indices", !27, !30, i32 5}
+; CHECK-LLVM-DAG: ![[SIMPLE_IVDEP_B]] = !{!"llvm.loop.parallel_access_indices", ![[SIMPLE_B_IDX_GR]], i32 6}
+!33 = !{!"llvm.loop.parallel_access_indices", !28, i32 6}
+; CHECK-LLVM-DAG: ![[SIMPLE_IVDEP_C]] = !{!"llvm.loop.parallel_access_indices", ![[SIMPLE_C_IDX_GR]]}
+!34 = !{!"llvm.loop.parallel_access_indices", !29}

--- a/test/transcoding/FPGAUnstructuredLoopAttr.ll
+++ b/test/transcoding/FPGAUnstructuredLoopAttr.ll
@@ -17,13 +17,13 @@
 ; CHECK-SPIRV: 2 Label [[ENTRY_1]]
 ; CHECK-SPIRV: 2 Branch [[FOR]]
 ; CHECK-SPIRV: 2 Label [[FOR]]
-; CHECK-SPIRV: 3 LoopControlINTEL 8 2
+; CHECK-SPIRV: 4 LoopControlINTEL 2147483648 5890 2
 ; CHECK-SPIRV: 2 Branch [[FOR]]
 ; CHECK-SPIRV: 5 Function 2 [[BOO]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: 2 Label [[ENTRY_2]]
 ; CHECK-SPIRV: 2 Branch [[WHILE]]
 ; CHECK-SPIRV: 2 Label [[WHILE]]
-; CHECK-SPIRV: 2 LoopControlINTEL 4
+; CHECK-SPIRV: 4 LoopControlINTEL 2147483648 5889 2
 ; CHECK-SPIRV: 2 Branch [[WHILE]]
 
 ; ModuleID = 'infinite.cl'
@@ -64,11 +64,11 @@ attributes #0 = { nounwind }
 !1 = !{i32 1, i32 2}
 !2 = !{!"clang version 9.0.0"}
 !3 = distinct !{!3, !4}
-!4 = !{!"llvm.loop.ivdep.safelen", i32 2}
+!4 = !{!"llvm.loop.max_concurrency.count", i32 2}
 !5 = distinct !{!5, !6}
-!6 = !{!"llvm.loop.ivdep.enable"}
+!6 = !{!"llvm.loop.ii.count", i32 2}
 
 ; CHECK-LLVM: ![[MD_1]] = distinct !{![[MD_1]], ![[LOOP_MD_1:[0-9]+]]}
-; CHECK-LLVM: ![[LOOP_MD_1]] = !{!"llvm.loop.ivdep.safelen", i32 2}
+; CHECK-LLVM: ![[LOOP_MD_1]] = !{!"llvm.loop.max_concurrency.count", i32 2}
 ; CHECK-LLVM: ![[MD_2]] = distinct !{![[MD_2]], ![[LOOP_MD_2:[0-9]+]]}
-; CHECK-LLVM: ![[LOOP_MD_2]] = !{!"llvm.loop.ivdep.enable"}
+; CHECK-LLVM: ![[LOOP_MD_2]] = !{!"llvm.loop.ii.count", i32 2}


### PR DESCRIPTION
The new LLVM IR representation of [[intelfpga::ivdep]] takes into account
the array variables being accessed from within the loop. A brief outline is
that each array variable's GetElementPtr instruction is marked with a
so-called "index group metadata". These index groups are referenced by
IVDep-specific "llvm.loop.parallel_access_indices", which is (finally!)
attached to "llvm.loop" metadata.

The SPIR-V specification for this version of the attribute can be found at:
https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/INTEL/SPV_INTEL_fpga_loop_controls.asciidoc

Some outline of refactoring that took place:
1) The getLoopControl() utility was moved from SPIRVUtil into SPIRVWriter,
the helper being Writer-specific anyway.
2) Several NFCs regarding getMDOperandAs...() helpers now allow safe and
convenient extraction of integer values and MDNode objects from the
"parent" metadata node.
3) Upon encountering loop control parameters, SPIRVReader is now
required to perform full loop analysis for the given function. This
is required to allow convenient access to the GEP instructions in
all of the embedded loops' body blocks.

The older representation of IVDep via {!llvm.loop.ivdep.*} metadata
was retained to ensure backwards compatibility. The unit testing that
used to rely on this representation while not being directly related
aimed at testing the IVDep was reworked to use the other loop attributes.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>