### PR TITLE
CI update: fix compilation issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,6 @@ matrix:
 
     - env: BUILD_EXTERNAL=1 CHECK_TIDY=1
   allow_failures:
-    - compiler: clang
     - os: osx
   fast_finish: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,18 @@ before_install:
     if [ $TRAVIS_OS_NAME == "linux" ]; then
       curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
       curl -L "http://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
+      curl -L "https://apt.kitware.com/keys/kitware-archive-latest.asc" | sudo apt-key add -
       echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
       echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
+      echo "deb https://apt.kitware.com/ubuntu/ bionic main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
       sudo apt-get update
       sudo apt-get -yq --no-install-suggests --no-install-recommends install \
         llvm-${LLVM_VERSION}-dev \
         clang-${LLVM_VERSION} \
         clang-format-${LLVM_VERSION} \
         clang-tidy-${LLVM_VERSION} \
-        spirv-tools
+        spirv-tools \
+        cmake
     fi
 
 compiler:
@@ -90,6 +93,7 @@ script:
       export PKG_CONFIG_PATH=$PWD/install/lib/pkgconfig
     fi
   - mkdir build && cd build
+  - PATH=/usr/bin:$PATH
   - |
     if [ $BUILD_EXTERNAL == "1" ]; then
       if [ $CHECK_FORMAT != "1" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,11 @@ matrix:
   include:
     - os: osx
       env: BUILD_TYPE=Release BUILD_EXTERNAL=0 MAKE_TARGETS="llvm-spirv" MAKE_TEST_TARGET="check-llvm-spirv"
-      osx_image: xcode9.3
+      osx_image: xcode12
 
     - os: osx
       env: BUILD_TYPE=Debug BUILD_EXTERNAL=0 MAKE_TARGETS="llvm-spirv" MAKE_TEST_TARGET="check-llvm-spirv"
-      osx_image: xcode9.3
+      osx_image: xcode12
 
     - env: BUILD_EXTERNAL=1 CHECK_FORMAT=1
 


### PR DESCRIPTION
Since [D78646](https://reviews.llvm.org/D78646), LLVM require CMake 3.13.4 to build.