### PR TITLE
[Backport] travis: Move to 18.04 (Bionic)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: cpp
 os:
   - linux
 
-# Use Ubuntu 16.04 LTS (Xenial) as the Linux testing environment.
-dist: xenial
+# Use Ubuntu 18.04 LTS (Bionic) as the Linux testing environment.
+dist: bionic
 sudo: false
 
 git:
@@ -23,9 +23,9 @@ branches:
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+    - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
       key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-    - sourceline: 'deb https://packages.lunarg.com/vulkan xenial main'
+    - sourceline: 'deb https://packages.lunarg.com/vulkan bionic main'
       key_url: 'http://packages.lunarg.com/lunarg-signing-key-pub.asc'
     packages:
     - llvm-9-tools
@@ -74,8 +74,6 @@ matrix:
   fast_finish: true
 
 script:
-  - |
-    pyenv global 3.7
   - |
     if [ $BUILD_EXTERNAL == "0" ]; then
       mkdir llvm-spirv


### PR DESCRIPTION
The Xenial binaries on apt.llvm.org have been outdated for a while,
whereas the Bionic binaries seem up to date now.  Switch Travis to
test on Bionic.

Drop the pyenv fix from df75cab ("Fix Travis CI build.", 2019-07-11)
as it no longer seems to be needed for 18.04.