### PR TITLE
[NFC] Refactor for upcoming D77278 Remove asserting getters from base Type

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -882,10 +882,10 @@ void OCL20ToSPIRV::visitCallConvert(CallInst *CI, StringRef MangledName,
   Op OC = OpNop;
   auto TargetTy = CI->getType();
   auto SrcTy = CI->getArgOperand(0)->getType();
-  if (isa<VectorType>(TargetTy))
-    TargetTy = TargetTy->getVectorElementType();
-  if (isa<VectorType>(SrcTy))
-    SrcTy = SrcTy->getVectorElementType();
+  if (auto *VecTy = dyn_cast<VectorType>(TargetTy))
+    TargetTy = VecTy->getElementType();
+  if (auto *VecTy = dyn_cast<VectorType>(SrcTy))
+    SrcTy = VecTy->getElementType();
   auto IsTargetInt = isa<IntegerType>(TargetTy);
 
   std::string TargetTyName(
@@ -1159,7 +1159,8 @@ void OCL20ToSPIRV::visitCallGetImageSize(CallInst *CI,
           if (Desc.Dim == Dim3D) {
             auto ZeroVec = ConstantVector::getSplat(
                 {3, false},
-                Constant::getNullValue(NCI->getType()->getVectorElementType()));
+                Constant::getNullValue(
+                    cast<VectorType>(NCI->getType())->getElementType()));
             Constant *Index[] = {getInt32(M, 0), getInt32(M, 1), getInt32(M, 2),
                                  getInt32(M, 3)};
             return new ShuffleVectorInst(NCI, ZeroVec,
@@ -1189,10 +1190,10 @@ bool OCL20ToSPIRV::eraseUselessConvert(CallInst *CI, StringRef MangledName,
                                        StringRef DemangledName) {
   auto TargetTy = CI->getType();
   auto SrcTy = CI->getArgOperand(0)->getType();
-  if (isa<VectorType>(TargetTy))
-    TargetTy = TargetTy->getVectorElementType();
-  if (isa<VectorType>(SrcTy))
-    SrcTy = SrcTy->getVectorElementType();
+  if (auto *VecTy = dyn_cast<VectorType>(TargetTy))
+    TargetTy = VecTy->getElementType();
+  if (auto *VecTy = dyn_cast<VectorType>(SrcTy))
+    SrcTy = VecTy->getElementType();
   if (TargetTy == SrcTy) {
     if (isa<IntegerType>(TargetTy) &&
         DemangledName.find("_sat") != StringRef::npos &&
@@ -1319,7 +1320,7 @@ void OCL20ToSPIRV::visitCallRelational(CallInst *CI, StringRef DemangledName) {
         if (CI->getOperand(0)->getType()->isVectorTy())
           Ret = VectorType::get(
               Type::getInt1Ty(*Ctx),
-              CI->getOperand(0)->getType()->getVectorNumElements());
+              cast<VectorType>(CI->getOperand(0)->getType())->getNumElements());
         return SPIRVName;
       },
       [=](CallInst *NewCI) -> Instruction * {
@@ -1334,8 +1335,8 @@ void OCL20ToSPIRV::visitCallRelational(CallInst *CI, StringRef DemangledName) {
                   ->getElementType()
                   ->isHalfTy())
             IntTy = Type::getInt16Ty(*Ctx);
-          Type *VTy =
-              VectorType::get(IntTy, NewCI->getType()->getVectorNumElements());
+          Type *VTy = VectorType::get(
+              IntTy, cast<VectorType>(NewCI->getType())->getNumElements());
           False = Constant::getNullValue(VTy);
           True = Constant::getAllOnesValue(VTy);
         } else {
@@ -1457,7 +1458,8 @@ void OCL20ToSPIRV::visitCallScalToVec(CallInst *CI, StringRef MangledName,
           Args[I] = CI->getOperand(I);
         }
         auto VecElemCount =
-            CI->getOperand(VecPos[0])->getType()->getVectorElementCount();
+            cast<VectorType>(CI->getOperand(VecPos[0])->getType())
+                ->getElementCount();
         for (auto I : ScalarPos) {
           Instruction *Inst = InsertElementInst::Create(
               UndefValue::get(CI->getOperand(VecPos[0])->getType()),
@@ -1601,8 +1603,8 @@ static void processSubgroupBlockReadWriteINTEL(CallInst *CI,
                                                OCLBuiltinTransInfo &Info,
                                                const Type *DataTy, Module *M) {
   unsigned VectorNumElements = 1;
-  if (DataTy->isVectorTy())
-    VectorNumElements = DataTy->getVectorNumElements();
+  if (auto *VecTy = dyn_cast<VectorType>(DataTy))
+    VectorNumElements = VecTy->getNumElements();
   unsigned ElementBitSize = DataTy->getScalarSizeInBits();
   Info.Postfix = "_";
   Info.Postfix +=

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -271,7 +271,7 @@ unsigned encodeVecTypeHint(Type *Ty) {
   }
   if (VectorType *VecTy = dyn_cast<VectorType>(Ty)) {
     Type *EleTy = VecTy->getElementType();
-    unsigned Size = VecTy->getVectorNumElements();
+    unsigned Size = VecTy->getNumElements();
     return Size << 16 | encodeVecTypeHint(EleTy);
   }
   llvm_unreachable("invalid type");

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1276,7 +1276,7 @@ SPIRVToLLVM::expandOCLBuiltinWithScalarArg(CallInst *CI,
         M, CI,
         [=](CallInst *, std::vector<Value *> &Args) {
           auto VecElemCount =
-              CI->getOperand(1)->getType()->getVectorElementCount();
+              cast<VectorType>(CI->getOperand(1)->getType())->getElementCount();
           Value *NewVec = nullptr;
           if (auto CA = dyn_cast<Constant>(Args[0]))
             NewVec = ConstantVector::getSplat(VecElemCount, CA);
@@ -1769,8 +1769,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     IRBuilder<> Builder(BB);
     auto Scalar = transValue(VTS->getScalar(), F, BB);
     auto Vector = transValue(VTS->getVector(), F, BB);
-    assert(Vector->getType()->isVectorTy() && "Invalid type");
-    unsigned VecSize = Vector->getType()->getVectorNumElements();
+    auto *VecTy = cast<VectorType>(Vector->getType());
+    unsigned VecSize = VecTy->getNumElements();
     auto NewVec = Builder.CreateVectorSplat(VecSize, Scalar, Scalar->getName());
     NewVec->takeName(Scalar);
     auto Scale = Builder.CreateFMul(Vector, NewVec, "scale");
@@ -1797,10 +1797,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
     unsigned M = Mat->getType()->getArrayNumElements();
 
-    VectorType *VTy =
-        VectorType::get(Vec->getType()->getVectorElementType(), M);
+    auto *VecTy = cast<VectorType>(Vec->getType());
+    VectorType *VTy = VectorType::get(VecTy->getElementType(), M);
     auto ETy = VTy->getElementType();
-    unsigned N = Vec->getType()->getVectorNumElements();
+    unsigned N = VecTy->getNumElements();
     Value *V = Builder.CreateVectorSplat(M, ConstantFP::get(ETy, 0.0));
 
     for (unsigned Idx = 0; Idx != N; ++Idx) {
@@ -1826,7 +1826,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto Matrix = transValue(MTS->getMatrix(), F, BB);
     uint64_t ColNum = Matrix->getType()->getArrayNumElements();
     auto ColType = cast<ArrayType>(Matrix->getType())->getElementType();
-    auto VecSize = ColType->getVectorNumElements();
+    auto VecSize = cast<VectorType>(ColType)->getNumElements();
     auto NewVec = Builder.CreateVectorSplat(VecSize, Scalar, Scalar->getName());
     NewVec->takeName(Scalar);
 
@@ -1865,7 +1865,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     unsigned M = Mat->getType()->getArrayNumElements();
     VectorType *VTy =
         cast<VectorType>(cast<ArrayType>(Mat->getType())->getElementType());
-    unsigned N = VTy->getVectorNumElements();
+    unsigned N = VTy->getNumElements();
     auto ETy = VTy->getElementType();
     Value *V = Builder.CreateVectorSplat(N, ConstantFP::get(ETy, 0.0));
 
@@ -1922,8 +1922,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         cast<VectorType>(cast<ArrayType>(M1->getType())->getElementType());
     VectorType *V2Ty =
         cast<VectorType>(cast<ArrayType>(M2->getType())->getElementType());
-    unsigned R1 = V1Ty->getVectorNumElements();
-    unsigned R2 = V2Ty->getVectorNumElements();
+    unsigned R1 = V1Ty->getNumElements();
+    unsigned R2 = V2Ty->getNumElements();
     auto ETy = V1Ty->getElementType();
 
     (void)C1;
@@ -1961,7 +1961,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     unsigned ColNum = Matrix->getType()->getArrayNumElements();
     VectorType *ColTy =
         cast<VectorType>(cast<ArrayType>(Matrix->getType())->getElementType());
-    unsigned RowNum = ColTy->getVectorNumElements();
+    unsigned RowNum = ColTy->getNumElements();
 
     auto VTy = VectorType::get(ColTy->getElementType(), ColNum);
     auto ResultTy = ArrayType::get(VTy, RowNum);
@@ -3621,7 +3621,8 @@ Instruction *SPIRVToLLVM::transOCLAllAny(SPIRVInstruction *I, BasicBlock *BB) {
                Type *Int32Ty = Type::getInt32Ty(*Context);
                auto OldArg = CI->getOperand(0);
                auto NewArgTy = VectorType::get(
-                   Int32Ty, OldArg->getType()->getVectorNumElements());
+                   Int32Ty,
+                   cast<VectorType>(OldArg->getType())->getNumElements());
                auto NewArg =
                    CastInst::CreateSExtOrBitCast(OldArg, NewArgTy, "", CI);
                Args[0] = NewArg;
@@ -3655,17 +3656,17 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
                          ->getElementType()
                          ->isHalfTy())
                    IntTy = Type::getInt16Ty(*Context);
-                 RetTy = VectorType::get(IntTy,
-                                         CI->getType()->getVectorNumElements());
+                 RetTy = VectorType::get(
+                     IntTy, cast<VectorType>(CI->getType())->getNumElements());
                }
                return CI->getCalledFunction()->getName().str();
              },
              [=](CallInst *NewCI) -> Instruction * {
                Type *RetTy = Type::getInt1Ty(*Context);
                if (NewCI->getType()->isVectorTy())
-                 RetTy =
-                     VectorType::get(Type::getInt1Ty(*Context),
-                                     NewCI->getType()->getVectorNumElements());
+                 RetTy = VectorType::get(
+                     Type::getInt1Ty(*Context),
+                     cast<VectorType>(NewCI->getType())->getNumElements());
                return CastInst::CreateTruncOrBitCast(NewCI, RetTy, "",
                                                      NewCI->getNextNode());
              },

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -193,17 +193,16 @@ void SPIRVToOCL::visitCallSPRIVImageQuerySize(CallInst *CI) {
     if (CI->getType()->getScalarType() != Int32Ty) {
       GetImageSize = CastInst::CreateIntegerCast(
           GetImageSize,
-          VectorType::get(CI->getType()->getScalarType(),
-                          GetImageSize->getType()->getVectorNumElements()),
+          VectorType::get(
+              CI->getType()->getScalarType(),
+              cast<VectorType>(GetImageSize->getType())->getNumElements()),
           false, CI->getName(), CI);
     }
   }
 
   if (ImgArray || ImgDim == 3) {
-    assert(
-        CI->getType()->isVectorTy() &&
-        "OpImageQuerySize[Lod] must return vector for arrayed and 3d images");
-    const unsigned ImgQuerySizeRetEls = CI->getType()->getVectorNumElements();
+    auto *VecTy = cast<VectorType>(CI->getType());
+    const unsigned ImgQuerySizeRetEls = VecTy->getNumElements();
 
     if (ImgDim == 1) {
       // get_image_width returns scalar result while OpImageQuerySize
@@ -211,8 +210,8 @@ void SPIRVToOCL::visitCallSPRIVImageQuerySize(CallInst *CI) {
       assert(ImgQuerySizeRetEls == 2 &&
              "OpImageQuerySize[Lod] must return <2 x iN> vector type");
       GetImageSize = InsertElementInst::Create(
-          UndefValue::get(CI->getType()), GetImageSize,
-          ConstantInt::get(Int32Ty, 0), CI->getName(), CI);
+          UndefValue::get(VecTy), GetImageSize, ConstantInt::get(Int32Ty, 0),
+          CI->getName(), CI);
     } else {
       // get_image_dim and OpImageQuerySize returns different vector
       // types for arrayed and 3d images.
@@ -230,6 +229,7 @@ void SPIRVToOCL::visitCallSPRIVImageQuerySize(CallInst *CI) {
   if (ImgArray) {
     assert((ImgDim == 1 || ImgDim == 2) && "invalid image array type");
     // Insert get_image_array_size to the last position of the resulting vector.
+    auto *VecTy = cast<VectorType>(CI->getType());
     Type *SizeTy =
         Type::getIntNTy(*Ctx, M->getDataLayout().getPointerSizeInBits(0));
     Instruction *GetImageArraySize = addCallInst(
@@ -237,15 +237,14 @@ void SPIRVToOCL::visitCallSPRIVImageQuerySize(CallInst *CI) {
         &Attributes, CI, &Mangle, CI->getName(), false);
     // The width of integer type returning by OpImageQuerySize[Lod] may
     // differ from size_t which is returned by get_image_array_size
-    if (GetImageArraySize->getType() != CI->getType()->getScalarType()) {
+    if (GetImageArraySize->getType() != VecTy->getElementType()) {
       GetImageArraySize = CastInst::CreateIntegerCast(
-          GetImageArraySize, CI->getType()->getScalarType(), false,
-          CI->getName(), CI);
+          GetImageArraySize, VecTy->getElementType(), false, CI->getName(), CI);
     }
     GetImageSize = InsertElementInst::Create(
         GetImageSize, GetImageArraySize,
-        ConstantInt::get(Int32Ty, CI->getType()->getVectorNumElements() - 1),
-        CI->getName(), CI);
+        ConstantInt::get(Int32Ty, VecTy->getNumElements() - 1), CI->getName(),
+        CI);
   }
 
   assert(GetImageSize && "must not be null");
@@ -341,8 +340,8 @@ void SPIRVToOCL::visitCallSPIRVImageMediaBlockBuiltin(CallInst *CI, Op OC) {
         else
           assert(0 && "Unsupported texel type!");
 
-        if (RetType->isVectorTy()) {
-          unsigned int NumEl = RetType->getVectorNumElements();
+        if (auto *VecTy = dyn_cast<VectorType>(RetType)) {
+          unsigned int NumEl = VecTy->getNumElements();
           assert((NumEl == 2 || NumEl == 4 || NumEl == 8 || NumEl == 16) &&
                  "Wrong function type!");
           FuncPostfix += std::to_string(NumEl);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -143,7 +143,7 @@ std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed) {
   }
   if (auto VecTy = dyn_cast<VectorType>(Ty)) {
     Type *EleTy = VecTy->getElementType();
-    unsigned Size = VecTy->getVectorNumElements();
+    unsigned Size = VecTy->getNumElements();
     std::stringstream Ss;
     Ss << mapLLVMTypeToOCLType(EleTy, Signed) << Size;
     return Ss.str();
@@ -741,10 +741,10 @@ void makeVector(Instruction *InsPos, std::vector<Value *> &Ops,
 void expandVector(Instruction *InsPos, std::vector<Value *> &Ops,
                   size_t VecPos) {
   auto Vec = Ops[VecPos];
-  auto VT = Vec->getType();
-  if (!VT->isVectorTy())
+  auto *VT = dyn_cast<VectorType>(Vec->getType());
+  if (!VT)
     return;
-  size_t N = VT->getVectorNumElements();
+  size_t N = VT->getNumElements();
   IRBuilder<> Builder(InsPos);
   for (size_t I = 0; I != N; ++I)
     Ops.insert(Ops.begin() + VecPos + I,
@@ -1048,10 +1048,9 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
     return SPIR::RefParamType(new SPIR::PrimitiveType(SPIR::PRIMITIVE_FLOAT));
   if (Ty->isDoubleTy())
     return SPIR::RefParamType(new SPIR::PrimitiveType(SPIR::PRIMITIVE_DOUBLE));
-  if (Ty->isVectorTy()) {
-    return SPIR::RefParamType(
-        new SPIR::VectorType(transTypeDesc(Ty->getVectorElementType(), Info),
-                             Ty->getVectorNumElements()));
+  if (auto *VecTy = dyn_cast<VectorType>(Ty)) {
+    return SPIR::RefParamType(new SPIR::VectorType(
+        transTypeDesc(VecTy->getElementType(), Info), VecTy->getNumElements()));
   }
   if (Ty->isArrayTy()) {
     return transTypeDesc(PointerType::get(Ty->getArrayElementType(), 0), Info);
@@ -1168,8 +1167,8 @@ Constant *getScalarOrVectorConstantInt(Type *T, uint64_t V, bool IsSigned) {
     return ConstantInt::get(IT, V);
   if (auto VT = dyn_cast<VectorType>(T)) {
     std::vector<Constant *> EV(
-        VT->getVectorNumElements(),
-        getScalarOrVectorConstantInt(VT->getVectorElementType(), V, IsSigned));
+        VT->getNumElements(),
+        getScalarOrVectorConstantInt(VT->getElementType(), V, IsSigned));
     return ConstantVector::get(EV);
   }
   llvm_unreachable("Invalid type");
@@ -1520,9 +1519,9 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
     if (II->getArgOperand(0)->getType() != Ty)
       return false;
     int NumElems = 1;
-    if (Ty->isVectorTy()) {
-      NumElems = Ty->getVectorNumElements();
-      Ty = cast<VectorType>(Ty)->getElementType();
+    if (auto *VecTy = dyn_cast<VectorType>(Ty)) {
+      NumElems = VecTy->getNumElements();
+      Ty = VecTy->getElementType();
     }
     if ((!Ty->isFloatTy() && !Ty->isDoubleTy()) ||
         ((NumElems > 4) && (NumElems != 8) && (NumElems != 16))) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -341,9 +341,9 @@ SPIRVType *LLVMToSPIRV::transType(Type *T) {
     }
   }
 
-  if (T->isVectorTy())
-    return mapType(T, BM->addVectorType(transType(T->getVectorElementType()),
-                                        T->getVectorNumElements()));
+  if (auto *VecTy = dyn_cast<VectorType>(T))
+    return mapType(T, BM->addVectorType(transType(VecTy->getElementType()),
+                                        VecTy->getNumElements()));
 
   if (T->isArrayTy()) {
     // SPIR-V 1.3 s3.32.6: Length is the number of elements in the array.
@@ -2482,7 +2482,8 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       Type *BoolTy = IntegerType::getInt1Ty(M->getContext());
       auto IsVector = ResultTy->isVectorTy();
       if (IsVector)
-        BoolTy = VectorType::get(BoolTy, ResultTy->getVectorNumElements());
+        BoolTy = VectorType::get(BoolTy,
+                                 cast<VectorType>(ResultTy)->getNumElements());
       auto BBT = transType(BoolTy);
       SPIRVInstruction *Res;
       if (isCmpOpCode(OC)) {


### PR DESCRIPTION
A few methods is going to be removed from Type class, see
https://reviews.llvm.org/D77278

Applied the following transformation to the code:

```
Ty->getVectorNumElements() -> cast<VectorType>(Ty)->getNumElements()
Ty->getVectorElementCount() -> cast<VectorType>(Ty)->getElementCount()
Ty->getVectorElementType() -> cast<llvm::VectorType>(Ty)->getElementType()
```