### PR TITLE
Fix emitting SPIRV metadata for non-kernel functions in PreprocessMetadata.cpp on llvm_release_90 branch

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -218,6 +218,9 @@ void PreprocessMetadata::preprocessVectorComputeMetadata(Module *M,
   auto EM = B->addNamedMD(kSPIRVMD::ExecutionMode);
 
   for (auto &F : *M) {
+    if (F.getCallingConv() != CallingConv::SPIR_KERNEL)
+      continue;
+
     // Add VC float control execution modes
     // RoundMode and FloatMode are always same for all types in VC
     // While Denorm could be different for double, float and half

--- a/test/nullptr-metadata-test.ll
+++ b/test/nullptr-metadata-test.ll
@@ -1,0 +1,10 @@
+; This test ensures that the translator does not crash
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+
+; ModuleID = 'test.bc'
+target triple = "spir64"
+
+declare dllexport void @test_func(i32) #0
+
+attributes #0 = { "VCSLMSize"="0" }


### PR DESCRIPTION
SPIRV metadata contains pointers to relevant functions
Passes like SPIRVLowerOCLBlocks and SPIRVRegularizeLLVM can erase
declarations with no usage and invalidate those pointers