### PR TITLE
Fix translation of SPIR-V OpControlBarier to LLVM IR

### DIFF
--- a/test/barrier_explicit_arguments.spt
+++ b/test/barrier_explicit_arguments.spt
@@ -4,7 +4,6 @@
 2 Capability Kernel
 5 ExtInstImport 1 "OpenCL.std"
 3 MemoryModel 1 2
-3 Source 3 102000
 4 Name 5 "test"
 3 Name 6 "val"
 4 Name 7 "entry"
@@ -12,6 +11,7 @@
 4 TypeInt 3 32 0
 4 Constant 3 8 2
 2 TypeVoid 2
+4 Constant 3 9 3
 4 TypeFunction 4 2 3
 
 5 Function 2 5 0 4
@@ -19,18 +19,26 @@
 
 2 Label 7
 4 ControlBarrier 8 8 6
+4 ControlBarrier 9 9 6
 1 Return
 
 1 FunctionEnd
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
-; RUN: llvm-dis < %t.bc | FileCheck %s
+; RUN: llvm-spirv -r -spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes=CHECK,CHECK-20
+; RUN: llvm-spirv -r -spirv-ocl-builtins-version=CL1.2 %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes=CHECK,CHECK-12
 
 ; CHECK: define spir_func void @test(i32 %val)
 ; CHECK: %call = call spir_func i32 @__translate_spirv_memory_fence(i32 %val)
-; CHECK: call spir_func void @_Z7barrierj(i32 %call)
+; CHECK-12: call spir_func void @_Z7barrierj(i32 %call)
+; There is no support for sub-groups in OpenCL 1.2, so sub-group barrier is
+; equal to regular barrier in there
+; CHECK-12: call spir_func void @_Z7barrierj(i32 %call1)
+; CHECK-20: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 %call
+; CHECK-20: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 %call
 ; CHECK: define private spir_func i32 @__translate_spirv_memory_fence(i32 %key)
 ; CHECK: entry:
 ; CHECK:   %key.masked = and i32 2816, %key
@@ -60,4 +68,3 @@
 ; CHECK: case.2816:
 ; CHECK:   ret i32 7
 ; CHECK: }
-; CHECK: declare spir_func void @_Z7barrierj(i32)


### PR DESCRIPTION
This patch features two things:
- fixed translation of OpControlBarrier into OpenCL 2.0 built-ins:

  Scope of the operation is now respected and we can either get
  work_group_barrier or sub_group_barrier depending on it

- improved the translation so it handles non-constant 'Memory Semantic'
  operand of the instruction