### PR TITLE
Support DebugInfoNone in DebugTypeComposite

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -227,7 +227,12 @@ SPIRVToLLVMDbgTran::transTypeComposite(const SPIRVExtInst *DebugInst) {
   DIFile *File = getFile(Ops[SourceIdx]);
   unsigned LineNo = Ops[LineIdx];
   DIScope *ParentScope = getScope(BM->getEntry(Ops[ParentIdx]));
-  uint64_t Size = BM->get<SPIRVConstant>(Ops[SizeIdx])->getZExtIntValue();
+
+  uint64_t Size = 0;
+  SPIRVEntry *SizeEntry = BM->getEntry(Ops[SizeIdx]);
+  if (!SizeEntry->isExtInst(SPIRVEIS_Debug, SPIRVDebug::DebugInfoNone)) {
+    Size = BM->get<SPIRVConstant>(Ops[SizeIdx])->getZExtIntValue();
+  }
 
   uint64_t Align = 0;
   DIType *DerivedFrom = nullptr;

--- a/test/DebugInfo/Generic/tu-member-opaque.spvasm
+++ b/test/DebugInfo/Generic/tu-member-opaque.spvasm
@@ -1,0 +1,74 @@
+; REQUIRES: spirv-as
+
+; RUN: cat %s > %t.spvasm
+; RUN: llvm-spirv %t.spvasm --to-binary -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s
+
+; SPIR-V generated via:
+;   clang -cc1 input.cl -triple spir -disable-llvm-passes -debug-info-kind=standalone -emit-llvm-bc -o - | ./bin/llvm-spirv -spirv-mem2reg -o input.spv; llvm-spirv input.spv --to-text -o -
+; where input.cl is:
+; struct Foo {
+;   int e;
+; };
+; void foo() {
+;   struct Foo f;
+; }
+;
+; The resulting SPIR-V was then tweaked to have the DebugTypeComposite use a
+; DebugInfoNone (%7) instead of the real size (%18). The resulting debug info
+; then contains a DICompositeType with no size information.
+
+; CHECK: {{![0-9]*}} = !DICompositeType(tag: DW_TAG_structure_type, name: "Foo", file: {{![0-9]*}}, line: 1, elements: {{![0-9]*}})
+
+119734787 65536 393230 8 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+5 ExtInstImport 1 "OpenCL.std"
+5 ExtInstImport 2 "SPIRV.debug"
+3 MemoryModel 1 2
+6 String 9 "/tmp/<stdin>"
+3 String 14 "Foo"
+6 String 15 "/tmp/input.cl"
+3 String 19 "e"
+3 String 20 "int"
+3 String 25 "foo"
+3 String 26 ""
+3 String 28 "f"
+3 Source 3 100000
+3 Name 5 "foo"
+4 Name 6 "entry"
+5 Name 30 "struct.Foo"
+5 Decorate 5 LinkageAttributes "foo" Export 
+4 TypeInt 17 32 0
+4 Constant 17 18 32
+4 Constant 17 22 0
+2 TypeVoid 3
+3 TypeFunction 4 3
+3 TypeStruct 30 17
+4 TypePointer 31 7 30
+3 Undef 31 32
+
+
+5 ExtInst 3 7 2 DebugInfoNone
+7 ExtInst 3 10 2 DebugSource 9 7
+9 ExtInst 3 11 2 DebugCompileUnit 65536 0 10 12
+7 ExtInst 3 12 2 DebugTypeFunction 0 7
+7 ExtInst 3 16 2 DebugSource 15 7
+8 ExtInst 3 21 2 DebugTypeBasic 20 18 4
+14 ExtInst 3 23 2 DebugTypeMember 19 21 16 2 0 13 22 18 0
+15 ExtInst 3 13 2 DebugTypeComposite 14 1 16 1 0 11 7 7 0 23
+16 ExtInst 3 27 2 DebugFunction 25 12 16 4 0 11 26 8328 4 5 7
+12 ExtInst 3 29 2 DebugLocalVariable 28 13 16 5 0 27 0
+5 ExtInst 3 33 2 DebugExpression
+
+5 Function 3 5 0 4
+
+2 Label 6
+6 ExtInst 3 34 2 DebugScope 27
+4 Line 15 5 0
+8 ExtInst 3 8 2 DebugDeclare 29 32 33
+4 Line 15 6 0
+1 Return
+
+1 FunctionEnd


### PR DESCRIPTION
Per the spec opaque types should use DebugInfoNone for the Size
operand