### PR TITLE
Fix travis on llvm_release_100 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,17 +23,15 @@ branches:
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main'
+    - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main'
       key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
     - sourceline: 'deb https://packages.lunarg.com/vulkan bionic main'
       key_url: 'http://packages.lunarg.com/lunarg-signing-key-pub.asc'
     packages:
-    - llvm-10-tools
     - llvm-10-dev
+    - clang-10
     - clang-format-10
     - clang-tidy-10
-    - libclang-10-dev
-    - lldb-10
     - spirv-tools
 
 compiler:
@@ -79,7 +77,7 @@ script:
     if [ $BUILD_EXTERNAL == "0" ]; then
       mkdir llvm-spirv
       mv * llvm-spirv
-      git clone https://github.com/llvm/llvm-project --depth 1
+      git clone https://github.com/llvm/llvm-project --depth 1 -b release/10.x
       mv llvm-spirv llvm-project/llvm-spirv
     fi
   - |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LLVM/SPIR-V Bi-Directional Translator
 
-[![Build Status](https://travis-ci.org/KhronosGroup/SPIRV-LLVM-Translator.svg?branch=master)](https://travis-ci.org/KhronosGroup/SPIRV-LLVM-Translator)
+[![Build Status](https://travis-ci.org/KhronosGroup/SPIRV-LLVM-Translator.svg?branch=llvm_release_100)](https://travis-ci.org/KhronosGroup/SPIRV-LLVM-Translator)
 
 This repository contains source code for the LLVM/SPIR-V Bi-Directional Translator, a library and tool for translation between LLVM IR and [SPIR-V](https://www.khronos.org/registry/spir-v/).
 


### PR DESCRIPTION
It seems like there are not all llvm packages from bionic link. I suggest to change link to xenial for a while.

Signed-off-by: Ilya Mashkov <ilya.mashkov@intel.com>