### PR TITLE
travis: Restore macOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,20 @@ branches:
     - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
 
 before_install:
-  - curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
-  - curl -L "http://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
-  - echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
-  - echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
-  - sudo apt-get update
-  - sudo apt-get -yq --no-install-suggests --no-install-recommends install
-      llvm-${LLVM_VERSION}-dev
-      clang-${LLVM_VERSION}
-      clang-format-${LLVM_VERSION}
-      clang-tidy-${LLVM_VERSION}
-      spirv-tools
+  - |
+    if [ $TRAVIS_OS_NAME == "linux" ]; then
+      curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
+      curl -L "http://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
+      echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
+      echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
+      sudo apt-get update
+      sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+        llvm-${LLVM_VERSION}-dev \
+        clang-${LLVM_VERSION} \
+        clang-format-${LLVM_VERSION} \
+        clang-tidy-${LLVM_VERSION} \
+        spirv-tools
+    fi
 
 compiler:
   - gcc


### PR DESCRIPTION
macOS builds seem to have been broken since 3027e3a ("Update version
of LLVM from 10 to 11", 2020-01-28) due to apt commands being moved
into the `before_install` step.  Restore macOS testing by only running
apt commands for Linux builds.