### PR TITLE
Clang, due to some ABI constraints needs to generate llvm.trap

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -425,9 +425,8 @@ bool isKernelQueryBI(const StringRef MangledName);
 /// Check that the type is the sampler_t
 bool isSamplerTy(Type *Ty);
 
-// Checks if clang did not generate llvm.fmuladd for fp multiply-add operations.
-// If so, it applies ContractionOff ExecutionMode to the kernel.
-void checkFpContract(BinaryOperator *B, SPIRVBasicBlock *BB);
+// Checks if the binary operator is an unfused fmul + fadd instruction.
+bool isUnfusedMulAdd(BinaryOperator *B);
 
 template <typename T> std::string toString(const T *Object) {
   std::string S;
@@ -496,12 +495,13 @@ Instruction *
 getOrCreateSwitchFunc(StringRef MapName, Value *V,
                       const SPIRVMap<KeyTy, ValTy, Identifier> &Map,
                       bool IsReverse, Optional<int> DefaultCase,
-                      Instruction *InsertPoint, Module *M, int KeyMask = 0) {
+                      Instruction *InsertPoint, int KeyMask = 0) {
   static_assert(std::is_convertible<KeyTy, int>::value &&
                     std::is_convertible<ValTy, int>::value,
                 "Can map only integer values");
   Type *Ty = V->getType();
   assert(Ty && Ty->isIntegerTy() && "Can't map non-integer types");
+  Module *M = InsertPoint->getModule();
   Function *F = getOrCreateFunction(M, Ty, Ty, MapName);
   if (!F->empty()) // The switch function already exists. just call it.
     return addCallInst(M, MapName, Ty, V, nullptr, InsertPoint);
@@ -542,6 +542,85 @@ getOrCreateSwitchFunc(StringRef MapName, Value *V,
   assert(SI->getDefaultDest() != BB && "Invalid default destination in switch");
   return addCallInst(M, MapName, Ty, V, nullptr, InsertPoint);
 }
+
+/// Performs conversion from OpenCL memory_scope into SPIR-V Scope.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemScope memory_scope value which needs to be translated
+/// \param [in] DefaultCase default value for switch..case construct if
+///             dynamic mapping is used
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemScope is not a constant
+/// \returns \c Value corresponding to SPIR-V Scope equivalent to OpenCL
+///          memory_scope passed in \arg MemScope
+Value *transOCLMemScopeIntoSPIRVScope(Value *MemScope,
+                                      Optional<int> DefaultCase,
+                                      Instruction *InsertBefore);
+
+/// Performs conversion from OpenCL memory_order into SPIR-V Memory Semantics.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemOrder memory_scope value which needs to be translated
+/// \param [in] DefaultCase default value for switch..case construct if
+///             dynamic mapping is used
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemOrder is not a constant
+/// \returns \c Value corresponding to SPIR-V Memory Semantics equivalent to
+///          OpenCL memory_order passed in \arg MemOrder
+Value *transOCLMemOrderIntoSPIRVMemorySemantics(Value *MemOrder,
+                                                Optional<int> DefaultCase,
+                                                Instruction *InsertBefore);
+
+/// Performs conversion from SPIR-V Scope into OpenCL memory_scope.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemScope Scope value which needs to be translated
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemScope is not a constant
+/// \returns \c Value corresponding to  OpenCL memory_scope equivalent to SPIR-V
+///          Scope passed in \arg MemScope
+Value *transSPIRVMemoryScopeIntoOCLMemoryScope(Value *MemScope,
+                                               Instruction *InsertBefore);
+
+/// Performs conversion from SPIR-V Memory Semantics into OpenCL memory_order.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemorySemantics Memory Semantics value which needs to be
+///             translated
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemorySemantics is not a constant
+/// \returns \c Value corresponding to  OpenCL memory_order equivalent to SPIR-V
+///          Memory Semantics passed in \arg MemorySemantics
+Value *transSPIRVMemorySemanticsIntoOCLMemoryOrder(Value *MemorySemantics,
+                                                   Instruction *InsertBefore);
+
+/// Performs conversion from SPIR-V Memory Semantics into OpenCL
+/// mem_fence_flags.
+///
+/// Supports both constant and non-constant values. To handle the latter case,
+/// function with switch..case statement will be inserted into module which
+/// \arg InsertBefore belongs to (in order to perform mapping at runtime)
+///
+/// \param [in] MemorySemantics Memory Semantics value which needs to be
+///             translated
+/// \param [in] InsertBefore insertion point for call into conversion function
+///             which is generated if \arg MemorySemantics is not a constant
+/// \returns \c Value corresponding to  OpenCL mem_fence_flags equivalent to
+///          SPIR-V Memory Semantics passed in \arg MemorySemantics
+Value *transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Value *MemorySemantics,
+                                                     Instruction *InsertBefore);
 
 template <> inline void SPIRVMap<std::string, SPIRVGroupOperationKind>::init() {
   add("reduce", GroupOperationReduce);

--- a/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
@@ -75,6 +75,10 @@ class SPIRVLowerOCLBlocks : public ModulePass {
 public:
   SPIRVLowerOCLBlocks() : ModulePass(ID) {}
 
+  StringRef getPassName() const override {
+    return "Lower OpenCL Blocks For SPIR-V";
+  }
+
   bool runOnModule(Module &M) {
     bool Changed = false;
     for (Function &F : M) {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2949,7 +2949,7 @@ bool SPIRVToLLVM::translate() {
     transFunction(BM->getFunction(I));
   }
 
-  if (!transKernelMetadata())
+  if (!transMetadata())
     return false;
   if (!transFPContractMetadata())
     return false;
@@ -3284,89 +3284,17 @@ static bool transKernelArgTypeMedataFromString(LLVMContext *Ctx,
   return true;
 }
 
-bool SPIRVToLLVM::transKernelMetadata() {
+bool SPIRVToLLVM::transMetadata() {
   for (unsigned I = 0, E = BM->getNumFunctions(); I != E; ++I) {
     SPIRVFunction *BF = BM->getFunction(I);
     Function *F = static_cast<Function *>(getTranslatedValue(BF));
     assert(F && "Invalid translated function");
+
+    transOCLMetadata(BF);
+
     if (F->getCallingConv() != CallingConv::SPIR_KERNEL)
       continue;
 
-    // Generate metadata for kernel_arg_address_spaces
-    addOCLKernelArgumentMetadata(
-        Context, SPIR_MD_KERNEL_ARG_ADDR_SPACE, BF, F,
-        [=](SPIRVFunctionParameter *Arg) {
-          SPIRVType *ArgTy = Arg->getType();
-          SPIRAddressSpace AS = SPIRAS_Private;
-          if (ArgTy->isTypePointer())
-            AS = SPIRSPIRVAddrSpaceMap::rmap(ArgTy->getPointerStorageClass());
-          else if (ArgTy->isTypeOCLImage() || ArgTy->isTypePipe())
-            AS = SPIRAS_Global;
-          return ConstantAsMetadata::get(
-              ConstantInt::get(Type::getInt32Ty(*Context), AS));
-        });
-    // Generate metadata for kernel_arg_access_qual
-    addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_ACCESS_QUAL, BF, F,
-                                 [=](SPIRVFunctionParameter *Arg) {
-                                   std::string Qual;
-                                   auto T = Arg->getType();
-                                   if (T->isTypeOCLImage()) {
-                                     auto ST = static_cast<SPIRVTypeImage *>(T);
-                                     Qual =
-                                         transOCLImageTypeAccessQualifier(ST);
-                                   } else if (T->isTypePipe()) {
-                                     auto PT = static_cast<SPIRVTypePipe *>(T);
-                                     Qual = transOCLPipeTypeAccessQualifier(PT);
-                                   } else
-                                     Qual = "none";
-                                   return MDString::get(*Context, Qual);
-                                 });
-    // Generate metadata for kernel_arg_type
-    if (!transKernelArgTypeMedataFromString(Context, BM, F))
-      addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_TYPE, BF, F,
-                                   [=](SPIRVFunctionParameter *Arg) {
-                                     return transOCLKernelArgTypeName(Arg);
-                                   });
-    // Generate metadata for kernel_arg_type_qual
-    addOCLKernelArgumentMetadata(
-        Context, SPIR_MD_KERNEL_ARG_TYPE_QUAL, BF, F,
-        [=](SPIRVFunctionParameter *Arg) {
-          std::string Qual;
-          if (Arg->hasDecorate(DecorationVolatile))
-            Qual = kOCLTypeQualifierName::Volatile;
-          Arg->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
-            Qual += Qual.empty() ? "" : " ";
-            switch (Kind) {
-            case FunctionParameterAttributeNoAlias:
-              Qual += kOCLTypeQualifierName::Restrict;
-              break;
-            case FunctionParameterAttributeNoWrite:
-              Qual += kOCLTypeQualifierName::Const;
-              break;
-            default:
-              // do nothing.
-              break;
-            }
-          });
-          if (Arg->getType()->isTypePipe()) {
-            Qual += Qual.empty() ? "" : " ";
-            Qual += kOCLTypeQualifierName::Pipe;
-          }
-          return MDString::get(*Context, Qual);
-        });
-    // Generate metadata for kernel_arg_base_type
-    addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_BASE_TYPE, BF, F,
-                                 [=](SPIRVFunctionParameter *Arg) {
-                                   return transOCLKernelArgTypeName(Arg);
-                                 });
-    // Generate metadata for kernel_arg_name
-    if (BM->isGenArgNameMDEnabled()) {
-      addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_NAME, BF, F,
-                                   [=](SPIRVFunctionParameter *Arg) {
-                                     return MDString::get(*Context,
-                                                          Arg->getName());
-                                   });
-    }
     // Generate metadata for reqd_work_group_size
     if (auto EM = BF->getExecutionMode(ExecutionModeLocalSize)) {
       F->setMetadata(kSPIR2MD::WGSize,
@@ -3411,6 +3339,89 @@ bool SPIRVToLLVM::transKernelMetadata() {
       F->setMetadata(kSPIR2MD::NumSIMD,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
+  }
+  return true;
+}
+
+bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
+  Function *F = static_cast<Function *>(getTranslatedValue(BF));
+  assert(F && "Invalid translated function");
+  if (F->getCallingConv() != CallingConv::SPIR_KERNEL)
+    return true;
+
+  // Generate metadata for kernel_arg_address_spaces
+  addOCLKernelArgumentMetadata(
+      Context, SPIR_MD_KERNEL_ARG_ADDR_SPACE, BF, F,
+      [=](SPIRVFunctionParameter *Arg) {
+        SPIRVType *ArgTy = Arg->getType();
+        SPIRAddressSpace AS = SPIRAS_Private;
+        if (ArgTy->isTypePointer())
+          AS = SPIRSPIRVAddrSpaceMap::rmap(ArgTy->getPointerStorageClass());
+        else if (ArgTy->isTypeOCLImage() || ArgTy->isTypePipe())
+          AS = SPIRAS_Global;
+        return ConstantAsMetadata::get(
+            ConstantInt::get(Type::getInt32Ty(*Context), AS));
+      });
+  // Generate metadata for kernel_arg_access_qual
+  addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_ACCESS_QUAL, BF, F,
+                               [=](SPIRVFunctionParameter *Arg) {
+                                 std::string Qual;
+                                 auto T = Arg->getType();
+                                 if (T->isTypeOCLImage()) {
+                                   auto ST = static_cast<SPIRVTypeImage *>(T);
+                                   Qual = transOCLImageTypeAccessQualifier(ST);
+                                 } else if (T->isTypePipe()) {
+                                   auto PT = static_cast<SPIRVTypePipe *>(T);
+                                   Qual = transOCLPipeTypeAccessQualifier(PT);
+                                 } else
+                                   Qual = "none";
+                                 return MDString::get(*Context, Qual);
+                               });
+  // Generate metadata for kernel_arg_type
+  if (!transKernelArgTypeMedataFromString(Context, BM, F))
+    addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_TYPE, BF, F,
+                                 [=](SPIRVFunctionParameter *Arg) {
+                                   return transOCLKernelArgTypeName(Arg);
+                                 });
+  // Generate metadata for kernel_arg_type_qual
+  addOCLKernelArgumentMetadata(
+      Context, SPIR_MD_KERNEL_ARG_TYPE_QUAL, BF, F,
+      [=](SPIRVFunctionParameter *Arg) {
+        std::string Qual;
+        if (Arg->hasDecorate(DecorationVolatile))
+          Qual = kOCLTypeQualifierName::Volatile;
+        Arg->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
+          Qual += Qual.empty() ? "" : " ";
+          switch (Kind) {
+          case FunctionParameterAttributeNoAlias:
+            Qual += kOCLTypeQualifierName::Restrict;
+            break;
+          case FunctionParameterAttributeNoWrite:
+            Qual += kOCLTypeQualifierName::Const;
+            break;
+          default:
+            // do nothing.
+            break;
+          }
+        });
+        if (Arg->getType()->isTypePipe()) {
+          Qual += Qual.empty() ? "" : " ";
+          Qual += kOCLTypeQualifierName::Pipe;
+        }
+        return MDString::get(*Context, Qual);
+      });
+  // Generate metadata for kernel_arg_base_type
+  addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_BASE_TYPE, BF, F,
+                               [=](SPIRVFunctionParameter *Arg) {
+                                 return transOCLKernelArgTypeName(Arg);
+                               });
+  // Generate metadata for kernel_arg_name
+  if (BM->isGenArgNameMDEnabled()) {
+    addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_NAME, BF, F,
+                                 [=](SPIRVFunctionParameter *Arg) {
+                                   return MDString::get(*Context,
+                                                        Arg->getName());
+                                 });
   }
   return true;
 }

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -102,7 +102,8 @@ public:
   Instruction *transWGSizeQueryBI(SPIRVInstruction *BI, BasicBlock *BB);
   Instruction *transSGSizeQueryBI(SPIRVInstruction *BI, BasicBlock *BB);
   bool transFPContractMetadata();
-  bool transKernelMetadata();
+  bool transMetadata();
+  bool transOCLMetadata(SPIRVFunction *BF);
   Value *transAsmINTEL(SPIRVAsmINTEL *BA);
   CallInst *transAsmCallINTEL(SPIRVAsmCallINTEL *BI, Function *F,
                               BasicBlock *BB);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -78,6 +78,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <queue>
 #include <set>
 #include <vector>
 
@@ -671,7 +672,14 @@ SPIRVInstruction *LLVMToSPIRV::transBinaryInst(BinaryOperator *B,
   SPIRVInstruction *BI = BM->addBinaryInst(
       transBoolOpCode(Op0, OpCodeMap::map(LLVMOC)), transType(B->getType()),
       Op0, transValue(B->getOperand(1), BB), BB);
-  checkFpContract(B, BB);
+
+  if (isUnfusedMulAdd(B)) {
+    Function *F = B->getFunction();
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
+                    << ": possible fma candidate " << *B << '\n');
+    joinFPContract(F, FPContract::DISABLED);
+  }
+
   return BI;
 }
 
@@ -1715,7 +1723,6 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
     // For llvm.fmuladd.* fusion is not guaranteed. If a fused multiply-add
     // is required the corresponding llvm.fma.* intrinsic function should be
     // used instead.
-    BB->getParent()->setContractedFMulAddFound();
     SPIRVType *Ty = transType(II->getType());
     SPIRVValue *Mul =
         BM->addBinaryInst(OpFMul, Ty, transValue(II->getArgOperand(0), BB),
@@ -1889,6 +1896,9 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
   case Intrinsic::invariant_start:
   case Intrinsic::invariant_end:
   case Intrinsic::dbg_label:
+  case Intrinsic::trap:
+    // llvm.trap intrinsic is not implemented. But for now don't crash. This change
+    // is pending the trap/abort intrisinc implementation.
     return nullptr;
   default:
     if (SPIRVAllowUnknownIntrinsics)
@@ -1909,12 +1919,24 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
 
 SPIRVValue *LLVMToSPIRV::transCallInst(CallInst *CI, SPIRVBasicBlock *BB) {
   assert(CI);
+  Function *F = CI->getFunction();
   if (isa<InlineAsm>(CI->getCalledOperand()) &&
-      BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_inline_assembly))
+      BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_inline_assembly)) {
+    // Inline asm is opaque, so we cannot reason about its FP contraction
+    // requirements.
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
+                    << ": inline asm " << *CI << '\n');
+    joinFPContract(F, FPContract::DISABLED);
     return transAsmCallINTEL(CI, BB);
+  }
 
-  if (CI->isIndirectCall())
+  if (CI->isIndirectCall()) {
+    // The function is not known in advance
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
+                    << ": indirect call " << *CI << '\n');
+    joinFPContract(F, FPContract::DISABLED);
     return transIndirectCallInst(CI, BB);
+  }
   return transDirectCallInst(CI, BB);
 }
 
@@ -1948,8 +1970,23 @@ SPIRVValue *LLVMToSPIRV::transDirectCallInst(CallInst *CI,
             BB),
         Dec);
 
+  Function *Callee = CI->getCalledFunction();
+  if (Callee->isDeclaration()) {
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName().str()
+                    << ": call to an undefined function " << *CI << '\n');
+    joinFPContract(CI->getFunction(), FPContract::DISABLED);
+  } else {
+    FPContract CalleeFPC = getFPContract(Callee);
+    joinFPContract(CI->getFunction(), CalleeFPC);
+    if (CalleeFPC == FPContract::DISABLED) {
+      SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName().str()
+                      << ": call to a function with disabled contraction: "
+                      << *CI << '\n');
+    }
+  }
+
   return BM->addCallInst(
-      transFunctionDecl(CI->getCalledFunction()),
+      transFunctionDecl(Callee),
       transArguments(CI, BB, SPIRVEntry::createUnique(OpFunctionCall).get()),
       BB);
 }
@@ -2172,6 +2209,67 @@ void LLVMToSPIRV::mutateFuncArgType(
   }
 }
 
+// Propagate contraction requirement of F up the call graph.
+void LLVMToSPIRV::fpContractUpdateRecursive(Function *F, FPContract FPC) {
+  std::queue<User *> Users;
+  for (User *FU : F->users()) {
+    Users.push(FU);
+  }
+
+  bool EnableLogger = FPC == FPContract::DISABLED && !Users.empty();
+  if (EnableLogger) {
+    SPIRVDBG(dbgs() << "[fp-contract] disabled for users of " << F->getName()
+                    << '\n');
+  }
+
+  while (!Users.empty()) {
+    User *U = Users.front();
+    Users.pop();
+
+    if (EnableLogger) {
+      SPIRVDBG(dbgs() << "[fp-contract]   user: " << *U << '\n');
+    }
+
+    // Move from an Instruction to its Function
+    if (Instruction *I = dyn_cast<Instruction>(U)) {
+      Users.push(I->getFunction());
+      continue;
+    }
+
+    if (Function *F = dyn_cast<Function>(U)) {
+      if (!joinFPContract(F, FPC)) {
+        // FP contract was not updated - no need to propagate
+        // This also terminates a recursion (if any).
+        if (EnableLogger) {
+          SPIRVDBG(dbgs() << "[fp-contract] already disabled " << F->getName()
+                          << '\n');
+        }
+        continue;
+      }
+      if (EnableLogger) {
+        SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
+                        << '\n');
+      }
+      for (User *FU : F->users()) {
+        Users.push(FU);
+      }
+      continue;
+    }
+
+    // Unwrap a constant until we reach an Instruction.
+    // This is checked after the Function, because a Function is also a
+    // Constant.
+    if (Constant *C = dyn_cast<Constant>(U)) {
+      for (User *CU : C->users()) {
+        Users.push(CU);
+      }
+      continue;
+    }
+
+    llvm_unreachable("Unexpected use.");
+  }
+}
+
 void LLVMToSPIRV::transFunction(Function *I) {
   SPIRVFunction *BF = transFunctionDecl(I);
   // Creating all basic blocks before creating any instruction.
@@ -2185,26 +2283,13 @@ void LLVMToSPIRV::transFunction(Function *I) {
       transValue(&BI, BB, false);
     }
   }
+  // Enable FP contraction unless proven otherwise
+  joinFPContract(I, FPContract::ENABLED);
+  fpContractUpdateRecursive(I, getFPContract(I));
 
   bool IsKernelEntryPoint =
       BF->getModule()->isEntryPoint(spv::ExecutionModelKernel, BF->getId());
-  bool DisableContraction = false;
-  switch (BM->getFPContractMode()) {
-  case FPContractMode::Fast:
-    DisableContraction = false;
-    break;
-  case FPContractMode::On:
-    DisableContraction = IsKernelEntryPoint && BF->shouldFPContractBeDisabled();
-    break;
-  case FPContractMode::Off:
-    DisableContraction = IsKernelEntryPoint;
-    break;
-  }
 
-  if (DisableContraction) {
-    BF->addExecutionMode(BF->getModule()->add(
-        new SPIRVExecutionMode(BF, spv::ExecutionModeContractionOff)));
-  }
   if (IsKernelEntryPoint) {
     collectInputOutputVariables(BF, I);
   }
@@ -2396,7 +2481,48 @@ bool LLVMToSPIRV::transExecutionMode() {
       }
     }
   }
+
+  transFPContract();
+
   return true;
+}
+
+void LLVMToSPIRV::transFPContract() {
+  FPContractMode Mode = BM->getFPContractMode();
+
+  for (Function &F : *M) {
+    SPIRVValue *TranslatedF = getTranslatedValue(&F);
+    if (!TranslatedF) {
+      continue;
+    }
+    SPIRVFunction *BF = static_cast<SPIRVFunction *>(TranslatedF);
+
+    bool IsKernelEntryPoint =
+        BF->getModule()->isEntryPoint(spv::ExecutionModelKernel, BF->getId());
+    if (!IsKernelEntryPoint)
+      continue;
+
+    FPContract FPC = getFPContract(&F);
+    assert(FPC != FPContract::UNDEF);
+
+    bool DisableContraction = false;
+    switch (Mode) {
+    case FPContractMode::Fast:
+      DisableContraction = false;
+      break;
+    case FPContractMode::On:
+      DisableContraction = FPC == FPContract::DISABLED;
+      break;
+    case FPContractMode::Off:
+      DisableContraction = true;
+      break;
+    }
+
+    if (DisableContraction) {
+      BF->addExecutionMode(BF->getModule()->add(
+          new SPIRVExecutionMode(BF, spv::ExecutionModeContractionOff)));
+    }
+  }
 }
 
 bool LLVMToSPIRV::transOCLKernelMetadata() {
@@ -2605,6 +2731,34 @@ LLVMToSPIRV::transLinkageType(const GlobalValue *GV) {
   if (GV->hasInternalLinkage() || GV->hasPrivateLinkage())
     return SPIRVLinkageTypeKind::LinkageTypeInternal;
   return SPIRVLinkageTypeKind::LinkageTypeExport;
+}
+
+LLVMToSPIRV::FPContract LLVMToSPIRV::getFPContract(Function *F) {
+  auto It = FPContractMap.find(F);
+  if (It == FPContractMap.end()) {
+    return FPContract::UNDEF;
+  }
+  return It->second;
+}
+
+bool LLVMToSPIRV::joinFPContract(Function *F, FPContract C) {
+  FPContract &Existing = FPContractMap[F];
+  switch (Existing) {
+  case FPContract::UNDEF:
+    if (C != FPContract::UNDEF) {
+      Existing = C;
+      return true;
+    }
+    return false;
+  case FPContract::ENABLED:
+    if (C == FPContract::DISABLED) {
+      Existing = C;
+      return true;
+    }
+    return false;
+  case FPContract::DISABLED:
+    return false;
+  }
 }
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -112,6 +112,7 @@ public:
   // Returns true if succeeds.
   bool translate();
   bool transExecutionMode();
+  void transFPContract();
   SPIRVValue *transConstant(Value *V);
   SPIRVValue *transValue(Value *V, SPIRVBasicBlock *BB,
                          bool CreateForward = true);
@@ -135,6 +136,12 @@ private:
   SPIRVWord SrcLangVer;
   std::unique_ptr<LLVMToSPIRVDbgTran> DbgTran;
   std::unique_ptr<CallGraph> CG;
+
+  enum class FPContract { UNDEF, DISABLED, ENABLED };
+  DenseMap<Function *, FPContract> FPContractMap;
+  FPContract getFPContract(Function *F);
+  bool joinFPContract(Function *F, FPContract C);
+  void fpContractUpdateRecursive(Function *F, FPContract FPC);
 
   SPIRVType *mapType(Type *T, SPIRVType *BT);
   SPIRVValue *mapValue(Value *V, SPIRVValue *BV);

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -145,22 +145,6 @@ public:
     assert(FuncType && "Invalid func type");
   }
 
-  bool shouldFPContractBeDisabled() const {
-    // We could find some instructions in LLVM IR which look exactly like an
-    // unfused fmuladd. So, we assume that FP_CONTRACT was disabled only if
-    // there are something that looks like uncointracted fmul + fadd, but there
-    // no calls to @llvm.fmuladd.*
-    return FoundUncontractedFMulAdd && !FoundContractedFMulAdd;
-  }
-
-  void setUncontractedFMulAddFound(bool Value = true) {
-    FoundUncontractedFMulAdd = Value;
-  }
-
-  void setContractedFMulAddFound(bool Value = true) {
-    FoundContractedFMulAdd = Value;
-  }
-
 private:
   SPIRVFunctionParameter *addArgument(unsigned TheArgNo, SPIRVId TheId) {
     SPIRVFunctionParameter *Arg = new SPIRVFunctionParameter(

--- a/test/ContractionON.ll
+++ b/test/ContractionON.ll
@@ -1,0 +1,116 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-fp-contract=on
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+; RUN: spirv-val %t.spv
+
+; CHECK: EntryPoint 6 [[K1:[0-9]+]] "kernel_off_1"
+; CHECK: EntryPoint 6 [[K2:[0-9]+]] "kernel_off_2"
+; CHECK: EntryPoint 6 [[K3:[0-9]+]] "kernel_off_3"
+; CHECK: EntryPoint 6 [[K4:[0-9]+]] "kernel_off_4"
+; CHECK: EntryPoint 6 [[K5:[0-9]+]] "kernel_off_5"
+; CHECK: EntryPoint 6 [[K6:[0-9]+]] "kernel_off_6"
+; CHECK: EntryPoint 6 [[K7:[0-9]+]] "kernel_on_7"
+
+; CHECK: ExecutionMode [[K1]] 31
+; CHECK: ExecutionMode [[K2]] 31
+; CHECK: ExecutionMode [[K3]] 31
+; CHECK: ExecutionMode [[K4]] 31
+; CHECK: ExecutionMode [[K5]] 31
+; CHECK: ExecutionMode [[K6]] 31
+; CHECK-NOT: ExecutionMode [[K7]] 31
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+define float @func_nested_off(float %a, float %b, float %c) {
+entry:
+  %0 = call float @func_off(float %a, float %b, float %c)
+  ret float %0
+}
+
+define float @func_off(float %a, float %b, float %c) {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %mul = fmul float %0, %b
+  %add = fadd float %mul, %c
+  ret float %add
+}
+
+declare float @llvm.fmuladd.f32(float, float, float) #0
+
+define float @func_on(float %a, float %b, float %c) {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  ret float %0
+}
+
+define float @func_mul(float %a, float %b) {
+entry:
+  %0 = fmul float %a, %b
+  ret float %0
+}
+
+declare float @func_extern(float, float, float)
+
+define spir_kernel void @kernel_off_1(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_off_2(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %call = call float @func_off(float %0, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_3(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %call = call float @func_nested_off(float %a, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_4(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %call = call float @func_extern(float %0, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_5(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_off(float %a, float %b, float %c)
+  %add = fadd contract float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_off_6(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_mul(float %a, float %b)
+  %add = fadd float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_on_7(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_mul(float %a, float %b)
+  %add = fadd contract float %mul, %c
+  ret void
+}
+
+attributes #0 = { nounwind readnone speculatable willreturn }
+
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{!"clang version 11.0.0"}
+!3 = !{i32 0, i32 0, i32 0}
+!4 = !{!"none", !"none", !"none"}
+!5 = !{!"float", !"float", !"float"}
+!6 = !{!"", !"", !""}

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -51,7 +51,7 @@
 
 ; CHECK-ON: ExecutionMode [[K1]] 31
 ; CHECK-ON-NOT: ExecutionMode [[K2]] 31
-; CHECK-ON-NOT: ExecutionMode [[K3]] 31
+; CHECK-ON: ExecutionMode [[K3]] 31
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"

--- a/test/atomic_explicit_arguments.spt
+++ b/test/atomic_explicit_arguments.spt
@@ -67,7 +67,8 @@
 
 ; CHECK: define private spir_func i32 @__translate_spirv_memory_order(i32 %key) {
 ; CHECK: entry:
-; CHECK:   switch i32 %key, label %default [
+; CHECK:   %key.masked = and i32 30, %key
+; CHECK:   switch i32 %key.masked, label %default [
 ; CHECK:     i32 0, label %case.0
 ; CHECK:     i32 2, label %case.2
 ; CHECK:     i32 4, label %case.4

--- a/test/mem_fence_explicit_arguments.spt
+++ b/test/mem_fence_explicit_arguments.spt
@@ -26,11 +26,15 @@
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
-; RUN: llvm-dis < %t.bc | FileCheck %s
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes CHECK,CHECK-12
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=CL2.0 -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes CHECK,CHECK-20
 
 ; CHECK: define spir_func void @test(i32 %val)
 ; CHECK: %call = call spir_func i32 @__translate_spirv_memory_fence(i32 %val)
-; CHECK: call spir_func void @_Z9mem_fencej(i32 %call)
+; CHECK-12: call spir_func void @_Z9mem_fencej(i32 %call)
+; CHECK-20: %call1 = call spir_func i32 @__translate_spirv_memory_order(i32 %val)
+; CHECK-20: call spir_func void @_Z22atomic_work_item_fencej12memory_order12memory_scope(i32 %call, i32 %call1
 ; CHECK: define private spir_func i32 @__translate_spirv_memory_fence(i32 %key)
 ; CHECK: entry:
 ; CHECK:   %key.masked = and i32 2816, %key
@@ -60,4 +64,26 @@
 ; CHECK: case.2816:
 ; CHECK:   ret i32 7
 ; CHECK: }
-; CHECK: declare spir_func void @_Z9mem_fencej(i32)
+; CHECK-20: define private spir_func i32 @__translate_spirv_memory_order(i32 %key) {
+; CHECK-20: entry:
+; CHECK-20:   %key.masked = and i32 30, %key
+; CHECK-20:   switch i32 %key.masked, label %default [
+; CHECK-20:     i32 0, label %case.0
+; CHECK-20:     i32 2, label %case.2
+; CHECK-20:     i32 4, label %case.4
+; CHECK-20:     i32 8, label %case.8
+; CHECK-20:     i32 16, label %case.16
+; CHECK-20:   ]
+; CHECK-20: default:
+; CHECK-20:   unreachable
+; CHECK-20: case.0:
+; CHECK-20:   ret i32 0
+; CHECK-20: case.2:
+; CHECK-20:   ret i32 2
+; CHECK-20: case.4:
+; CHECK-20:   ret i32 3
+; CHECK-20: case.8:
+; CHECK-20:   ret i32 4
+; CHECK-20: case.16:
+; CHECK-20:   ret i32 5
+; CHECK-20: }

--- a/test/trap.ll
+++ b/test/trap.ll
@@ -1,0 +1,40 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+; CHECK: Capability Addresses
+; CHECK: "foo"
+
+; Function Attrs: cold noreturn nounwind
+declare void @llvm.trap() #8
+
+define spir_kernel void @foo(i32 addrspace(1)* %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+entry:
+  %a.addr = alloca i32 addrspace(1)*, align 4
+  store i32 addrspace(1)* %a, i32 addrspace(1)** %a.addr, align 4
+  call void @llvm.trap() #12
+  ret void
+}
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #12 = { noreturn nounwind }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!6}
+!opencl.used.extensions = !{!7}
+!opencl.used.optional.core.features = !{!7}
+!opencl.compiler.options = !{!7}
+
+!1 = !{i32 1}
+!2 = !{!"none"}
+!3 = !{!"int*"}
+!4 = !{!"int*"}
+!5 = !{!""}
+!6 = !{i32 1, i32 2}
+!7 = !{}


### PR DESCRIPTION
intrinsics. According to the LangRef documentation a trap instruction
is lowered to a target's trap instruction or to an abort() function
if the target doesn't have a trap instruction. SPIRV has neither a
trap nor an abort instruction and no current opcode has the semantics
of an abort/trap.
Currently the IR to SPIRV translator is crashing when it finds an
llvm.trap intrinsic. The solution will require some thoughts on the
SPIRV side to decide how to implement an abort instruction.
This patch changes the translator so it doesn't crash. This will be
revised when a decision is taken.

NOTE: clang could eventually not generate an llvm.trap instruction in
the current case (non-base destructor of an abstract class needs to be
emmitted) but keep in mind that clang might generate an llvm.trap
intrinsic some other ways and we might stumble into this issue again.
An alternative to this, could be to add an LLVM pass that will get rid
of the llvm.trap intrisincs in the code before the SPIRV translator.
But having the translator solve this issue is a preferred solution.