### PR TITLE
[NFC] Fix build after LLVM API change (D62475)

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -594,7 +594,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgEnumType(const DICompositeType *ET) {
   size_t ElemCount = Elements.size();
   for (unsigned I = 0; I < ElemCount; ++I) {
     DIEnumerator *E = cast<DIEnumerator>(Elements[I]);
-    ConstantInt *EnumValue = getInt(M, E->getValue());
+    ConstantInt *EnumValue = getInt(M, E->getValue().getSExtValue());
     SPIRVValue *Val = SPIRVWriter->transValue(EnumValue, nullptr);
     assert(Val->getOpCode() == OpConstant &&
            "LLVM constant must be translated to SPIRV constant");


### PR DESCRIPTION
See https://reviews.llvm.org/D62475: [DebugInfo] Change DIEnumerator
payload type from int64_t to APInt