### PR TITLE
Be more tolerant with buffer_location MDNode type

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -559,7 +559,10 @@ SPIRVFunction *LLVMToSPIRV::transFunctionDecl(Function *F) {
       // Order of integer numbers in MD node follows the order of function
       // parameters on which we shall attach the appropriate decoration. Add
       // decoration only if MD value is not negative.
-      int LocID = getMDOperandAsInt(BufferLocation, ArgNo);
+      int LocID = -1;
+      if (!isa<MDString>(BufferLocation->getOperand(ArgNo)) &&
+          !isa<MDNode>(BufferLocation->getOperand(ArgNo)))
+        LocID = getMDOperandAsInt(BufferLocation, ArgNo);
       if (LocID >= 0) {
         BM->addCapability(CapabilityFPGABufferLocationINTEL);
         BA->addDecorate(DecorationBufferLocationINTEL, LocID);


### PR DESCRIPTION
Ignore other than constant integer type instead of crashing.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>