### PR TITLE
Add SmallString include after LLVM change 465dca79b31

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -40,6 +40,7 @@
 #define SPIRV_OCLUTIL_H
 
 #include "SPIRVInternal.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"


### PR DESCRIPTION
Update for 465dca79b31 ("Avoid SmallString.h include in MD5.h, NFC",
2020-02-26).