### PR TITLE
Fix build after a58b62b4a

### DIFF
--- a/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
@@ -267,7 +267,7 @@ private:
       LLVM_DEBUG(dbgs() << "[lowerGetBlockInvoke]  " << *CallInv);
       // Handle ret = block_func_ptr(context_ptr, args)
       auto CI = cast<CallInst>(CallInv);
-      auto F = CI->getCalledValue();
+      auto F = CI->getCalledOperand();
       if (InvokeF == nullptr) {
         getBlockInvokeFuncAndContext(CallGetBlkInvoke->getArgOperand(0),
                                      &InvokeF, nullptr);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1523,7 +1523,7 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
     if ((!Ty->isFloatTy() && !Ty->isDoubleTy()) ||
         ((NumElems > 4) && (NumElems != 8) && (NumElems != 16))) {
       BM->getErrorLog().checkError(false, SPIRVEC_InvalidFunctionCall,
-                                   II->getCalledValue()->getName().str(), "",
+                                   II->getCalledOperand()->getName().str(), "",
                                    __FILE__, __LINE__);
       return false;
     }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1862,7 +1862,7 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
       // Other LLVM intrinsics shouldn't get to SPIRV, because they
       // can't be represented in SPIRV or aren't implemented yet.
       BM->getErrorLog().checkError(false, SPIRVEC_InvalidFunctionCall,
-                                   II->getCalledValue()->getName().str(), "",
+                                   II->getCalledOperand()->getName().str(), "",
                                    __FILE__, __LINE__);
   }
   return nullptr;
@@ -1922,7 +1922,7 @@ SPIRVValue *LLVMToSPIRV::transIndirectCallInst(CallInst *CI,
     return nullptr;
 
   return BM->addIndirectCallInst(
-      transValue(CI->getCalledValue(), BB), transType(CI->getType()),
+      transValue(CI->getCalledOperand(), BB), transType(CI->getType()),
       transArguments(CI, BB, SPIRVEntry::createUnique(OpFunctionCall).get()),
       BB);
 }


### PR DESCRIPTION
"Replace all uses of CallBase::getCalledValue() with getCalledOperand()"

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>