### PR TITLE
[Backport] Fix for trunc to bool lowering (LLVM-7)

### DIFF
--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -77,8 +77,10 @@ public:
   virtual void visitTruncInst(TruncInst &I) {
     if (isBoolType(I.getType())) {
       auto Op = I.getOperand(0);
+      auto And = BinaryOperator::CreateAnd(
+          Op, getScalarOrVectorConstantInt(Op->getType(), 1, false), "", &I);
       auto Zero = getScalarOrVectorConstantInt(Op->getType(), 0, false);
-      auto Cmp = new ICmpInst(&I, CmpInst::ICMP_NE, Op, Zero);
+      auto Cmp = new ICmpInst(&I, CmpInst::ICMP_NE, And, Zero);
       replace(&I, Cmp);
     }
   }

--- a/test/TruncToBool.ll
+++ b/test/TruncToBool.ll
@@ -1,0 +1,45 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; CHECK-SPIRV: 5 BitwiseAnd
+; CHECK-SPIRV-NEXT: 5 INotEqual
+
+; LLVM IR was generated with -cl-std=c++ option
+
+; ModuleID = 'main'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @test(i32 %op1, i32 %op2, i8 %op3) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+entry:
+  %0 = trunc i8 %op3 to i1
+  %call = call spir_func i32 @_Z14__spirv_Selectbii(i1 zeroext %0, i32 %op1, i32 %op2) #2
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare spir_func i32 @_Z14__spirv_Selectbii(i1 zeroext, i32, i32) #1
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind readnone }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!8}
+!llvm.ident = !{!9}
+
+!1 = !{i32 0, i32 0}
+!2 = !{!"none", !"none"}
+!3 = !{!"i32", !"i32"}
+!4 = !{!"i32", !"i32"}
+!5 = !{!"", !""}
+!6 = !{i32 1, i32 2}
+!7 = !{i32 2, i32 0}
+!8 = !{}
+!9 = !{!"clang version 3.6.1"}


### PR DESCRIPTION
Merged to master in #568

This version is slightly different: test doesn't contain spirv-val call. As I understood, it isn't called in this branch.