### PR TITLE
Update after LLVM changes

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -1173,7 +1173,7 @@ void OCL20ToSPIRV::visitCallGetImageSize(CallInst *CI,
         if (DemangledName == kOCLBuiltinName::GetImageDim) {
           if (Desc.Dim == Dim3D) {
             auto ZeroVec = ConstantVector::getSplat(
-                {3, false},
+                ElementCount::getFixed(3),
                 Constant::getNullValue(
                     cast<VectorType>(NCI->getType())->getElementType()));
             Constant *Index[] = {getInt32(M, 0), getInt32(M, 1), getInt32(M, 2),

--- a/test/DebugInfo/Generic/template-recursive-void.ll
+++ b/test/DebugInfo/Generic/template-recursive-void.ll
@@ -23,7 +23,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK: DW_TAG_template_type_parameter [{{.*}}]
 ; CHECK-NEXT: DW_AT_name{{.*}}"T"
 ; CHECK-NOT: DW_AT_type
-; CHECK: NULL
+; CHECK: {{DW_TAG|NULL}}
 
 source_filename = "test/DebugInfo/Generic/template-recursive-void.ll"
 


### PR DESCRIPTION
Propagate the change from LLVM commit 24c3dabef44 ("DebugInfo: Emit
class template parameters first, before members", 2020-08-17).

Update for LLVM commit a407ec9b6db ("Revert "Revert "[NFC][llvm] Make
the contructors of `ElementCount` private.""", 2020-08-19).