### PR TITLE
Introduce a workaround for emitting only required capabilities

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -78,7 +78,9 @@ public:
   void setOwner(SPIRVDecorationGroup *Owner) { this->Owner = Owner; }
 
   SPIRVCapVec getRequiredCapability() const override {
-    return getCapability(Dec);
+    auto Caps = getAllEnablingCapabilities(Dec);
+    Module->chooseBestCapability(Caps);
+    return Caps;
   }
 
   SPIRVWord getRequiredSPIRVVersion() const override {

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -507,6 +507,12 @@ void SPIRVExecutionMode::decode(std::istream &I) {
   getOrCreateTarget()->addExecutionMode(Module->add(this));
 }
 
+SPIRVCapVec SPIRVExecutionMode::getRequiredCapability() const {
+  auto Caps = getAllEnablingCapabilities(ExecMode);
+  getModule()->chooseBestCapability(Caps);
+  return Caps;
+}
+
 SPIRVForward *SPIRVAnnotationGeneric::getOrCreateTarget() const {
   SPIRVEntry *Entry = nullptr;
   bool Found = Module->exist(Target, &Entry);

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -648,9 +648,7 @@ public:
   SPIRVExecutionMode() : ExecMode(ExecutionModeInvocations) {}
   SPIRVExecutionModeKind getExecutionMode() const { return ExecMode; }
   const std::vector<SPIRVWord> &getLiterals() const { return WordLiterals; }
-  SPIRVCapVec getRequiredCapability() const override {
-    return getCapability(ExecMode);
-  }
+  SPIRVCapVec getRequiredCapability() const override;
 
   SPIRVWord getRequiredSPIRVVersion() const override {
     switch (ExecMode) {

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -123,7 +123,7 @@ template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
 }
 typedef SPIRVMap<SPIRVExtInstSetKind, std::string> SPIRVBuiltinSetNameMap;
 
-template <typename K> SPIRVCapVec getCapability(K Key) {
+template <typename K> SPIRVCapVec getAllEnablingCapabilities(K Key) {
   SPIRVCapVec V;
   SPIRVMap<K, SPIRVCapVec>::find(Key, &V);
   return V;

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -473,6 +473,11 @@ public:
       return std::vector<SPIRVEntry *>(1, V);
     return std::vector<SPIRVEntry *>();
   }
+  SPIRVCapVec getRequiredCapability() const override {
+    auto Caps = getAllEnablingCapabilities(StorageClass);
+    getModule()->chooseBestCapability(Caps);
+    return Caps;
+  }
 
 protected:
   void validate() const override {

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -124,6 +124,7 @@ public:
   // Module query functions
   virtual SPIRVAddressingModelKind getAddressingModel() = 0;
   virtual const SPIRVCapMap &getCapability() const = 0;
+  virtual void chooseBestCapability(SPIRVCapVec &) const = 0;
   virtual bool hasCapability(SPIRVCapabilityKind) const = 0;
   virtual SPIRVExtInstSetKind getBuiltinSet(SPIRVId) const = 0;
   virtual SPIRVFunction *getEntryPoint(SPIRVExecutionModelKind,

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -249,7 +249,8 @@ public:
     auto Cap = getVec(CapabilityAddresses);
     if (getElementType()->isTypeFloat(16))
       Cap.push_back(CapabilityFloat16Buffer);
-    auto C = getCapability(ElemStorageClass);
+    auto C = getAllEnablingCapabilities(ElemStorageClass);
+    Module->chooseBestCapability(C);
     Cap.insert(Cap.end(), C.begin(), C.end());
     return Cap;
   }
@@ -277,6 +278,12 @@ public:
 
   SPIRVTypeForwardPointer()
       : Pointer(nullptr), SC(StorageClassUniformConstant) {}
+
+  SPIRVCapVec getRequiredCapability() const override {
+    auto Caps = getAllEnablingCapabilities(SC);
+    getModule()->chooseBestCapability(Caps);
+    return Caps;
+  }
 
   SPIRVTypePointer *getPointer() const { return Pointer; }
   _SPIRV_DCL_ENCDEC

--- a/test/capability_vector_compute.ll
+++ b/test/capability_vector_compute.ll
@@ -1,0 +1,31 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute,+SPV_KHR_float_controls,+SPV_INTEL_float_controls2 --spirv-allow-unknown-intrinsics
+; RUN: llvm-spirv %t.spv -o %t.spt --to-text
+; RUN: FileCheck %s --input-file %t.spt  -check-prefix=SPV
+
+; ModuleID = 'slm.bc'
+source_filename = "slm.cpp"
+target datalayout = "e-p:64:64-i64:64-n8:16:32"
+target triple = "spir"
+
+; SPV-NOT: Capability Shader
+; SPV: Capability VectorComputeINTEL
+@in = internal global <256 x i8> undef, align 256 #0
+declare <256 x i8> @llvm.genx.vload(<256 x i8>* nonnull %aaa)
+
+; Function Attrs: noinline norecurse nounwind readnone
+define dso_local dllexport spir_kernel void @k_rte(i32 %ibuf, i32 %obuf) local_unnamed_addr #1 {
+entry:
+  %gload53 = tail call <256 x i8> @llvm.genx.vload(<256 x i8>* nonnull @in)
+  ret void
+}
+
+attributes #0 = { "VCGlobalVariable"}
+attributes #1 = { noinline norecurse nounwind readnone "VCFloatControl"="0" "VCFunction" "VCSLMSize"="256" "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "oclrt"="1" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!llvm.module.flags = !{!0}
+!llvm.ident = !{!1}
+
+; Note
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{!"clang version 8.0.1"}


### PR DESCRIPTION
Introduce a workaround for emitting only required capabilities instead of all listed in SPIRVEnum.h

SPIRV specification declares that:
When an instruction, enumerant, or other feature specifies multiple
enabling capabilities, only one such capability needs to be declared to
use the feature. This declaration does not itself imply anything about
the presence of the other enabling capabilities: The execution
environment needs to support only the declared capability.
  
But the translator always emits all listed capabilities. This patch is a
workaround for choosing only actually needed capabilities for specific
cases.

https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_capabilities_a_language_capabilities