### PR TITLE
Add volatile qualifier for atom_ builtins

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -483,6 +483,14 @@ public:
       addUnsignedArg(0);
       setEnumArg(1, SPIR::PRIMITIVE_MEMORY_ORDER);
       setEnumArg(2, SPIR::PRIMITIVE_MEMORY_SCOPE);
+    } else if (UnmangledName.find("atom_") == 0) {
+      setArgAttr(0, SPIR::ATTR_VOLATILE);
+      if (UnmangledName.find("atom_umax") == 0 ||
+          UnmangledName.find("atom_umin") == 0) {
+        addUnsignedArg(0);
+        addUnsignedArg(1);
+        UnmangledName.erase(5, 1);
+      }
     } else if (UnmangledName.find("atomic") == 0) {
       setArgAttr(0, SPIR::ATTR_VOLATILE);
       if (UnmangledName.find("atomic_umax") == 0 ||

--- a/test/transcoding/atomics_int64.spt
+++ b/test/transcoding/atomics_int64.spt
@@ -56,24 +56,24 @@
 ; RUN: FileCheck %s < %t.ll
 
 ; OpAtomicLoad is emulated via atom_add(*p, 0)
-; CHECK: call spir_func i64 @_Z8atom_add
+; CHECK: call spir_func i64 @_Z8atom_addPU3AS4Vll
 
 ; OpAtomicStore is emulated via atom_xchg(*p, val)
-; CHECK: call spir_func i64 @_Z9atom_xchg
+; CHECK: call spir_func i64 @_Z9atom_xchgPU3AS4Vll
 
-; CHECK: call spir_func i64 @_Z9atom_xchg
-; CHECK: call spir_func i64 @_Z12atom_cmpxchg
-; CHECK: call spir_func i64 @_Z8atom_inc
-; CHECK: call spir_func i64 @_Z8atom_dec
-; CHECK: call spir_func i64 @_Z8atom_add
-; CHECK: call spir_func i64 @_Z8atom_sub
-; CHECK: call spir_func i64 @_Z8atom_min
-; CHECK: call spir_func i64 @_Z8atom_min
-; CHECK: call spir_func i64 @_Z8atom_max
-; CHECK: call spir_func i64 @_Z8atom_max
-; CHECK: call spir_func i64 @_Z8atom_and
-; CHECK: call spir_func i64 @_Z7atom_or
-; CHECK: call spir_func i64 @_Z8atom_xor
+; CHECK: call spir_func i64 @_Z9atom_xchgPU3AS4Vll
+; CHECK: call spir_func i64 @_Z12atom_cmpxchgPU3AS4Vlll
+; CHECK: call spir_func i64 @_Z8atom_incPU3AS4Vl
+; CHECK: call spir_func i64 @_Z8atom_decPU3AS4Vl
+; CHECK: call spir_func i64 @_Z8atom_addPU3AS4Vll
+; CHECK: call spir_func i64 @_Z8atom_subPU3AS4Vll
+; CHECK: call spir_func i64 @_Z8atom_minPU3AS4Vll
+; CHECK: call spir_func i64 @_Z8atom_minPU3AS4Vmm
+; CHECK: call spir_func i64 @_Z8atom_maxPU3AS4Vll
+; CHECK: call spir_func i64 @_Z8atom_maxPU3AS4Vmm
+; CHECK: call spir_func i64 @_Z8atom_andPU3AS4Vll
+; CHECK: call spir_func i64 @_Z7atom_orPU3AS4Vll
+; CHECK: call spir_func i64 @_Z8atom_xorPU3AS4Vll
 
 ; OpAtomicFlagTestAndSet is emulated via atomic_xchg(*p, 1)
 ; CHECK: call spir_func i32 @_Z11atomic_xchg


### PR DESCRIPTION
Commit 10dee68 ("Fix translation of 64-bit atomics to OpenCL 1.2",
2019-08-15) changes the "atomic_" prefix to "atom_" for 64-bit types,
but this caused the "atom_" builtins to no longer have the volatile
qualifier to their pointer argument.

Update the atomics_int64.spt test to check for the fully mangled
names; these should include the volatile qualifier.