### PR TITLE
[DebugInfo] Set ModFlagBehavior=Max for the "Dwarf Version" metadata

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -113,8 +113,7 @@ SPIRVToLLVMDbgTran::transCompileUnit(const SPIRVExtInst *DebugInst) {
 
   using namespace SPIRVDebug::Operand::CompilationUnit;
   assert(Ops.size() == OperandCount && "Invalid number of operands");
-  M->addModuleFlag(llvm::Module::Warning, "Dwarf Version",
-                   Ops[DWARFVersionIdx]);
+  M->addModuleFlag(llvm::Module::Max, "Dwarf Version", Ops[DWARFVersionIdx]);
   SPIRVExtInst *Source = BM->get<SPIRVExtInst>(Ops[SourceIdx]);
   SPIRVId FileId = Source->getArguments()[SPIRVDebug::Operand::Source::FileIdx];
   std::string File = getString(FileId);

--- a/test/DebugInfo/Generic/version.ll
+++ b/test/DebugInfo/Generic/version.ll
@@ -3,12 +3,15 @@
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv -spirv-mem2reg=false
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
+; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
 
 ; RUN: llc -mtriple=%triple -O0 -filetype=obj < %t.ll > %t
 ; RUN: llvm-dwarfdump %t | FileCheck %s
 
 ; Make sure we are generating DWARF version 3 when module flag says so.
 ; CHECK: Compile Unit: length = {{.*}} version = 0x0003
+
+; CHECK-LLVM: !{i32 7, !"Dwarf Version", i32 3}
 
 define i32 @main() #0 !dbg !4 {
 entry:


### PR DESCRIPTION
This commit mirrors llvm/llvm-project@e956952edec140d2475aa7c8cbe20fbdd3320634

"DebugInfo: Flag Dwarf Version metadata for merging during LTO

When the Dwarf Version metadata was initially added (r184276) there was
no support for Module::Max - though the comment suggested that was the
desired behavior. The original behavior was Module::Warn which would
warn and then pick whichever version came first - which is pretty
arbitrary/luck-based if the consumer has some need for one version or
the other.

Now that the functionality's been added (r303590) this change updates
the implementation to match the desired goal.

The general logic here is - if you compile /some/ of your program with a
more recent DWARF version, you must have a consumer that can handle it,
so might as well use it for /everything/.

The only place where this might fall down is if you have a need to use
an old tool (supporting only the older DWARF version) for some subset of
your program. In which case now it'll all be the higher version. That
seems pretty narrow (& the inverse could happen too - you specifically
/need/ the higher DWARF version for some extra expressivity, etc, in
some part of the program)"

Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>