### PR TITLE
Improve error handling for llvm::getSpecConstInfo API

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -128,8 +128,11 @@ bool writeSpirv(Module *M, const SPIRV::TranslatorOpts &Opts, std::ostream &OS,
 bool readSpirv(LLVMContext &C, const SPIRV::TranslatorOpts &Opts,
                std::istream &IS, Module *&M, std::string &ErrMsg);
 
+/// \brief Partially load SPIR-V from the stream and decode only instructions
+/// needed to get information about specialization constants.
+/// \returns true if succeeds.
 using SpecConstInfoTy = std::pair<uint32_t, uint32_t>;
-void getSpecConstInfo(std::istream &IS,
+bool getSpecConstInfo(std::istream &IS,
                       std::vector<SpecConstInfoTy> &SpecConstInfo);
 
 /// \brief Convert a SPIRVModule into LLVM IR.

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3675,7 +3675,7 @@ bool llvm::readSpirv(LLVMContext &C, const SPIRV::TranslatorOpts &Opts,
   return true;
 }
 
-void llvm::getSpecConstInfo(std::istream &IS,
+bool llvm::getSpecConstInfo(std::istream &IS,
                             std::vector<SpecConstInfoTy> &SpecConstInfo) {
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule());
   BM->setAutoAddExtensions(false);
@@ -3684,7 +3684,7 @@ void llvm::getSpecConstInfo(std::istream &IS,
   D >> Magic;
   if (!BM->getErrorLog().checkError(Magic == MagicNumber, SPIRVEC_InvalidModule,
                                     "invalid magic number")) {
-    return;
+    return false;
   }
   // Skip the rest of the header
   D.ignore(4);
@@ -3718,4 +3718,5 @@ void llvm::getSpecConstInfo(std::istream &IS,
       D.ignoreInstruction();
     }
   }
+  return !IS.fail();
 }

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -381,7 +381,8 @@ bool parseSpecConstOpt(llvm::StringRef SpecConstStr,
                        SPIRV::TranslatorOpts &Opts) {
   std::ifstream IFS(InputFile, std::ios::binary);
   std::vector<SpecConstInfoTy> SpecConstInfo;
-  getSpecConstInfo(IFS, SpecConstInfo);
+  if (!getSpecConstInfo(IFS, SpecConstInfo))
+    return true;
 
   SmallVector<StringRef, 8> Split;
   SpecConstStr.split(Split, ' ', -1, false);
@@ -547,7 +548,10 @@ int main(int Ac, char **Av) {
   if (SpecConstInfo) {
     std::ifstream IFS(InputFile, std::ios::binary);
     std::vector<SpecConstInfoTy> SpecConstInfo;
-    getSpecConstInfo(IFS, SpecConstInfo);
+    if (!getSpecConstInfo(IFS, SpecConstInfo)) {
+      std::cout << "Invalid SPIR-V binary";
+      return -1;
+    }
     std::cout << "Number of scalar specialization constants in the module = "
               << SpecConstInfo.size() << "\n";
     for (auto &SpecConst : SpecConstInfo)


### PR DESCRIPTION
Cherry-pick https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/bab8e491396b98decf53dbe73b025f9fb8de3362 from master