### PR TITLE
Drop unused CLVer member

### DIFF
--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -58,8 +58,7 @@ namespace SPIRV {
 
 char OCLTypeToSPIRV::ID = 0;
 
-OCLTypeToSPIRV::OCLTypeToSPIRV()
-    : ModulePass(ID), M(nullptr), Ctx(nullptr), CLVer(0) {
+OCLTypeToSPIRV::OCLTypeToSPIRV() : ModulePass(ID), M(nullptr), Ctx(nullptr) {
   initializeOCLTypeToSPIRVPass(*PassRegistry::getPassRegistry());
 }
 

--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -71,7 +71,6 @@ public:
 private:
   Module *M;
   LLVMContext *Ctx;
-  unsigned CLVer;
   std::map<Value *, Type *> AdaptedTy; // Adapted types for values
   std::set<Function *> WorkSet;        // Functions to be adapted
 


### PR DESCRIPTION
Its use was removed in dff07df ("[SPIRV] Fix assertion due to
duplicate operands in opencl version metadata. This happens when two
SPIR modules are linked together. Remove check for OCL version in
OCLTypeToSPIRV. Only check if language is C or C++.", 2015-12-16).