### PR TITLE
Cherry-pick FP contract changes to llvm-8

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -709,31 +709,56 @@ bool isKernelQueryBI(const StringRef MangledName) {
          MangledName == "__get_kernel_preferred_work_group_size_multiple_impl";
 }
 
-// Checks if we have the following (most common for fp contranction) pattern
-// in LLVM IR:
-// %mul = fmul float %a, %b
-// %add = fadd float %mul, %c
+// isUnfusedMulAdd checks if we have the following (most common for fp
+// contranction) pattern in LLVM IR:
+//
+//   %mul = fmul float %a, %b
+//   %add = fadd float %mul, %c
+//
 // This pattern indicates that fp contraction could have been disabled by
-// // #pragma OPENCL FP_CONTRACT OFF. Otherwise the current version of clang
-// would generate:
-// %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
-// TODO We need a more reliable mechanism to expres the FP_CONTRACT pragma
-// in LLVM IR. Fox example adding the 'contract' attribute to fp operations
-// by default (according the OpenCL spec fp contraction is enabled by default).
-void checkFpContract(BinaryOperator *B, SPIRVBasicBlock *BB) {
+// #pragma OPENCL FP_CONTRACT OFF. When contraction is enabled (by a pragma or
+// by clang's -ffp-contract=fast), clang would generate:
+//
+//   %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+//
+// or
+//
+//   %mul = fmul contract float %a, %b
+//   %add = fadd contract float %mul, %c
+//
+// Note that optimizations may form an unfused fmuladd from fadd+load or
+// fadd+call, so this check is quite restrictive (see the comment below).
+//
+bool isUnfusedMulAdd(BinaryOperator *B) {
   if (B->getOpcode() != Instruction::FAdd &&
       B->getOpcode() != Instruction::FSub)
-    return;
-  // Ok, this is fadd or fsub. Now check its operands.
-  for (auto *Op : B->operand_values()) {
-    if (auto *I = dyn_cast<Instruction>(Op)) {
-      if (I->getOpcode() == Instruction::FMul) {
-        SPIRVFunction *BF = BB->getParent();
-        BF->setUncontractedFMulAddFound();
-        break;
-      }
-    }
+    return false;
+
+  if (B->hasAllowContract()) {
+    // If this fadd or fsub itself has a contract flag, the operation can be
+    // contracted regardless of the operands.
+    return false;
   }
+
+  // Otherwise, we cannot easily tell if the operation can be a candidate for
+  // contraction or not. Consider the following cases:
+  //
+  //   %mul = alloca float
+  //   %t1 = fmul float %a, %b
+  //   store float* %mul, float %t
+  //   %t2 = load %mul
+  //   %r = fadd float %t2, %c
+  //
+  // LLVM IR does not allow %r to be contracted. However, after an optimization
+  // it becomes a candidate for contraction if ContractionOFF is not set in
+  // SPIR-V:
+  //
+  //   %t1 = fmul float %a, %b
+  //   %r = fadd float %t1, %c
+  //
+  // To be on a safe side, we disallow everything that is even remotely similar
+  // to fmul + fadd.
+  return true;
 }
 } // namespace OCLUtil
 

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -406,9 +406,8 @@ bool isKernelQueryBI(const StringRef MangledName);
 /// Check that the type is the sampler_t
 bool isSamplerTy(Type *Ty);
 
-// Checks if clang did not generate llvm.fmuladd for fp multiply-add operations.
-// If so, it applies ContractionOff ExecutionMode to the kernel.
-void checkFpContract(BinaryOperator *B, SPIRVBasicBlock *BB);
+// Checks if the binary operator is an unfused fmul + fadd instruction.
+bool isUnfusedMulAdd(BinaryOperator *B);
 
 } // namespace OCLUtil
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1872,6 +1872,7 @@ bool LLVMToSPIRV::joinFPContract(Function *F, FPContract C) {
   case FPContract::DISABLED:
     return false;
   }
+  llvm_unreachable("Unhandled FPContract value.");
 }
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -111,6 +111,7 @@ public:
   // Returns true if succeeds.
   bool translate();
   bool transExecutionMode();
+  void transFPContract();
   SPIRVValue *transConstant(Value *V);
   SPIRVValue *transValue(Value *V, SPIRVBasicBlock *BB,
                          bool CreateForward = true);
@@ -130,6 +131,12 @@ private:
   SPIRVWord SrcLangVer;
   std::unique_ptr<LLVMToSPIRVDbgTran> DbgTran;
   std::unique_ptr<CallGraph> CG;
+
+  enum class FPContract { UNDEF, DISABLED, ENABLED };
+  DenseMap<Function *, FPContract> FPContractMap;
+  FPContract getFPContract(Function *F);
+  bool joinFPContract(Function *F, FPContract C);
+  void fpContractUpdateRecursive(Function *F, FPContract FPC);
 
   SPIRVType *mapType(Type *T, SPIRVType *BT);
   SPIRVValue *mapValue(Value *V, SPIRVValue *BV);

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -144,22 +144,6 @@ public:
     assert(FuncType && "Invalid func type");
   }
 
-  bool shouldFPContractBeDisabled() const {
-    // We could find some instructions in LLVM IR which look exactly like an
-    // unfused fmuladd. So, we assume that FP_CONTRACT was disabled only if
-    // there are something that looks like uncointracted fmul + fadd, but there
-    // no calls to @llvm.fmuladd.*
-    return FoundUncontractedFMulAdd && !FoundContractedFMulAdd;
-  }
-
-  void setUncontractedFMulAddFound(bool Value = true) {
-    FoundUncontractedFMulAdd = Value;
-  }
-
-  void setContractedFMulAddFound(bool Value = true) {
-    FoundContractedFMulAdd = Value;
-  }
-
 private:
   SPIRVFunctionParameter *addArgument(unsigned TheArgNo, SPIRVId TheId) {
     SPIRVFunctionParameter *Arg = new SPIRVFunctionParameter(

--- a/test/ContractionON.ll
+++ b/test/ContractionON.ll
@@ -1,0 +1,115 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK: EntryPoint 6 [[K1:[0-9]+]] "kernel_off_1"
+; CHECK: EntryPoint 6 [[K2:[0-9]+]] "kernel_off_2"
+; CHECK: EntryPoint 6 [[K3:[0-9]+]] "kernel_off_3"
+; CHECK: EntryPoint 6 [[K4:[0-9]+]] "kernel_off_4"
+; CHECK: EntryPoint 6 [[K5:[0-9]+]] "kernel_off_5"
+; CHECK: EntryPoint 6 [[K6:[0-9]+]] "kernel_off_6"
+; CHECK: EntryPoint 6 [[K7:[0-9]+]] "kernel_on_7"
+
+; CHECK: ExecutionMode [[K1]] 31
+; CHECK: ExecutionMode [[K2]] 31
+; CHECK: ExecutionMode [[K3]] 31
+; CHECK: ExecutionMode [[K4]] 31
+; CHECK: ExecutionMode [[K5]] 31
+; CHECK: ExecutionMode [[K6]] 31
+; CHECK-NOT: ExecutionMode [[K7]] 31
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+define float @func_nested_off(float %a, float %b, float %c) {
+entry:
+  %0 = call float @func_off(float %a, float %b, float %c)
+  ret float %0
+}
+
+define float @func_off(float %a, float %b, float %c) {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %mul = fmul float %0, %b
+  %add = fadd float %mul, %c
+  ret float %add
+}
+
+declare float @llvm.fmuladd.f32(float, float, float) #0
+
+define float @func_on(float %a, float %b, float %c) {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  ret float %0
+}
+
+define float @func_mul(float %a, float %b) {
+entry:
+  %0 = fmul float %a, %b
+  ret float %0
+}
+
+declare float @func_extern(float, float, float)
+
+define spir_kernel void @kernel_off_1(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = fmul float %a, %b
+  %add = fadd float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_off_2(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %call = call float @func_off(float %0, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_3(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %call = call float @func_nested_off(float %a, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_4(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  %call = call float @func_extern(float %0, float %b, float %c)
+  ret void
+}
+
+define spir_kernel void @kernel_off_5(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_off(float %a, float %b, float %c)
+  %add = fadd contract float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_off_6(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_mul(float %a, float %b)
+  %add = fadd float %mul, %c
+  ret void
+}
+
+define spir_kernel void @kernel_on_7(float %a, float %b, float %c) !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %mul = call float @func_mul(float %a, float %b)
+  %add = fadd contract float %mul, %c
+  ret void
+}
+
+attributes #0 = { nounwind readnone speculatable }
+
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{!"clang version 11.0.0"}
+!3 = !{i32 0, i32 0, i32 0}
+!4 = !{!"none", !"none", !"none"}
+!5 = !{!"float", !"float", !"float"}
+!6 = !{!"", !"", !""}

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -23,9 +23,18 @@
 ; CHECK: EntryPoint 6 [[K1:[0-9]+]] "k1"
 ; CHECK: EntryPoint 6 [[K2:[0-9]+]] "k2"
 ; CHECK: EntryPoint 6 [[K3:[0-9]+]] "k3"
-; CHECK: ExecutionMode [[K1]] 31
-; CHECK-NOT: ExecutionMode [[K2]] 31
-; CHECK-NOT: ExecutionMode [[K3]] 31
+
+; CHECK-OFF: ExecutionMode [[K1]] 31
+; CHECK-OFF: ExecutionMode [[K2]] 31
+; CHECK-OFF: ExecutionMode [[K3]] 31
+
+; CHECK-FAST-NOT: ExecutionMode [[K1]] 31
+; CHECK-FAST-NOT: ExecutionMode [[K2]] 31
+; CHECK-FAST-NOT: ExecutionMode [[K3]] 31
+
+; CHECK-ON: ExecutionMode [[K1]] 31
+; CHECK-ON-NOT: ExecutionMode [[K2]] 31
+; CHECK-ON: ExecutionMode [[K3]] 31
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"


### PR DESCRIPTION
Add --spirv-fp-contract={on|off|fast} option (#509) is **NOT** cherry-picked, because translation options are not implemented in llvm-8 branch.