### PR TITLE
Add --spirv-fp-contract={on|off|fast} option

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -133,7 +133,7 @@ public:
 
   void setFPContractMode(FPContractMode Mode) { FPCMode = Mode; }
 
-  FPContractMode getFPContractMode() { return FPCMode; }
+  FPContractMode getFPContractMode() const { return FPCMode; }
 
 private:
   // Common translation options

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -131,13 +131,9 @@ public:
     return DesiredRepresentationOfBIs;
   }
 
-  void setFPContractMode(FPContractMode Mode) {
-    FPCMode = Mode;
-  }
+  void setFPContractMode(FPContractMode Mode) { FPCMode = Mode; }
 
-  FPContractMode getFPContractMode() {
-    return FPCMode;
-  }
+  FPContractMode getFPContractMode() { return FPCMode; }
 
 private:
   // Common translation options

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -67,6 +67,8 @@ enum class ExtensionID : uint32_t {
 
 enum class BIsRepresentation : uint32_t { OpenCL12, OpenCL20, SPIRVFriendlyIR };
 
+enum class FPContractMode : uint32_t { On, Off, Fast };
+
 /// \brief Helper class to manage SPIR-V translation
 class TranslatorOpts {
 public:
@@ -129,6 +131,14 @@ public:
     return DesiredRepresentationOfBIs;
   }
 
+  void setFPContractMode(FPContractMode Mode) {
+    FPCMode = Mode;
+  }
+
+  FPContractMode getFPContractMode() {
+    return FPCMode;
+  }
+
 private:
   // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
@@ -141,6 +151,16 @@ private:
   // Representation of built-ins, which should be used while translating from
   // SPIR-V to back to LLVM IR
   BIsRepresentation DesiredRepresentationOfBIs = BIsRepresentation::OpenCL12;
+  // Controls floating point contraction.
+  //
+  // - FPContractMode::On allows to choose a mode according to
+  //   presence of fused LLVM intrinsics
+  //
+  // - FPContractMode::Off disables contratction for all entry points
+  //
+  // - FPContractMode::Fast allows *all* operations to be contracted
+  //   for all entry points
+  FPContractMode FPCMode = FPContractMode::On;
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2166,7 +2166,7 @@ void LLVMToSPIRV::transFunction(Function *I) {
     BF->addExecutionMode(BF->getModule()->add(
         new SPIRVExecutionMode(BF, spv::ExecutionModeContractionOff)));
   }
-  if (BF->getModule()->isEntryPoint(spv::ExecutionModelKernel, BF->getId())) {
+  if (IsKernelEntryPoint) {
     collectInputOutputVariables(BF, I);
   }
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -94,6 +94,23 @@ cl::opt<bool> SPIRVAllowUnknownIntrinsics(
     cl::desc("Unknown LLVM intrinsics will be translated as external function "
              "calls in SPIR-V"));
 
+enum FPContract {
+  FPContractOn,
+  FPContractOff,
+  FPContractFast,
+};
+
+cl::opt<FPContract> FPContractMode(
+    "ffp-contract", cl::desc("Fused FP operations:"), cl::init(FPContractOn),
+    cl::values(
+        clEnumValN(FPContractOn, "on",
+                   "choose a mode according to presence of fused LLVM "
+                   "intrinsics"),
+        clEnumValN(FPContractOff, "off", "disable for all entry points"),
+        clEnumValN(
+            FPContractFast, "fast",
+            "allow all operations to be contracted for all entry points")));
+
 static void foreachKernelArgMD(
     MDNode *MD, SPIRVFunction *BF,
     std::function<void(const std::string &Str, SPIRVFunctionParameter *BA)>
@@ -2147,8 +2164,22 @@ void LLVMToSPIRV::transFunction(Function *I) {
     }
   }
 
-  if (BF->getModule()->isEntryPoint(spv::ExecutionModelKernel, BF->getId()) &&
-      BF->shouldFPContractBeDisabled()) {
+  bool IsKernelEntryPoint =
+      BF->getModule()->isEntryPoint(spv::ExecutionModelKernel, BF->getId());
+  bool DisableContraction = false;
+  switch (FPContractMode) {
+  case FPContractFast:
+    DisableContraction = false;
+    break;
+  case FPContractOn:
+    DisableContraction = IsKernelEntryPoint && BF->shouldFPContractBeDisabled();
+    break;
+  case FPContractOff:
+    DisableContraction = IsKernelEntryPoint;
+    break;
+  }
+
+  if (DisableContraction) {
     BF->addExecutionMode(BF->getModule()->add(
         new SPIRVExecutionMode(BF, spv::ExecutionModeContractionOff)));
   }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -465,7 +465,7 @@ public:
     return TranslationOpts.getSpecializationConstant(SpecId, ConstValue);
   }
 
-  FPContractMode getFPContractMode() {
+  FPContractMode getFPContractMode() const {
     return TranslationOpts.getFPContractMode();
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -465,6 +465,10 @@ public:
     return TranslationOpts.getSpecializationConstant(SpecId, ConstValue);
   }
 
+  FPContractMode getFPContractMode() {
+    return TranslationOpts.getFPContractMode();
+  }
+
   // I/O functions
   friend spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M);
   friend std::istream &operator>>(std::istream &I, SPIRVModule &M);

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -18,27 +18,23 @@
 ; opt -mem2reg 1.ll -S -o 1.o.ll
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t.default
-; RUN: FileCheck < %t.default %s --check-prefixes CHECK,CHECK-ON
 ; RUN: llvm-spirv %t.bc -o %t.spv.default
+; RUN: llvm-spirv %t.spv.default -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-ON
 ; RUN: spirv-val %t.spv.default
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t.off -ffp-contract=off
-; RUN: FileCheck < %t.off %s --check-prefixes CHECK,CHECK-OFF
 ; RUN: llvm-spirv %t.bc -o %t.spv.off -ffp-contract=off
+; RUN: llvm-spirv %t.spv.off -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-OFF
 ; RUN: spirv-val %t.spv.off
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t.fast -ffp-contract=fast
-; RUN: FileCheck < %t.fast %s --check-prefixes CHECK,CHECK-FAST
 ; RUN: llvm-spirv %t.bc -o %t.spv.fast -ffp-contract=fast
+; RUN: llvm-spirv %t.spv.fast -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-FAST
 ; RUN: spirv-val %t.spv.fast
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t.on -ffp-contract=on
-; RUN: FileCheck < %t.on %s --check-prefixes CHECK,CHECK-ON
 ; RUN: llvm-spirv %t.bc -o %t.spv.on -ffp-contract=on
+; RUN: llvm-spirv %t.spv.on -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-ON
 ; RUN: spirv-val %t.spv.on
 
 ; CHECK: EntryPoint 6 [[K1:[0-9]+]] "k1"

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -18,17 +18,44 @@
 ; opt -mem2reg 1.ll -S -o 1.o.ll
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t
-; RUN: FileCheck < %t %s
-; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.default
+; RUN: FileCheck < %t.default %s --check-prefixes CHECK,CHECK-ON
+; RUN: llvm-spirv %t.bc -o %t.spv.default
+; RUN: spirv-val %t.spv.default
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.off -ffp-contract=off
+; RUN: FileCheck < %t.off %s --check-prefixes CHECK,CHECK-OFF
+; RUN: llvm-spirv %t.bc -o %t.spv.off -ffp-contract=off
+; RUN: spirv-val %t.spv.off
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.fast -ffp-contract=fast
+; RUN: FileCheck < %t.fast %s --check-prefixes CHECK,CHECK-FAST
+; RUN: llvm-spirv %t.bc -o %t.spv.fast -ffp-contract=fast
+; RUN: spirv-val %t.spv.fast
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.on -ffp-contract=on
+; RUN: FileCheck < %t.on %s --check-prefixes CHECK,CHECK-ON
+; RUN: llvm-spirv %t.bc -o %t.spv.on -ffp-contract=on
+; RUN: spirv-val %t.spv.on
 
 ; CHECK: EntryPoint 6 [[K1:[0-9]+]] "k1"
 ; CHECK: EntryPoint 6 [[K2:[0-9]+]] "k2"
 ; CHECK: EntryPoint 6 [[K3:[0-9]+]] "k3"
-; CHECK: ExecutionMode [[K1]] 31
-; CHECK-NOT: ExecutionMode [[K2]] 31
-; CHECK-NOT: ExecutionMode [[K3]] 31
+
+; CHECK-OFF: ExecutionMode [[K1]] 31
+; CHECK-OFF: ExecutionMode [[K2]] 31
+; CHECK-OFF: ExecutionMode [[K3]] 31
+
+; CHECK-FAST-NOT: ExecutionMode [[K1]] 31
+; CHECK-FAST-NOT: ExecutionMode [[K2]] 31
+; CHECK-FAST-NOT: ExecutionMode [[K3]] 31
+
+; CHECK-ON: ExecutionMode [[K1]] 31
+; CHECK-ON-NOT: ExecutionMode [[K2]] 31
+; CHECK-ON-NOT: ExecutionMode [[K3]] 31
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -23,17 +23,17 @@
 ; RUN: spirv-val %t.spv.default
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv.off -ffp-contract=off
+; RUN: llvm-spirv %t.bc -o %t.spv.off --spirv-fp-contract=off
 ; RUN: llvm-spirv %t.spv.off -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-OFF
 ; RUN: spirv-val %t.spv.off
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv.fast -ffp-contract=fast
+; RUN: llvm-spirv %t.bc -o %t.spv.fast --spirv-fp-contract=fast
 ; RUN: llvm-spirv %t.spv.fast -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-FAST
 ; RUN: spirv-val %t.spv.fast
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv.on -ffp-contract=on
+; RUN: llvm-spirv %t.bc -o %t.spv.on --spirv-fp-contract=on
 ; RUN: llvm-spirv %t.spv.on -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-ON
 ; RUN: spirv-val %t.spv.on
 

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -163,6 +163,19 @@ static cl::opt<bool> SpecConstInfo(
     cl::desc("Display id of constants available for specializaion and their "
              "size in bytes"));
 
+static cl::opt<SPIRV::FPContractMode> FPCMode(
+    "ffp-contract", cl::desc("Fused FP operations:"),
+    cl::init(SPIRV::FPContractMode::On),
+    cl::values(
+        clEnumValN(SPIRV::FPContractMode::On, "on",
+                   "choose a mode according to presence of fused LLVM "
+                   "intrinsics"),
+        clEnumValN(SPIRV::FPContractMode::Off, "off",
+                   "disable for all entry points"),
+        clEnumValN(
+            SPIRV::FPContractMode::Fast, "fast",
+            "allow all operations to be contracted for all entry points")));
+
 static std::string removeExt(const std::string &FileName) {
   size_t Pos = FileName.find_last_of(".");
   if (Pos != std::string::npos)
@@ -526,6 +539,8 @@ int main(int Ac, char **Av) {
       Opts.setDesiredBIsRepresentation(BIsRepresentation);
     }
   }
+
+  Opts.setFPContractMode(FPCMode);
 
   if (SPIRVMemToReg)
     Opts.setMemToRegEnabled(SPIRVMemToReg);

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -164,14 +164,14 @@ static cl::opt<bool> SpecConstInfo(
              "size in bytes"));
 
 static cl::opt<SPIRV::FPContractMode> FPCMode(
-    "ffp-contract", cl::desc("Fused FP operations:"),
+    "spirv-fp-contract", cl::desc("Set FP Contraction mode:"),
     cl::init(SPIRV::FPContractMode::On),
     cl::values(
         clEnumValN(SPIRV::FPContractMode::On, "on",
-                   "choose a mode according to presence of fused LLVM "
-                   "intrinsics"),
+                   "choose a mode according to presence of llvm.fmuladd "
+                   "intrinsic or `contract' flag on fp operations"),
         clEnumValN(SPIRV::FPContractMode::Off, "off",
-                   "disable for all entry points"),
+                   "disable FP contraction for all entry points"),
         clEnumValN(
             SPIRV::FPContractMode::Fast, "fast",
             "allow all operations to be contracted for all entry points")));


### PR DESCRIPTION
In SPIR-V, floating point contraction (fused multiply add) can only be
controlled per entry point using ContractionOFF execution mode: it can
either allow any floating point operation to contract across a call
graph (with an entry point as a root), or disallow contraction for a
call graph.

SPIR-V translator currently have an algorithm to determine if
ContractionOFF should be set, but this algorithm is supposed to be
very pessimistic. A single non-contracted fmul + fadd or a single
undefined function must force ContractionOFF for the entire call
graph. This behavior is used by default, or when `-ffp-contract=on` is
set.

Two more modes are added:
    - `off` disables contraction for all entry points
    - `fast` unconditionally enables contraction for all entry points

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>