### PR TITLE
[NFC] Refactor uses of Type::getPointerElementType

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -618,10 +618,13 @@ CallInst *OCL20ToSPIRV::visitCallAtomicCmpXchg(CallInst *CI) {
       M, CI,
       [&](CallInst *CI, std::vector<Value *> &Args, Type *&RetTy) {
         Expected = Args[1]; // temporary save second argument.
-        Args[1] = new LoadInst(Args[1]->getType()->getPointerElementType(),
-                               Args[1], "exp", false, CI);
+        Args[1] = new LoadInst(
+            cast<PointerType>(Args[1]->getType())->getPointerElementType(),
+            Args[1], "exp", false, CI);
         RetTy = Args[2]->getType();
-        assert(Args[0]->getType()->getPointerElementType()->isIntegerTy() &&
+        assert(cast<PointerType>(Args[0]->getType())
+                   ->getPointerElementType()
+                   ->isIntegerTy() &&
                Args[1]->getType()->isIntegerTy() &&
                Args[2]->getType()->isIntegerTy() &&
                "In SPIR-V 1.0 arguments of OpAtomicCompareExchange must be "

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -229,7 +229,8 @@ void OCLTypeToSPIRV::adaptFunctionArguments(Function *F) {
   for (unsigned I = 0; I < F->arg_size(); ++I, ++PI, ++Arg) {
     auto NewTy = *PI;
     if (isPointerToOpaqueStructType(NewTy)) {
-      auto STName = NewTy->getPointerElementType()->getStructName();
+      auto STName =
+          cast<PointerType>(NewTy)->getPointerElementType()->getStructName();
       if (!hasAccessQualifiedName(STName))
         continue;
       if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
@@ -263,7 +264,8 @@ void OCLTypeToSPIRV::adaptArgumentsByMetadata(Function *F) {
       addAdaptedType(&(*Arg), getSamplerType(M));
       Changed = true;
     } else if (isPointerToOpaqueStructType(NewTy)) {
-      auto STName = NewTy->getPointerElementType()->getStructName();
+      auto STName =
+          cast<PointerType>(NewTy)->getPointerElementType()->getStructName();
       if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
         auto Ty = STName.str();
         auto AccMD = F->getMetadata(SPIR_MD_KERNEL_ARG_ACCESS_QUAL);

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -742,8 +742,9 @@ public:
       // distinguish write to image and other data types as position
       // of uint argument is different though name is the same.
       assert(ArgTypes.size() && "lack of necessary information");
-      if (ArgTypes[0]->isPointerTy() &&
-          ArgTypes[0]->getPointerElementType()->isIntegerTy()) {
+      if (ArgTypes[0]->isPointerTy() && cast<PointerType>(ArgTypes[0])
+                                            ->getPointerElementType()
+                                            ->isIntegerTy()) {
         addUnsignedArg(0);
         addUnsignedArg(1);
       } else {
@@ -754,8 +755,9 @@ public:
       // distinguish read from image and other data types as position
       // of uint argument is different though name is the same.
       assert(ArgTypes.size() && "lack of necessary information");
-      if (ArgTypes[0]->isPointerTy() &&
-          ArgTypes[0]->getPointerElementType()->isIntegerTy()) {
+      if (ArgTypes[0]->isPointerTy() && cast<PointerType>(ArgTypes[0])
+                                            ->getPointerElementType()
+                                            ->isIntegerTy()) {
         setArgAttr(0, SPIR::ATTR_CONST);
         addUnsignedArg(0);
       }
@@ -794,10 +796,10 @@ getSrcAndDstElememntTypeName(BitCastInst *BIC) {
 
   Type *SrcTy = BIC->getSrcTy();
   Type *DstTy = BIC->getDestTy();
-  if (SrcTy->isPointerTy())
-    SrcTy = SrcTy->getPointerElementType();
-  if (DstTy->isPointerTy())
-    DstTy = DstTy->getPointerElementType();
+  if (auto *SrcPtrTy = dyn_cast<PointerType>(SrcTy))
+    SrcTy = SrcPtrTy->getPointerElementType();
+  if (auto *DstPtrTy = dyn_cast<PointerType>(DstTy))
+    DstTy = DstPtrTy->getPointerElementType();
   auto SrcST = dyn_cast<StructType>(SrcTy);
   auto DstST = dyn_cast<StructType>(DstTy);
   if (!DstST || !DstST->hasName() || !SrcST || !SrcST->hasName())

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -579,10 +579,10 @@ bool containsUnsignedAtomicType(StringRef Name) {
 }
 
 bool isFunctionPointerType(Type *T) {
-  if (isa<PointerType>(T) && isa<FunctionType>(T->getPointerElementType())) {
-    return true;
-  }
-  return false;
+  auto *PtrTy = dyn_cast<PointerType>(T);
+  if (!T)
+    return false;
+  return isa<FunctionType>(PtrTy->getPointerElementType());
 }
 
 bool hasFunctionPointerArg(Function *F, Function::arg_iterator &AI) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -277,8 +277,8 @@ SPIRVType *LLVMToSPIRV::transType(Type *T) {
 
   // A pointer to image or pipe type in LLVM is translated to a SPIRV
   // (non-pointer) image or pipe type.
-  if (T->isPointerTy()) {
-    auto ET = T->getPointerElementType();
+  if (auto *PtrTy = dyn_cast<PointerType>(T)) {
+    auto ET = PtrTy->getPointerElementType();
     if (ET->isFunctionTy() &&
         !BM->checkExtension(ExtensionID::SPV_INTEL_function_pointers,
                             SPIRVEC_FunctionPointers, toString(T)))
@@ -421,7 +421,7 @@ SPIRVType *LLVMToSPIRV::transType(Type *T) {
 }
 
 SPIRVType *LLVMToSPIRV::transSPIRVOpaqueType(Type *T) {
-  auto ET = T->getPointerElementType();
+  auto ET = cast<PointerType>(T)->getPointerElementType();
   auto ST = cast<StructType>(ET);
   auto STName = ST->getStructName();
   assert(STName.startswith(kSPIRVTypeName::PrefixAndDelim) &&
@@ -2520,7 +2520,8 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       if (!RetTy->isVoidTy()) {
         SPRetTy = transType(RetTy);
       } else if (Args.size() > 0 && F->arg_begin()->hasStructRetAttr()) {
-        SPRetTy = transType(F->arg_begin()->getType()->getPointerElementType());
+        SPRetTy = transType(cast<PointerType>(F->arg_begin()->getType())
+                                ->getPointerElementType());
         Args.erase(Args.begin());
       }
       auto SPI = BM->addInstTemplate(OC, BB, SPRetTy);


### PR DESCRIPTION
Corresponding method is going to be removed and need to be replaced with
PointerType::getPointerElementType. See https://reviews.llvm.org/D15689