### PR TITLE
Use LLVM FixedVectorType::get

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -1126,7 +1126,7 @@ void OCL20ToSPIRV::visitCallReadImageWithSampler(CallInst *CI,
 
         // SPIR-V instruction always returns 4-element vector
         if (IsRetScalar)
-          Ret = VectorType::get(Ret, 4);
+          Ret = FixedVectorType::get(Ret, 4);
         return getSPIRVFuncName(OpImageSampleExplicitLod,
                                 std::string(kSPIRVPostfix::ExtDivider) +
                                     getPostfixForReturnType(Ret));
@@ -1159,7 +1159,7 @@ void OCL20ToSPIRV::visitCallGetImageSize(CallInst *CI,
         Ret = CI->getType()->isIntegerTy(64) ? Type::getInt64Ty(*Ctx)
                                              : Type::getInt32Ty(*Ctx);
         if (Dim > 1)
-          Ret = VectorType::get(Ret, Dim);
+          Ret = FixedVectorType::get(Ret, Dim);
         if (Desc.Dim == DimBuffer)
           return getSPIRVFuncName(OpImageQuerySize, CI->getType());
         else {
@@ -1253,7 +1253,7 @@ void OCL20ToSPIRV::transWorkItemBuiltinsToVariables() {
     LLVM_DEBUG(dbgs() << "builtin variable name: " << BuiltinVarName << '\n');
     bool IsVec = I.getFunctionType()->getNumParams() > 0;
     Type *GVType =
-        IsVec ? VectorType::get(I.getReturnType(), 3) : I.getReturnType();
+        IsVec ? FixedVectorType::get(I.getReturnType(), 3) : I.getReturnType();
     auto BV = new GlobalVariable(*M, GVType, true, GlobalValue::ExternalLinkage,
                                  nullptr, BuiltinVarName, 0,
                                  GlobalVariable::NotThreadLocal, SPIRAS_Input);
@@ -1333,7 +1333,7 @@ void OCL20ToSPIRV::visitCallRelational(CallInst *CI, StringRef DemangledName) {
       [=](CallInst *, std::vector<Value *> &Args, Type *&Ret) {
         Ret = Type::getInt1Ty(*Ctx);
         if (CI->getOperand(0)->getType()->isVectorTy())
-          Ret = VectorType::get(
+          Ret = FixedVectorType::get(
               Type::getInt1Ty(*Ctx),
               cast<VectorType>(CI->getOperand(0)->getType())->getNumElements());
         return SPIRVName;
@@ -1350,7 +1350,7 @@ void OCL20ToSPIRV::visitCallRelational(CallInst *CI, StringRef DemangledName) {
                   ->getElementType()
                   ->isHalfTy())
             IntTy = Type::getInt16Ty(*Ctx);
-          Type *VTy = VectorType::get(
+          Type *VTy = FixedVectorType::get(
               IntTy, cast<VectorType>(NewCI->getType())->getNumElements());
           False = Constant::getNullValue(VTy);
           True = Constant::getAllOnesValue(VTy);

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -303,7 +303,7 @@ Type *decodeVecTypeHint(LLVMContext &C, unsigned Code) {
   }
   if (VecWidth < 1)
     return ST;
-  return VectorType::get(ST, VecWidth);
+  return FixedVectorType::get(ST, VecWidth);
 }
 
 unsigned transVecTypeHint(MDNode *Node) {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -391,8 +391,9 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool IsClassMember) {
                transType(T->getPointerElementType(), IsClassMember),
                SPIRSPIRVAddrSpaceMap::rmap(T->getPointerStorageClass())));
   case OpTypeVector:
-    return mapType(T, VectorType::get(transType(T->getVectorComponentType()),
-                                      T->getVectorComponentCount()));
+    return mapType(T,
+                   FixedVectorType::get(transType(T->getVectorComponentType()),
+                                        T->getVectorComponentCount()));
   case OpTypeMatrix:
     return mapType(T, ArrayType::get(transType(T->getMatrixColumnType()),
                                      T->getMatrixColumnCount()));
@@ -1169,7 +1170,7 @@ Instruction *SPIRVToLLVM::postProcessOCLReadImage(SPIRVInstruction *BI,
       [=](CallInst *NewCI) -> Instruction * {
         if (IsDepthImage)
           return InsertElementInst::Create(
-              UndefValue::get(VectorType::get(NewCI->getType(), 4)), NewCI,
+              UndefValue::get(FixedVectorType::get(NewCI->getType(), 4)), NewCI,
               getSizet(M, 0), "", NewCI->getParent());
         return NewCI;
       },
@@ -1815,7 +1816,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     unsigned M = Mat->getType()->getArrayNumElements();
 
     auto *VecTy = cast<VectorType>(Vec->getType());
-    VectorType *VTy = VectorType::get(VecTy->getElementType(), M);
+    VectorType *VTy = FixedVectorType::get(VecTy->getElementType(), M);
     auto ETy = VTy->getElementType();
     unsigned N = VecTy->getNumElements();
     Value *V = Builder.CreateVectorSplat(M, ConstantFP::get(ETy, 0.0));
@@ -1946,7 +1947,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     (void)C1;
     assert(C1 == R2 && "Unmatched matrix");
 
-    auto VTy = VectorType::get(ETy, R1);
+    auto VTy = FixedVectorType::get(ETy, R1);
     auto ResultTy = ArrayType::get(VTy, C2);
 
     Value *Res = UndefValue::get(ResultTy);
@@ -1980,7 +1981,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         cast<VectorType>(cast<ArrayType>(Matrix->getType())->getElementType());
     unsigned RowNum = ColTy->getNumElements();
 
-    auto VTy = VectorType::get(ColTy->getElementType(), ColNum);
+    auto VTy = FixedVectorType::get(ColTy->getElementType(), ColNum);
     auto ResultTy = ArrayType::get(VTy, RowNum);
     Value *V = UndefValue::get(ResultTy);
 
@@ -2502,7 +2503,7 @@ void SPIRVToLLVM::transOCLBuiltinFromInstPreproc(
     if (BT->isTypeBool())
       RetTy = IntegerType::getInt32Ty(*Context);
     else if (BT->isTypeVectorBool())
-      RetTy = VectorType::get(
+      RetTy = FixedVectorType::get(
           IntegerType::get(
               *Context,
               Args[0]->getType()->getVectorComponentType()->getBitWidth()),
@@ -3736,7 +3737,7 @@ Instruction *SPIRVToLLVM::transOCLAllAny(SPIRVInstruction *I, BasicBlock *BB) {
              [=](CallInst *, std::vector<Value *> &Args, llvm::Type *&RetTy) {
                Type *Int32Ty = Type::getInt32Ty(*Context);
                auto OldArg = CI->getOperand(0);
-               auto NewArgTy = VectorType::get(
+               auto NewArgTy = FixedVectorType::get(
                    Int32Ty,
                    cast<VectorType>(OldArg->getType())->getNumElements());
                auto NewArg =
@@ -3772,7 +3773,7 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
                          ->getElementType()
                          ->isHalfTy())
                    IntTy = Type::getInt16Ty(*Context);
-                 RetTy = VectorType::get(
+                 RetTy = FixedVectorType::get(
                      IntTy, cast<VectorType>(CI->getType())->getNumElements());
                }
                return CI->getCalledFunction()->getName().str();
@@ -3780,7 +3781,7 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
              [=](CallInst *NewCI) -> Instruction * {
                Type *RetTy = Type::getInt1Ty(*Context);
                if (NewCI->getType()->isVectorTy())
-                 RetTy = VectorType::get(
+                 RetTy = FixedVectorType::get(
                      Type::getInt1Ty(*Context),
                      cast<VectorType>(NewCI->getType())->getNumElements());
                return CastInst::CreateTruncOrBitCast(NewCI, RetTy, "",

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -179,7 +179,7 @@ void SPIRVToOCL::visitCallSPRIVImageQuerySize(CallInst *CI) {
            "this code can handle vector result type only");
     // get_image_dim returns int2 and int4 for 2d and 3d images respecitvely.
     const unsigned ImgDimRetEls = ImgDim == 2 ? 2 : 4;
-    VectorType *RetTy = VectorType::get(Int32Ty, ImgDimRetEls);
+    VectorType *RetTy = FixedVectorType::get(Int32Ty, ImgDimRetEls);
     GetImageSize = addCallInst(M, kOCLBuiltinName::GetImageDim, RetTy,
                                CI->getArgOperand(0), &Attributes, CI, &Mangle,
                                CI->getName(), false);
@@ -188,7 +188,7 @@ void SPIRVToOCL::visitCallSPRIVImageQuerySize(CallInst *CI) {
     if (CI->getType()->getScalarType() != Int32Ty) {
       GetImageSize = CastInst::CreateIntegerCast(
           GetImageSize,
-          VectorType::get(
+          FixedVectorType::get(
               CI->getType()->getScalarType(),
               cast<VectorType>(GetImageSize->getType())->getNumElements()),
           false, CI->getName(), CI);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2823,8 +2823,8 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       Type *BoolTy = IntegerType::getInt1Ty(M->getContext());
       auto IsVector = ResultTy->isVectorTy();
       if (IsVector)
-        BoolTy = VectorType::get(BoolTy,
-                                 cast<VectorType>(ResultTy)->getNumElements());
+        BoolTy = FixedVectorType::get(
+            BoolTy, cast<VectorType>(ResultTy)->getNumElements());
       auto BBT = transType(BoolTy);
       SPIRVInstruction *Res;
       if (isCmpOpCode(OC)) {


### PR DESCRIPTION
Update for commit eb81c85afdc ("[SVE] Deprecate default false variant
of VectorType::get", 2020-06-16).