### PR TITLE
added missing implementation of getPassName for SPIRVLowerOCLBlocks

### DIFF
--- a/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
@@ -76,7 +76,7 @@ public:
   SPIRVLowerOCLBlocks() : ModulePass(ID) {}
 
   StringRef getPassName() const override {
-    return "Lower OCL Blocks For SPIRV";
+    return "Lower OpenCL Blocks For SPIR-V";
   }
 
   bool runOnModule(Module &M) {

--- a/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
@@ -75,6 +75,10 @@ class SPIRVLowerOCLBlocks : public ModulePass {
 public:
   SPIRVLowerOCLBlocks() : ModulePass(ID) {}
 
+  StringRef getPassName() const override {
+    return "Lower OCL Blocks For SPIRV";
+  }
+
   bool runOnModule(Module &M) {
     bool Changed = false;
     for (Function &F : M) {


### PR DESCRIPTION
SPIRV Lower OCL blocks pass does not have getPassName implementation. This commit adds one