### PR TITLE
Float Controls Decoration backport for 110 release

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -267,17 +267,17 @@ void PreprocessMetadata::preprocessVectorComputeMetadata(Module *M,
           .getValueAsString()
           .getAsInteger(0, Mode);
       spv::ExecutionMode ExecRoundMode =
-          VCRoundModeExecModeMap::map(getVCRoundMode(Mode));
+          FPRoundingModeExecModeMap::map(getFPRoundingMode(Mode));
       spv::ExecutionMode ExecFloatMode =
-          VCFloatModeExecModeMap::map(getVCFloatMode(Mode));
+          FPOperationModeExecModeMap::map(getFPOperationMode(Mode));
       VCFloatTypeSizeMap::foreach (
           [&](VCFloatType FloatType, unsigned TargetWidth) {
             EM.addOp().add(&F).add(ExecRoundMode).add(TargetWidth).done();
             EM.addOp().add(&F).add(ExecFloatMode).add(TargetWidth).done();
             EM.addOp()
                 .add(&F)
-                .add(VCDenormModeExecModeMap::map(
-                    getVCDenormPreserve(Mode, FloatType)))
+                .add(FPDenormModeExecModeMap::map(
+                    getFPDenormMode(Mode, FloatType)))
                 .add(TargetWidth)
                 .done();
           });

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3823,7 +3823,7 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
           static_cast<SPIRVDecorateFunctionFloatingPointModeINTEL const *>(
               FloatModes.at(0));
       auto FloatingMode = DecFlt->getOperationMode();
-#ifdef NDEBUG
+#ifndef NDEBUG
       for (auto *DecPreCast : FloatModes) {
         auto *Dec =
             static_cast<SPIRVDecorateFunctionFloatingPointModeINTEL const *>(

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3749,27 +3749,95 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
   unsigned FloatControl = 0;
   // RoundMode and FloatMode are always same for all types in Cm
   // While Denorm could be different for double, float and half
-  VCRoundModeExecModeMap::foreach ([&](VCRoundMode VCRM, ExecutionMode EM) {
-    if (BF->getExecutionMode(EM)) {
+  if (isKernel(BF)) {
+    FPRoundingModeExecModeMap::foreach (
+        [&](FPRoundingMode VCRM, ExecutionMode EM) {
+          if (BF->getExecutionMode(EM)) {
+            IsVCFloatControl = true;
+            FloatControl |= getVCFloatControl(VCRM);
+          }
+        });
+    FPOperationModeExecModeMap::foreach (
+        [&](FPOperationMode VCFM, ExecutionMode EM) {
+          if (BF->getExecutionMode(EM)) {
+            IsVCFloatControl = true;
+            FloatControl |= getVCFloatControl(VCFM);
+          }
+        });
+    FPDenormModeExecModeMap::foreach ([&](FPDenormMode VCDM, ExecutionMode EM) {
+      auto ExecModes = BF->getExecutionModeRange(EM);
+      for (auto It = ExecModes.first; It != ExecModes.second; It++) {
+        IsVCFloatControl = true;
+        unsigned TargetWidth = (*It).second->getLiterals()[0];
+        VCFloatType FloatType = VCFloatTypeSizeMap::rmap(TargetWidth);
+        FloatControl |= getVCFloatControl(VCDM, FloatType);
+      }
+    });
+  } else {
+    if (BF->hasDecorate(DecorationFunctionRoundingModeINTEL)) {
+      std::vector<SPIRVDecorate const *> RoundModes =
+          BF->getDecorations(DecorationFunctionRoundingModeINTEL);
+
+      assert(RoundModes.size() == 3 && "Function must have precisely 3 "
+                                       "FunctionRoundingModeINTEL decoration");
+
+      auto *DecRound =
+          static_cast<SPIRVDecorateFunctionRoundingModeINTEL const *>(
+              RoundModes.at(0));
+      auto RoundingMode = DecRound->getRoundingMode();
+#ifndef NDEBUG
+      for (auto *DecPreCast : RoundModes) {
+        auto *Dec = static_cast<SPIRVDecorateFunctionRoundingModeINTEL const *>(
+            DecPreCast);
+        assert(Dec->getRoundingMode() == RoundingMode &&
+               "Rounding Mode must be equal within all targets");
+      }
+#endif
       IsVCFloatControl = true;
-      FloatControl |= getVCFloatControl(VCRM);
+      FloatControl |= getVCFloatControl(RoundingMode);
     }
-  });
-  VCFloatModeExecModeMap::foreach ([&](VCFloatMode VCFM, ExecutionMode EM) {
-    if (BF->getExecutionMode(EM)) {
+
+    if (BF->hasDecorate(DecorationFunctionDenormModeINTEL)) {
+      std::vector<SPIRVDecorate const *> DenormModes =
+          BF->getDecorations(DecorationFunctionDenormModeINTEL);
       IsVCFloatControl = true;
-      FloatControl |= getVCFloatControl(VCFM);
+
+      for (auto DecPtr : DenormModes) {
+        auto DecDenorm =
+            static_cast<SPIRVDecorateFunctionDenormModeINTEL const *>(DecPtr);
+        VCFloatType FType =
+            VCFloatTypeSizeMap::rmap(DecDenorm->getTargetWidth());
+        FloatControl |= getVCFloatControl(DecDenorm->getDenormMode(), FType);
+      }
     }
-  });
-  VCDenormModeExecModeMap::foreach ([&](VCDenormMode VCDM, ExecutionMode EM) {
-    auto ExecModes = BF->getExecutionModeRange(EM);
-    for (auto It = ExecModes.first; It != ExecModes.second; It++) {
+
+    if (BF->hasDecorate(DecorationFunctionFloatingPointModeINTEL)) {
+      std::vector<SPIRVDecorate const *> FloatModes =
+          BF->getDecorations(DecorationFunctionFloatingPointModeINTEL);
+
+      assert(FloatModes.size() == 3 &&
+             "Function must have precisely 3 FunctionFloatingPointModeINTEL "
+             "decoration");
+
+      auto *DecFlt =
+          static_cast<SPIRVDecorateFunctionFloatingPointModeINTEL const *>(
+              FloatModes.at(0));
+      auto FloatingMode = DecFlt->getOperationMode();
+#ifdef NDEBUG
+      for (auto *DecPreCast : FloatModes) {
+        auto *Dec =
+            static_cast<SPIRVDecorateFunctionFloatingPointModeINTEL const *>(
+                DecPreCast);
+        assert(Dec->getOperationMode() == FloatingMode &&
+               "Rounding Mode must be equal within all targets");
+      }
+#endif
+
       IsVCFloatControl = true;
-      unsigned TargetWidth = (*It).second->getLiterals()[0];
-      VCFloatType FloatType = VCFloatTypeSizeMap::rmap(TargetWidth);
-      FloatControl |= getVCFloatControl(VCDM, FloatType);
+      FloatControl |= getVCFloatControl(FloatingMode);
     }
-  });
+  }
+
   if (IsVCFloatControl) {
     Attribute Attr = Attribute::get(*Context, kVCMetadata::VCFloatControl,
                                     std::to_string(FloatControl));

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -584,6 +584,7 @@ SPIRVFunction *LLVMToSPIRV::transFunctionDecl(Function *F) {
 }
 
 void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
+  using namespace VectorComputeUtil;
   if (!BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
     return;
   auto BF = static_cast<SPIRVFunction *>(getTranslatedValue(F));
@@ -616,6 +617,27 @@ void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
           .getAsInteger(0, Kind);
       BA->addDecorate(DecorationFuncParamIOKind, Kind);
     }
+  }
+  if (!isKernel(F) &&
+      BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_float_controls2) &&
+      Attrs.hasFnAttribute(kVCMetadata::VCFloatControl)) {
+
+    SPIRVWord Mode = 0;
+    Attrs
+        .getAttribute(AttributeList::FunctionIndex, kVCMetadata::VCFloatControl)
+        .getValueAsString()
+        .getAsInteger(0, Mode);
+    VCFloatTypeSizeMap::foreach (
+        [&](VCFloatType FloatType, unsigned TargetWidth) {
+          BF->addDecorate(new SPIRVDecorateFunctionDenormModeINTEL(
+              BF, TargetWidth, getFPDenormMode(Mode, FloatType)));
+
+          BF->addDecorate(new SPIRVDecorateFunctionRoundingModeINTEL(
+              BF, TargetWidth, getFPRoundingMode(Mode)));
+
+          BF->addDecorate(new SPIRVDecorateFunctionFloatingPointModeINTEL(
+              BF, TargetWidth, getFPOperationMode(Mode)));
+        });
   }
 }
 

--- a/lib/SPIRV/VectorComputeUtil.cpp
+++ b/lib/SPIRV/VectorComputeUtil.cpp
@@ -62,18 +62,18 @@ enum VCFloatControlMask {
   VC_FLOAT_MASK = (VC_FLOAT_MODE_IEEE | VC_FLOAT_MODE_ALT)
 };
 
-typedef SPIRVMap<VCRoundMode, VCFloatControl> VCRoundModeControlBitMap;
-typedef SPIRVMap<VCFloatMode, VCFloatControl> VCFloatModeControlBitMap;
+typedef SPIRVMap<FPRoundingMode, VCFloatControl> FPRoundingModeControlBitMap;
+typedef SPIRVMap<FPOperationMode, VCFloatControl> FPOperationModeControlBitMap;
 typedef SPIRVMap<VCFloatType, VCFloatControl> VCFloatTypeDenormMaskMap;
-template <> inline void SPIRVMap<VCRoundMode, VCFloatControl>::init() {
-  add(RTE, VC_RTE);
-  add(RTP, VC_RTP);
-  add(RTN, VC_RTN);
-  add(RTZ, VC_RTZ);
+template <> inline void SPIRVMap<FPRoundingMode, VCFloatControl>::init() {
+  add(spv::FPRoundingModeRTE, VC_RTE);
+  add(spv::FPRoundingModeRTP, VC_RTP);
+  add(spv::FPRoundingModeRTN, VC_RTN);
+  add(spv::FPRoundingModeRTZ, VC_RTZ);
 }
-template <> inline void SPIRVMap<VCFloatMode, VCFloatControl>::init() {
-  add(IEEE, VC_FLOAT_MODE_IEEE);
-  add(ALT, VC_FLOAT_MODE_ALT);
+template <> inline void SPIRVMap<FPOperationMode, VCFloatControl>::init() {
+  add(spv::FPOperationModeIEEE, VC_FLOAT_MODE_IEEE);
+  add(spv::FPOperationModeALT, VC_FLOAT_MODE_ALT);
 }
 template <> inline void SPIRVMap<VCFloatType, VCFloatControl>::init() {
   add(Double, VC_DENORM_D_ALLOW);
@@ -83,32 +83,34 @@ template <> inline void SPIRVMap<VCFloatType, VCFloatControl>::init() {
 
 namespace VectorComputeUtil {
 
-VCRoundMode getVCRoundMode(unsigned FloatControl) noexcept {
-  return VCRoundModeControlBitMap::rmap(
+FPRoundingMode getFPRoundingMode(unsigned FloatControl) noexcept {
+  return FPRoundingModeControlBitMap::rmap(
       VCFloatControl(VC_ROUND_MASK & FloatControl));
 }
 
-VCDenormMode getVCDenormPreserve(unsigned FloatControl,
-                                 VCFloatType FloatType) noexcept {
+FPDenormMode getFPDenormMode(unsigned FloatControl,
+                             VCFloatType FloatType) noexcept {
   VCFloatControl DenormMask =
       VCFloatTypeDenormMaskMap::map(FloatType); // 1 Bit mask
-  return (DenormMask == (DenormMask & FloatControl)) ? Preserve : FlushToZero;
+  return (DenormMask == (DenormMask & FloatControl))
+             ? spv::FPDenormModePreserve
+             : spv::FPDenormModeFlushToZero;
 }
 
-VCFloatMode getVCFloatMode(unsigned FloatControl) noexcept {
-  return VCFloatModeControlBitMap::rmap(
+FPOperationMode getFPOperationMode(unsigned FloatControl) noexcept {
+  return FPOperationModeControlBitMap::rmap(
       VCFloatControl(VC_FLOAT_MASK & FloatControl));
 }
 
-unsigned getVCFloatControl(VCRoundMode RoundMode) noexcept {
-  return VCRoundModeControlBitMap::map(RoundMode);
+unsigned getVCFloatControl(FPRoundingMode RoundMode) noexcept {
+  return FPRoundingModeControlBitMap::map(RoundMode);
 }
-unsigned getVCFloatControl(VCFloatMode FloatMode) noexcept {
-  return VCFloatModeControlBitMap::map(FloatMode);
+unsigned getVCFloatControl(FPOperationMode FloatMode) noexcept {
+  return FPOperationModeControlBitMap::map(FloatMode);
 }
-unsigned getVCFloatControl(VCDenormMode DenormMode,
+unsigned getVCFloatControl(FPDenormMode DenormMode,
                            VCFloatType FloatType) noexcept {
-  if (DenormMode == Preserve)
+  if (DenormMode == spv::FPDenormModePreserve)
     return VCFloatTypeDenormMaskMap::map(FloatType);
   return VC_DENORM_FTZ;
 }

--- a/lib/SPIRV/VectorComputeUtil.h
+++ b/lib/SPIRV/VectorComputeUtil.h
@@ -52,40 +52,28 @@ namespace VectorComputeUtil {
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-enum VCRoundMode {
-  RTE, // Round to nearest or even
-  RTP, // Round towards +ve inf
-  RTN, // Round towards -ve inf
-  RTZ, // Round towards zero
-};
-enum VCDenormMode {
-  FlushToZero,
-  Preserve,
-};
-enum VCFloatMode {
-  IEEE, // Single precision float IEEE mode
-  ALT,  // Single precision float ALT mode
-};
 enum VCFloatType {
   Double,
   Float,
   Half,
 };
 
-VCRoundMode getVCRoundMode(unsigned FloatControl) noexcept;
-VCDenormMode getVCDenormPreserve(unsigned FloatControl,
-                                 VCFloatType FloatType) noexcept;
-VCFloatMode getVCFloatMode(unsigned FloatControl) noexcept;
+FPRoundingMode getFPRoundingMode(unsigned FloatControl) noexcept;
+FPDenormMode getFPDenormMode(unsigned FloatControl,
+                             VCFloatType FloatType) noexcept;
+FPOperationMode getFPOperationMode(unsigned FloatControl) noexcept;
 
-unsigned getVCFloatControl(VCRoundMode RoundMode) noexcept;
-unsigned getVCFloatControl(VCFloatMode FloatMode) noexcept;
-unsigned getVCFloatControl(VCDenormMode DenormMode,
+unsigned getVCFloatControl(FPRoundingMode RoundMode) noexcept;
+unsigned getVCFloatControl(FPOperationMode FloatMode) noexcept;
+unsigned getVCFloatControl(FPDenormMode DenormMode,
                            VCFloatType FloatType) noexcept;
 
-typedef SPIRV::SPIRVMap<VCRoundMode, spv::ExecutionMode> VCRoundModeExecModeMap;
-typedef SPIRV::SPIRVMap<VCFloatMode, spv::ExecutionMode> VCFloatModeExecModeMap;
-typedef SPIRV::SPIRVMap<VCDenormMode, spv::ExecutionMode>
-    VCDenormModeExecModeMap;
+typedef SPIRV::SPIRVMap<FPRoundingMode, spv::ExecutionMode>
+    FPRoundingModeExecModeMap;
+typedef SPIRV::SPIRVMap<FPOperationMode, spv::ExecutionMode>
+    FPOperationModeExecModeMap;
+typedef SPIRV::SPIRVMap<FPDenormMode, spv::ExecutionMode>
+    FPDenormModeExecModeMap;
 typedef SPIRV::SPIRVMap<VCFloatType, unsigned> VCFloatTypeSizeMap;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -127,24 +115,21 @@ const static char VCSIMTCall[] = "VCSIMTCall";
 
 namespace SPIRV {
 template <>
-inline void
-SPIRVMap<VectorComputeUtil::VCRoundMode, spv::ExecutionMode>::init() {
-  add(VectorComputeUtil::RTE, spv::ExecutionModeRoundingModeRTE);
-  add(VectorComputeUtil::RTZ, spv::ExecutionModeRoundingModeRTZ);
-  add(VectorComputeUtil::RTP, spv::ExecutionModeRoundingModeRTPINTEL);
-  add(VectorComputeUtil::RTN, spv::ExecutionModeRoundingModeRTNINTEL);
+inline void SPIRVMap<spv::FPRoundingMode, spv::ExecutionMode>::init() {
+  add(spv::FPRoundingModeRTE, spv::ExecutionModeRoundingModeRTE);
+  add(spv::FPRoundingModeRTZ, spv::ExecutionModeRoundingModeRTZ);
+  add(spv::FPRoundingModeRTP, spv::ExecutionModeRoundingModeRTPINTEL);
+  add(spv::FPRoundingModeRTN, spv::ExecutionModeRoundingModeRTNINTEL);
 }
 template <>
-inline void
-SPIRVMap<VectorComputeUtil::VCDenormMode, spv::ExecutionMode>::init() {
-  add(VectorComputeUtil::FlushToZero, spv::ExecutionModeDenormFlushToZero);
-  add(VectorComputeUtil::Preserve, spv::ExecutionModeDenormPreserve);
+inline void SPIRVMap<spv::FPDenormMode, spv::ExecutionMode>::init() {
+  add(spv::FPDenormModeFlushToZero, spv::ExecutionModeDenormFlushToZero);
+  add(spv::FPDenormModePreserve, spv::ExecutionModeDenormPreserve);
 }
 template <>
-inline void
-SPIRVMap<VectorComputeUtil::VCFloatMode, spv::ExecutionMode>::init() {
-  add(VectorComputeUtil::IEEE, spv::ExecutionModeFloatingPointModeIEEEINTEL);
-  add(VectorComputeUtil::ALT, spv::ExecutionModeFloatingPointModeALTINTEL);
+inline void SPIRVMap<spv::FPOperationMode, spv::ExecutionMode>::init() {
+  add(spv::FPOperationModeIEEE, spv::ExecutionModeFloatingPointModeIEEEINTEL);
+  add(spv::FPOperationModeALT, spv::ExecutionModeFloatingPointModeALTINTEL);
 }
 template <>
 inline void SPIRVMap<VectorComputeUtil::VCFloatType, unsigned>::init() {

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -71,6 +71,15 @@ SPIRVDecorateGeneric::SPIRVDecorateGeneric(Op OC, SPIRVWord WC,
   updateModuleVersion();
 }
 
+SPIRVDecorateGeneric::SPIRVDecorateGeneric(Op OC, SPIRVWord WC,
+                                           Decoration TheDec,
+                                           SPIRVEntry *TheTarget, SPIRVWord V1,
+                                           SPIRVWord V2)
+    : SPIRVDecorateGeneric(OC, WC, TheDec, TheTarget, V1) {
+  Literals.push_back(V2);
+  validate();
+  updateModuleVersion();
+}
 SPIRVDecorateGeneric::SPIRVDecorateGeneric(Op OC)
     : SPIRVAnnotationGeneric(OC), Dec(DecorationRelaxedPrecision),
       Owner(nullptr) {}

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -57,6 +57,9 @@ public:
   // Complete constructor for decorations with one word literal
   SPIRVDecorateGeneric(Op OC, SPIRVWord WC, Decoration TheDec,
                        SPIRVEntry *TheTarget, SPIRVWord V);
+  // Complete constructor for decorations with two word literals
+  SPIRVDecorateGeneric(Op OC, SPIRVWord WC, Decoration TheDec,
+                       SPIRVEntry *TheTarget, SPIRVWord V1, SPIRVWord V2);
   // Incomplete constructor
   SPIRVDecorateGeneric(Op OC);
 
@@ -134,6 +137,10 @@ public:
   // Complete constructor for decorations with one word literal
   SPIRVDecorate(Decoration TheDec, SPIRVEntry *TheTarget, SPIRVWord V)
       : SPIRVDecorateGeneric(OC, 4, TheDec, TheTarget, V) {}
+  // Complete constructor for decorations with two word literals
+  SPIRVDecorate(Decoration TheDec, SPIRVEntry *TheTarget, SPIRVWord V1,
+                SPIRVWord V2)
+      : SPIRVDecorateGeneric(OC, 5, TheDec, TheTarget, V1, V2) {}
   // Incomplete constructor
   SPIRVDecorate() : SPIRVDecorateGeneric(OC) {}
 

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -173,6 +173,10 @@ public:
       return getSet(ExtensionID::SPV_INTEL_io_pipes);
     case DecorationBufferLocationINTEL:
       return getSet(ExtensionID::SPV_INTEL_fpga_buffer_location);
+    case DecorationFunctionFloatingPointModeINTEL:
+    case DecorationFunctionRoundingModeINTEL:
+    case DecorationFunctionDenormModeINTEL:
+      return getSet(ExtensionID::SPV_INTEL_float_controls2);
     default:
       return SPIRVExtSet();
     }
@@ -550,6 +554,51 @@ public:
     Literals = TheBits;
     WordCount += Literals.size();
   }
+};
+
+class SPIRVDecorateFunctionRoundingModeINTEL : public SPIRVDecorate {
+public:
+  // Complete constructor for SPIRVDecorateFunctionRoundingModeINTEL
+  SPIRVDecorateFunctionRoundingModeINTEL(SPIRVEntry *TheTarget,
+                                         SPIRVWord TargetWidth,
+                                         spv::FPRoundingMode FloatControl)
+      : SPIRVDecorate(spv::DecorationFunctionRoundingModeINTEL, TheTarget,
+                      TargetWidth, static_cast<SPIRVWord>(FloatControl)){};
+
+  SPIRVWord getTargetWidth() const { return Literals.at(0); };
+  spv::FPRoundingMode getRoundingMode() const {
+    return static_cast<spv::FPRoundingMode>(Literals.at(1));
+  };
+};
+
+class SPIRVDecorateFunctionDenormModeINTEL : public SPIRVDecorate {
+public:
+  // Complete constructor for SPIRVDecorateFunctionDenormModeINTEL
+  SPIRVDecorateFunctionDenormModeINTEL(SPIRVEntry *TheTarget,
+                                       SPIRVWord TargetWidth,
+                                       spv::FPDenormMode FloatControl)
+      : SPIRVDecorate(spv::DecorationFunctionDenormModeINTEL, TheTarget,
+                      TargetWidth, static_cast<SPIRVWord>(FloatControl)){};
+
+  SPIRVWord getTargetWidth() const { return Literals.at(0); };
+  spv::FPDenormMode getDenormMode() const {
+    return static_cast<spv::FPDenormMode>(Literals.at(1));
+  };
+};
+
+class SPIRVDecorateFunctionFloatingPointModeINTEL : public SPIRVDecorate {
+public:
+  // Complete constructor for SPIRVDecorateFunctionOperationModeINTEL
+  SPIRVDecorateFunctionFloatingPointModeINTEL(SPIRVEntry *TheTarget,
+                                              SPIRVWord TargetWidth,
+                                              spv::FPOperationMode FloatControl)
+      : SPIRVDecorate(spv::DecorationFunctionFloatingPointModeINTEL, TheTarget,
+                      TargetWidth, static_cast<SPIRVWord>(FloatControl)){};
+
+  SPIRVWord getTargetWidth() const { return Literals.at(0); };
+  spv::FPOperationMode getOperationMode() const {
+    return static_cast<spv::FPOperationMode>(Literals.at(1));
+  };
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -388,6 +388,17 @@ std::set<SPIRVWord> SPIRVEntry::getDecorate(Decoration Kind,
   return Value;
 }
 
+std::vector<SPIRVDecorate const *>
+SPIRVEntry::getDecorations(Decoration Kind) const {
+  auto Range = Decorates.equal_range(Kind);
+  std::vector<SPIRVDecorate const *> Decors;
+  Decors.reserve(Decorates.count(Kind));
+  for (auto I = Range.first, E = Range.second; I != E; ++I) {
+    Decors.push_back(I->second);
+  }
+  return Decors;
+}
+
 bool SPIRVEntry::hasLinkageType() const {
   return OpCode == OpFunction || OpCode == OpVariable;
 }

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -304,6 +304,7 @@ public:
   getMemberDecorationStringLiteral(Decoration Kind,
                                    SPIRVWord MemberNumber) const;
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;
+  std::vector<SPIRVDecorate const *> getDecorations(Decoration Kind) const;
   bool hasId() const { return !(Attrib & SPIRVEA_NOID); }
   bool hasLine() const { return Line != nullptr; }
   bool hasLinkageType() const;

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -832,6 +832,7 @@ public:
       return getSet(ExtensionID::SPV_KHR_float_controls);
     case CapabilityRoundToInfinityINTEL:
     case CapabilityFloatingPointModeINTEL:
+    case CapabilityFunctionFloatControlINTEL:
       return getSet(ExtensionID::SPV_INTEL_float_controls2);
     case CapabilityVectorComputeINTEL:
     case CapabilityVectorAnyINTEL:

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -402,6 +402,12 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationPrefetchINTEL, {CapabilityFPGAMemoryAccessesINTEL});
   ADD_VEC_INIT(DecorationBufferLocationINTEL,
                {CapabilityFPGABufferLocationINTEL});
+  ADD_VEC_INIT(DecorationFunctionRoundingModeINTEL,
+               {CapabilityFunctionFloatControlINTEL});
+  ADD_VEC_INIT(DecorationFunctionDenormModeINTEL,
+               {CapabilityFunctionFloatControlINTEL});
+  ADD_VEC_INIT(DecorationFunctionFloatingPointModeINTEL,
+               {CapabilityFunctionFloatControlINTEL});
 }
 
 template <> inline void SPIRVMap<BuiltIn, SPIRVCapVec>::init() {

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -434,6 +434,9 @@ inline bool isValid(spv::Decoration V) {
   case DecorationGlobalVariableOffsetINTEL:
   case DecorationFuncParamIOKind:
   case DecorationSIMTCallINTEL:
+  case DecorationFunctionRoundingModeINTEL:
+  case DecorationFunctionDenormModeINTEL:
+  case DecorationFunctionFloatingPointModeINTEL:
     return true;
   default:
     return false;
@@ -616,6 +619,7 @@ inline bool isValid(spv::Capability V) {
   case CapabilityUnstructuredLoopControlsINTEL:
   case CapabilityKernelAttributesINTEL:
   case CapabilityFPGAKernelAttributesINTEL:
+  case CapabilityFunctionFloatControlINTEL:
     return true;
   default:
     return false;

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -375,6 +375,11 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationFuncParamIOKind, "FuncParamIOKind");
   add(DecorationSIMTCallINTEL, "SIMTCallINTEL");
   add(DecorationBufferLocationINTEL, "BufferLocationINTEL");
+  add(DecorationFunctionRoundingModeINTEL, "FunctionRoundingModeINTEL");
+  add(DecorationFunctionDenormModeINTEL, "FunctionDenormModeINTEL");
+  add(DecorationFunctionFloatingPointModeINTEL,
+      "FunctionFloatingPointModeINTEL");
+  add(DecorationMax, "Max");
 }
 SPIRV_DEF_NAMEMAP(Decoration, SPIRVDecorationNameMap)
 
@@ -562,6 +567,10 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilityFPGABufferLocationINTEL, "FPGABufferLocationINTEL");
   add(CapabilityArbitraryPrecisionFloatingPointINTEL,
       "ArbitraryPrecisionFloatingPointINTEL");
+  add(CapabilityArbitraryPrecisionFloatingPointINTEL,
+      "ArbitraryPrecisionFloatingPointINTEL");
+  add(CapabilityFunctionFloatControlINTEL, "FunctionFloatControlINTEL");
+  add(CapabilityMax, "Max");
 }
 SPIRV_DEF_NAMEMAP(Capability, SPIRVCapabilityNameMap)
 

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -386,6 +386,16 @@ enum FPRoundingMode {
     FPRoundingModeMax = 0x7fffffff,
 };
 
+enum FPDenormMode {
+  FPDenormModePreserve = 0,
+  FPDenormModeFlushToZero = 1,
+};
+
+enum FPOperationMode {
+  FPOperationModeIEEE = 0,
+  FPOperationModeALT = 1,
+};
+
 enum LinkageType {
     LinkageTypeExport = 0,
     LinkageTypeImport = 1,
@@ -490,6 +500,8 @@ enum Decoration {
   DecorationHlslSemanticGOOGLE = 5635,
   DecorationUserSemantic = 5635,
   DecorationUserTypeGOOGLE = 5636,
+  DecorationFunctionRoundingModeINTEL = 5822,
+  DecorationFunctionDenormModeINTEL = 5823,
   DecorationRegisterINTEL = 5825,
   DecorationMemoryINTEL = 5826,
   DecorationNumbanksINTEL = 5827,
@@ -508,6 +520,7 @@ enum Decoration {
   DecorationPrefetchINTEL = 5902,
   DecorationBufferLocationINTEL = 5921,
   DecorationIOPipeStorageINTEL = 5944,
+  DecorationFunctionFloatingPointModeINTEL = 6080,
   DecorationMax = 0x7fffffff,
 };
 
@@ -953,6 +966,7 @@ enum Capability {
   CapabilitySubgroupAvcMotionEstimationChromaINTEL = 5698,
   CapabilityRoundToInfinityINTEL = 5582,
   CapabilityFloatingPointModeINTEL = 5583,
+  CapabilityFunctionFloatControlINTEL = 5821,
   CapabilityFPGAMemoryAttributesINTEL = 5824,
   CapabilityArbitraryPrecisionIntegersINTEL = 5844,
   CapabilityArbitraryPrecisionFloatingPointINTEL = 5845,

--- a/test/float-controls-decorations.ll
+++ b/test/float-controls-decorations.ll
@@ -1,0 +1,48 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute,+SPV_INTEL_float_controls2
+; RUN: llvm-spirv %t.spv -o %t.spt --to-text
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -o %t.bc -r 
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
+target triple = "spir64"
+
+
+define dso_local <4 x i32> @foo(<4 x i32> %a, <4 x i32> %b) #0 {
+entry:
+  ret <4 x i32> %a
+}
+
+define dso_local <4 x i32> @bar(<4 x i32> %a, <4 x i32> %b) #1 {
+entry:
+  ret <4 x i32> %b
+}
+
+
+; CHECK-LLVM: "VCFloatControl"="0"
+; CHECK-LLVM: "VCFloatControl"="48"
+; CHECK-SPIRV: 3 Name [[#FOO_ID:]] "foo"
+; CHECK-SPIRV: 3 Name [[#BAR_ID:]] "bar"
+; CHECK-SPIRV: 5 Decorate [[#DEC_DENORM_GROUP_ID:]] FunctionDenormModeINTEL 16 1
+; CHECK-SPIRV: 5 Decorate [[#DEC_DENORM_GROUP_ID+1]] FunctionDenormModeINTEL 32 1
+; CHECK-SPIRV: 5 Decorate [[#DEC_DENORM_GROUP_ID+2]] FunctionDenormModeINTEL 64 1
+; CHECK-SPIRV: 5 Decorate [[#DEC_FLT_GROUP_ID:]] FunctionFloatingPointModeINTEL 16 0
+; CHECK-SPIRV: 5 Decorate [[#DEC_FLT_GROUP_ID+1]] FunctionFloatingPointModeINTEL 32 0
+; CHECK-SPIRV: 5 Decorate [[#DEC_FLT_GROUP_ID+2]] FunctionFloatingPointModeINTEL 64 0
+; CHECK-SPIRV: 5 Decorate [[#FOO_ID]] FunctionRoundingModeINTEL 16 0
+; CHECK-SPIRV-NEXT: 5 Decorate [[#BAR_ID]] FunctionRoundingModeINTEL 16 1
+; CHECK-SPIRV-NEXT: 5 Decorate [[#FOO_ID]] FunctionRoundingModeINTEL 32 0
+; CHECK-SPIRV-NEXT: 5 Decorate [[#BAR_ID]] FunctionRoundingModeINTEL 32 1
+; CHECK-SPIRV-NEXT: 5 Decorate [[#FOO_ID]] FunctionRoundingModeINTEL 64 0
+; CHECK-SPIRV-NEXT: 5 Decorate [[#BAR_ID]] FunctionRoundingModeINTEL 64 1
+; CHECK-SPIRV: 4 GroupDecorate [[#DEC_DENORM_GROUP_ID]] [[#FOO_ID]] [[#BAR_ID]]
+; CHECK-SPIRV-NEXT: 4 GroupDecorate [[#DEC_DENORM_GROUP_ID+1]] [[#FOO_ID]] [[#BAR_ID]]
+; CHECK-SPIRV-NEXT: 4 GroupDecorate [[#DEC_DENORM_GROUP_ID+2]] [[#FOO_ID]] [[#BAR_ID]]
+; CHECK-SPIRV-NEXT: 4 GroupDecorate [[#DEC_FLT_GROUP_ID]] [[#FOO_ID]] [[#BAR_ID]]
+; CHECK-SPIRV-NEXT: 4 GroupDecorate [[#DEC_FLT_GROUP_ID+1]] [[#FOO_ID]] [[#BAR_ID]]
+; CHECK-SPIRV-NEXT: 4 GroupDecorate [[#DEC_FLT_GROUP_ID+2]] [[#FOO_ID]] [[#BAR_ID]]
+
+attributes #0 = { "VCFloatControl"="0" "VCFunction"  }
+attributes #1 = { "VCFloatControl"="48" "VCFunction" }
+
+


### PR DESCRIPTION
Backport of implementation of new Float Controls added by following specification:
https://github.com/intel/llvm/pull/1611

(Master pull request https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/677)