### PR TITLE
Update DebugInfo test after LLVM change 9f6ff07f8a

### DIFF
--- a/test/DebugInfo/X86/dbg-value-range.ll
+++ b/test/DebugInfo/X86/dbg-value-range.ll
@@ -60,7 +60,7 @@ declare void @llvm.dbg.value(metadata, metadata, metadata) nounwind readnone
 ;CHECK-NEXT:	.quad	[[CLOBBER_OFF]]
 ;CHECK-NEXT:  .short 1 ## Loc expr size
 ;CHECK-NEXT:	.byte	85 ## DW_OP_reg
-;CHECK-NEXT:	.quad	0
+;CHECK:	.quad	0
 ;CHECK-NEXT:	.quad	0
 !24 = !{i32 1, !"Debug Info Version", i32 3}
 target triple = "spir64-unknown-unknown"


### PR DESCRIPTION
Update for 9f6ff07f8a3 ("[DebugInfo] Enable the debug entry values
feature by default", 2020-02-10).