### PR TITLE
Backport fix translation of read_image* built-ins to SPIR-V to 8.0 release

### DIFF
--- a/test/read_image.cl
+++ b/test/read_image.cl
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -triple spir64 -finclude-default-header -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv -s %t.bc -o %t1.bc
+// RUN: llvm-dis %t1.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+// CHECK-SPIRV: TypeInt [[IntTy:[0-9]+]]
+// CHECK-SPIRV: TypeVector [[IVecTy:[0-9]+]] [[IntTy]]
+// CHECK-SPIRV: TypeFloat [[FloatTy:[0-9]+]]
+// CHECK-SPIRV: TypeVector [[FVecTy:[0-9]+]] [[FloatTy]]
+// CHECK-SPIRV: ImageRead [[IVecTy]]
+// CHECK-SPIRV: ImageRead [[FVecTy]]
+
+// CHECK-LLVM: call spir_func <4 x i32> @_Z24__spirv_ImageRead_Ruint414ocl_image3d_roDv4_i
+// CHECK-LLVM: call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat414ocl_image3d_roDv4_i
+
+__kernel void kernelA(__read_only image3d_t input) {
+  uint4 c = read_imageui(input, (int4)(0, 0, 0, 0));
+}
+
+__kernel void kernelB(__read_only image3d_t input) {
+  float4 f = read_imagef(input, (int4)(0, 0, 0, 0));
+}


### PR DESCRIPTION
There are several overloads of read_image function defined by OpenCL C
spec, but all of them use the same SPIR-V instruction, so, we need to
add one more optional postfix to differentiate instructions with the
same argument types, but different return types.

Example:
- int4 read_imagei(image2d_t, sampler_t, int2)
- float4 read_imagef(image2d_t, sampler_t, int2)

Both functions above are represented by the same SPIR-V instruction and
we need to distinguish them in SPIR-V friendly LLVM IR.