### PR TITLE
Enable strict rules to set ContractionOFF

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -893,8 +893,8 @@ bool isKernelQueryBI(const StringRef MangledName) {
 //   %mul = fmul contract float %a, %b
 //   %add = fadd contract float %mul, %c
 //
-// Note that optimizations that may form an unfused fmuladd, so this check is
-// quite restrictive (see the comment below).
+// Note that optimizations may form an unfused fmuladd from fadd+load or
+// fadd+call, so this check is quite restrictive (see the comment below).
 //
 bool isUnfusedMulAdd(BinaryOperator *B) {
   if (B->getOpcode() != Instruction::FAdd &&

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -425,9 +425,8 @@ bool isKernelQueryBI(const StringRef MangledName);
 /// Check that the type is the sampler_t
 bool isSamplerTy(Type *Ty);
 
-// Checks if clang did not generate llvm.fmuladd for fp multiply-add operations.
-// If so, it applies ContractionOff ExecutionMode to the kernel.
-void checkFpContract(BinaryOperator *B, SPIRVBasicBlock *BB);
+// Checks if the binary operator is an unfused fmul + fadd instruction.
+bool isUnfusedMulAdd(BinaryOperator *B);
 
 template <typename T> std::string toString(const T *Object) {
   std::string S;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -78,6 +78,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <queue>
 #include <set>
 #include <vector>
 
@@ -671,7 +672,14 @@ SPIRVInstruction *LLVMToSPIRV::transBinaryInst(BinaryOperator *B,
   SPIRVInstruction *BI = BM->addBinaryInst(
       transBoolOpCode(Op0, OpCodeMap::map(LLVMOC)), transType(B->getType()),
       Op0, transValue(B->getOperand(1), BB), BB);
-  checkFpContract(B, BB);
+
+  if (isUnfusedMulAdd(B)) {
+    Function *F = B->getFunction();
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
+                    << ": possible fma candidate " << *B << '\n');
+    joinFPContract(F, FPContract::DISABLED);
+  }
+
   return BI;
 }
 
@@ -1715,7 +1723,6 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
     // For llvm.fmuladd.* fusion is not guaranteed. If a fused multiply-add
     // is required the corresponding llvm.fma.* intrinsic function should be
     // used instead.
-    BB->getParent()->setContractedFMulAddFound();
     SPIRVType *Ty = transType(II->getType());
     SPIRVValue *Mul =
         BM->addBinaryInst(OpFMul, Ty, transValue(II->getArgOperand(0), BB),
@@ -1909,12 +1916,24 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
 
 SPIRVValue *LLVMToSPIRV::transCallInst(CallInst *CI, SPIRVBasicBlock *BB) {
   assert(CI);
+  Function *F = CI->getFunction();
   if (isa<InlineAsm>(CI->getCalledOperand()) &&
-      BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_inline_assembly))
+      BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_inline_assembly)) {
+    // Inline asm is opaque, so we cannot reason about its FP contraction
+    // requirements.
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
+                    << ": inline asm " << *CI << '\n');
+    joinFPContract(F, FPContract::DISABLED);
     return transAsmCallINTEL(CI, BB);
+  }
 
-  if (CI->isIndirectCall())
+  if (CI->isIndirectCall()) {
+    // The function is not known in advance
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
+                    << ": indirect call " << *CI << '\n');
+    joinFPContract(F, FPContract::DISABLED);
     return transIndirectCallInst(CI, BB);
+  }
   return transDirectCallInst(CI, BB);
 }
 
@@ -1948,8 +1967,23 @@ SPIRVValue *LLVMToSPIRV::transDirectCallInst(CallInst *CI,
             BB),
         Dec);
 
+  Function *Callee = CI->getCalledFunction();
+  if (Callee->isDeclaration()) {
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName().str()
+                    << ": call to an undefined function " << *CI << '\n');
+    joinFPContract(CI->getFunction(), FPContract::DISABLED);
+  } else {
+    FPContract CalleeFPC = getFPContract(Callee);
+    joinFPContract(CI->getFunction(), CalleeFPC);
+    if (CalleeFPC == FPContract::DISABLED) {
+      SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName().str()
+                      << ": call to a function with disabled contraction: "
+                      << *CI << '\n');
+    }
+  }
+
   return BM->addCallInst(
-      transFunctionDecl(CI->getCalledFunction()),
+      transFunctionDecl(Callee),
       transArguments(CI, BB, SPIRVEntry::createUnique(OpFunctionCall).get()),
       BB);
 }
@@ -2172,6 +2206,67 @@ void LLVMToSPIRV::mutateFuncArgType(
   }
 }
 
+// Propagate contraction requirement of F up the call graph.
+void LLVMToSPIRV::fpContractUpdateRecursive(Function *F, FPContract FPC) {
+  std::queue<User *> Users;
+  for (User *FU : F->users()) {
+    Users.push(FU);
+  }
+
+  bool EnableLogger = FPC == FPContract::DISABLED && !Users.empty();
+  if (EnableLogger) {
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for users of " << F->getName()
+                    << '\n');
+  }
+
+  while (!Users.empty()) {
+    User *U = Users.front();
+    Users.pop();
+
+    if (EnableLogger) {
+      SPIRVDBG(dbgs() << "[fp-contract]   user: " << *U << '\n');
+    }
+
+    // Move from an Instruction to its Function
+    if (Instruction *I = dyn_cast<Instruction>(U)) {
+      Users.push(I->getFunction());
+      continue;
+    }
+
+    if (Function *F = dyn_cast<Function>(U)) {
+      if (!joinFPContract(F, FPC)) {
+        // FP contract was not updated - no need to propagate
+        // This also terminates a recursion (if any).
+        if (EnableLogger) {
+          SPIRVDBG(dbgs() << "[fp-contract] already disabled " << F->getName()
+                          << '\n');
+        }
+        continue;
+      }
+      if (EnableLogger) {
+        SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
+                        << '\n');
+      }
+      for (User *FU : F->users()) {
+        Users.push(FU);
+      }
+      continue;
+    }
+
+    // Unwrap a constant until we reach an Instruction.
+    // This is checked after the Function, because a Function is also a
+    // Constant.
+    if (Constant *C = dyn_cast<Constant>(U)) {
+      for (User *CU : C->users()) {
+        Users.push(CU);
+      }
+      continue;
+    }
+
+    llvm_unreachable("Unexpected use.");
+  }
+}
+
 void LLVMToSPIRV::transFunction(Function *I) {
   SPIRVFunction *BF = transFunctionDecl(I);
   // Creating all basic blocks before creating any instruction.
@@ -2185,26 +2280,13 @@ void LLVMToSPIRV::transFunction(Function *I) {
       transValue(&BI, BB, false);
     }
   }
+  // Enable FP contraction unless proven otherwise
+  joinFPContract(I, FPContract::ENABLED);
+  fpContractUpdateRecursive(I, getFPContract(I));
 
   bool IsKernelEntryPoint =
       BF->getModule()->isEntryPoint(spv::ExecutionModelKernel, BF->getId());
-  bool DisableContraction = false;
-  switch (BM->getFPContractMode()) {
-  case FPContractMode::Fast:
-    DisableContraction = false;
-    break;
-  case FPContractMode::On:
-    DisableContraction = IsKernelEntryPoint && BF->shouldFPContractBeDisabled();
-    break;
-  case FPContractMode::Off:
-    DisableContraction = IsKernelEntryPoint;
-    break;
-  }
 
-  if (DisableContraction) {
-    BF->addExecutionMode(BF->getModule()->add(
-        new SPIRVExecutionMode(BF, spv::ExecutionModeContractionOff)));
-  }
   if (IsKernelEntryPoint) {
     collectInputOutputVariables(BF, I);
   }
@@ -2396,7 +2478,48 @@ bool LLVMToSPIRV::transExecutionMode() {
       }
     }
   }
+
+  transFPContract();
+
   return true;
+}
+
+void LLVMToSPIRV::transFPContract() {
+  FPContractMode Mode = BM->getFPContractMode();
+
+  for (Function &F : *M) {
+    SPIRVValue *TranslatedF = getTranslatedValue(&F);
+    if (!TranslatedF) {
+      continue;
+    }
+    SPIRVFunction *BF = static_cast<SPIRVFunction *>(TranslatedF);
+
+    bool IsKernelEntryPoint =
+        BF->getModule()->isEntryPoint(spv::ExecutionModelKernel, BF->getId());
+    if (!IsKernelEntryPoint)
+      continue;
+
+    FPContract FPC = getFPContract(&F);
+    assert(FPC != FPContract::UNDEF);
+
+    bool DisableContraction = false;
+    switch (Mode) {
+    case FPContractMode::Fast:
+      DisableContraction = false;
+      break;
+    case FPContractMode::On:
+      DisableContraction = FPC == FPContract::DISABLED;
+      break;
+    case FPContractMode::Off:
+      DisableContraction = true;
+      break;
+    }
+
+    if (DisableContraction) {
+      BF->addExecutionMode(BF->getModule()->add(
+          new SPIRVExecutionMode(BF, spv::ExecutionModeContractionOff)));
+    }
+  }
 }
 
 bool LLVMToSPIRV::transOCLKernelMetadata() {
@@ -2605,6 +2728,34 @@ LLVMToSPIRV::transLinkageType(const GlobalValue *GV) {
   if (GV->hasInternalLinkage() || GV->hasPrivateLinkage())
     return SPIRVLinkageTypeKind::LinkageTypeInternal;
   return SPIRVLinkageTypeKind::LinkageTypeExport;
+}
+
+LLVMToSPIRV::FPContract LLVMToSPIRV::getFPContract(Function *F) {
+  auto It = FPContractMap.find(F);
+  if (It == FPContractMap.end()) {
+    return FPContract::UNDEF;
+  }
+  return It->second;
+}
+
+bool LLVMToSPIRV::joinFPContract(Function *F, FPContract C) {
+  FPContract &Existing = FPContractMap[F];
+  switch (Existing) {
+  case FPContract::UNDEF:
+    if (C != FPContract::UNDEF) {
+      Existing = C;
+      return true;
+    }
+    return false;
+  case FPContract::ENABLED:
+    if (C == FPContract::DISABLED) {
+      Existing = C;
+      return true;
+    }
+    return false;
+  case FPContract::DISABLED:
+    return false;
+  }
 }
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -112,6 +112,7 @@ public:
   // Returns true if succeeds.
   bool translate();
   bool transExecutionMode();
+  void transFPContract();
   SPIRVValue *transConstant(Value *V);
   SPIRVValue *transValue(Value *V, SPIRVBasicBlock *BB,
                          bool CreateForward = true);
@@ -135,6 +136,12 @@ private:
   SPIRVWord SrcLangVer;
   std::unique_ptr<LLVMToSPIRVDbgTran> DbgTran;
   std::unique_ptr<CallGraph> CG;
+
+  enum class FPContract { UNDEF, DISABLED, ENABLED };
+  DenseMap<Function *, FPContract> FPContractMap;
+  FPContract getFPContract(Function *F);
+  bool joinFPContract(Function *F, FPContract C);
+  void fpContractUpdateRecursive(Function *F, FPContract FPC);
 
   SPIRVType *mapType(Type *T, SPIRVType *BT);
   SPIRVValue *mapValue(Value *V, SPIRVValue *BV);

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -145,22 +145,6 @@ public:
     assert(FuncType && "Invalid func type");
   }
 
-  bool shouldFPContractBeDisabled() const {
-    // We could find some instructions in LLVM IR which look exactly like an
-    // unfused fmuladd. So, we assume that FP_CONTRACT was disabled only if
-    // there are something that looks like uncointracted fmul + fadd, but there
-    // no calls to @llvm.fmuladd.*
-    return FoundUncontractedFMulAdd && !FoundContractedFMulAdd;
-  }
-
-  void setUncontractedFMulAddFound(bool Value = true) {
-    FoundUncontractedFMulAdd = Value;
-  }
-
-  void setContractedFMulAddFound(bool Value = true) {
-    FoundContractedFMulAdd = Value;
-  }
-
 private:
   SPIRVFunctionParameter *addArgument(unsigned TheArgNo, SPIRVId TheId) {
     SPIRVFunctionParameter *Arg = new SPIRVFunctionParameter(

--- a/test/ContractionON.ll
+++ b/test/ContractionON.ll
@@ -1,7 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t -ffp-contract=on
-; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv -ffp-contract=on
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
 ; RUN: spirv-val %t.spv
 
 ; CHECK: EntryPoint 6 [[K1:[0-9]+]] "kernel_off_1"

--- a/test/ContractionON.ll
+++ b/test/ContractionON.ll
@@ -1,0 +1,117 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t -ffp-contract=on
+; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv -ffp-contract=on
+; RUN: spirv-val %t.spv
+
+; CHECK: EntryPoint 6 [[K1:[0-9]+]] "kernel_off_1"
+; CHECK: EntryPoint 6 [[K2:[0-9]+]] "kernel_off_2"
+; CHECK: EntryPoint 6 [[K3:[0-9]+]] "kernel_off_3"
+; CHECK: EntryPoint 6 [[K4:[0-9]+]] "kernel_off_4"
+; CHECK: EntryPoint 6 [[K5:[0-9]+]] "kernel_off_5"
+; CHECK: EntryPoint 6 [[K6:[0-9]+]] "kernel_off_6"
+; CHECK: EntryPoint 6 [[K7:[0-9]+]] "kernel_on_7"
+
+; CHECK: ExecutionMode [[K1]] 31
+; CHECK: ExecutionMode [[K2]] 31
+; CHECK: ExecutionMode [[K3]] 31
+; CHECK: ExecutionMode [[K4]] 31
+; CHECK: ExecutionMode [[K5]] 31
+; CHECK: ExecutionMode [[K6]] 31
+; CHECK-NOT: ExecutionMode [[K7]] 31
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+define float @func_nested_off(float %a, float %b, float %c) {
+entry:
+  %0 = call float @func_off(float %a, float %b, float %c)
+  ret float %0
+}
+
+define float @func_off(float %a, float %b, float %c) {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %mul = fmul float %0, %b
+  %add = fadd float %mul, %c
+  ret float %add
+}
+
+declare float @llvm.fmuladd.f32(float, float, float) #0
+
+define float @func_on(float %a, float %b, float %c) {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  ret float %0
+}
+
+define float @func_mul(float %a, float %b) {
+entry:
+  %0 = fmul float %a, %b
+  ret float %0
+}
+
+declare float @func_extern(float, float, float)
+
+define spir_kernel void @kernel_off_1(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_off_2(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %call = call float @func_off(float %0, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_3(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %call = call float @func_nested_off(float %a, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_4(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %call = call float @func_extern(float %0, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_5(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_off(float %a, float %b, float %c)
+  %add = fadd contract float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_off_6(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_mul(float %a, float %b)
+  %add = fadd float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_on_7(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_mul(float %a, float %b)
+  %add = fadd contract float %mul, %c
+  ret void
+}
+
+attributes #0 = { nounwind readnone speculatable willreturn }
+
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{!"clang version 11.0.0"}
+!3 = !{i32 0, i32 0, i32 0}
+!4 = !{!"none", !"none", !"none"}
+!5 = !{!"float", !"float", !"float"}
+!6 = !{!"", !"", !""}

--- a/test/ContractionON.ll
+++ b/test/ContractionON.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv -ffp-contract=on
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-fp-contract=on
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
 ; RUN: spirv-val %t.spv
 

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -52,7 +52,6 @@
 ; CHECK-ON: ExecutionMode [[K1]] 31
 ; CHECK-ON-NOT: ExecutionMode [[K2]] 31
 ; CHECK-ON: ExecutionMode [[K3]] 31
-; CHECK-ON-NOT: ExecutionMode [[K2]] 31
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -51,7 +51,8 @@
 
 ; CHECK-ON: ExecutionMode [[K1]] 31
 ; CHECK-ON-NOT: ExecutionMode [[K2]] 31
-; CHECK-ON-NOT: ExecutionMode [[K3]] 31
+; CHECK-ON: ExecutionMode [[K3]] 31
+; CHECK-ON-NOT: ExecutionMode [[K2]] 31
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"


### PR DESCRIPTION
This patch makes several improvements to enable correct setting for
ContractionOFF:

  1) Plain `fadd` or `fsub` instruction trigger ContractionOFF to
     avoid optimizations that may fold them to an FMA.

  2) `contract` flag is recognized on `fadd` and `fsub`, and it allows
     to suppress (1).

  3) Undefined (external) functions, function pointers and inline asm
     calls force ContractionOFF flag.

  4) Contraction information is now propagated up the call stack until
     an entry point.