### PR TITLE
Update DebugInfo test after LLVM changes D80197

### DIFF
--- a/test/DebugInfo/X86/default-subrange-array.ll
+++ b/test/DebugInfo/X86/default-subrange-array.ll
@@ -31,7 +31,7 @@ source_filename = "test/DebugInfo/X86/default-subrange-array.ll"
 ; CHECK-NEXT:         DW_AT_type
 ; CHECK:            DW_TAG_subrange_type
 ; CHECK-NEXT:         DW_AT_type
-; DWARF4-NEXT:        DW_AT_lower_bound [DW_FORM_data1] (0x00)
+; DWARF4-NEXT:        DW_AT_lower_bound [DW_FORM_sdata] (0)
 ; CHECK-NEXT:         DW_AT_count [DW_FORM_data1]       (0x2a)
 ; DWARF5-NOT:         DW_AT_lower_bound
 


### PR DESCRIPTION
Update after LLVM commit llvm/llvm-project@d20bf5a
"[DebugInfo] Upgrade DISubrange to support Fortran dynamic arrays"

Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>