### PR TITLE
Fix build warnings

### DIFF
--- a/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
@@ -79,7 +79,7 @@ public:
     return "Lower OpenCL Blocks For SPIR-V";
   }
 
-  bool runOnModule(Module &M) {
+  bool runOnModule(Module &M) override {
     bool Changed = false;
     for (Function &F : M) {
       if (!isBlockInvoke(F))

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -167,9 +167,6 @@ private:
   std::vector<const SPIRVValue *> Variables;
   typedef std::vector<SPIRVBasicBlock *> SPIRVLBasicBlockVector;
   SPIRVLBasicBlockVector BBVec;
-
-  bool FoundUncontractedFMulAdd = false;
-  bool FoundContractedFMulAdd = false;
 };
 
 typedef SPIRVEntryOpCodeOnly<OpFunctionEnd> SPIRVFunctionEnd;


### PR DESCRIPTION
Found*contractedFMulAdd became unused after commit e89518b ("Enable
strict rules to set ContractionOFF (#521)", 2020-05-20).

Add a missing override to suppress a -Winconsistent-missing-override
warning.