### PR TITLE
Implement -spirv-allow-unknown-intrinsics option

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -91,6 +91,11 @@ namespace SPIRV {
 cl::opt<bool> SPIRVMemToReg("spirv-mem2reg", cl::init(false),
                             cl::desc("LLVM/SPIR-V translation enable mem2reg"));
 
+cl::opt<bool> SPIRVAllowUnknownIntrinsics(
+    "spirv-allow-unknown-intrinsics", cl::init(false),
+    cl::desc("Unknown LLVM intrinsics will be translated as external function "
+             "calls in SPIR-V"));
+
 static void foreachKernelArgMD(
     MDNode *MD, SPIRVFunction *BF,
     std::function<void(const std::string &Str, SPIRVFunctionParameter *BA)>
@@ -475,7 +480,7 @@ SPIRVFunction *LLVMToSPIRV::transFunctionDecl(Function *F) {
   if (auto BF = getTranslatedValue(F))
     return static_cast<SPIRVFunction *>(BF);
 
-  if (F->isIntrinsic()) {
+  if (F->isIntrinsic() && !SPIRVAllowUnknownIntrinsics) {
     // We should not translate LLVM intrinsics as a function
     assert(none_of(F->user_begin(), F->user_end(),
                    [this](User *U) { return getTranslatedValue(U); }) &&
@@ -1766,11 +1771,18 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
   case Intrinsic::dbg_label:
     return nullptr;
   default:
-    // Other LLVM intrinsics shouldn't get to SPIRV, because they
-    // can't be represented in SPIRV or not implemented yet.
-    BM->getErrorLog().checkError(false, SPIRVEC_InvalidFunctionCall,
-                                 II->getCalledValue()->getName().str(), "",
-                                 __FILE__, __LINE__);
+    if (SPIRVAllowUnknownIntrinsics)
+      return BM->addCallInst(
+          transFunctionDecl(II->getCalledFunction()),
+          transArguments(II, BB,
+                         SPIRVEntry::createUnique(OpFunctionCall).get()),
+          BB);
+    else
+      // Other LLVM intrinsics shouldn't get to SPIRV, because they
+      // can't be represented in SPIRV or aren't implemented yet.
+      BM->getErrorLog().checkError(false, SPIRVEC_InvalidFunctionCall,
+                                   II->getCalledValue()->getName().str(), "",
+                                   __FILE__, __LINE__);
   }
   return nullptr;
 }

--- a/test/AllowIntrinsics.ll
+++ b/test/AllowIntrinsics.ll
@@ -1,0 +1,38 @@
+; The test checks command-line option for the translator
+; which will allow to represent unknown llvm intrinsics as external function call in SPIR-V.
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv -spirv-allow-unknown-intrinsics %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: declare float @llvm.fma.f32(float, float, float)
+; CHECK-SPIRV: LinkageAttributes "llvm.fma.f32" Import
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64"
+
+; Function Attrs: nounwind
+define spir_func void @foo(float %a, float %b, float %c) #0 {
+entry:
+  %0 = call float @llvm.fma.f32(float %a, float %b, float %c)
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare float @llvm.fma.f32(float, float, float) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind readnone }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!3}
+!opencl.compiler.options = !{!2}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 2, i32 0}
+!2 = !{}
+!3 = !{!"cl_doubles"}


### PR DESCRIPTION
Here is implementation of command-line option which will allow
to represent unknown llvm intrinsics as external function call in SPIR-V

Signed-off-by: Ilya Mashkov <ilya.mashkov@intel.com>