### PR TITLE
Update for LLVM API changes to CreateMemCpy

### DIFF
--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -79,7 +79,7 @@ public:
       // The source could be bit-cast from another type,
       // need the original type for the allocation of the temporary variable
       SrcTy = cast<BitCastInst>(Src)->getOperand(0)->getType();
-    auto Align = I.getSourceAlignment();
+    MaybeAlign Align = I.getSourceAlign();
     auto Volatile = I.isVolatile();
     Value *NumElements = nullptr;
     uint64_t ElementsCount = 1;
@@ -95,10 +95,10 @@ public:
 
     auto *Alloca =
         Builder.CreateAlloca(SrcTy->getPointerElementType(), NumElements);
-    Alloca->setAlignment(MaybeAlign(Align));
+    Alloca->setAlignment(Align);
     Builder.CreateLifetimeStart(Alloca);
     Builder.CreateMemCpy(Alloca, Align, Src, Align, Length, Volatile);
-    auto *SecondCpy = Builder.CreateMemCpy(Dest, I.getDestAlignment(), Alloca,
+    auto *SecondCpy = Builder.CreateMemCpy(Dest, I.getDestAlign(), Alloca,
                                            Align, Length, Volatile);
     Builder.CreateLifetimeEnd(Alloca);
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1522,7 +1522,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     SPIRVCopyMemorySized *BC = static_cast<SPIRVCopyMemorySized *>(BV);
     CallInst *CI = nullptr;
     llvm::Value *Dst = transValue(BC->getTarget(), F, BB);
-    unsigned Align = BC->getAlignment();
+    MaybeAlign Align(BC->getAlignment());
     llvm::Value *Size = transValue(BC->getSize(), F, BB);
     bool IsVolatile = BC->SPIRVMemoryAccess::isVolatile();
     IRBuilder<> Builder(BB);
@@ -1545,8 +1545,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
               NewDst = llvm::BitCastInst::CreatePointerCast(Dst, Int8PointerTy,
                                                             "", BB);
             }
-            CI = Builder.CreateMemSet(NewDst, Src, Size, MaybeAlign(Align),
-                                      IsVolatile);
+            CI = Builder.CreateMemSet(NewDst, Src, Size, Align, IsVolatile);
           }
         }
       }


### PR DESCRIPTION
LLVM commit 531c1161b97 ("Resubmit "[Alignment][NFC] Deprecate
CreateMemCpy/CreateMemMove"", 2019-12-16) deprecated the variants that
do not take `MaybeAlign` arguments.