### PR TITLE
Fix -Wunused-variable warnings

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -215,8 +215,7 @@ void PreprocessMetadata::visit(Module *M) {
     }
 
     // !{void (i32 addrspace(1)*)* @kernel, i32 no_global_work_offset}
-    if (MDNode *NoGlobalOffsetINTEL =
-            Kernel.getMetadata(kSPIR2MD::NoGlobalOffset)) {
+    if (Kernel.getMetadata(kSPIR2MD::NoGlobalOffset)) {
       EM.addOp().add(&Kernel).add(spv::ExecutionModeNoGlobalOffsetINTEL).done();
     }
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3286,7 +3286,7 @@ bool SPIRVToLLVM::transKernelMetadata() {
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
     // Generate metadata for no_global_work_offset
-    if (auto EM = BF->getExecutionMode(ExecutionModeNoGlobalOffsetINTEL)) {
+    if (BF->getExecutionMode(ExecutionModeNoGlobalOffsetINTEL)) {
       F->setMetadata(kSPIR2MD::NoGlobalOffset, MDNode::get(*Context, {}));
     }
     // Generate metadata for max_global_work_dim


### PR DESCRIPTION
These were introduced by commit 33d4946 ("Enable NoGlobalOffsetINTEL
execution mode translation", 2020-01-16).