### PR TITLE
Change capability for SpecId decoration

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -312,7 +312,7 @@ template <> inline void SPIRVMap<ImageOperandsMask, SPIRVCapVec>::init() {
 
 template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationRelaxedPrecision, {CapabilityShader});
-  ADD_VEC_INIT(DecorationSpecId, {CapabilityShader});
+  ADD_VEC_INIT(DecorationSpecId, {CapabilityKernel});
   ADD_VEC_INIT(DecorationBlock, {CapabilityShader});
   ADD_VEC_INIT(DecorationBufferBlock, {CapabilityShader});
   ADD_VEC_INIT(DecorationRowMajor, {CapabilityMatrix});

--- a/test/transcoding/spec_const.ll
+++ b/test/transcoding/spec_const.ll
@@ -7,6 +7,10 @@
 ; RUN: llvm-spirv -r -spec-const "0:i1:1 1:i8:11 2:i16:22 3:i32:33 4:i64:44 5:f16:5.5 6:f32:6.6 7:f64:7.7" %t.spv -o %t.rev.spec.bc
 ; RUN: llvm-dis < %t.rev.spec.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPEC
 
+; CHECK-SPIRV-NOT: Capability Matrix
+; CHECK-SPIRV-NOT: Capability Shader
+; CHECK-SPIRV: Capability Kernel
+
 ; CHECK-SPIRV-DAG: Decorate [[SC0:[0-9]+]] SpecId 0
 ; CHECK-SPIRV-DAG: Decorate [[SC1:[0-9]+]] SpecId 1
 ; CHECK-SPIRV-DAG: Decorate [[SC2:[0-9]+]] SpecId 2


### PR DESCRIPTION
Per the SPIR-V spec the SpecId decoration has 2 enabling capabilities:
Shader, Kernel. Also in section 2.1 the spec says:
"When an instruction, enumerant, or other feature specifies multiple
enabling capabilities, only one such capability needs to be declared to
use the feature."
With this commit we choose to emit Kernel capability over Shader.