### PR TITLE
Fix building in-tree with cmake -DLLVM_LINK_LLVM_DYLIB=ON

### DIFF
--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -14,7 +14,7 @@ add_llvm_tool(llvm-spirv
   NO_INSTALL_RPATH
 )
 
-if (LLVM_SPIRV_BUILD_EXTERNAL)
+if (LLVM_SPIRV_BUILD_EXTERNAL OR LLVM_LINK_LLVM_DYLIB)
   target_link_libraries(llvm-spirv PRIVATE LLVMSPIRVLib)
 endif()
 


### PR DESCRIPTION
Building in-tree with LLVM 11.0 master with the LLVM_LINK_LLVM_DYLIB cmake flag fails to link with the LLVMSPIRVLib library.

Add an explicit dependency to force the correct build order and linking.

Signed-off-by: Andrea Bocci <andrea.bocci@cern.ch>