### PR TITLE
Use -fdeclare-opencl-builtins for more .cl tests

### DIFF
--- a/test/read_image.cl
+++ b/test/read_image.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64 -finclude-default-header -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir64 -fdeclare-opencl-builtins -finclude-default-header -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_media_block_io.cl
+++ b/test/transcoding/SPV_INTEL_media_block_io.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv --spirv-ext=+SPV_INTEL_media_block_io %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: spirv-val %t.spv

--- a/test/transcoding/enqueue_marker.cl
+++ b/test/transcoding/enqueue_marker.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -finclude-default-header -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir-unknown-unknown -fdeclare-opencl-builtins -finclude-default-header -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 // RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/group_ops.cl
+++ b/test/transcoding/group_ops.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/pipe_builtins.cl
+++ b/test/transcoding/pipe_builtins.cl
@@ -1,6 +1,6 @@
 // Pipe built-ins are mangled accordingly to SPIR2.0/C++ ABI.
 
-// RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple spir64-unknonw-unknown -emit-llvm-bc -finclude-default-header -Dcl_khr_subgroups %s -o %t.bc
+// RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple spir64-unknonw-unknown -emit-llvm-bc -fdeclare-opencl-builtins -finclude-default-header -Dcl_khr_subgroups %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv


### PR DESCRIPTION
The combination of `-fdeclare-opencl-builtins -finclude-default-header`
stops Clang from parsing its large opencl-c.h file.  Switch some more
.cl tests that do not need the full opencl-c.h file to this flag
combination, to speed up test execution.