### PR TITLE
Update DebugInfo tests for LLVM -dwarf-column-info change

### DIFF
--- a/test/DebugInfo/BuiltinCallLocation.cl
+++ b/test/DebugInfo/BuiltinCallLocation.cl
@@ -1,6 +1,6 @@
 // Check that DebugLoc attached to a builtin call is preserved after translation.
 
-// RUN: %clang_cc1 -triple spir -fdeclare-opencl-builtins -finclude-default-header %s -disable-llvm-passes -emit-llvm-bc -debug-info-kind=line-tables-only -dwarf-column-info -o %t.bc
+// RUN: %clang_cc1 -triple spir -fdeclare-opencl-builtins -finclude-default-header %s -disable-llvm-passes -emit-llvm-bc -debug-info-kind=line-tables-only -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/DebugInfo/DebugControlFlow.cl
+++ b/test/DebugInfo/DebugControlFlow.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown -cl-std=CL2.0 -O0 -debug-info-kind=standalone -emit-llvm %s -o %t.ll
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -cl-std=CL2.0 -O0 -debug-info-kind=standalone -gno-column-info -emit-llvm %s -o %t.ll
 // RUN: llvm-as %t.ll -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/DebugInfo/DebugUnstructuredControlFlow.cl
+++ b/test/DebugInfo/DebugUnstructuredControlFlow.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown -cl-std=CL2.0 -O0 -debug-info-kind=standalone -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -cl-std=CL2.0 -O0 -debug-info-kind=standalone -gno-column-info -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_unstructured_loop_controls -o %t.spv
 // RUN: llvm-spirv %t.spv --to-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV


### PR DESCRIPTION
Update for LLVM commit b0b5162fc23 ("[Driver] Pass -gno-column-info
instead of -dwarf-column-info", 2020-07-05).  Either remove the
obsolete `-dwarf-column-info` flag, or add the `-gno-column-info` flag
for tests for which column info is not relevant.