### PR TITLE
Initialize a TranslatorOpts field

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -117,7 +117,7 @@ private:
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
   ExtensionsStatusMap ExtStatusMap;
   // SPIR-V to LLVM translation options
-  bool GenKernelArgNameMD;
+  bool GenKernelArgNameMD = false;
   std::unordered_map<uint32_t, uint64_t> ExternalSpecialization;
 };
 


### PR DESCRIPTION
The GenKernelArgNameMD field would be left uninitialized when calling
the default constructor.