### PR TITLE
Remove deprecated spirv-atomic-prefix option

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -47,11 +47,6 @@
 
 namespace SPIRV {
 
-static cl::opt<std::string>
-    MangledAtomicTypeNamePrefix("spirv-atomic-prefix",
-                                cl::desc("Mangled atomic type name prefix"),
-                                cl::init("U7_Atomic"));
-
 void SPIRVToOCL::visitCallInst(CallInst &CI) {
   LLVM_DEBUG(dbgs() << "[visistCallInst] " << CI << '\n');
   auto F = CI.getCalledFunction();
@@ -360,23 +355,6 @@ void SPIRVToOCL::visitCallSPIRVBuiltin(CallInst *CI, Op OC) {
         return OCLSPIRVBuiltinMap::rmap(OC);
       },
       &Attrs);
-}
-
-void SPIRVToOCL::translateMangledAtomicTypeName() {
-  for (auto &I : M->functions()) {
-    if (!I.hasName())
-      continue;
-    std::string MangledName{I.getName()};
-    StringRef DemangledName;
-    if (!oclIsBuiltin(MangledName, DemangledName) ||
-        DemangledName.find(kOCLBuiltinName::AtomPrefix) != 0)
-      continue;
-    auto Loc = MangledName.find(kOCLBuiltinName::AtomPrefix);
-    Loc = MangledName.find(kMangledName::AtomicPrefixInternal, Loc);
-    MangledName.replace(Loc, strlen(kMangledName::AtomicPrefixInternal),
-                        MangledAtomicTypeNamePrefix);
-    I.setName(MangledName);
-  }
 }
 
 std::string SPIRVToOCL::getGroupBuiltinPrefix(CallInst *CI) {

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -97,10 +97,6 @@ public:
   /// No change with arguments.
   void visitCallSPIRVBuiltin(CallInst *CI, Op OC);
 
-  /// Translate mangled atomic type name: "atomic_" =>
-  ///   MangledAtomicTypeNamePrefix
-  void translateMangledAtomicTypeName();
-
   /// Get prefix work_/sub_ for OCL group builtin functions.
   /// Assuming the first argument of \param CI is a constant integer for
   /// workgroup/subgroup scope enums.

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -92,8 +92,6 @@ bool SPIRVToOCL20::runOnModule(Module &Module) {
   Ctx = &M->getContext();
   visit(*M);
 
-  translateMangledAtomicTypeName();
-
   eraseUselessFunctions(&Module);
 
   LLVM_DEBUG(dbgs() << "After SPIRVToOCL20:\n" << *M);


### PR DESCRIPTION
For details about motivation of removing this code check: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/514