### PR TITLE
Add support for usub.sat intrinsic

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2027,13 +2027,14 @@ SPIRVValue *LLVMToSPIRV::transIntrinsicInst(IntrinsicInst *II,
     // usub.sat(a, b) -> (a > b) ? a - b : 0
     SPIRVType *Ty = transType(II->getType());
     Type *BoolTy = IntegerType::getInt1Ty(M->getContext());
+    SPIRVValue *FirstArgVal = transValue(II->getArgOperand(0), BB);
+    SPIRVValue *SecondArgVal = transValue(II->getArgOperand(1), BB);
+
     SPIRVValue *Sub =
-        BM->addBinaryInst(OpISub, Ty, transValue(II->getArgOperand(0), BB),
-                          transValue(II->getArgOperand(1), BB), BB);
-    SPIRVValue *Cmp = BM->addCmpInst(
-        OpUGreaterThan, transType(BoolTy), transValue(II->getArgOperand(0), BB),
-        transValue(II->getArgOperand(1), BB), BB);
-    auto Zero = transValue(Constant::getNullValue(II->getType()), BB);
+        BM->addBinaryInst(OpISub, Ty, FirstArgVal, SecondArgVal, BB);
+    SPIRVValue *Cmp = BM->addCmpInst(OpUGreaterThan, transType(BoolTy),
+                                     FirstArgVal, SecondArgVal, BB);
+    SPIRVValue *Zero = transValue(Constant::getNullValue(II->getType()), BB);
     return BM->addSelectInst(Cmp, Sub, Zero, BB);
   }
   case Intrinsic::memset: {

--- a/test/usub-sat.ll
+++ b/test/usub-sat.ll
@@ -21,6 +21,7 @@ entry:
 ; CHECK: ISub {{[0-9]+}} [[sub_res:[0-9]+]] [[three]] [[x]]
 ; CHECK: UGreaterThan {{[0-9]+}} [[cmp_res:[0-9]+]] [[three]] [[x]]
 ; CHECK: Select {{[0-9]+}} [[sel_res:[0-9]+]] [[cmp_res]] [[sub_res]] [[zero]]
+; CHECK: ReturnValue [[sel_res]]
 
 ; Function Attrs: nounwind readnone speculatable willreturn
 declare i32 @llvm.usub.sat.i32(i32, i32) #1

--- a/test/usub-sat.ll
+++ b/test/usub-sat.ll
@@ -1,0 +1,37 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: nounwind readnone
+define spir_func i32 @Test(i32 %x) local_unnamed_addr #0 {
+entry:
+  %0 = call i32 @llvm.usub.sat.i32(i32 3, i32 %x)
+  ret i32 %0
+}
+
+; CHECK: Constant {{[0-9]+}} [[three:[0-9]+]] 3
+; CHECK: Constant {{[0-9]+}} [[zero:[0-9]+]] 0
+
+; CHECK: Function
+; CHECK: FunctionParameter {{[0-9]+}} [[x:[0-9]+]]
+; CHECK: ISub {{[0-9]+}} [[sub_res:[0-9]+]] [[three]] [[x]]
+; CHECK: UGreaterThan {{[0-9]+}} [[cmp_res:[0-9]+]] [[three]] [[x]]
+; CHECK: Select {{[0-9]+}} [[sel_res:[0-9]+]] [[cmp_res]] [[sub_res]] [[zero]]
+
+; Function Attrs: nounwind readnone speculatable willreturn
+declare i32 @llvm.usub.sat.i32(i32, i32) #1
+
+attributes #0 = { nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { nounwind readnone speculatable willreturn }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{i32 1, i32 2}


### PR DESCRIPTION
Translate usub.sat(a, b) as (a > b) ? a - b : 0 sequence.