### PR TITLE
[SYCL][FPGA] Lift the restriction on LSU intrinsic operands

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3193,12 +3193,10 @@ void generateIntelFPGAAnnotationForStructMember(
 }
 
 void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
-  if (!BV->isVariable() && BV->getOpCode() != OpLoad &&
-      BV->getOpCode() != OpInBoundsPtrAccessChain)
+  if (!BV->isVariable() && !BV->isInst())
     return;
 
-  if (isa<AllocaInst>(V) || isa<LoadInst>(V) || isa<GetElementPtrInst>(V)) {
-    auto *Inst = cast<Instruction>(V);
+  if (auto *Inst = dyn_cast<Instruction>(V)) {
     auto *AL = dyn_cast<AllocaInst>(Inst);
     Type *AllocatedTy = AL ? AL->getAllocatedType() : Inst->getType();
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2206,17 +2206,16 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
         return transValue(BI, BB);
       } else {
         // Memory accesses to a standalone pointer variable
-        auto *LI = dyn_cast<LoadInst>(AnnotSubj);
-        auto *LoadResPtr = transValue(LI, BB);
+        auto *DecSubj = transValue(II->getArgOperand(0), BB);
         if (Decorations.MemoryAccessesVec.empty())
-          LoadResPtr->addDecorate(new SPIRVDecorateUserSemanticAttr(
-              LoadResPtr, AnnotationString.str()));
+          DecSubj->addDecorate(new SPIRVDecorateUserSemanticAttr(
+              DecSubj, AnnotationString.str()));
         else
-          // Apply the LSU parameter decoration to the pointer result of a load
+          // Apply the LSU parameter decoration to the pointer result of an
           // instruction. Note it's the address to the accessed memory that's
           // loaded from the original pointer variable, and not the value
           // accessed by the latter.
-          addIntelFPGADecorations(LoadResPtr, Decorations.MemoryAccessesVec);
+          addIntelFPGADecorations(DecSubj, Decorations.MemoryAccessesVec);
         II->replaceAllUsesWith(II->getOperand(0));
       }
     }


### PR DESCRIPTION
The initial implementation had required that the first
ptr.annotation operand be a result of a load intruction.
However, it may be the case that the LSU built-in gets applied
to a cast result/to a result of a function call, therefore
this patch drops the unfeasible requirement.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>