### PR TITLE
Generate specialization constant instructions

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -128,8 +128,11 @@ bool writeSpirv(Module *M, const SPIRV::TranslatorOpts &Opts, std::ostream &OS,
 bool readSpirv(LLVMContext &C, const SPIRV::TranslatorOpts &Opts,
                std::istream &IS, Module *&M, std::string &ErrMsg);
 
+/// \brief Partially load SPIR-V from the stream and decode only instructions
+/// needed to get information about specialization constants.
+/// \returns true if succeeds.
 using SpecConstInfoTy = std::pair<uint32_t, uint32_t>;
-void getSpecConstInfo(std::istream &IS,
+bool getSpecConstInfo(std::istream &IS,
                       std::vector<SpecConstInfoTy> &SpecConstInfo);
 
 /// \brief Convert a SPIRVModule into LLVM IR.

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3650,7 +3650,7 @@ bool llvm::readSpirv(LLVMContext &C, const SPIRV::TranslatorOpts &Opts,
   return true;
 }
 
-void llvm::getSpecConstInfo(std::istream &IS,
+bool llvm::getSpecConstInfo(std::istream &IS,
                             std::vector<SpecConstInfoTy> &SpecConstInfo) {
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
   BM->setAutoAddExtensions(false);
@@ -3659,7 +3659,7 @@ void llvm::getSpecConstInfo(std::istream &IS,
   D >> Magic;
   if (!BM->getErrorLog().checkError(Magic == MagicNumber, SPIRVEC_InvalidModule,
                                     "invalid magic number")) {
-    return;
+    return false;
   }
   // Skip the rest of the header
   D.ignore(4);
@@ -3693,4 +3693,5 @@ void llvm::getSpecConstInfo(std::istream &IS,
       D.ignoreInstruction();
     }
   }
+  return !IS.fail();
 }

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -163,6 +163,7 @@ private:
   bool transOCLKernelMetadata();
   SPIRVInstruction *transBuiltinToInst(StringRef DemangledName, CallInst *CI,
                                        SPIRVBasicBlock *BB);
+  SPIRVValue *transBuiltinToConstant(StringRef DemangledName, CallInst *CI);
   SPIRVInstruction *transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
                                                         SPIRVBasicBlock *BB);
   void mutateFuncArgType(const std::map<unsigned, Type *> &ChangedType,

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -257,6 +257,7 @@ public:
                                    const std::vector<SPIRVValue *> &) override;
   SPIRVValue *addConstant(SPIRVValue *) override;
   SPIRVValue *addConstant(SPIRVType *, uint64_t) override;
+  SPIRVValue *addSpecConstant(SPIRVType *, uint64_t) override;
   SPIRVValue *addDoubleConstant(SPIRVTypeFloat *, double) override;
   SPIRVValue *addFloatConstant(SPIRVTypeFloat *, float) override;
   SPIRVValue *addIntegerConstant(SPIRVTypeInt *, uint64_t) override;
@@ -1045,6 +1046,16 @@ SPIRVValue *SPIRVModuleImpl::addCompositeConstant(
 
 SPIRVValue *SPIRVModuleImpl::addUndef(SPIRVType *TheType) {
   return addConstant(new SPIRVUndef(this, TheType, getId()));
+}
+
+SPIRVValue *SPIRVModuleImpl::addSpecConstant(SPIRVType *Ty, uint64_t V) {
+  if (Ty->isTypeBool()) {
+    if (V)
+      return add(new SPIRVSpecConstantTrue(this, Ty, getId()));
+    else
+      return add(new SPIRVSpecConstantFalse(this, Ty, getId()));
+  }
+  return add(new SPIRVSpecConstant(this, Ty, getId(), V));
 }
 
 // Instruction creation functions

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -247,6 +247,7 @@ public:
   addCompositeConstant(SPIRVType *, const std::vector<SPIRVValue *> &) = 0;
   virtual SPIRVValue *addConstant(SPIRVValue *) = 0;
   virtual SPIRVValue *addConstant(SPIRVType *, uint64_t) = 0;
+  virtual SPIRVValue *addSpecConstant(SPIRVType *, uint64_t) = 0;
   virtual SPIRVValue *addDoubleConstant(SPIRVTypeFloat *, double) = 0;
   virtual SPIRVValue *addFloatConstant(SPIRVTypeFloat *, float) = 0;
   virtual SPIRVValue *addIntegerConstant(SPIRVTypeInt *, uint64_t) = 0;

--- a/lib/SPIRV/libSPIRV/SPIRVOpCode.h
+++ b/lib/SPIRV/libSPIRV/SPIRVOpCode.h
@@ -173,6 +173,11 @@ inline bool isTypeOpCode(Op OpCode) {
          isSubgroupAvcINTELTypeOpCode(OpCode) || OC == OpTypeVmeImageINTEL;
 }
 
+inline bool isSpecConstantOpCode(Op OpCode) {
+  unsigned OC = OpCode;
+  return OpSpecConstantTrue <= OC && OC <= OpSpecConstantOp;
+}
+
 inline bool isConstantOpCode(Op OpCode) {
   unsigned OC = OpCode;
   return (OpConstantTrue <= OC && OC <= OpSpecConstantOp) || OC == OpUndef ||

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -191,7 +191,7 @@ public:
     SPIRVCapVec CV;
     if (isTypeFloat(16)) {
       CV.push_back(CapabilityFloat16Buffer);
-      auto Extensions = getModule()->getExtension();
+      auto Extensions = getModule()->getSourceExtension();
       if (std::any_of(Extensions.begin(), Extensions.end(),
                       [](const std::string &I) { return I == "cl_khr_fp16"; }))
         CV.push_back(CapabilityFloat16);

--- a/test/half_extension.ll
+++ b/test/half_extension.ll
@@ -13,7 +13,8 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 
-; CHECK-SPIRV: {{[0-9]+}} Capability Float16
+; CHECK-SPIRV-DAG: {{[0-9]+}} Capability Float16Buffer
+; CHECK-SPIRV-DAG: {{[0-9]+}} Capability Float16
 
 ; ModuleID = 'main'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/test/transcoding/spec_const.ll
+++ b/test/transcoding/spec_const.ll
@@ -1,0 +1,102 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r -spec-const "0:i1:1 1:i8:11 2:i16:22 3:i32:33 4:i64:44 5:f16:5.5 6:f32:6.6 7:f64:7.7" %t.spv -o %t.rev.spec.bc
+; RUN: llvm-dis < %t.rev.spec.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPEC
+
+; CHECK-SPIRV-DAG: Decorate [[SC0:[0-9]+]] SpecId 0
+; CHECK-SPIRV-DAG: Decorate [[SC1:[0-9]+]] SpecId 1
+; CHECK-SPIRV-DAG: Decorate [[SC2:[0-9]+]] SpecId 2
+; CHECK-SPIRV-DAG: Decorate [[SC3:[0-9]+]] SpecId 3
+; CHECK-SPIRV-DAG: Decorate [[SC4:[0-9]+]] SpecId 4
+; CHECK-SPIRV-DAG: Decorate [[SC5:[0-9]+]] SpecId 5
+; CHECK-SPIRV-DAG: Decorate [[SC6:[0-9]+]] SpecId 6
+; CHECK-SPIRV-DAG: Decorate [[SC7:[0-9]+]] SpecId 7
+
+; CHECK-SPIRV-DAG: SpecConstantFalse {{[0-9]+}} [[SC0]]
+; CHECK-SPIRV-DAG: SpecConstant {{[0-9]+}} [[SC1]] 100
+; CHECK-SPIRV-DAG: SpecConstant {{[0-9]+}} [[SC2]] 1
+; CHECK-SPIRV-DAG: SpecConstant {{[0-9]+}} [[SC3]] 2
+; CHECK-SPIRV-DAG: SpecConstant {{[0-9]+}} [[SC4]] 3 0
+; CHECK-SPIRV-DAG: SpecConstant {{[0-9]+}} [[SC5]] 14336
+; CHECK-SPIRV-DAG: SpecConstant {{[0-9]+}} [[SC6]] 1067450368
+; CHECK-SPIRV-DAG: SpecConstant {{[0-9]+}} [[SC7]] 0 1073807360
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+; Function Attrs: nofree norecurse nounwind writeonly
+ define spir_kernel void @foo(i8 addrspace(1)* nocapture %b, i8 addrspace(1)* nocapture %c, i16 addrspace(1)* nocapture %s, i32 addrspace(1)* nocapture %i, i64 addrspace(1)* nocapture %l, half addrspace(1)* nocapture %h, float addrspace(1)* nocapture %f, double addrspace(1)* nocapture %d) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  ; CHECK-LLVM: %conv = select i1 false, i8 1, i8 0
+  ; CHECK-LLVM: store i8 %conv, i8 addrspace(1)* %b, align 1
+  ; CHECK-LLVM-SPEC: %conv = select i1 true, i8 1, i8 0
+  ; CHECK-LLVM-SPEC: store i8 %conv, i8 addrspace(1)* %b, align 1
+  %0 = call i1 @_Z20__spirv_SpecConstantib(i32 0, i1 false)
+  %conv = zext i1 %0 to i8
+  store i8 %conv, i8 addrspace(1)* %b, align 1
+
+  ; CHECK-LLVM: store i8 100, i8 addrspace(1)* %c, align 1
+  ; CHECK-LLVM-SPEC: store i8 11, i8 addrspace(1)* %c, align 1
+  %1 = call i8 @_Z20__spirv_SpecConstantia(i32 1, i8 100)
+  store i8 %1, i8 addrspace(1)* %c, align 1
+
+  ; CHECK-LLVM: store i16 1, i16 addrspace(1)* %s, align 2
+  ; CHECK-LLVM-SPEC: store i16 22, i16 addrspace(1)* %s, align 2
+  %2 = call i16 @_Z20__spirv_SpecConstantis(i32 2, i16 1)
+  store i16 %2, i16 addrspace(1)* %s, align 2
+
+  ; CHECK-LLVM: store i32 2, i32 addrspace(1)* %i, align 4
+  ; CHECK-LLVM-SPEC: store i32 33, i32 addrspace(1)* %i, align 4
+  %3 = call i32 @_Z20__spirv_SpecConstantii(i32 3, i32 2)
+  store i32 %3, i32 addrspace(1)* %i, align 4
+
+  ; CHECK-LLVM: store i64 3, i64 addrspace(1)* %l, align 8
+  ; CHECK-LLVM-SPEC: store i64 44, i64 addrspace(1)* %l, align 8
+  %4 = call i64 @_Z20__spirv_SpecConstantix(i32 4, i64 3)
+  store i64 %4, i64 addrspace(1)* %l, align 8
+
+  ; CHECK-LLVM: store half 0xH3800, half addrspace(1)* %h, align 2
+  ; CHECK-LLVM-SPEC: store half 0xH4580, half addrspace(1)* %h, align 2
+  %5 = call half @_Z20__spirv_SpecConstantih(i32 5, half 0xH3800)
+  store half %5, half addrspace(1)* %h, align 2
+
+  ; CHECK-LLVM: store float 1.250000e+00, float addrspace(1)* %f, align 4
+  ; CHECK-LLVM-SPEC: store float 0x401A666660000000, float addrspace(1)* %f, align 4
+  %6 = call float @_Z20__spirv_SpecConstantif(i32 6, float 1.250000e+00)
+  store float %6, float addrspace(1)* %f, align 4
+
+  ; CHECK-LLVM: store double 2.125000e+00, double addrspace(1)* %d, align 8
+  ; CHECK-LLVM-SPEC: store double 7.700000e+00, double addrspace(1)* %d, align 8
+  %7 = call double @_Z20__spirv_SpecConstantid(i32 7, double 2.125000e+00)
+  store double %7, double addrspace(1)* %d, align 8
+  ret void
+}
+
+declare i1 @_Z20__spirv_SpecConstantib(i32, i1)
+declare i8 @_Z20__spirv_SpecConstantia(i32, i8)
+declare i16 @_Z20__spirv_SpecConstantis(i32, i16)
+declare i32 @_Z20__spirv_SpecConstantii(i32, i32)
+declare i64 @_Z20__spirv_SpecConstantix(i32, i64)
+declare half @_Z20__spirv_SpecConstantih(i32, half)
+declare float @_Z20__spirv_SpecConstantif(i32, float)
+declare double @_Z20__spirv_SpecConstantid(i32, double)
+
+attributes #0 = { nofree norecurse nounwind writeonly "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!opencl.used.extensions = !{!7}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 11.0.0 (https://github.com/llvm/llvm-project.git f11016b41a94d2bad8824d5e2833d141fda24502)"}
+!3 = !{i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1}
+!4 = !{!"none", !"none", !"none", !"none", !"none", !"none", !"none", !"none"}
+!5 = !{!"bool*", !"char*", !"short*", !"int*", !"long*", !"half*", !"float*", !"double*"}
+!6 = !{!"", !"", !"", !"", !"", !"", !"", !""}
+!7 = !{!"cl_khr_fp16"}

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -377,7 +377,8 @@ bool parseSpecConstOpt(llvm::StringRef SpecConstStr,
                        SPIRV::TranslatorOpts &Opts) {
   std::ifstream IFS(InputFile, std::ios::binary);
   std::vector<SpecConstInfoTy> SpecConstInfo;
-  getSpecConstInfo(IFS, SpecConstInfo);
+  if (!getSpecConstInfo(IFS, SpecConstInfo))
+    return true;
 
   SmallVector<StringRef, 8> Split;
   SpecConstStr.split(Split, ' ', -1, false);
@@ -540,7 +541,10 @@ int main(int Ac, char **Av) {
   if (SpecConstInfo) {
     std::ifstream IFS(InputFile, std::ios::binary);
     std::vector<SpecConstInfoTy> SpecConstInfo;
-    getSpecConstInfo(IFS, SpecConstInfo);
+    if (!getSpecConstInfo(IFS, SpecConstInfo)) {
+      std::cout << "Invalid SPIR-V binary";
+      return -1;
+    }
     std::cout << "Number of scalar specialization constants in the module = "
               << SpecConstInfo.size() << "\n";
     for (auto &SpecConst : SpecConstInfo)


### PR DESCRIPTION
Translate SPIRV-friendly LLVM IR builtins represnting specialization constants `__spirv_SpecConstant` to corresponding SPIR-V instructions.

This approach works only for scalar constants, so support for `OpSpecConstantComposite` and `OpSpecConstantOp` is not implemented in this patch.

This PR also includes a patch to improve error handling for `llvm::getSpecConstInfo` API: Change return value from void to bool. Return `false` to indicate a failure. Return `true` on success.