### PR TITLE
Enable NoGlobalOffsetINTEL execution mode translation

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -214,6 +214,12 @@ void PreprocessMetadata::visit(Module *M) {
           .done();
     }
 
+    // !{void (i32 addrspace(1)*)* @kernel, i32 no_global_work_offset}
+    if (MDNode *NoGlobalOffsetINTEL =
+            Kernel.getMetadata(kSPIR2MD::NoGlobalOffset)) {
+      EM.addOp().add(&Kernel).add(spv::ExecutionModeNoGlobalOffsetINTEL).done();
+    }
+
     // !{void (i32 addrspace(1)*)* @kernel, i32 max_global_work_dim, i32 dim}
     if (MDNode *MaxWorkDimINTEL = Kernel.getMetadata(kSPIR2MD::MaxWGDim)) {
       EM.addOp()

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -376,6 +376,7 @@ const static char WGSize[] = "reqd_work_group_size";
 const static char WGSizeHint[] = "work_group_size_hint";
 const static char SubgroupSize[] = "intel_reqd_sub_group_size";
 const static char MaxWGSize[] = "max_work_group_size";
+const static char NoGlobalOffset[] = "no_global_work_offset";
 const static char MaxWGDim[] = "max_global_work_dim";
 const static char NumSIMD[] = "num_simd_work_items";
 } // namespace kSPIR2MD

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3285,6 +3285,10 @@ bool SPIRVToLLVM::transKernelMetadata() {
       F->setMetadata(kSPIR2MD::MaxWGSize,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
+    // Generate metadata for no_global_work_offset
+    if (auto EM = BF->getExecutionMode(ExecutionModeNoGlobalOffsetINTEL)) {
+      F->setMetadata(kSPIR2MD::NoGlobalOffset, MDNode::get(*Context, {}));
+    }
     // Generate metadata for max_global_work_dim
     if (auto EM = BF->getExecutionMode(ExecutionModeMaxWorkDimINTEL)) {
       F->setMetadata(kSPIR2MD::MaxWGDim,

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2119,6 +2119,14 @@ bool LLVMToSPIRV::transExecutionMode() {
           BM->addCapability(CapabilityKernelAttributesINTEL);
         }
       } break;
+      case spv::ExecutionModeNoGlobalOffsetINTEL: {
+        if (BM->isAllowedToUseExtension(
+                ExtensionID::SPV_INTEL_kernel_attributes)) {
+          BF->addExecutionMode(BM->add(
+              new SPIRVExecutionMode(BF, static_cast<ExecutionMode>(EMode))));
+          BM->addCapability(CapabilityKernelAttributesINTEL);
+        }
+      } break;
       case spv::ExecutionModeVecTypeHint:
       case spv::ExecutionModeSubgroupSize:
       case spv::ExecutionModeSubgroupsPerWorkgroup: {

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -141,6 +141,7 @@ inline bool isValid(spv::ExecutionMode V) {
   case ExecutionModeSubgroupSize:
   case ExecutionModeSubgroupsPerWorkgroup:
   case ExecutionModeMaxWorkgroupSizeINTEL:
+  case ExecutionModeNoGlobalOffsetINTEL:
   case ExecutionModeMaxWorkDimINTEL:
   case ExecutionModeNumSIMDWorkitemsINTEL:
     return true;

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -120,6 +120,7 @@ template <> inline void SPIRVMap<ExecutionMode, std::string>::init() {
   add(ExecutionModeVecTypeHint, "VecTypeHint");
   add(ExecutionModeContractionOff, "ContractionOff");
   add(ExecutionModeMaxWorkgroupSizeINTEL, "MaxWorkgroupSizeINTEL");
+  add(ExecutionModeNoGlobalOffsetINTEL, "NoGlobalOffsetINTEL");
   add(ExecutionModeMaxWorkDimINTEL, "MaxWorkDimINTEL");
   add(ExecutionModeNumSIMDWorkitemsINTEL, "NumSIMDWorkitemsINTEL");
 }

--- a/test/IntelFPGAFunctionAttributes.ll
+++ b/test/IntelFPGAFunctionAttributes.ll
@@ -1,7 +1,8 @@
 ;; Can be compiled using https://github.com/intel/llvm SYCL compiler from:
 ;; class Foo {
 ;; public:
-;;   [[intelfpga::max_global_work_dim(1),
+;;   [[intelfpga::no_global_work_offset,
+;;     intelfpga::max_global_work_dim(1),
 ;;     intelfpga::max_work_group_size(1,1,1),
 ;;     intelfpga::num_simd_work_items(8)]] void operator()() {}
 ;; };
@@ -14,6 +15,7 @@
 ;; void bar() {
 ;;   Foo boo;
 ;;   kernel<class kernel_name>(boo);
+;;   kernel<class kernel_name2>([]() [[intelfpga::no_global_work_offset(0)]]{});
 ;; }
 
 ; RUN: llvm-as %s -o %t.bc
@@ -31,10 +33,13 @@
 ; CHECK-SPIRV: 2 Capability FPGAKernelAttributesINTEL
 ; CHECK-SPIRV: 6 ExecutionMode [[FUNCENTRY:[0-9]+]] 5893 1 1 1
 ; CHECK-SPIRV: 4 ExecutionMode [[FUNCENTRY]] 5894 1
+; CHECK-SPIRV: 3 ExecutionMode [[FUNCENTRY]] 5895
 ; CHECK-SPIRV: 4 ExecutionMode [[FUNCENTRY]] 5896 8
 ; CHECK-SPIRV: 5 Function {{.*}} [[FUNCENTRY]] {{.*}}
 
-; CHECK-LLVM: define spir_kernel void {{.*}}kernel_name() {{.*}} !max_work_group_size ![[MAXWG:[0-9]+]] !max_global_work_dim ![[MAXWD:[0-9]+]] !num_simd_work_items ![[NUMSIMD:[0-9]+]]
+; CHECK-LLVM: define spir_kernel void {{.*}}kernel_name() {{.*}} !max_work_group_size ![[MAXWG:[0-9]+]] !no_global_work_offset ![[OFFSET:[0-9]+]] !max_global_work_dim ![[MAXWD:[0-9]+]] !num_simd_work_items ![[NUMSIMD:[0-9]+]]
+; CHECK-LLVM-NOT: define spir_kernel void {{.*}}kernel_name2 {{.*}} !no_global_work_offset {{.*}}
+; CHECK-LLVM: ![[OFFSET]] = !{}
 ; CHECK-LLVM: ![[MAXWG]] = !{i32 1, i32 1, i32 1}
 ; CHECK-LLVM: ![[MAXWD]] = !{i32 1}
 ; CHECK-LLVM: ![[NUMSIMD]] = !{i32 8}
@@ -45,19 +50,20 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-linux-sycldevice"
 
 %class._ZTS3Foo.Foo = type { i8 }
+%"class._ZTSZ3barvE3$_0.anon" = type { i8 }
 
 $_ZN3FooclEv = comdat any
 
 ; Function Attrs: nounwind
-define spir_kernel void @_ZTSZ3barvE11kernel_name() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 !num_simd_work_items !5 !max_work_group_size !6 !max_global_work_dim !7 {
+define spir_kernel void @_ZTSZ3barvE11kernel_name() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 !num_simd_work_items !5 !max_work_group_size !6 !max_global_work_dim !7 !no_global_work_offset !4 {
 entry:
   %Foo = alloca %class._ZTS3Foo.Foo, align 1
   %0 = bitcast %class._ZTS3Foo.Foo* %Foo to i8*
-  call void @llvm.lifetime.start.p0i8(i64 1, i8* %0) #3
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %0) #4
   %1 = addrspacecast %class._ZTS3Foo.Foo* %Foo to %class._ZTS3Foo.Foo addrspace(4)*
   call spir_func void @_ZN3FooclEv(%class._ZTS3Foo.Foo addrspace(4)* %1)
   %2 = bitcast %class._ZTS3Foo.Foo* %Foo to i8*
-  call void @llvm.lifetime.end.p0i8(i64 1, i8* %2) #3
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %2) #4
   ret void
 }
 
@@ -75,11 +81,32 @@ entry:
 
 ; Function Attrs: argmemonly nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+; Function Attrs: nounwind
+define spir_kernel void @_ZTSZ3barvE12kernel_name2() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
+entry:
+  %0 = alloca %"class._ZTSZ3barvE3$_0.anon", align 1
+  %1 = bitcast %"class._ZTSZ3barvE3$_0.anon"* %0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %1) #4
+  %2 = addrspacecast %"class._ZTSZ3barvE3$_0.anon"* %0 to %"class._ZTSZ3barvE3$_0.anon" addrspace(4)*
+  call spir_func void @"_ZZ3barvENK3$_0clEv"(%"class._ZTSZ3barvE3$_0.anon" addrspace(4)* %2)
+  %3 = bitcast %"class._ZTSZ3barvE3$_0.anon"* %0 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %3) #4
+  ret void
+}
+; Function Attrs: inlinehint nounwind
+define internal spir_func void @"_ZZ3barvENK3$_0clEv"(%"class._ZTSZ3barvE3$_0.anon" addrspace(4)* %this) #3 align 2 {
+entry:
+  %this.addr = alloca %"class._ZTSZ3barvE3$_0.anon" addrspace(4)*, align 8
+  store %"class._ZTSZ3barvE3$_0.anon" addrspace(4)* %this, %"class._ZTSZ3barvE3$_0.anon" addrspace(4)** %this.addr, align 8, !tbaa !8
+  %this1 = load %"class._ZTSZ3barvE3$_0.anon" addrspace(4)*, %"class._ZTSZ3barvE3$_0.anon" addrspace(4)** %this.addr, align 8
+  ret void
+}
 
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "sycl-module-id"="kernel-attrs.cpp" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { argmemonly nounwind willreturn }
 attributes #2 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #3 = { nounwind }
+attributes #3 = { inlinehint nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #4 = { nounwind }
 
 !llvm.module.flags = !{!0}
 !opencl.spir.version = !{!1}
@@ -89,7 +116,7 @@ attributes #3 = { nounwind }
 !0 = !{i32 1, !"wchar_size", i32 4}
 !1 = !{i32 1, i32 2}
 !2 = !{i32 4, i32 100000}
-!3 = !{!"clang version 10.0.0"}
+!3 = !{!"clang version 11.0.0"}
 !4 = !{}
 !5 = !{i32 8}
 !6 = !{i32 1, i32 1, i32 1}


### PR DESCRIPTION
This patch implements the rest of SPV_INTEL_kernel_attributes extension.
NoGlobalOffsetINTEL execution mode indicates that the global offset is
always (0, 0, 0). Only valid with the Kernel Execution Model.

Specification can be found there: https://github.com/KhronosGroup/SPIRV-Registry/pull/55
