### PR TITLE
[SYCL] Fix translation of kernel args of arbitrary integer pointer type

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -487,7 +487,7 @@ std::string SPIRVToLLVM::transTypeToOCLTypeName(SPIRVType *T, bool IsSigned) {
     case 64:
       return Prefix + "long";
     default:
-      llvm_unreachable("invalid integer size");
+      // Arbitrary precision integer
       return Prefix + std::string("int") + T->getIntegerBitWidth() + "_t";
     }
   } break;

--- a/test/kernel-arg-ext_int-ptr.spt
+++ b/test/kernel-arg-ext_int-ptr.spt
@@ -1,0 +1,33 @@
+119734787 65536 393230 10 0 
+2 Capability Addresses 
+2 Capability Kernel 
+2 Capability ArbitraryPrecisionIntegersINTEL 
+11 Extension "SPV_INTEL_arbitrary_precision_integers"
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 2 2 
+7 EntryPoint 6 6 "kernel_func1"
+13 String 9 "kernel_arg_type.kernel_func1._ExtInt(31)*,"
+3 Source 4 100000 
+4 Name 7 "_arg_"
+4 Name 8 "entry"
+4 TypeInt 3 31 0 
+2 TypeVoid 2 
+4 TypePointer 4 5 3 
+4 TypeFunction 5 2 4 
+
+5 Function 2 6 0 5 
+3 FunctionParameter 4 7 
+
+2 Label 8 
+1 Return 
+
+1 FunctionEnd 
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; Reverse translation shouldn't crash:
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: define spir_kernel void @kernel_func1(i31 addrspace(1)* %_arg_){{.*}} !kernel_arg_type ![[ArgTy:[0-9]+]]{{.*}} !kernel_arg_base_type ![[BaseArgTy:[0-9]+]]
+; CHECK-LLVM: ![[ArgTy]] = !{!"_ExtInt(31)*"}
+; CHECK-LLVM: ![[BaseArgTy]] = !{!"int31_t*"}


### PR DESCRIPTION
Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>