### PR TITLE
Modify SPIR-V kernel linkage

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -511,9 +511,9 @@ SPIRVFunction *LLVMToSPIRV::transFunctionDecl(Function *F) {
   BF->setFunctionControlMask(transFunctionControlMask(F));
   if (F->hasName())
     BM->setName(BF, F->getName().str());
-  if (isKernel(F))
+  if (isKernel(F) && F->getInstructionCount())
     BM->addEntryPoint(ExecutionModelKernel, BF->getId());
-  else if (F->getLinkage() != GlobalValue::InternalLinkage)
+  if (F->getLinkage() != GlobalValue::InternalLinkage)
     BF->setLinkageType(transLinkageType(F));
   auto Attrs = F->getAttributes();
 


### PR DESCRIPTION
OpenCL requires the ability to link modules where one module contains a call to a kernel via extern forward declaration, while the other contains its definition. The existing SPIRV-Tools linker requires linkage attributes to be present in order to properly link this type of call.

This change does 2 things:
1. Allow "export" linkage on kernels, so that they can be called from other modules. Technically this violates 2 rules of the SPIR-V spec as it stands, though I think that needs to be changed (see https://github.com/KhronosGroup/SPIRV-Registry/issues/74).
2. Prevent annotating kernel forward-declarations as entry points. The module containing the kernel definition will contain the entry point declaration, and the linker will merge those declarations. The entry point declaration is useless on forward-declarations, since the only thing that can be done is call them, and the CL spec is clear that they should be treated as basic functions in that case.

Fixes #587. 