### PR TITLE
Align FPGA Loop Controls translation with the spec (rev C)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -702,7 +702,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
     // A single run over the loop to retrieve all GetElementPtr instructions
     // that access relevant array variables
     std::map<Value *, std::vector<GetElementPtrInst *>> ArrayGEPMap;
-    for (auto &BB : LoopObj->blocks()) {
+    for (const auto &BB : LoopObj->blocks()) {
       for (Instruction &I : *BB) {
         auto *GEP = dyn_cast<GetElementPtrInst>(&I);
         if (!GEP)
@@ -741,10 +741,9 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
         // dimension", we will mark such GEP's into a separate joined node
         // that will refer to the previous levels' index groups AND to the
         // index group specific to the current loop.
-        std::vector<llvm::Metadata *> CurrentDepthOperands;
-        for (auto &Op : PreviousIdxGroup->operands())
-          CurrentDepthOperands.push_back(Op);
-        if (CurrentDepthOperands.size() == 0)
+        std::vector<llvm::Metadata *> CurrentDepthOperands(
+            PreviousIdxGroup->op_begin(), PreviousIdxGroup->op_end());
+        if (CurrentDepthOperands.empty())
           CurrentDepthOperands.push_back(PreviousIdxGroup);
         CurrentDepthOperands.push_back(CurrentDepthIdxGroup);
         auto *JointIdxGroup = llvm::MDNode::get(*Context, CurrentDepthOperands);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -822,15 +822,13 @@ getLoopControl(const BranchInst *Branch, std::vector<SPIRVWord> &Parameters,
         Parameters.push_back(I);
         LoopControl |= spv::LoopControlDependencyLengthMask;
       } else if (S == "llvm.loop.ii.count") {
-        Parameters.push_back(InitiationIntervalINTEL);
         size_t I = getMDOperandAsInt(Node, 1);
         Parameters.push_back(I);
-        LoopControl |= spv::LoopControlExtendedControlsMask;
+        LoopControl |= spv::InitiationIntervalINTEL;
       } else if (S == "llvm.loop.max_concurrency.count") {
-        Parameters.push_back(MaxConcurrencyINTEL);
         size_t I = getMDOperandAsInt(Node, 1);
         Parameters.push_back(I);
-        LoopControl |= spv::LoopControlExtendedControlsMask;
+        LoopControl |= spv::MaxConcurrencyINTEL;
       } else if (S == "llvm.loop.parallel_access_indices") {
         // Intel FPGA IVDep loop attribute
         LLVMParallelAccessIndices IVDep(Node, IndexGroupArrayMap);
@@ -850,7 +848,6 @@ getLoopControl(const BranchInst *Branch, std::vector<SPIRVWord> &Parameters,
   // If any loop control parameters were held back until fully collected,
   // now is the time to move the information to the main parameters collection
   if (!DependencyArrayParameters.empty()) {
-    Parameters.push_back(DependencyArrayINTEL);
     // The first parameter states the number of <array, safelen> pairs to be
     // listed
     Parameters.push_back(DependencyArrayParameters.size());
@@ -858,7 +855,7 @@ getLoopControl(const BranchInst *Branch, std::vector<SPIRVWord> &Parameters,
       Parameters.push_back(ArraySflnPair.first);
       Parameters.push_back(ArraySflnPair.second);
     }
-    LoopControl |= spv::LoopControlExtendedControlsMask;
+    LoopControl |= spv::DependencyArrayINTEL;
   }
 
   return static_cast<spv::LoopControlMask>(LoopControl);

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -1058,7 +1058,9 @@ inline bool isValidLoopControlMask(SPIRVWord Mask) {
   ValidMask |= LoopControlPartialCountMask;
   ValidMask |= LoopControlDependencyInfiniteMask;
   ValidMask |= LoopControlDependencyLengthMask;
-  ValidMask |= LoopControlExtendedControlsMask;
+  ValidMask |= InitiationIntervalINTEL;
+  ValidMask |= MaxConcurrencyINTEL;
+  ValidMask |= DependencyArrayINTEL;
 
   return (Mask & ~ValidMask) == 0;
 }

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -499,16 +499,9 @@ enum LoopControlMask {
     LoopControlIterationMultipleMask = 0x00000040,
     LoopControlPeelCountMask = 0x00000080,
     LoopControlPartialCountMask = 0x00000100,
-    LoopControlExtendedControlsMask = 0x80000000,
-};
-
-// TODO: Align the controls handling with the latest revision
-// of the SPIR-V specification for FPGA Loop Controls by removing
-// the extended controls token and using the control bits directly
-enum ExtendedControls {
-    InitiationIntervalINTEL = 5889,
-    MaxConcurrencyINTEL = 5890,
-    DependencyArrayINTEL = 5891,
+    InitiationIntervalINTEL = 0x10000,
+    MaxConcurrencyINTEL = 0x20000,
+    DependencyArrayINTEL = 0x40000,
 };
 
 enum FunctionControlShift {

--- a/test/transcoding/FPGAIVDepLoopAttr.ll
+++ b/test/transcoding/FPGAIVDepLoopAttr.ll
@@ -130,7 +130,7 @@ define dso_local spir_func void @_Z34ivdep_embedded_multiple_dimensionsv() #3 {
 10:                                               ; preds = %70, %0
   %11 = load i32, i32* %3, align 4, !tbaa !9
   %12 = icmp ne i32 %11, 10
-  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 2147483648 5891 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
+  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 262144 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
   ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
   br i1 %12, label %15, label %13
 
@@ -161,7 +161,7 @@ define dso_local spir_func void @_Z34ivdep_embedded_multiple_dimensionsv() #3 {
 25:                                               ; preds = %66, %15
   %26 = load i32, i32* %5, align 4, !tbaa !9
   %27 = icmp ne i32 %26, 10
-  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 2147483648 5891 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
+  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 262144 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
   ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
   br i1 %27, label %30, label %28
 
@@ -196,7 +196,7 @@ define dso_local spir_func void @_Z34ivdep_embedded_multiple_dimensionsv() #3 {
 44:                                               ; preds = %62, %30
   %45 = load i32, i32* %6, align 4, !tbaa !9
   %46 = icmp ne i32 %45, 10
-  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 2147483648 5891 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
+  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 262144 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
   ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
   br i1 %46, label %49, label %47
 
@@ -292,7 +292,7 @@ define dso_local spir_func void @_Z27ivdep_mul_arrays_and_globalv() #3 {
 11:                                               ; preds = %29, %0
   %12 = load i32, i32* %5, align 4, !tbaa !9
   %13 = icmp ne i32 %12, 10
-  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 2147483648 5891 4 [[ARRAY_A]] 5 [[ARRAY_D]] 5 [[ARRAY_B]] 6 [[ARRAY_C]] 0
+  ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 262144 4 [[ARRAY_A]] 5 [[ARRAY_D]] 5 [[ARRAY_B]] 6 [[ARRAY_C]] 0
   ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
   br i1 %13, label %16, label %14
 

--- a/test/transcoding/FPGAIVDepLoopAttr.ll
+++ b/test/transcoding/FPGAIVDepLoopAttr.ll
@@ -130,6 +130,8 @@ define dso_local spir_func void @_Z34ivdep_embedded_multiple_dimensionsv() #3 {
 10:                                               ; preds = %70, %0
   %11 = load i32, i32* %3, align 4, !tbaa !9
   %12 = icmp ne i32 %11, 10
+  ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+  ; DependencyArrayINTEL = 0x40000 (262144)
   ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 262144 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
   ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
   br i1 %12, label %15, label %13
@@ -161,6 +163,8 @@ define dso_local spir_func void @_Z34ivdep_embedded_multiple_dimensionsv() #3 {
 25:                                               ; preds = %66, %15
   %26 = load i32, i32* %5, align 4, !tbaa !9
   %27 = icmp ne i32 %26, 10
+  ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+  ; DependencyArrayINTEL = 0x40000 (262144)
   ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 262144 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
   ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
   br i1 %27, label %30, label %28
@@ -196,6 +200,8 @@ define dso_local spir_func void @_Z34ivdep_embedded_multiple_dimensionsv() #3 {
 44:                                               ; preds = %62, %30
   %45 = load i32, i32* %6, align 4, !tbaa !9
   %46 = icmp ne i32 %45, 10
+  ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+  ; DependencyArrayINTEL = 0x40000 (262144)
   ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 262144 2 [[ARRAY_A]] 0 [[ARRAY_B]] 0
   ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
   br i1 %46, label %49, label %47
@@ -292,6 +298,8 @@ define dso_local spir_func void @_Z27ivdep_mul_arrays_and_globalv() #3 {
 11:                                               ; preds = %29, %0
   %12 = load i32, i32* %5, align 4, !tbaa !9
   %13 = icmp ne i32 %12, 10
+  ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+  ; DependencyArrayINTEL = 0x40000 (262144)
   ; CHECK-SPIRV: LoopMerge [[MERGE_BLOCK:[0-9]+]] {{[0-9]+}} 262144 4 [[ARRAY_A]] 5 [[ARRAY_D]] 5 [[ARRAY_B]] 6 [[ARRAY_C]] 0
   ; CHECK-SPIRV-NEXT: BranchConditional {{[0-9]+}} {{[0-9]+}} [[MERGE_BLOCK]]
   br i1 %13, label %16, label %14

--- a/test/transcoding/FPGALoopAttr.ll
+++ b/test/transcoding/FPGALoopAttr.ll
@@ -22,8 +22,9 @@ entry:
   %i28 = alloca i32, align 4
   store i32 0, i32* %i, align 4
   br label %for.cond
+; Per SPIR-V spec, LoopControlDependencyInfiniteMask = 0x00000004
 ; CHECK-SPIRV: 4 LoopMerge {{[0-9]+}} {{[0-9]+}} 4
-; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 for.cond:                                         ; preds = %for.inc, %entry
   %0 = load i32, i32* %i, align 4
   %cmp = icmp ne i32 %0, 10
@@ -46,8 +47,9 @@ for.end:                                          ; preds = %for.cond
   store i32 0, i32* %i1, align 4
   br label %for.cond2
 
+; Per SPIR-V spec, LoopControlDependencyLengthMask = 0x00000008
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 8 2
-; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 for.cond2:                                        ; preds = %for.inc7, %for.end
   %3 = load i32, i32* %i1, align 4
   %cmp3 = icmp ne i32 %3, 10
@@ -70,8 +72,10 @@ for.end9:                                         ; preds = %for.cond2
   store i32 0, i32* %i10, align 4
   br label %for.cond11
 
+; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+; InitiationIntervalINTEL = 0x10000 (65536)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 65536 2
-; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 for.cond11:                                       ; preds = %for.inc16, %for.end9
   %6 = load i32, i32* %i10, align 4
   %cmp12 = icmp ne i32 %6, 10
@@ -94,8 +98,10 @@ for.end18:                                        ; preds = %for.cond11
   store i32 0, i32* %i19, align 4
   br label %for.cond20
 
+; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+; MaxConcurrencyINTEL = 0x20000 (131072)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 131072 2
-; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 for.cond20:                                       ; preds = %for.inc25, %for.end18
   %9 = load i32, i32* %i19, align 4
   %cmp21 = icmp ne i32 %9, 10
@@ -118,6 +124,8 @@ for.end27:                                        ; preds = %for.cond20
   store i32 0, i32* %i28, align 4
   br label %for.cond29
 
+; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+; InitiationIntervalINTEL & MaxConcurrencyINTEL = 0x10000 & 0x20000 = 0x30000 (196608)
 ; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 196608 2 2
 ; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 for.cond29:                                       ; preds = %for.inc34, %for.end27

--- a/test/transcoding/FPGALoopAttr.ll
+++ b/test/transcoding/FPGALoopAttr.ll
@@ -70,7 +70,7 @@ for.end9:                                         ; preds = %for.cond2
   store i32 0, i32* %i10, align 4
   br label %for.cond11
 
-; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 2147483648 5889 2
+; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 65536 2
 ; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 for.cond11:                                       ; preds = %for.inc16, %for.end9
   %6 = load i32, i32* %i10, align 4
@@ -94,7 +94,7 @@ for.end18:                                        ; preds = %for.cond11
   store i32 0, i32* %i19, align 4
   br label %for.cond20
 
-; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 2147483648 5890 2
+; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 131072 2
 ; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 for.cond20:                                       ; preds = %for.inc25, %for.end18
   %9 = load i32, i32* %i19, align 4
@@ -118,7 +118,7 @@ for.end27:                                        ; preds = %for.cond20
   store i32 0, i32* %i28, align 4
   br label %for.cond29
 
-; CHECK-SPIRV: 8 LoopMerge {{[0-9]+}} {{[0-9]+}} 2147483648 5889 2 5890 2
+; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 196608 2 2
 ; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 for.cond29:                                       ; preds = %for.inc34, %for.end27
   %12 = load i32, i32* %i28, align 4

--- a/test/transcoding/FPGALoopMergeInst.ll
+++ b/test/transcoding/FPGALoopMergeInst.ll
@@ -126,7 +126,7 @@ if.end:                                           ; preds = %while.body
 
 while.end:                                        ; preds = %while.cond
   br label %while.cond1
-; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 2147483648 5889 2
+; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 65536 2
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 while.cond1:                                      ; preds = %if.end8, %if.then6, %while.end
   %6 = load i32, i32* %i, align 4, !tbaa !9
@@ -151,7 +151,7 @@ if.end8:                                          ; preds = %while.body3
 
 while.end9:                                       ; preds = %while.cond1
   br label %while.cond10
-; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 2147483648 5890 4
+; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 131072 4
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 while.cond10:                                     ; preds = %if.end17, %if.then15, %while.end9
   %10 = load i32, i32* %i, align 4, !tbaa !9

--- a/test/transcoding/FPGALoopMergeInst.ll
+++ b/test/transcoding/FPGALoopMergeInst.ll
@@ -44,6 +44,13 @@
 ;   }
 ; }
 
+; TODO: This source code will result in different LLVM IR after
+; rev [a47242e4b2c1c9] of https://github.com/intel/llvm (the
+; [[intelfpga::ivdep]] attribute will be represented otherwise).
+; It's worth factoring out the old representation's translation:
+; (!"llvm.loop.ivdep.*" <-> LoopControlDependency*Mask)
+; into a separate test file
+
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-ext=+all -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o %t.spt
@@ -126,6 +133,8 @@ if.end:                                           ; preds = %while.body
 
 while.end:                                        ; preds = %while.cond
   br label %while.cond1
+; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+; InitiationIntervalINTEL = 0x10000 (65536)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 65536 2
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 while.cond1:                                      ; preds = %if.end8, %if.then6, %while.end
@@ -151,6 +160,8 @@ if.end8:                                          ; preds = %while.body3
 
 while.end9:                                       ; preds = %while.cond1
   br label %while.cond10
+; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+; MaxConcurrencyINTEL = 0x20000 (131072)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 131072 4
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 while.cond10:                                     ; preds = %if.end17, %if.then15, %while.end9

--- a/test/transcoding/FPGAUnstructuredLoopAttr.ll
+++ b/test/transcoding/FPGAUnstructuredLoopAttr.ll
@@ -17,13 +17,13 @@
 ; CHECK-SPIRV: 2 Label [[ENTRY_1]]
 ; CHECK-SPIRV: 2 Branch [[FOR]]
 ; CHECK-SPIRV: 2 Label [[FOR]]
-; CHECK-SPIRV: 4 LoopControlINTEL 2147483648 5890 2
+; CHECK-SPIRV: 3 LoopControlINTEL 131072 2
 ; CHECK-SPIRV: 2 Branch [[FOR]]
 ; CHECK-SPIRV: 5 Function 2 [[BOO]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: 2 Label [[ENTRY_2]]
 ; CHECK-SPIRV: 2 Branch [[WHILE]]
 ; CHECK-SPIRV: 2 Label [[WHILE]]
-; CHECK-SPIRV: 4 LoopControlINTEL 2147483648 5889 2
+; CHECK-SPIRV: 3 LoopControlINTEL 65536 2
 ; CHECK-SPIRV: 2 Branch [[WHILE]]
 
 ; ModuleID = 'infinite.cl'

--- a/test/transcoding/FPGAUnstructuredLoopAttr.ll
+++ b/test/transcoding/FPGAUnstructuredLoopAttr.ll
@@ -13,18 +13,24 @@
 ; CHECK-SPIRV: 5 Name [[FOR:[0-9]+]] "for.cond"
 ; CHECK-SPIRV: 4 Name [[ENTRY_2:[0-9]+]] "entry"
 ; CHECK-SPIRV: 5 Name [[WHILE:[0-9]+]] "while.body"
+
 ; CHECK-SPIRV: 5 Function 2 [[FOO]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: 2 Label [[ENTRY_1]]
 ; CHECK-SPIRV: 2 Branch [[FOR]]
 ; CHECK-SPIRV: 2 Label [[FOR]]
+; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+; MaxConcurrencyINTEL = 0x20000 (131072)
 ; CHECK-SPIRV: 3 LoopControlINTEL 131072 2
-; CHECK-SPIRV: 2 Branch [[FOR]]
+; CHECK-SPIRV-NEXT: 2 Branch [[FOR]]
+
 ; CHECK-SPIRV: 5 Function 2 [[BOO]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV: 2 Label [[ENTRY_2]]
 ; CHECK-SPIRV: 2 Branch [[WHILE]]
 ; CHECK-SPIRV: 2 Label [[WHILE]]
+; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
+; InitiationIntervalINTEL = 0x10000 (65536)
 ; CHECK-SPIRV: 3 LoopControlINTEL 65536 2
-; CHECK-SPIRV: 2 Branch [[WHILE]]
+; CHECK-SPIRV-NEXT: 2 Branch [[WHILE]]
 
 ; ModuleID = 'infinite.cl'
 source_filename = "infinite.cl"


### PR DESCRIPTION
The specification itself can be found at
https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/INTEL/SPV_INTEL_fpga_loop_controls.asciidoc

As per revision B -> revision C transition in the spec, the patch
removes the "extended loop controls" field, storing the FPGA loop
controls as bit fields in the "common" LoopControl mask.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>