### PR TITLE
[NFC] Fix Intel loop control masks spelling

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -687,7 +687,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
     assert(NumParam <= LoopControlParameters.size() &&
            "Missing loop control parameter!");
   }
-  if (LC & LoopControlInitiationIntervalINTEL) {
+  if (LC & LoopControlInitiationIntervalINTELMask) {
     Metadata.push_back(llvm::MDNode::get(
         *Context, getMetadataFromNameAndParameter(
                       "llvm.loop.ii.count", LoopControlParameters[NumParam])));
@@ -695,7 +695,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
     assert(NumParam <= LoopControlParameters.size() &&
            "Missing loop control parameter!");
   }
-  if (LC & LoopControlMaxConcurrencyINTEL) {
+  if (LC & LoopControlMaxConcurrencyINTELMask) {
     Metadata.push_back(llvm::MDNode::get(
         *Context,
         getMetadataFromNameAndParameter("llvm.loop.max_concurrency.count",
@@ -704,7 +704,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
     assert(NumParam <= LoopControlParameters.size() &&
            "Missing loop control parameter!");
   }
-  if (LC & LoopControlDependencyArrayINTEL) {
+  if (LC & LoopControlDependencyArrayINTELMask) {
     // Collect array variable <-> safelen information
     std::map<Value *, unsigned> ArraySflnMap;
     unsigned NumOperandPairs = LoopControlParameters[NumParam];
@@ -786,7 +786,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
       Metadata.push_back(llvm::MDNode::get(*Context, Parameters));
     }
   }
-  if (LC & LoopControlPipelineEnableINTEL) {
+  if (LC & LoopControlPipelineEnableINTELMask) {
     Metadata.push_back(llvm::MDNode::get(
         *Context,
         getMetadataFromNameAndParameter("llvm.loop.intel.pipelining.enable",
@@ -794,7 +794,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
     assert(NumParam <= LoopControlParameters.size() &&
            "Missing loop control parameter!");
   }
-  if (LC & LoopControlLoopCoalesceINTEL) {
+  if (LC & LoopControlLoopCoalesceINTELMask) {
     // If LoopCoalesce has no parameters
     if (LoopControlParameters.empty()) {
       Metadata.push_back(llvm::MDNode::get(
@@ -808,7 +808,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
     assert(NumParam <= LoopControlParameters.size() &&
            "Missing loop control parameter!");
   }
-  if (LC & LoopControlMaxInterleavingINTEL) {
+  if (LC & LoopControlMaxInterleavingINTELMask) {
     Metadata.push_back(llvm::MDNode::get(
         *Context,
         getMetadataFromNameAndParameter("llvm.loop.max_interleaving.count",
@@ -816,7 +816,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
     assert(NumParam <= LoopControlParameters.size() &&
            "Missing loop control parameter!");
   }
-  if (LC & LoopControlSpeculatedIterationsINTEL) {
+  if (LC & LoopControlSpeculatedIterationsINTELMask) {
     Metadata.push_back(llvm::MDNode::get(
         *Context, getMetadataFromNameAndParameter(
                       "llvm.loop.intel.speculated.iterations.count",

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -869,13 +869,13 @@ LLVMToSPIRV::getLoopControl(const BranchInst *Branch,
           BM->addCapability(CapabilityFPGALoopControlsINTEL);
           size_t I = getMDOperandAsInt(Node, 1);
           Parameters.push_back(I);
-          LoopControl |= spv::LoopControlInitiationIntervalINTEL;
+          LoopControl |= spv::LoopControlInitiationIntervalINTELMask;
         } else if (S == "llvm.loop.max_concurrency.count") {
           BM->addExtension(ExtensionID::SPV_INTEL_fpga_loop_controls);
           BM->addCapability(CapabilityFPGALoopControlsINTEL);
           size_t I = getMDOperandAsInt(Node, 1);
           Parameters.push_back(I);
-          LoopControl |= spv::LoopControlMaxConcurrencyINTEL;
+          LoopControl |= spv::LoopControlMaxConcurrencyINTELMask;
         } else if (S == "llvm.loop.parallel_access_indices") {
           // Intel FPGA IVDep loop attribute
           LLVMParallelAccessIndices IVDep(Node, IndexGroupArrayMap);
@@ -893,29 +893,29 @@ LLVMToSPIRV::getLoopControl(const BranchInst *Branch,
           BM->addCapability(CapabilityFPGALoopControlsINTEL);
           size_t I = getMDOperandAsInt(Node, 1);
           Parameters.push_back(I);
-          LoopControl |= spv::LoopControlPipelineEnableINTEL;
+          LoopControl |= spv::LoopControlPipelineEnableINTELMask;
         } else if (S == "llvm.loop.coalesce.enable") {
           BM->addExtension(ExtensionID::SPV_INTEL_fpga_loop_controls);
           BM->addCapability(CapabilityFPGALoopControlsINTEL);
-          LoopControl |= spv::LoopControlLoopCoalesceINTEL;
+          LoopControl |= spv::LoopControlLoopCoalesceINTELMask;
         } else if (S == "llvm.loop.coalesce.count") {
           BM->addExtension(ExtensionID::SPV_INTEL_fpga_loop_controls);
           BM->addCapability(CapabilityFPGALoopControlsINTEL);
           size_t I = getMDOperandAsInt(Node, 1);
           Parameters.push_back(I);
-          LoopControl |= spv::LoopControlLoopCoalesceINTEL;
+          LoopControl |= spv::LoopControlLoopCoalesceINTELMask;
         } else if (S == "llvm.loop.max_interleaving.count") {
           BM->addExtension(ExtensionID::SPV_INTEL_fpga_loop_controls);
           BM->addCapability(CapabilityFPGALoopControlsINTEL);
           size_t I = getMDOperandAsInt(Node, 1);
           Parameters.push_back(I);
-          LoopControl |= spv::LoopControlMaxInterleavingINTEL;
+          LoopControl |= spv::LoopControlMaxInterleavingINTELMask;
         } else if (S == "llvm.loop.intel.speculated.iterations.count") {
           BM->addExtension(ExtensionID::SPV_INTEL_fpga_loop_controls);
           BM->addCapability(CapabilityFPGALoopControlsINTEL);
           size_t I = getMDOperandAsInt(Node, 1);
           Parameters.push_back(I);
-          LoopControl |= spv::LoopControlSpeculatedIterationsINTEL;
+          LoopControl |= spv::LoopControlSpeculatedIterationsINTELMask;
         }
       }
     }
@@ -933,7 +933,7 @@ LLVMToSPIRV::getLoopControl(const BranchInst *Branch,
     }
     BM->addExtension(ExtensionID::SPV_INTEL_fpga_loop_controls);
     BM->addCapability(CapabilityFPGALoopControlsINTEL);
-    LoopControl |= spv::LoopControlDependencyArrayINTEL;
+    LoopControl |= spv::LoopControlDependencyArrayINTELMask;
   }
 
   return static_cast<spv::LoopControlMask>(LoopControl);

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -1087,13 +1087,13 @@ inline bool isValidLoopControlMask(SPIRVWord Mask) {
   ValidMask |= LoopControlPartialCountMask;
   ValidMask |= LoopControlDependencyInfiniteMask;
   ValidMask |= LoopControlDependencyLengthMask;
-  ValidMask |= LoopControlInitiationIntervalINTEL;
-  ValidMask |= LoopControlMaxConcurrencyINTEL;
-  ValidMask |= LoopControlDependencyArrayINTEL;
-  ValidMask |= LoopControlPipelineEnableINTEL;
-  ValidMask |= LoopControlLoopCoalesceINTEL;
-  ValidMask |= LoopControlMaxInterleavingINTEL;
-  ValidMask |= LoopControlSpeculatedIterationsINTEL;
+  ValidMask |= LoopControlInitiationIntervalINTELMask;
+  ValidMask |= LoopControlMaxConcurrencyINTELMask;
+  ValidMask |= LoopControlDependencyArrayINTELMask;
+  ValidMask |= LoopControlPipelineEnableINTELMask;
+  ValidMask |= LoopControlLoopCoalesceINTELMask;
+  ValidMask |= LoopControlMaxInterleavingINTELMask;
+  ValidMask |= LoopControlSpeculatedIterationsINTELMask;
 
   return (Mask & ~ValidMask) == 0;
 }

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -635,13 +635,13 @@ enum LoopControlMask {
     LoopControlIterationMultipleMask = 0x00000040,
     LoopControlPeelCountMask = 0x00000080,
     LoopControlPartialCountMask = 0x00000100,
-    LoopControlInitiationIntervalINTEL = 0x10000,
-    LoopControlMaxConcurrencyINTEL = 0x20000,
-    LoopControlDependencyArrayINTEL = 0x40000,
-    LoopControlPipelineEnableINTEL = 0x80000,
-    LoopControlLoopCoalesceINTEL = 0x100000,
-    LoopControlMaxInterleavingINTEL = 0x200000,
-    LoopControlSpeculatedIterationsINTEL = 0x400000,
+    LoopControlInitiationIntervalINTELMask = 0x10000,
+    LoopControlMaxConcurrencyINTELMask = 0x20000,
+    LoopControlDependencyArrayINTELMask = 0x40000,
+    LoopControlPipelineEnableINTELMask = 0x80000,
+    LoopControlLoopCoalesceINTELMask = 0x100000,
+    LoopControlMaxInterleavingINTELMask = 0x200000,
+    LoopControlSpeculatedIterationsINTELMask = 0x400000,
 };
 
 enum FunctionControlShift {

--- a/test/transcoding/FPGALoopAttr.ll
+++ b/test/transcoding/FPGALoopAttr.ll
@@ -88,7 +88,7 @@ for.end9:                                         ; preds = %for.cond2
   br label %for.cond11
 
 ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
-; LoopControlInitiationIntervalINTEL = 0x10000 (65536)
+; LoopControlInitiationIntervalINTELMask = 0x10000 (65536)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 65536 2
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEGATIVE-NOT: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 65536 2
@@ -115,7 +115,7 @@ for.end18:                                        ; preds = %for.cond11
   br label %for.cond20
 
 ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
-; LoopControlMaxConcurrencyINTEL = 0x20000 (131072)
+; LoopControlMaxConcurrencyINTELMask = 0x20000 (131072)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 131072 2
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEGATIVE-NOT: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 131072 2
@@ -142,7 +142,7 @@ for.end27:                                        ; preds = %for.cond20
   br label %for.cond29
 
 ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
-; LoopControlInitiationIntervalINTEL & LoopControlMaxConcurrencyINTEL = 0x10000 & 0x20000 = 0x30000 (196608)
+; LoopControlInitiationIntervalINTELMask & LoopControlMaxConcurrencyINTELMask = 0x10000 & 0x20000 = 0x30000 (196608)
 ; CHECK-SPIRV: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 196608 2 2
 ; CHECK-SPIRV: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEGATIVE-NOT: 6 LoopMerge {{[0-9]+}} {{[0-9]+}} 196608 2 2

--- a/test/transcoding/FPGALoopMergeInst.ll
+++ b/test/transcoding/FPGALoopMergeInst.ll
@@ -177,7 +177,7 @@ if.end:                                           ; preds = %while.body
 while.end:                                        ; preds = %while.cond
   br label %while.cond1
 ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
-; LoopControlInitiationIntervalINTEL = 0x10000 (65536)
+; LoopControlInitiationIntervalINTELMask = 0x10000 (65536)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 65536 2
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 while.cond1:                                      ; preds = %if.end8, %if.then6, %while.end
@@ -204,7 +204,7 @@ if.end8:                                          ; preds = %while.body3
 while.end9:                                       ; preds = %while.cond1
   br label %while.cond10
 ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
-; LoopControlMaxConcurrencyINTEL = 0x20000 (131072)
+; LoopControlMaxConcurrencyINTELMask = 0x20000 (131072)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 131072 4
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 while.cond10:                                     ; preds = %if.end17, %if.then15, %while.end9
@@ -276,7 +276,7 @@ entry:
   store i32 0, i32* %i, align 4
   br label %for.cond
 
-; Per SPIR-V spec, LoopControlPipelineEnableINTEL = 0x80000 (524288)
+; Per SPIR-V spec, LoopControlPipelineEnableINTELMask = 0x80000 (524288)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 524288 1
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEGATIVE-NOT: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 524288 1
@@ -311,7 +311,7 @@ entry:
   store i32 42, i32* %m, align 4
   br label %while.cond
 
-; Per SPIR-V spec, LoopControlLoopCoalesceINTEL = 0x100000 (1048576)
+; Per SPIR-V spec, LoopControlLoopCoalesceINTELMask = 0x100000 (1048576)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 1048576 4
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEGATIVE-NOT: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 1048576 4
@@ -340,7 +340,7 @@ while.end:                                        ; preds = %while.cond
   store i32 0, i32* %i, align 4
   br label %while.cond1
 
-; Per SPIR-V spec, LoopControlLoopCoalesceINTEL = 0x100000 (1048576)
+; Per SPIR-V spec, LoopControlLoopCoalesceINTELMask = 0x100000 (1048576)
 ; CHECK-SPIRV: 4 LoopMerge {{[0-9]+}} {{[0-9]+}} 1048576
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEGATIVE-NOT: 4 LoopMerge {{[0-9]+}} {{[0-9]+}} 1048576
@@ -377,7 +377,7 @@ entry:
   store i32 0, i32* %i, align 4
   br label %for.cond
 
-; Per SPIR-V spec, LoopControlMaxInterleavingINTEL = 0x200000 (2097152)
+; Per SPIR-V spec, LoopControlMaxInterleavingINTELMask = 0x200000 (2097152)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 2097152 3
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEGATIVE-NOT: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 2097152 3
@@ -411,7 +411,7 @@ entry:
   store i32 0, i32* %i, align 4
   br label %for.cond
 
-; Per SPIR-V spec, LoopControlSpeculatedIterationsINTEL = 0x400000 (4194304)
+; Per SPIR-V spec, LoopControlSpeculatedIterationsINTELMask = 0x400000 (4194304)
 ; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 4194304 4
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEGATIVE-NOT: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 4194304 4

--- a/test/transcoding/FPGAUnstructuredLoopAttr.ll
+++ b/test/transcoding/FPGAUnstructuredLoopAttr.ll
@@ -21,7 +21,7 @@
 ; CHECK-SPIRV: 2 Branch [[FOR]]
 ; CHECK-SPIRV: 2 Label [[FOR]]
 ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
-; LoopControlMaxConcurrencyINTEL = 0x20000 (131072)
+; LoopControlMaxConcurrencyINTELMask = 0x20000 (131072)
 ; CHECK-SPIRV: 3 LoopControlINTEL 131072 2
 ; CHECK-SPIRV-NEXT: 2 Branch [[FOR]]
 
@@ -30,7 +30,7 @@
 ; CHECK-SPIRV: 2 Branch [[WHILE]]
 ; CHECK-SPIRV: 2 Label [[WHILE]]
 ; Per SPIR-V spec extension INTEL/SPV_INTEL_fpga_loop_controls,
-; LoopControlInitiationIntervalINTEL = 0x10000 (65536)
+; LoopControlInitiationIntervalINTELMask = 0x10000 (65536)
 ; CHECK-SPIRV: 3 LoopControlINTEL 65536 2
 ; CHECK-SPIRV-NEXT: 2 Branch [[WHILE]]
 


### PR DESCRIPTION
One more step to align spirv.hpp versions

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>