### PR TITLE
Fix ExecutionMode parsing

### DIFF
--- a/lib/SPIRV/SPIRVMDWalker.h
+++ b/lib/SPIRV/SPIRVMDWalker.h
@@ -66,7 +66,7 @@ public:
       if (!Q)
         assert(I < E && "out of bound");
       return MDWrapper<NamedMDWrapper>(
-          (NMD && I < E) ? NMD->getOperand(I++) : nullptr, *this, W);
+          (NMD && I < E) ? NMD->getOperand(I) : nullptr, *this, W, I);
     }
 
     NamedMDWrapper &setQuiet(bool Quiet) {
@@ -82,8 +82,8 @@ public:
   };
 
   template <typename ParentT> struct MDWrapper {
-    MDWrapper(MDNode *Node, ParentT &Parent, SPIRVMDWalker &Walker)
-        : M(Node), P(Parent), W(Walker), I(0), Q(false) {
+    MDWrapper(MDNode *Node, ParentT &Parent, SPIRVMDWalker &Walker, unsigned Pos)
+        : M(Node), P(Parent), W(Walker), I(Pos), Q(false) {
       E = Node ? Node->getNumOperands() : 0;
     }
 
@@ -139,11 +139,14 @@ public:
       if (!Q)
         assert(I < E && "out of bound");
       return MDWrapper<MDWrapper>(
-          (M && I < E) ? dyn_cast<MDNode>(M->getOperand(I++)) : nullptr, *this,
-          W);
+          (M && I < E) ? dyn_cast<MDNode>(M->getOperand(I)) : nullptr, *this,
+          W, I);
     }
 
-    ParentT &done() { return P; }
+    ParentT &done() {
+      P.I = I;
+      return P;
+    }
 
     MDWrapper &setQuiet(bool Quiet) {
       Q = Quiet;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2726,6 +2726,7 @@ bool LLVMToSPIRV::transExecutionMode() {
       default:
         llvm_unreachable("invalid execution mode");
       }
+      N.done();
     }
   }
 


### PR DESCRIPTION
Those 2 commits fix the ExecutionMode parsing when the MDNode contains more than one entry or contains properties covering more than one slot.

Here is a reproducer of the bug I'm trying to fix:

```
__kernel __attribute__((reqd_work_group_size(2, 1, 1)))
void main_test(__global float *inout)
{
   __local float2 tmp[2];
   tmp[get_local_id(0)].x = inout[get_global_id(0)] + 1;
   tmp[get_local_id(0)].y = inout[get_global_id(0)] - 1;
   barrier(CLK_LOCAL_MEM_FENCE);\n\
   inout[get_global_id(0)] = tmp[get_local_id(0) % 2].x * tmp[(get_local_id(0) + 1) % 2].y;
}
```

Without those 2 patches, I hit this assert:
```
Assertion failed: IsCompatible(ExecMode, (*I).second) && "Found incompatible execution modes", file C:\Users\Boris\llvm-project\llvm\projects\SPIRV-LLVM-Translator\lib\SPIRV\libSPIRV\SPIRVEntry.h, line 724
```
