### PR TITLE
Refactor translation of memory scopes, orders and flags

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -944,6 +944,105 @@ std::string getIntelSubgroupBlockDataPostfix(unsigned ElementBitSize,
 }
 } // namespace OCLUtil
 
+Value *SPIRV::transOCLMemScopeIntoSPIRVScope(Value *MemScope,
+                                             Optional<int> DefaultCase,
+                                             Instruction *InsertBefore) {
+  if (auto *C = dyn_cast<ConstantInt>(MemScope)) {
+    return ConstantInt::get(
+        C->getType(), map<Scope>(static_cast<OCLScopeKind>(C->getZExtValue())));
+  }
+
+  // If memory_scope is not a constant, then we have to insert dynamic mapping:
+  return getOrCreateSwitchFunc(kSPIRVName::TranslateOCLMemScope, MemScope,
+                               OCLMemScopeMap::getMap(), /* IsReverse */ false,
+                               DefaultCase, InsertBefore);
+}
+
+Value *SPIRV::transOCLMemOrderIntoSPIRVMemorySemantics(
+    Value *MemOrder, Optional<int> DefaultCase, Instruction *InsertBefore) {
+  if (auto *C = dyn_cast<ConstantInt>(MemOrder)) {
+    return ConstantInt::get(
+        C->getType(), mapOCLMemSemanticToSPIRV(
+                          0, static_cast<OCLMemOrderKind>(C->getZExtValue())));
+  }
+
+  return getOrCreateSwitchFunc(kSPIRVName::TranslateOCLMemOrder, MemOrder,
+                               OCLMemOrderMap::getMap(), /* IsReverse */ false,
+                               DefaultCase, InsertBefore);
+}
+
+Value *
+SPIRV::transSPIRVMemoryScopeIntoOCLMemoryScope(Value *MemScope,
+                                               Instruction *InsertBefore) {
+  if (auto *C = dyn_cast<ConstantInt>(MemScope)) {
+    return ConstantInt::get(C->getType(), rmap<OCLScopeKind>(static_cast<Scope>(
+                                              C->getZExtValue())));
+  }
+
+  if (auto *CI = dyn_cast<CallInst>(MemScope)) {
+    Function *F = CI->getCalledFunction();
+    if (F && F->getName().equals(kSPIRVName::TranslateOCLMemScope)) {
+      // In case the SPIR-V module was created from an OpenCL program by
+      // *this* SPIR-V generator, we know that the value passed to
+      // __translate_ocl_memory_scope is what we should pass to the
+      // OpenCL builtin now.
+      return CI->getArgOperand(0);
+    }
+  }
+
+  return getOrCreateSwitchFunc(kSPIRVName::TranslateSPIRVMemScope, MemScope,
+                               OCLMemScopeMap::getRMap(),
+                               /* IsReverse */ true, None, InsertBefore);
+}
+
+Value *
+SPIRV::transSPIRVMemorySemanticsIntoOCLMemoryOrder(Value *MemorySemantics,
+                                                   Instruction *InsertBefore) {
+  if (auto *C = dyn_cast<ConstantInt>(MemorySemantics)) {
+    return ConstantInt::get(C->getType(),
+                            mapSPIRVMemSemanticToOCL(C->getZExtValue()).second);
+  }
+
+  if (auto *CI = dyn_cast<CallInst>(MemorySemantics)) {
+    Function *F = CI->getCalledFunction();
+    if (F && F->getName().equals(kSPIRVName::TranslateOCLMemOrder)) {
+      // In case the SPIR-V module was created from an OpenCL program by
+      // *this* SPIR-V generator, we know that the value passed to
+      // __translate_ocl_memory_order is what we should pass to the
+      // OpenCL builtin now.
+      return CI->getArgOperand(0);
+    }
+  }
+
+  // SPIR-V MemorySemantics contains both OCL mem_fence_flags and mem_order and
+  // therefore, we need to apply mask
+  int Mask = MemorySemanticsMaskNone | MemorySemanticsAcquireMask |
+             MemorySemanticsReleaseMask | MemorySemanticsAcquireReleaseMask |
+             MemorySemanticsSequentiallyConsistentMask;
+  return getOrCreateSwitchFunc(kSPIRVName::TranslateSPIRVMemOrder,
+                               MemorySemantics, OCLMemOrderMap::getRMap(),
+                               /* IsReverse */ true, None, InsertBefore, Mask);
+}
+
+Value *SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
+    Value *MemorySemantics, Instruction *InsertBefore) {
+  if (auto *C = dyn_cast<ConstantInt>(MemorySemantics)) {
+    return ConstantInt::get(C->getType(),
+                            mapSPIRVMemSemanticToOCL(C->getZExtValue()).first);
+  }
+
+  // TODO: any possible optimizations?
+  // SPIR-V MemorySemantics contains both OCL mem_fence_flags and mem_order and
+  // therefore, we need to apply mask
+  int Mask = MemorySemanticsWorkgroupMemoryMask |
+             MemorySemanticsCrossWorkgroupMemoryMask |
+             MemorySemanticsImageMemoryMask;
+  return getOrCreateSwitchFunc(kSPIRVName::TranslateSPIRVMemFence,
+                               MemorySemantics,
+                               OCLMemFenceExtendedMap::getRMap(),
+                               /* IsReverse */ true, None, InsertBefore, Mask);
+}
+
 void llvm::mangleOpenClBuiltin(const std::string &UniqName,
                                ArrayRef<Type *> ArgTypes,
                                std::string &MangledName) {

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -496,12 +496,13 @@ Instruction *
 getOrCreateSwitchFunc(StringRef MapName, Value *V,
                       const SPIRVMap<KeyTy, ValTy, Identifier> &Map,
                       bool IsReverse, Optional<int> DefaultCase,
-                      Instruction *InsertPoint, Module *M, int KeyMask = 0) {
+                      Instruction *InsertPoint, int KeyMask = 0) {
   static_assert(std::is_convertible<KeyTy, int>::value &&
                     std::is_convertible<ValTy, int>::value,
                 "Can map only integer values");
   Type *Ty = V->getType();
   assert(Ty && Ty->isIntegerTy() && "Can't map non-integer types");
+  Module *M = InsertPoint->getModule();
   Function *F = getOrCreateFunction(M, Ty, Ty, MapName);
   if (!F->empty()) // The switch function already exists. just call it.
     return addCallInst(M, MapName, Ty, V, nullptr, InsertPoint);
@@ -542,6 +543,85 @@ getOrCreateSwitchFunc(StringRef MapName, Value *V,
   assert(SI->getDefaultDest() != BB && "Invalid default destination in switch");
   return addCallInst(M, MapName, Ty, V, nullptr, InsertPoint);
 }
+
+/// Performs conversion from OpenCL memory_scope into SPIR-V Scope.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemScope memory_scope value which needs to be translated
+/// \param [in] DefaultCase default value for switch..case construct if
+///             dynamic mapping is used
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemScope is not a constant
+/// \returns \c Value corresponding to SPIR-V Scope equivalent to OpenCL
+///          memory_scope passed in \arg MemScope
+Value *transOCLMemScopeIntoSPIRVScope(Value *MemScope,
+                                      Optional<int> DefaultCase,
+                                      Instruction *InsertBefore);
+
+/// Performs conversion from OpenCL memory_order into SPIR-V Memory Semantics.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemOrder memory_scope value which needs to be translated
+/// \param [in] DefaultCase default value for switch..case construct if
+///             dynamic mapping is used
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemOrder is not a constant
+/// \returns \c Value corresponding to SPIR-V Memory Semantics equivalent to
+///          OpenCL memory_order passed in \arg MemOrder
+Value *transOCLMemOrderIntoSPIRVMemorySemantics(Value *MemOrder,
+                                                Optional<int> DefaultCase,
+                                                Instruction *InsertBefore);
+
+/// Performs conversion from SPIR-V Scope into OpenCL memory_scope.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemScope Scope value which needs to be translated
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemScope is not a constant
+/// \returns \c Value corresponding to  OpenCL memory_scope equivalent to SPIR-V
+///          Scope passed in \arg MemScope
+Value *transSPIRVMemoryScopeIntoOCLMemoryScope(Value *MemScope,
+                                               Instruction *InsertBefore);
+
+/// Performs conversion from SPIR-V Memory Semantics into OpenCL memory_order.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemorySemantics Memory Semantics value which needs to be
+///             translated
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemorySemantics is not a constant
+/// \returns \c Value corresponding to  OpenCL memory_order equivalent to SPIR-V
+///          Memory Semantics passed in \arg MemorySemantics
+Value *transSPIRVMemorySemanticsIntoOCLMemoryOrder(Value *MemorySemantics,
+                                                   Instruction *InsertBefore);
+
+/// Performs conversion from SPIR-V Memory Semantics into OpenCL
+/// mem_fence_flags.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemorySemantics Memory Semantics value which needs to be
+///             translated
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemorySemantics is not a constant
+/// \returns \c Value corresponding to  OpenCL mem_fence_flags equivalent to
+///          SPIR-V Memory Semantics passed in \arg MemorySemantics
+Value *transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Value *MemorySemantics,
+                                                     Instruction *InsertBefore);
 
 template <> inline void SPIRVMap<std::string, SPIRVGroupOperationKind>::init() {
   add("reduce", GroupOperationReduce);

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -37,6 +37,7 @@
 //===----------------------------------------------------------------------===//
 #define DEBUG_TYPE "spvtocl20"
 
+#include "OCLUtil.h"
 #include "SPIRVToOCL.h"
 #include "llvm/IR/Verifier.h"
 
@@ -133,22 +134,14 @@ void SPIRVToOCL20::visitCallSPIRVControlBarrier(CallInst *CI) {
           return cast<ConstantInt>(Args[I])->getZExtValue();
         };
         auto ExecScope = static_cast<Scope>(GetArg(0));
-        auto MemScope = static_cast<Scope>(GetArg(1));
+        Value *MemScope =
+            getInt32(M, rmap<OCLScopeKind>(static_cast<Scope>(GetArg(1))));
+        Value *MemFenceFlags =
+            SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Args[2], CI);
 
-        if (auto Arg = dyn_cast<ConstantInt>(Args[2])) {
-          auto Sema = mapSPIRVMemSemanticToOCL(Arg->getZExtValue());
-          Args[0] = getInt32(M, Sema.first);
-        } else {
-          int ClMemFenceMask = MemorySemanticsWorkgroupMemoryMask |
-                               MemorySemanticsCrossWorkgroupMemoryMask |
-                               MemorySemanticsImageMemoryMask;
-          Args[0] = getOrCreateSwitchFunc(
-              kSPIRVName::TranslateSPIRVMemFence, Args[2],
-              OCLMemFenceExtendedMap::getRMap(), true /*IsReverse*/, None, CI,
-              M, ClMemFenceMask);
-        }
-        Args[1] = getInt32(M, rmap<OCLScopeKind>(MemScope));
         Args.resize(2);
+        Args[0] = MemFenceFlags;
+        Args[1] = MemScope;
 
         return (ExecScope == ScopeWorkgroup) ? kOCLBuiltinName::WorkGroupBarrier
                                              : kOCLBuiltinName::SubGroupBarrier;
@@ -231,46 +224,13 @@ CallInst *SPIRVToOCL20::mutateCommonAtomicArguments(CallInst *CI, Op OC) {
         auto NumOrder = getSPIRVAtomicBuiltinNumMemoryOrderArgs(OC);
         auto ScopeIdx = Ptr + 1;
         auto OrderIdx = Ptr + 2;
-        if (auto *ScopeInt = dyn_cast_or_null<ConstantInt>(Args[ScopeIdx])) {
-          Args[ScopeIdx] = mapUInt(M, ScopeInt, [](unsigned I) {
-            return rmap<OCLScopeKind>(static_cast<Scope>(I));
-          });
-        } else {
-          CallInst *TransCall = dyn_cast<CallInst>(Args[ScopeIdx]);
-          Function *F = TransCall ? TransCall->getCalledFunction() : nullptr;
-          if (F && F->getName().equals(kSPIRVName::TranslateOCLMemScope)) {
-            // In case the SPIR-V module was created from an OpenCL program by
-            // *this* SPIR-V generator, we know that the value passed to
-            // __translate_ocl_memory_scope is what we should pass to the OpenCL
-            // builtin now.
-            Args[ScopeIdx] = TransCall->getArgOperand(0);
-          } else {
-            Args[ScopeIdx] = getOrCreateSwitchFunc(
-                kSPIRVName::TranslateSPIRVMemScope, Args[ScopeIdx],
-                OCLMemScopeMap::getRMap(), true /*IsReverse*/, None, CI, M);
-          }
-        }
+
+        Args[ScopeIdx] =
+            SPIRV::transSPIRVMemoryScopeIntoOCLMemoryScope(Args[ScopeIdx], CI);
         for (size_t I = 0; I < NumOrder; ++I) {
-          if (auto OrderInt =
-                  dyn_cast_or_null<ConstantInt>(Args[OrderIdx + I])) {
-            Args[OrderIdx + I] = mapUInt(M, OrderInt, [](unsigned Ord) {
-              return mapSPIRVMemOrderToOCL(Ord);
-            });
-          } else {
-            CallInst *TransCall = dyn_cast<CallInst>(Args[OrderIdx + I]);
-            Function *F = TransCall ? TransCall->getCalledFunction() : nullptr;
-            if (F && F->getName().equals(kSPIRVName::TranslateOCLMemOrder)) {
-              // In case the SPIR-V module was created from an OpenCL program by
-              // *this* SPIR-V generator, we know that the value passed to
-              // __translate_ocl_memory_order is what we should pass to the
-              // OpenCL builtin now.
-              Args[OrderIdx + I] = TransCall->getArgOperand(0);
-            } else {
-              Args[OrderIdx + I] = getOrCreateSwitchFunc(
-                  kSPIRVName::TranslateSPIRVMemOrder, Args[OrderIdx + I],
-                  OCLMemOrderMap::getRMap(), true /*IsReverse*/, None, CI, M);
-            }
-          }
+          Args[OrderIdx + I] =
+              SPIRV::transSPIRVMemorySemanticsIntoOCLMemoryOrder(
+                  Args[OrderIdx + I], CI);
         }
         std::swap(Args[ScopeIdx], Args.back());
         return Name;

--- a/test/atomic_explicit_arguments.spt
+++ b/test/atomic_explicit_arguments.spt
@@ -67,7 +67,8 @@
 
 ; CHECK: define private spir_func i32 @__translate_spirv_memory_order(i32 %key) {
 ; CHECK: entry:
-; CHECK:   switch i32 %key, label %default [
+; CHECK:   %key.masked = and i32 30, %key
+; CHECK:   switch i32 %key.masked, label %default [
 ; CHECK:     i32 0, label %case.0
 ; CHECK:     i32 2, label %case.2
 ; CHECK:     i32 4, label %case.4

--- a/test/mem_fence_explicit_arguments.spt
+++ b/test/mem_fence_explicit_arguments.spt
@@ -26,11 +26,15 @@
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
-; RUN: llvm-dis < %t.bc | FileCheck %s
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes CHECK,CHECK-12
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=CL2.0 -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes CHECK,CHECK-20
 
 ; CHECK: define spir_func void @test(i32 %val)
 ; CHECK: %call = call spir_func i32 @__translate_spirv_memory_fence(i32 %val)
-; CHECK: call spir_func void @_Z9mem_fencej(i32 %call)
+; CHECK-12: call spir_func void @_Z9mem_fencej(i32 %call)
+; CHECK-20: %call1 = call spir_func i32 @__translate_spirv_memory_order(i32 %val)
+; CHECK-20: call spir_func void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 %call, i32 %call1
 ; CHECK: define private spir_func i32 @__translate_spirv_memory_fence(i32 %key)
 ; CHECK: entry:
 ; CHECK:   %key.masked = and i32 2816, %key
@@ -60,4 +64,26 @@
 ; CHECK: case.2816:
 ; CHECK:   ret i32 7
 ; CHECK: }
-; CHECK: declare spir_func void @_Z9mem_fencej(i32)
+; CHECK-20: define private spir_func i32 @__translate_spirv_memory_order(i32 %key) {
+; CHECK-20: entry:
+; CHECK-20:   %key.masked = and i32 30, %key
+; CHECK-20:   switch i32 %key.masked, label %default [
+; CHECK-20:     i32 0, label %case.0
+; CHECK-20:     i32 2, label %case.2
+; CHECK-20:     i32 4, label %case.4
+; CHECK-20:     i32 8, label %case.8
+; CHECK-20:     i32 16, label %case.16
+; CHECK-20:   ]
+; CHECK-20: default:
+; CHECK-20:   unreachable
+; CHECK-20: case.0:
+; CHECK-20:   ret i32 0
+; CHECK-20: case.2:
+; CHECK-20:   ret i32 2
+; CHECK-20: case.4:
+; CHECK-20:   ret i32 3
+; CHECK-20: case.8:
+; CHECK-20:   ret i32 4
+; CHECK-20: case.16:
+; CHECK-20:   ret i32 5
+; CHECK-20: }


### PR DESCRIPTION
We have a lot of duplicated code for handling memory scope, order and flags arguments of different OpenCL built-ins, like barriers, atomics and fences.

Refactored all common code into helper functions. (This should be an NFC change.)

Improved translation of `OpMemoryBarrier` by adding handling for non-const operands. (This is actually what I want to achieve, but while doing so, I decided to perform a refactoring.)

Note: I'm not going to add support for non-const memory scopes, orders and flags for each and every built-in and SPIR-V instruction in scope of this PR: this is just improvement of `OpMemoryBarrier` + refactoring.
