### PR TITLE
Add DebugInfoEIS option to allow setting desired extended instruction set for debug info on llvm_release_110 branch

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -71,6 +71,8 @@ enum class BIsRepresentation : uint32_t { OpenCL12, OpenCL20, SPIRVFriendlyIR };
 
 enum class FPContractMode : uint32_t { On, Off, Fast };
 
+enum class DebugInfoEIS : uint32_t { SPIRV_Debug, OpenCL_DebugInfo_100 };
+
 /// \brief Helper class to manage SPIR-V translation
 class TranslatorOpts {
 public:
@@ -146,6 +148,10 @@ public:
     SPIRVAllowUnknownIntrinsics = AllowUnknownIntrinsics;
   }
 
+  DebugInfoEIS getDebugInfoEIS() const { return DebugInfoVersion; }
+
+  void setDebugInfoEIS(DebugInfoEIS EIS) { DebugInfoVersion = EIS; }
+
 private:
   // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
@@ -172,6 +178,8 @@ private:
   // Unknown LLVM intrinsics will be translated as external function calls in
   // SPIR-V
   bool SPIRVAllowUnknownIntrinsics = false;
+
+  DebugInfoEIS DebugInfoVersion = DebugInfoEIS::OpenCL_DebugInfo_100;
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -86,7 +86,7 @@ SPIRVValue *LLVMToSPIRVDbgTran::createDebugDeclarePlaceholder(
   DbgDeclareIntrinsics.push_back(DbgDecl);
   using namespace SPIRVDebug::Operand::DebugDeclare;
   SPIRVWordVec Ops(OperandCount, getDebugInfoNoneId());
-  SPIRVId ExtSetId = BM->getExtInstSetId(SPIRVEIS_OpenCL_DebugInfo_100);
+  SPIRVId ExtSetId = BM->getExtInstSetId(BM->getDebugInfoEIS());
   return BM->addExtInst(getVoidTy(), ExtSetId, SPIRVDebug::Declare, Ops, BB);
 }
 
@@ -94,11 +94,9 @@ void LLVMToSPIRVDbgTran::finalizeDebugDeclare(
     const DbgVariableIntrinsic *DbgDecl) {
   SPIRVValue *V = SPIRVWriter->getTranslatedValue(DbgDecl);
   assert(V && "llvm.dbg.declare intrinsic isn't mapped to a SPIRV instruction");
-  assert(
-      V->isExtInst(SPIRV::SPIRVEIS_OpenCL_DebugInfo_100, SPIRVDebug::Declare) &&
-      "llvm.dbg.declare intrinsic has been translated wrong!");
-  if (!V ||
-      !V->isExtInst(SPIRV::SPIRVEIS_OpenCL_DebugInfo_100, SPIRVDebug::Declare))
+  assert(V->isExtInst(BM->getDebugInfoEIS(), SPIRVDebug::Declare) &&
+         "llvm.dbg.declare intrinsic has been translated wrong!");
+  if (!V || !V->isExtInst(BM->getDebugInfoEIS(), SPIRVDebug::Declare))
     return;
   SPIRVExtInst *DD = static_cast<SPIRVExtInst *>(V);
   SPIRVBasicBlock *BB = DD->getBasicBlock();
@@ -123,7 +121,7 @@ SPIRVValue *LLVMToSPIRVDbgTran::createDebugValuePlaceholder(
   DbgValueIntrinsics.push_back(DbgValue);
   using namespace SPIRVDebug::Operand::DebugValue;
   SPIRVWordVec Ops(MinOperandCount, getDebugInfoNone()->getId());
-  SPIRVId ExtSetId = BM->getExtInstSetId(SPIRVEIS_OpenCL_DebugInfo_100);
+  SPIRVId ExtSetId = BM->getExtInstSetId(BM->getDebugInfoEIS());
   return BM->addExtInst(getVoidTy(), ExtSetId, SPIRVDebug::Value, Ops, BB);
 }
 
@@ -131,11 +129,9 @@ void LLVMToSPIRVDbgTran::finalizeDebugValue(
     const DbgVariableIntrinsic *DbgValue) {
   SPIRVValue *V = SPIRVWriter->getTranslatedValue(DbgValue);
   assert(V && "llvm.dbg.value intrinsic isn't mapped to a SPIRV instruction");
-  assert(
-      V->isExtInst(SPIRV::SPIRVEIS_OpenCL_DebugInfo_100, SPIRVDebug::Value) &&
-      "llvm.dbg.value intrinsic has been translated wrong!");
-  if (!V ||
-      !V->isExtInst(SPIRV::SPIRVEIS_OpenCL_DebugInfo_100, SPIRVDebug::Value))
+  assert(V->isExtInst(BM->getDebugInfoEIS(), SPIRVDebug::Value) &&
+         "llvm.dbg.value intrinsic has been translated wrong!");
+  if (!V || !V->isExtInst(BM->getDebugInfoEIS(), SPIRVDebug::Value))
     return;
   SPIRVExtInst *DV = static_cast<SPIRVExtInst *>(V);
   SPIRVBasicBlock *BB = DV->getBasicBlock();
@@ -892,7 +888,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgScope(const DIScope *S) {
 SPIRVEntry *LLVMToSPIRVDbgTran::transDebugLoc(const DebugLoc &Loc,
                                               SPIRVBasicBlock *BB,
                                               SPIRVInstruction *InsertBefore) {
-  SPIRVId ExtSetId = BM->getExtInstSetId(SPIRVEIS_OpenCL_DebugInfo_100);
+  SPIRVId ExtSetId = BM->getExtInstSetId(BM->getDebugInfoEIS());
   if (!Loc.get())
     return BM->addExtInst(getVoidTy(), ExtSetId, SPIRVDebug::NoScope,
                           std::vector<SPIRVWord>(), BB, InsertBefore);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -175,7 +175,7 @@ bool LLVMToSPIRV::isBuiltinTransToExtInst(Function *F,
   SPIRVExtInstSetKind Set = SPIRVEIS_Count;
   if (!SPIRVExtSetShortNameMap::rfind(ExtSetName.str(), &Set))
     return false;
-  assert((Set == SPIRVEIS_OpenCL || Set == SPIRVEIS_OpenCL_DebugInfo_100) &&
+  assert((Set == SPIRVEIS_OpenCL || Set == BM->getDebugInfoEIS()) &&
          "Unsupported extended instruction set");
 
   auto ExtOpName = S.substr(Loc + 1);
@@ -1609,7 +1609,8 @@ bool LLVMToSPIRV::transBuiltinSet() {
   if (!BM->importBuiltinSet("OpenCL.std", &EISId))
     return false;
   if (SPIRVMDWalker(*M).getNamedMD("llvm.dbg.cu")) {
-    if (!BM->importBuiltinSet("OpenCL.DebugInfo.100", &EISId))
+    if (!BM->importBuiltinSet(
+            SPIRVBuiltinSetNameMap::map(BM->getDebugInfoEIS()), &EISId))
       return false;
   }
   return true;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1222,9 +1222,9 @@ SPIRVInstruction *SPIRVModuleImpl::addExtInst(
 
 SPIRVEntry *SPIRVModuleImpl::addDebugInfo(SPIRVWord InstId, SPIRVType *TheType,
                                           const std::vector<SPIRVWord> &Args) {
-  return addEntry(new SPIRVExtInst(
-      this, getId(), TheType, SPIRVEIS_OpenCL_DebugInfo_100,
-      ExtInstSetIds[SPIRVEIS_OpenCL_DebugInfo_100], InstId, Args));
+  return addEntry(
+      new SPIRVExtInst(this, getId(), TheType, SPIRVEIS_OpenCL_DebugInfo_100,
+                       ExtInstSetIds[getDebugInfoEIS()], InstId, Args));
 }
 
 SPIRVInstruction *

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -484,6 +484,18 @@ public:
     return TranslationOpts.isSPIRVAllowUnknownIntrinsicsEnabled();
   }
 
+  SPIRVExtInstSetKind getDebugInfoEIS() const {
+    switch (TranslationOpts.getDebugInfoEIS()) {
+    case DebugInfoEIS::SPIRV_Debug:
+      return SPIRVEIS_Debug;
+    case DebugInfoEIS::OpenCL_DebugInfo_100:
+      return SPIRVEIS_OpenCL_DebugInfo_100;
+    default:
+      assert(false && "Unexpected debug info EIS!");
+      return SPIRVEIS_Debug;
+    }
+  }
+
   // I/O functions
   friend spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M);
   friend std::istream &operator>>(std::istream &I, SPIRVModule &M);

--- a/test/DebugInfo/Generic/debug-info-eis-option.ll
+++ b/test/DebugInfo/Generic/debug-info-eis-option.ll
@@ -1,0 +1,83 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=legacy
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
+
+; RUN: llc -mtriple=%triple -stop-before=finalize-isel -pre-RA-sched=linearize < %t.ll | FileCheck %s
+
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck --check-prefix CHECK-SPIRV %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+; CHECK-SPIRV: ExtInstImport [[Set:[0-9]+]] "SPIRV.debug"
+; CHECK-SPIRV: TypeVoid [[Void:[0-9]+]]
+; CHECK-SPIRV: ExtInst [[Void]] {{[0-9]+}} [[Set]] DebugValue
+
+source_filename = "linear-dbg-value.ll"
+
+; Function Attrs: nounwind readonly uwtable
+define i32 @foo(i32* nocapture readonly %a, i32 %N) local_unnamed_addr #0 !dbg !6 {
+entry:
+  %cmp6 = icmp sgt i32 %N, 0, !dbg !11
+  br i1 %cmp6, label %for.body.preheader, label %for.cond.cleanup, !dbg !15
+
+for.body.preheader:                               ; preds = %entry
+  %wide.trip.count = zext i32 %N to i64
+  br label %for.body, !dbg !17
+
+for.cond.cleanup.loopexit:                        ; preds = %for.body
+  br label %for.cond.cleanup, !dbg !19
+
+for.cond.cleanup:                                 ; preds = %for.cond.cleanup.loopexit, %entry
+  %x.0.lcssa = phi i32 [ 0, %entry ], [ %add, %for.cond.cleanup.loopexit ]
+  ret i32 %x.0.lcssa, !dbg !19
+
+for.body:                                         ; preds = %for.body, %for.body.preheader
+; CHECK: ![[X:[0-9]+]] = !DILocalVariable(name: "x",
+; CHECK-LABEL: bb.3.for.body:
+; CHECK: DBG_VALUE {{.*}} ![[X]], !DIExpression()
+; CHECK: DBG_VALUE {{.*}} ![[X]], !DIExpression()
+  %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %for.body.preheader ]
+  %x.07 = phi i32 [ %add, %for.body ], [ 0, %for.body.preheader ]
+  %arrayidx = getelementptr inbounds i32, i32* %a, i64 %indvars.iv, !dbg !17
+  %0 = load i32, i32* %arrayidx, align 4, !dbg !17
+  %add = add nsw i32 %0, %x.07, !dbg !17
+  call void @llvm.dbg.value(metadata i32 %add, metadata !9, metadata !DIExpression()), !dbg !20
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1, !dbg !21
+  call void @llvm.dbg.value(metadata i32 %add, metadata !9, metadata !DIExpression()), !dbg !20
+  %exitcond = icmp eq i64 %indvars.iv.next, %wide.trip.count, !dbg !11
+  br i1 %exitcond, label %for.cond.cleanup.loopexit, label %for.body, !dbg !15
+}
+
+; Function Attrs: nounwind readnone speculatable
+declare void @llvm.dbg.value(metadata, metadata, metadata) #1
+
+attributes #0 = { nounwind readonly uwtable }
+attributes #1 = { nounwind readnone speculatable }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+!llvm.ident = !{!5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 4.0.1 ", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2)
+!1 = !DIFile(filename: "foo.c", directory: "/tmp")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{!"clang version 4.0.1 "}
+!6 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 2, type: !7, isLocal: false, isDefinition: true, scopeLine: 2, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !8)
+!7 = !DISubroutineType(types: !2)
+!8 = !{!9}
+!9 = !DILocalVariable(name: "x", scope: !6, file: !1, line: 3, type: !10)
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !DILocation(line: 4, scope: !12)
+!12 = !DILexicalBlockFile(scope: !13, file: !1, discriminator: 1)
+!13 = distinct !DILexicalBlock(scope: !14, file: !1, line: 4, column: 3)
+!14 = distinct !DILexicalBlock(scope: !6, file: !1, line: 4, column: 3)
+!15 = !DILocation(line: 4, scope: !16)
+!16 = !DILexicalBlockFile(scope: !14, file: !1, discriminator: 1)
+!17 = !DILocation(line: 5, scope: !18)
+!18 = distinct !DILexicalBlock(scope: !13, file: !1, line: 4, column: 31)
+!19 = !DILocation(line: 7, scope: !6)
+!20 = !DILocation(line: 3, scope: !6)
+!21 = !DILocation(line: 4, scope: !22)
+!22 = !DILexicalBlockFile(scope: !13, file: !1, discriminator: 3)

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -183,6 +183,19 @@ cl::opt<bool> SPIRVAllowUnknownIntrinsics(
     cl::desc("Unknown LLVM intrinsics will be translated as external function "
              "calls in SPIR-V"));
 
+static cl::opt<SPIRV::DebugInfoEIS> DebugEIS(
+    "spirv-debug-info-version", cl::desc("Set SPIR-V debug info version:"),
+    cl::init(SPIRV::DebugInfoEIS::OpenCL_DebugInfo_100),
+    cl::values(
+        clEnumValN(SPIRV::DebugInfoEIS::SPIRV_Debug, "legacy",
+                   "Emit debug info compliant with the SPIRV.debug extended "
+                   "instruction set. This option is used for compatibility "
+                   "with older versions of the translator"),
+        clEnumValN(SPIRV::DebugInfoEIS::OpenCL_DebugInfo_100, "ocl-100",
+                   "Emit debug info compliant with the OpenCL.DebugInfo.100 "
+                   "extended instruction set. This version of SPIR-V debug "
+                   "info format is compatible with the SPIRV-Tools")));
+
 static std::string removeExt(const std::string &FileName) {
   size_t Pos = FileName.find_last_of(".");
   if (Pos != std::string::npos)
@@ -565,6 +578,15 @@ int main(int Ac, char **Av) {
              "affects translation from LLVM IR to SPIR-V";
     } else {
       Opts.setSPIRVAllowUnknownIntrinsicsEnabled(SPIRVAllowUnknownIntrinsics);
+    }
+  }
+
+  if (DebugEIS.getNumOccurrences() != 0) {
+    if (IsReverse) {
+      errs() << "Note: --spirv-debug-info-version option ignored as it only "
+                "affects translation from LLVM IR to SPIR-V";
+    } else {
+      Opts.setDebugInfoEIS(DebugEIS);
     }
   }
 


### PR DESCRIPTION
This option required for compatibility with older version of translator