### PR TITLE
Update for InlineFunction API change

### DIFF
--- a/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
@@ -348,7 +348,7 @@ private:
         return ACT->getAssumptionCache(F);
       };
       InlineFunctionInfo IFI(CG, &GetAssumptionCache);
-      InlineFunction(CI, IFI);
+      InlineFunction(*cast<CallBase>(CI), IFI);
       Inlined = true;
     }
     return Changed || Inlined;


### PR DESCRIPTION
Update for LLVM commit 4aae4e3f48b ("[llvm][NFC] CallSite removal
from inliner-related files", 2020-04-13).