### PR TITLE
Do not rely on OpSource while translating into LLVM IR

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -140,6 +140,13 @@ bool getSpecConstInfo(std::istream &IS,
 std::unique_ptr<Module>
 convertSpirvToLLVM(LLVMContext &C, SPIRV::SPIRVModule &BM, std::string &ErrMsg);
 
+/// \brief Convert a SPIRVModule into LLVM IR using specified options
+/// \returns null on failure.
+std::unique_ptr<Module> convertSpirvToLLVM(LLVMContext &C,
+                                           SPIRV::SPIRVModule &BM,
+                                           const SPIRV::TranslatorOpts &Opts,
+                                           std::string &ErrMsg);
+
 /// \brief Regularize LLVM module by removing entities not representable by
 /// SPIRV.
 bool regularizeLlvmForSpirv(Module *M, std::string &ErrMsg);
@@ -183,7 +190,7 @@ ModulePass *createSPIRVRegularizeLLVM();
 
 /// Create a pass for translating SPIR-V builtin functions to OCL builtin
 /// functions.
-ModulePass *createSPIRVToOCL(Module &M);
+ModulePass *createSPIRVToOCL(Module &, SPIRV::BIsRepresentation);
 
 /// Create a pass for translating SPIR-V builtin functions to OCL 1.2 builtin
 /// functions.

--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -188,9 +188,9 @@ ModulePass *createSPIRVLowerMemmove();
 /// Create a pass for regularize LLVM module to be translated to SPIR-V.
 ModulePass *createSPIRVRegularizeLLVM();
 
-/// Create a pass for translating SPIR-V builtin functions to OCL builtin
-/// functions.
-ModulePass *createSPIRVToOCL(Module &, SPIRV::BIsRepresentation);
+/// Create a pass for translating SPIR-V Instructions to desired
+/// representation in LLVM IR (OpenCL built-ins, SPIR-V Friendly IR, etc.)
+ModulePass *createSPIRVBIsLoweringPass(Module &, SPIRV::BIsRepresentation);
 
 /// Create a pass for translating SPIR-V builtin functions to OCL 1.2 builtin
 /// functions.

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -65,12 +65,7 @@ enum class ExtensionID : uint32_t {
   Last,
 };
 
-enum class BIsRepresentation : uint32_t {
-  OpenCL12,
-  OpenCL20
-  // TODO: consider targeting SPIR-V friendly IR for some non-OpenCL backends,
-  // if there are any
-};
+enum class BIsRepresentation : uint32_t { OpenCL12, OpenCL20, SPIRVFriendlyIR };
 
 /// \brief Helper class to manage SPIR-V translation
 class TranslatorOpts {
@@ -134,8 +129,8 @@ private:
   // SPIR-V to LLVM translation options
   bool GenKernelArgNameMD = false;
   std::unordered_map<uint32_t, uint64_t> ExternalSpecialization;
-  // Version of OpenCL C, which should be used while translating from SPIR-V to
-  // back to LLVM IR
+  // Representation of built-ins, which should be used while translating from
+  // SPIR-V to back to LLVM IR
   BIsRepresentation DesiredRepresentationOfBIs = BIsRepresentation::OpenCL12;
 };
 

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -65,6 +65,13 @@ enum class ExtensionID : uint32_t {
   Last,
 };
 
+enum class BIsRepresentation : uint32_t {
+  OpenCL12,
+  OpenCL20
+  // TODO: consider targeting SPIR-V friendly IR for some non-OpenCL backends,
+  // if there are any
+};
+
 /// \brief Helper class to manage SPIR-V translation
 class TranslatorOpts {
 public:
@@ -112,6 +119,14 @@ public:
     return true;
   }
 
+  void setDesiredBIsRepresentation(BIsRepresentation Value) {
+    DesiredRepresentationOfBIs = Value;
+  }
+
+  BIsRepresentation getDesiredBIsRepresentation() const {
+    return DesiredRepresentationOfBIs;
+  }
+
 private:
   // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
@@ -119,6 +134,9 @@ private:
   // SPIR-V to LLVM translation options
   bool GenKernelArgNameMD = false;
   std::unordered_map<uint32_t, uint64_t> ExternalSpecialization;
+  // Version of OpenCL C, which should be used while translating from SPIR-V to
+  // back to LLVM IR
+  BIsRepresentation DesiredRepresentationOfBIs = BIsRepresentation::OpenCL12;
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3693,7 +3693,9 @@ std::unique_ptr<SPIRVModule> readSpirvModule(std::istream &IS,
 } // namespace SPIRV
 
 std::unique_ptr<Module>
-llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM, std::string &ErrMsg) {
+llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM,
+                         const SPIRV::TranslatorOpts &Opts,
+                         std::string &ErrMsg) {
   std::unique_ptr<Module> M(new Module("", C));
   SPIRVToLLVM BTL(M.get(), &BM);
 
@@ -3703,10 +3705,16 @@ llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM, std::string &ErrMsg) {
   }
 
   llvm::legacy::PassManager PassMgr;
-  PassMgr.add(createSPIRVToOCL(*M));
+  PassMgr.add(createSPIRVToOCL(*M, Opts.getDesiredBIsRepresentation()));
   PassMgr.run(*M);
 
   return M;
+}
+
+std::unique_ptr<Module>
+llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM, std::string &ErrMsg) {
+  SPIRV::TranslatorOpts DefaultOpts;
+  return llvm::convertSpirvToLLVM(C, BM, DefaultOpts, ErrMsg);
 }
 
 bool llvm::readSpirv(LLVMContext &C, std::istream &IS, Module *&M,
@@ -3725,7 +3733,7 @@ bool llvm::readSpirv(LLVMContext &C, const SPIRV::TranslatorOpts &Opts,
   if (!BM)
     return false;
 
-  M = convertSpirvToLLVM(C, *BM, ErrMsg).release();
+  M = convertSpirvToLLVM(C, *BM, Opts, ErrMsg).release();
 
   if (!M)
     return false;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3704,9 +3704,14 @@ llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM,
     return nullptr;
   }
 
-  llvm::legacy::PassManager PassMgr;
-  PassMgr.add(createSPIRVToOCL(*M, Opts.getDesiredBIsRepresentation()));
-  PassMgr.run(*M);
+  llvm::ModulePass *LoweringPass =
+      createSPIRVBIsLoweringPass(*M, Opts.getDesiredBIsRepresentation());
+  if (LoweringPass) {
+    // nullptr means no additional lowering is required
+    llvm::legacy::PassManager PassMgr;
+    PassMgr.add(LoweringPass);
+    PassMgr.run(*M);
+  }
 
   return M;
 }

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -398,15 +398,19 @@ std::string SPIRVToOCL::getGroupBuiltinPrefix(CallInst *CI) {
 
 } // namespace SPIRV
 
-ModulePass *llvm::createSPIRVToOCL(Module &M,
-                                   SPIRV::BIsRepresentation BIsRepresentation) {
+ModulePass *
+llvm::createSPIRVBIsLoweringPass(Module &M,
+                                 SPIRV::BIsRepresentation BIsRepresentation) {
   switch (BIsRepresentation) {
-    case SPIRV::BIsRepresentation::OpenCL12:
-      return createSPIRVToOCL12();
-    case SPIRV::BIsRepresentation::OpenCL20:
-      return createSPIRVToOCL20();
-    default:
-      assert(false && "Unsupported built-ins representation");
-      return nullptr;
+  case SPIRV::BIsRepresentation::OpenCL12:
+    return createSPIRVToOCL12();
+  case SPIRV::BIsRepresentation::OpenCL20:
+    return createSPIRVToOCL20();
+  case SPIRV::BIsRepresentation::SPIRVFriendlyIR:
+    // nothing to do, already done
+    return nullptr;
+  default:
+    llvm_unreachable("Unsupported built-ins representation");
+    return nullptr;
   }
 }

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -52,11 +52,6 @@ static cl::opt<std::string>
                                 cl::desc("Mangled atomic type name prefix"),
                                 cl::init("U7_Atomic"));
 
-static cl::opt<std::string>
-    OCLBuiltinsVersion("spirv-ocl-builtins-version",
-                       cl::desc("Specify version of OCL builtins to translate "
-                                "to (CL1.2, CL2.0, CL2.1)"));
-
 void SPIRVToOCL::visitCallInst(CallInst &CI) {
   LLVM_DEBUG(dbgs() << "[visistCallInst] " << CI << '\n');
   auto F = CI.getCalledFunction();
@@ -403,31 +398,15 @@ std::string SPIRVToOCL::getGroupBuiltinPrefix(CallInst *CI) {
 
 } // namespace SPIRV
 
-ModulePass *llvm::createSPIRVToOCL(Module &M) {
-  if (OCLBuiltinsVersion.getNumOccurrences() > 0) {
-    if (OCLBuiltinsVersion.getValue() == "CL1.2")
+ModulePass *llvm::createSPIRVToOCL(Module &M,
+                                   SPIRV::BIsRepresentation BIsRepresentation) {
+  switch (BIsRepresentation) {
+    case SPIRV::BIsRepresentation::OpenCL12:
       return createSPIRVToOCL12();
-    else if (OCLBuiltinsVersion.getValue() == "CL2.0" ||
-             OCLBuiltinsVersion.getValue() == "CL2.1")
+    case SPIRV::BIsRepresentation::OpenCL20:
       return createSPIRVToOCL20();
-    else {
-      assert(0 && "Invalid spirv-ocl-builtins-version value");
+    default:
+      assert(false && "Unsupported built-ins representation");
       return nullptr;
-    }
-  }
-  // Below part of code is here just temporarily (to not broke existing
-  // projects based on translator), because ocl builtins versions shouldn't has
-  // a dependency on OpSource spirv opcode. OpSource spec: "This has no semantic
-  // impact and can safely be removed from a module." After some time it can be
-  // removed, then only factor impacting version of ocl builtins will be
-  // spirv-ocl-builtins-version command option.
-  unsigned OCLVersion = getOCLVersion(&M);
-  if (OCLVersion <= kOCLVer::CL12)
-    return createSPIRVToOCL12();
-  else if (OCLVersion >= kOCLVer::CL20)
-    return createSPIRVToOCL20();
-  else {
-    assert(0 && "Invalid ocl version in llvm module");
-    return nullptr;
   }
 }

--- a/test/atomic_explicit_arguments.spt
+++ b/test/atomic_explicit_arguments.spt
@@ -31,7 +31,7 @@
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s
 
 ; CHECK: define spir_func i32 @load(i32 addrspace(4)* %obj, i32 %order, i32 %scope) #0 {

--- a/test/atomic_explicit_arguments.spt
+++ b/test/atomic_explicit_arguments.spt
@@ -31,7 +31,7 @@
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s
 
 ; CHECK: define spir_func i32 @load(i32 addrspace(4)* %obj, i32 %order, i32 %scope) #0 {

--- a/test/barrier_explicit_arguments.spt
+++ b/test/barrier_explicit_arguments.spt
@@ -26,9 +26,9 @@
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r -spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes=CHECK,CHECK-20
-; RUN: llvm-spirv -r -spirv-ocl-builtins-version=CL1.2 %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL1.2 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes=CHECK,CHECK-12
 
 ; CHECK: define spir_func void @test(i32 %val)

--- a/test/float_atomic_spv_to_ocl12.spt
+++ b/test/float_atomic_spv_to_ocl12.spt
@@ -74,7 +74,7 @@
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc -spirv-ocl-builtins-version="CL1.2"
+; RUN: llvm-spirv -r %t.spv -o %t.bc --spirv-target-env="CL1.2"
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM-12
 
 ; CHECK-LLVM-12: %{{[0-9]+}} = call spir_func float @{{[_A-Z0-9]+}}atomic_xchg{{[_A-Za-z0-9]+}}ff(float addrspace({{[0-9]+}})* %{{[0-9]+}}, float %{{[0-9]+}})

--- a/test/spirv-ocl-builtins-version.spt
+++ b/test/spirv-ocl-builtins-version.spt
@@ -30,9 +30,10 @@
 
 1 FunctionEnd
 
-; RUN: llvm-spirv %s -to-binary -o %t1.spv
-; RUN: spirv-val %t1.spv
-; RUN: llvm-spirv -r %t1.spv -o %t1.bc -spirv-ocl-builtins-version="CL1.2"
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: llvm-spirv -r %t.spv -o %t1.bc --spirv-target-env="CL1.2"
 ; RUN: llvm-dis < %t1.bc | FileCheck %s --check-prefix=CHECK-LLVM-12
 
 ; CHECK-LLVM-12: call spir_func void @_Z7barrierj(i32 2) [[attr:#[0-9]+]]
@@ -43,9 +44,7 @@
 ; CHECK-LLVM-12: call spir_func void @_Z7barrierj(i32 7) [[attr]]
 ; CHECK-LLVM-12: attributes [[attr]] = { convergent nounwind }
 
-; RUN: llvm-spirv %s -to-binary -o %t2.spv
-; RUN: spirv-val %t2.spv
-; RUN: llvm-spirv -r %t2.spv -o %t2.bc -spirv-ocl-builtins-version="CL2.0"
+; RUN: llvm-spirv -r %t.spv -o %t2.bc --spirv-target-env="CL2.0"
 ; RUN: llvm-dis < %t2.bc | FileCheck %s --check-prefix=CHECK-LLVM-20
 
 ; CHECK-LLVM-20: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 2, i32 1) [[attr:#[0-9]+]]
@@ -55,3 +54,15 @@
 ; CHECK-LLVM-20: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 5, i32 1) [[attr]]
 ; CHECK-LLVM-20: call spir_func void @_Z18work_group_barrierj12memory_scope(i32 7, i32 1) [[attr]]
 ; CHECK-LLVM-20: attributes [[attr]] = { convergent nounwind }
+
+; RUN: llvm-spirv -r %t.spv -o %t3.bc --spirv-target-env="SPV-IR"
+; RUN: llvm-dis < %t3.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPV-IR
+
+; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 528) [[attr:#[0-9]+]]
+; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 272) [[attr]]
+; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2064) [[attr]]
+; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 784) [[attr]]
+; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2320) [[attr]]
+; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2832) [[attr]]
+; FIXME: shall we apply convergent attribute to SPIR-V friendly IR representaiton as well?
+; CHECK-LLVM-SPV-IR: attributes [[attr]] = { nounwind }

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 __kernel void testAtomicCompareExchangeExplicit_cl20(

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 __kernel void testAtomicCompareExchangeExplicit_cl20(

--- a/test/transcoding/AtomicCompareExchange_cl20.ll
+++ b/test/transcoding/AtomicCompareExchange_cl20.ll
@@ -4,7 +4,7 @@ target triple = "spir-unknown-unknown"
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s
 
 ; Check 'LLVM ==> SPIR-V ==> LLVM' conversion of atomic_compare_exchange_strong and atomic_compare_exchange_weak.

--- a/test/transcoding/AtomicCompareExchange_cl20.ll
+++ b/test/transcoding/AtomicCompareExchange_cl20.ll
@@ -4,7 +4,7 @@ target triple = "spir-unknown-unknown"
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s
 
 ; Check 'LLVM ==> SPIR-V ==> LLVM' conversion of atomic_compare_exchange_strong and atomic_compare_exchange_weak.

--- a/test/transcoding/OpControlBarrier_cl20.ll
+++ b/test/transcoding/OpControlBarrier_cl20.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; work_group_barrier with the default scope (memory_scope_work_group)

--- a/test/transcoding/OpControlBarrier_cl20.ll
+++ b/test/transcoding/OpControlBarrier_cl20.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; work_group_barrier with the default scope (memory_scope_work_group)

--- a/test/transcoding/OpControlBarrier_cl20_subgroup.ll
+++ b/test/transcoding/OpControlBarrier_cl20_subgroup.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 2, i32 1) [[attr:#[0-9]+]]

--- a/test/transcoding/OpControlBarrier_cl20_subgroup.ll
+++ b/test/transcoding/OpControlBarrier_cl20_subgroup.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 2, i32 1) [[attr:#[0-9]+]]

--- a/test/transcoding/OpControlBarrier_cl21.ll
+++ b/test/transcoding/OpControlBarrier_cl21.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 2, i32 1) [[attr:#[0-9]+]]

--- a/test/transcoding/OpControlBarrier_cl21.ll
+++ b/test/transcoding/OpControlBarrier_cl21.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: call spir_func void @_Z17sub_group_barrierj12memory_scope(i32 2, i32 1) [[attr:#[0-9]+]]

--- a/test/transcoding/OpMemoryBarrier_cl20.ll
+++ b/test/transcoding/OpMemoryBarrier_cl20.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM:      call spir_func void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 2, i32 3, i32 0)

--- a/test/transcoding/OpMemoryBarrier_cl20.ll
+++ b/test/transcoding/OpMemoryBarrier_cl20.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM:      call spir_func void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 2, i32 3, i32 0)

--- a/test/transcoding/atomic_explicit_arguments.cl
+++ b/test/transcoding/atomic_explicit_arguments.cl
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple spir -cl-std=cl2.0 %s -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv %t.spv -r -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: llvm-spirv %t.spv -r --spirv-ocl-builtins-version=CL2.0 -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 int load (volatile atomic_int* obj, memory_order order, memory_scope scope) {
   return atomic_load_explicit(obj, order, scope);

--- a/test/transcoding/atomic_explicit_arguments.cl
+++ b/test/transcoding/atomic_explicit_arguments.cl
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple spir -cl-std=cl2.0 %s -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv %t.spv -r --spirv-ocl-builtins-version=CL2.0 -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: llvm-spirv %t.spv -r --spirv-target-env=CL2.0 -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 int load (volatile atomic_int* obj, memory_order order, memory_scope scope) {
   return atomic_load_explicit(obj, order, scope);

--- a/test/transcoding/atomic_flag.cl
+++ b/test/transcoding/atomic_flag.cl
@@ -2,7 +2,7 @@
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 kernel void testAtomicFlag(global int *res) {

--- a/test/transcoding/atomic_flag.cl
+++ b/test/transcoding/atomic_flag.cl
@@ -2,7 +2,7 @@
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 kernel void testAtomicFlag(global int *res) {

--- a/test/transcoding/atomic_load_store.ll
+++ b/test/transcoding/atomic_load_store.ll
@@ -7,7 +7,7 @@ target triple = "spir-unknown-unknown"
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; Check 'LLVM ==> SPIR-V ==> LLVM' conversion of atomic_load and atomic_store.

--- a/test/transcoding/atomic_load_store.ll
+++ b/test/transcoding/atomic_load_store.ll
@@ -7,7 +7,7 @@ target triple = "spir-unknown-unknown"
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; Check 'LLVM ==> SPIR-V ==> LLVM' conversion of atomic_load and atomic_store.

--- a/test/transcoding/atomics.spt
+++ b/test/transcoding/atomics.spt
@@ -52,7 +52,7 @@
 
 ; RUN: llvm-spirv %s -to-binary -o %t1.spv
 ; RUN: spirv-val %t1.spv
-; RUN: llvm-spirv -r %t1.spv -o %t1.bc -spirv-ocl-builtins-version="CL1.2"
+; RUN: llvm-spirv -r %t1.spv -o %t1.bc --spirv-target-env="CL1.2"
 ; RUN: llvm-dis < %t1.bc | FileCheck %s --check-prefix=CHECK-LLVM-12
 
 ; CHECK-LLVM-12: call spir_func i32 @_Z10atomic_incPU3AS1Vi(i32 addrspace(1)* %dst) [[attr:#[0-9]+]]
@@ -74,7 +74,7 @@
 ; CHECK-LLVM-12: trunc i32 %.tmp to i1
 ; CHECK-LLVM-12: call spir_func i32 @_Z11atomic_xchgPU3AS1Vii(i32 addrspace(1)* %object, i32 0) [[attr]]
 
-; RUN: llvm-spirv -r %t1.spv -o %t2.bc -spirv-ocl-builtins-version="CL2.0"
+; RUN: llvm-spirv -r %t1.spv -o %t2.bc --spirv-target-env="CL2.0"
 ; RUN: llvm-dis < %t2.bc | FileCheck %s --check-prefix=CHECK-LLVM-20
 
 ; CHECK-LLVM-20: call spir_func i32 @_Z25atomic_fetch_add_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %dst.as, i32 1, i32 5, i32 2) [[attr:#[0-9]+]]

--- a/test/transcoding/atomics_int64.spt
+++ b/test/transcoding/atomics_int64.spt
@@ -52,7 +52,7 @@
 
 ; RUN: llvm-spirv --to-binary %s -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv --spirv-ocl-builtins-version=CL1.2 -r %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llvm-spirv --spirv-target-env=CL1.2 -r %t.spv -o - | llvm-dis -o %t.ll
 ; RUN: FileCheck %s < %t.ll
 
 ; OpAtomicLoad is emulated via atom_add(*p, 0)

--- a/test/transcoding/memory_access.ll
+++ b/test/transcoding/memory_access.ll
@@ -3,7 +3,7 @@
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV-NOT: 6 Store {{[0-9]+}} {{[0-9]+}} 1 2 8

--- a/test/transcoding/memory_access.ll
+++ b/test/transcoding/memory_access.ll
@@ -3,7 +3,7 @@
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r --spirv-ocl-builtins-version=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV-NOT: 6 Store {{[0-9]+}} {{[0-9]+}} 1 2 8

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -116,6 +116,17 @@ static cl::opt<bool> SPIRVGenKernelArgNameMD(
     cl::desc("Enable generating OpenCL kernel argument name "
              "metadata"));
 
+// TODO: rename this option if we decide to target some representations of
+// SPIR-V instructions in LLVM IR which are not tied to OpenCL ones
+static cl::opt<SPIRV::BIsRepresentation>
+    BIsRepresentation("spirv-ocl-builtins-version",
+                      cl::desc("Specify version of OCL builtins to translate "),
+                      cl::values(clEnumValN(SPIRV::BIsRepresentation::OpenCL12,
+                                            "CL1.2", "OpenCL C 1.2"),
+                                 clEnumValN(SPIRV::BIsRepresentation::OpenCL20,
+                                            "CL2.0", "OpenCL C 2.0")),
+                          cl::init(SPIRV::BIsRepresentation::OpenCL12));
+
 using SPIRV::ExtensionID;
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
@@ -504,6 +515,14 @@ int main(int Ac, char **Av) {
 
   SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, ExtensionsStatus,
                              SPIRVGenKernelArgNameMD);
+  if (BIsRepresentation.getNumOccurrences() != 0) {
+    if (!IsReverse) {
+      errs() << "Note: --spirv-ocl-builtins-version option ignored as it only "
+                "affects translation from SPIR-V to LLVM IR";
+    } else {
+      Opts.setDesiredBIsRepresentation(BIsRepresentation);
+    }
+  }
 
   if (IsReverse && !SpecConst.empty()) {
     if (parseSpecConstOpt(SpecConst, Opts))

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -116,16 +116,16 @@ static cl::opt<bool> SPIRVGenKernelArgNameMD(
     cl::desc("Enable generating OpenCL kernel argument name "
              "metadata"));
 
-// TODO: rename this option if we decide to target some representations of
-// SPIR-V instructions in LLVM IR which are not tied to OpenCL ones
-static cl::opt<SPIRV::BIsRepresentation>
-    BIsRepresentation("spirv-ocl-builtins-version",
-                      cl::desc("Specify version of OCL builtins to translate "),
-                      cl::values(clEnumValN(SPIRV::BIsRepresentation::OpenCL12,
-                                            "CL1.2", "OpenCL C 1.2"),
-                                 clEnumValN(SPIRV::BIsRepresentation::OpenCL20,
-                                            "CL2.0", "OpenCL C 2.0")),
-                          cl::init(SPIRV::BIsRepresentation::OpenCL12));
+static cl::opt<SPIRV::BIsRepresentation> BIsRepresentation(
+    "spirv-target-env",
+    cl::desc("Specify a representation of different SPIR-V Instructions which "
+             "is used when translating from SPIR-V to LLVM IR"),
+    cl::values(
+        clEnumValN(SPIRV::BIsRepresentation::OpenCL12, "CL1.2", "OpenCL C 1.2"),
+        clEnumValN(SPIRV::BIsRepresentation::OpenCL20, "CL2.0", "OpenCL C 2.0"),
+        clEnumValN(SPIRV::BIsRepresentation::SPIRVFriendlyIR, "SPV-IR",
+                   "SPIR-V Friendly IR")),
+    cl::init(SPIRV::BIsRepresentation::OpenCL12));
 
 using SPIRV::ExtensionID;
 


### PR DESCRIPTION
- Refactored `--spirv-ocl-builtins-version` option so it can be set via library
  interface as well and renamed it into `--spirv-target-env`
- Removed logic that relied on OpSource while generating LLVM IR for
  OpenCL built-in functions
- Added one more library entry entry point: 'convertSpirvToLLVM' which
  is a copy of existing one, but accept TranslatorOpts argument