### PR TITLE
Add DW_OP_and operation to SPIRV.debug.h

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -105,7 +105,8 @@ enum ExpressionOpCode {
   Xderef     = 6,
   StackValue = 7,
   Constu     = 8,
-  Fragment   = 9
+  Fragment   = 9,
+  And        = 10,
 };
 
 enum ImportedEntityTag {
@@ -441,7 +442,8 @@ static std::map<ExpressionOpCode, unsigned> OpCountMap {
   { Xderef,     1 },
   { StackValue, 1 },
   { Constu,     2 },
-  { Fragment,   3 }
+  { Fragment,   3 },
+  { And,        1 },
 };
 }
 
@@ -508,6 +510,7 @@ inline void DbgExpressionOpCodeMap::init() {
   add(dwarf::DW_OP_stack_value,   SPIRVDebug::StackValue);
   add(dwarf::DW_OP_constu,        SPIRVDebug::Constu);
   add(dwarf::DW_OP_LLVM_fragment, SPIRVDebug::Fragment);
+  add(dwarf::DW_OP_and,           SPIRVDebug::And);
 }
 
 typedef SPIRVMap<dwarf::Tag, SPIRVDebug::ImportedEntityTag>


### PR DESCRIPTION
This operation cannot be merged yet because "Debug Information Extended Instruction Set" is lacking this operation:
https://www.khronos.org/registry/spir-v/specs/unified1/DebugInfo.html#_debug_operations_a_id_operation_a

It would be great if the specification could be amended with this operation