### PR TITLE
[NFC] Avoid verifying module in release builds

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -40,6 +40,7 @@
 #include "OCLTypeToSPIRV.h"
 #include "OCLUtil.h"
 #include "SPIRVInternal.h"
+#include "libSPIRV/SPIRVDebug.h"
 
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Analysis/ValueTracking.h"
@@ -49,8 +50,6 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <set>
@@ -60,12 +59,6 @@ using namespace SPIRV;
 using namespace OCLUtil;
 
 namespace SPIRV {
-
-cl::opt<bool> SPIRVOCL20ToSPIRVValidate(
-    "cl20tospv-validate", cl::init(_SPIRVDBG),
-    cl::desc("Validate module after lowering OpenCL-specific into SPIR-V "
-             "friendly IR"));
-
 static size_t getOCLCpp11AtomicMaxNumOps(StringRef Name) {
   return StringSwitch<size_t>(Name)
       .Cases("load", "flag_test_and_set", "flag_clear", 3)
@@ -356,13 +349,7 @@ bool OCL20ToSPIRV::runOnModule(Module &Module) {
   eraseUselessFunctions(M); // remove unused functions declarations
   LLVM_DEBUG(dbgs() << "After OCL20ToSPIRV:\n" << *M);
 
-  if (SPIRVOCL20ToSPIRVValidate) {
-    std::string Err;
-    raw_string_ostream ErrorOS(Err);
-    if (verifyModule(*M, &ErrorOS)) {
-      LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
-    }
-  }
+  VERIFY_REGULARIZATION_PASS(*M, "OCL20ToSPIRV")
 
   return true;
 }

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -48,7 +48,6 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
 
 #include <algorithm>
@@ -349,7 +348,7 @@ bool OCL20ToSPIRV::runOnModule(Module &Module) {
   eraseUselessFunctions(M); // remove unused functions declarations
   LLVM_DEBUG(dbgs() << "After OCL20ToSPIRV:\n" << *M);
 
-  VERIFY_REGULARIZATION_PASS(*M, "OCL20ToSPIRV")
+  verifyRegularizationPass(*M, "OCL20ToSPIRV");
 
   return true;
 }

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -45,6 +45,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 #include <set>
@@ -54,6 +55,11 @@ using namespace SPIRV;
 using namespace OCLUtil;
 
 namespace SPIRV {
+
+cl::opt<bool>
+    SPIRVOCL21ToSPIRVValidate("cl21tospv-validate", cl::init(_SPIRVDBG),
+                              cl::desc("Validate module after lowering OpenCL "
+                                       "2.1 specific into SPIR-V friendly IR"));
 
 class OCL21ToSPIRV : public ModulePass, public InstVisitor<OCL21ToSPIRV> {
 public:
@@ -122,11 +128,14 @@ bool OCL21ToSPIRV::runOnModule(Module &Module) {
       GV->eraseFromParent();
 
   LLVM_DEBUG(dbgs() << "After OCL21ToSPIRV:\n" << *M);
-  std::string Err;
-  raw_string_ostream ErrorOS(Err);
-  if (verifyModule(*M, &ErrorOS)) {
-    LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
+  if (SPIRVOCL21ToSPIRVValidate) {
+    std::string Err;
+    raw_string_ostream ErrorOS(Err);
+    if (verifyModule(*M, &ErrorOS)) {
+      LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
+    }
   }
+
   return true;
 }
 

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -45,7 +45,6 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
 
 #include <set>
@@ -122,7 +121,7 @@ bool OCL21ToSPIRV::runOnModule(Module &Module) {
       GV->eraseFromParent();
 
   LLVM_DEBUG(dbgs() << "After OCL21ToSPIRV:\n" << *M);
-  VERIFY_REGULARIZATION_PASS(*M, "OCL21ToSPIRV")
+  verifyRegularizationPass(*M, "OCL21ToSPIRV");
 
   return true;
 }

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -39,14 +39,14 @@
 
 #include "OCLUtil.h"
 #include "SPIRVInternal.h"
+#include "libSPIRV/SPIRVDebug.h"
+
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 
 #include <set>
 
@@ -55,12 +55,6 @@ using namespace SPIRV;
 using namespace OCLUtil;
 
 namespace SPIRV {
-
-cl::opt<bool>
-    SPIRVOCL21ToSPIRVValidate("cl21tospv-validate", cl::init(_SPIRVDBG),
-                              cl::desc("Validate module after lowering OpenCL "
-                                       "2.1 specific into SPIR-V friendly IR"));
-
 class OCL21ToSPIRV : public ModulePass, public InstVisitor<OCL21ToSPIRV> {
 public:
   OCL21ToSPIRV() : ModulePass(ID), M(nullptr), Ctx(nullptr), CLVer(0) {
@@ -128,13 +122,7 @@ bool OCL21ToSPIRV::runOnModule(Module &Module) {
       GV->eraseFromParent();
 
   LLVM_DEBUG(dbgs() << "After OCL21ToSPIRV:\n" << *M);
-  if (SPIRVOCL21ToSPIRVValidate) {
-    std::string Err;
-    raw_string_ostream ErrorOS(Err);
-    if (verifyModule(*M, &ErrorOS)) {
-      LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
-    }
-  }
+  VERIFY_REGULARIZATION_PASS(*M, "OCL21ToSPIRV")
 
   return true;
 }

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -46,7 +46,6 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"

--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -48,7 +48,6 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
 
 using namespace llvm;
@@ -89,7 +88,7 @@ bool PreprocessMetadata::runOnModule(Module &Module) {
   visit(M);
   LLVM_DEBUG(dbgs() << "After PreprocessMetadata:\n" << *M);
 
-  VERIFY_REGULARIZATION_PASS(*M, "PreprocessMetadata")
+  verifyRegularizationPass(*M, "PreprocessMetadata");
 
   return true;
 }

--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -61,6 +61,10 @@ namespace SPIRV {
 cl::opt<bool> EraseOCLMD("spirv-erase-cl-md", cl::init(true),
                          cl::desc("Erase OpenCL metadata"));
 
+cl::opt<bool> SPIRVPreprocessMetadataValidate(
+    "clmdtospv-validate", cl::init(_SPIRVDBG),
+    cl::desc("Validate module after metadata preprocessing"));
+
 class PreprocessMetadata : public ModulePass {
 public:
   PreprocessMetadata() : ModulePass(ID), M(nullptr), Ctx(nullptr) {
@@ -89,12 +93,15 @@ bool PreprocessMetadata::runOnModule(Module &Module) {
   LLVM_DEBUG(dbgs() << "Enter PreprocessMetadata:\n");
   visit(M);
 
-  LLVM_DEBUG(dbgs() << "After PreprocessMetadata:\n" << *M);
-  std::string Err;
-  raw_string_ostream ErrorOS(Err);
-  if (verifyModule(*M, &ErrorOS)) {
-    LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
+  if (SPIRVPreprocessMetadataValidate) {
+    LLVM_DEBUG(dbgs() << "After PreprocessMetadata:\n" << *M);
+    std::string Err;
+    raw_string_ostream ErrorOS(Err);
+    if (verifyModule(*M, &ErrorOS)) {
+      LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
+    }
   }
+
   return true;
 }
 

--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -43,7 +43,6 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
 
 using namespace llvm;
@@ -115,7 +114,7 @@ public:
     Context = &M.getContext();
     visit(M);
 
-    VERIFY_REGULARIZATION_PASS(M, "SPIRVLowerBool")
+    verifyRegularizationPass(M, "SPIRVLowerBool");
     return true;
   }
 

--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -38,23 +38,18 @@
 #define DEBUG_TYPE "spvbool"
 
 #include "SPIRVInternal.h"
+#include "libSPIRV/SPIRVDebug.h"
+
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 
 using namespace llvm;
 using namespace SPIRV;
 
 namespace SPIRV {
-cl::opt<bool> SPIRVLowerBoolValidate(
-    "spvbool-validate",
-    cl::desc("Validate module after lowering boolean instructions for SPIR-V"),
-    cl::init(_SPIRVDBG));
-
 class SPIRVLowerBool : public ModulePass, public InstVisitor<SPIRVLowerBool> {
 public:
   SPIRVLowerBool() : ModulePass(ID), Context(nullptr) {
@@ -120,15 +115,7 @@ public:
     Context = &M.getContext();
     visit(M);
 
-    if (SPIRVLowerBoolValidate) {
-      LLVM_DEBUG(dbgs() << "After SPIRVLowerBool:\n" << M);
-      std::string Err;
-      raw_string_ostream ErrorOS(Err);
-      if (verifyModule(M, &ErrorOS)) {
-        Err = std::string("Fails to verify module: ") + Err;
-        report_fatal_error(Err.c_str(), false);
-      }
-    }
+    VERIFY_REGULARIZATION_PASS(M, "SPIRVLowerBool")
     return true;
   }
 

--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -52,7 +52,8 @@ using namespace SPIRV;
 namespace SPIRV {
 cl::opt<bool> SPIRVLowerBoolValidate(
     "spvbool-validate",
-    cl::desc("Validate module after lowering boolean instructions for SPIR-V"));
+    cl::desc("Validate module after lowering boolean instructions for SPIR-V"),
+    cl::init(_SPIRVDBG));
 
 class SPIRVLowerBool : public ModulePass, public InstVisitor<SPIRVLowerBool> {
 public:

--- a/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -48,7 +48,6 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
 
 #include <list>
@@ -92,7 +91,7 @@ bool SPIRVLowerConstExpr::runOnModule(Module &Module) {
   LLVM_DEBUG(dbgs() << "Enter SPIRVLowerConstExpr:\n");
   visit(M);
 
-  VERIFY_REGULARIZATION_PASS(*M, "SPIRVLowerConstExpr")
+  verifyRegularizationPass(*M, "SPIRVLowerConstExpr");
 
   return true;
 }

--- a/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -65,6 +65,10 @@ cl::opt<bool> SPIRVLowerConst(
     "spirv-lower-const-expr", cl::init(true),
     cl::desc("LLVM/SPIR-V translation enable lowering constant expression"));
 
+cl::opt<bool> SPIRVLowerConstExprValidate(
+    "spirv-lower-const-expr-validate", cl::init(_SPIRVDBG),
+    cl::desc("Validate module after lowering constant expressions"));
+
 class SPIRVLowerConstExpr : public ModulePass {
 public:
   SPIRVLowerConstExpr() : ModulePass(ID), M(nullptr), Ctx(nullptr) {
@@ -93,12 +97,15 @@ bool SPIRVLowerConstExpr::runOnModule(Module &Module) {
   LLVM_DEBUG(dbgs() << "Enter SPIRVLowerConstExpr:\n");
   visit(M);
 
-  LLVM_DEBUG(dbgs() << "After SPIRVLowerConstExpr:\n" << *M);
-  std::string Err;
-  raw_string_ostream ErrorOS(Err);
-  if (verifyModule(*M, &ErrorOS)) {
-    LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
+  if (SPIRVLowerConstExprValidate) {
+    LLVM_DEBUG(dbgs() << "After SPIRVLowerConstExpr:\n" << *M);
+    std::string Err;
+    raw_string_ostream ErrorOS(Err);
+    if (verifyModule(*M, &ErrorOS)) {
+      LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
+    }
   }
+
   return true;
 }
 

--- a/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -41,6 +41,7 @@
 #include "SPIRVInternal.h"
 #include "SPIRVMDBuilder.h"
 #include "SPIRVMDWalker.h"
+#include "libSPIRV/SPIRVDebug.h"
 
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Triple.h"
@@ -49,8 +50,6 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 
 #include <list>
 #include <set>
@@ -64,10 +63,6 @@ namespace SPIRV {
 cl::opt<bool> SPIRVLowerConst(
     "spirv-lower-const-expr", cl::init(true),
     cl::desc("LLVM/SPIR-V translation enable lowering constant expression"));
-
-cl::opt<bool> SPIRVLowerConstExprValidate(
-    "spirv-lower-const-expr-validate", cl::init(_SPIRVDBG),
-    cl::desc("Validate module after lowering constant expressions"));
 
 class SPIRVLowerConstExpr : public ModulePass {
 public:
@@ -97,14 +92,7 @@ bool SPIRVLowerConstExpr::runOnModule(Module &Module) {
   LLVM_DEBUG(dbgs() << "Enter SPIRVLowerConstExpr:\n");
   visit(M);
 
-  if (SPIRVLowerConstExprValidate) {
-    LLVM_DEBUG(dbgs() << "After SPIRVLowerConstExpr:\n" << *M);
-    std::string Err;
-    raw_string_ostream ErrorOS(Err);
-    if (verifyModule(*M, &ErrorOS)) {
-      LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
-    }
-  }
+  VERIFY_REGULARIZATION_PASS(*M, "SPIRVLowerConstExpr")
 
   return true;
 }

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -38,24 +38,19 @@
 #define DEBUG_TYPE "spvmemmove"
 
 #include "SPIRVInternal.h"
+#include "libSPIRV/SPIRVDebug.h"
+
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 
 using namespace llvm;
 using namespace SPIRV;
 
 namespace SPIRV {
-cl::opt<bool> SPIRVLowerMemmoveValidate(
-    "spvmemmove-validate", cl::init(_SPIRVDBG),
-    cl::desc("Validate module after lowering llvm.memmove instructions into "
-             "llvm.memcpy"));
-
 class SPIRVLowerMemmove : public ModulePass,
                           public InstVisitor<SPIRVLowerMemmove> {
 public:
@@ -119,15 +114,7 @@ public:
     Mod = &M;
     visit(M);
 
-    if (SPIRVLowerMemmoveValidate) {
-      LLVM_DEBUG(dbgs() << "After SPIRVLowerMemmove:\n" << M);
-      std::string Err;
-      raw_string_ostream ErrorOS(Err);
-      if (verifyModule(M, &ErrorOS)) {
-        Err = std::string("Fails to verify module: ") + Err;
-        report_fatal_error(Err.c_str(), false);
-      }
-    }
+    VERIFY_REGULARIZATION_PASS(M, "SPIRVLowerMemmove")
     return true;
   }
 

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -52,7 +52,7 @@ using namespace SPIRV;
 
 namespace SPIRV {
 cl::opt<bool> SPIRVLowerMemmoveValidate(
-    "spvmemmove-validate",
+    "spvmemmove-validate", cl::init(_SPIRVDBG),
     cl::desc("Validate module after lowering llvm.memmove instructions into "
              "llvm.memcpy"));
 

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -44,7 +44,6 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
 
 using namespace llvm;
@@ -114,7 +113,7 @@ public:
     Mod = &M;
     visit(M);
 
-    VERIFY_REGULARIZATION_PASS(M, "SPIRVLowerMemmove")
+    verifyRegularizationPass(M, "SPIRVLowerMemmove");
     return true;
   }
 

--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
@@ -57,7 +57,7 @@ using namespace SPIRV;
 
 namespace SPIRV {
 cl::opt<bool> SPIRVLowerSaddWithOverflowValidate(
-    "spv-lower-saddwithoverflow-validate",
+    "spv-lower-saddwithoverflow-validate", cl::init(_SPIRVDBG),
     cl::desc("Validate module after lowering llvm.sadd.with.overflow.*"
              "intrinsics"));
 

--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
@@ -48,7 +48,6 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/Pass.h"
@@ -121,7 +120,7 @@ public:
     Mod = &M;
     visit(M);
 
-    VERIFY_REGULARIZATION_PASS(M, "SPIRVLowerSaddWithOverflow")
+    verifyRegularizationPass(M, "SPIRVLowerSaddWithOverflow");
     return TheModuleIsModified;
   }
 

--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
@@ -39,9 +39,12 @@
 //===----------------------------------------------------------------------===//
 #define DEBUG_TYPE "spv-lower-llvm_sadd_with_overflow"
 
-#include "LLVMSPIRVLib.h"
 #include "LLVMSaddWithOverflow.h"
+
+#include "LLVMSPIRVLib.h"
 #include "SPIRVError.h"
+#include "libSPIRV/SPIRVDebug.h"
+
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
@@ -49,18 +52,11 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 
 using namespace llvm;
 using namespace SPIRV;
 
 namespace SPIRV {
-cl::opt<bool> SPIRVLowerSaddWithOverflowValidate(
-    "spv-lower-saddwithoverflow-validate", cl::init(_SPIRVDBG),
-    cl::desc("Validate module after lowering llvm.sadd.with.overflow.*"
-             "intrinsics"));
-
 class SPIRVLowerSaddWithOverflow
     : public ModulePass,
       public InstVisitor<SPIRVLowerSaddWithOverflow> {
@@ -125,15 +121,7 @@ public:
     Mod = &M;
     visit(M);
 
-    if (SPIRVLowerSaddWithOverflowValidate) {
-      LLVM_DEBUG(dbgs() << "After SPIRVLowerSaddWithOverflow:\n" << M);
-      std::string Err;
-      raw_string_ostream ErrorOS(Err);
-      if (verifyModule(M, &ErrorOS)) {
-        Err = std::string("Fails to verify module: ") + Err;
-        report_fatal_error(Err.c_str(), false);
-      }
-    }
+    VERIFY_REGULARIZATION_PASS(M, "SPIRVLowerSaddWithOverflow")
     return TheModuleIsModified;
   }
 

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -39,14 +39,13 @@
 
 #include "OCLUtil.h"
 #include "SPIRVInternal.h"
+#include "libSPIRV/SPIRVDebug.h"
 
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 
 #include <set>
 #include <vector>
@@ -56,10 +55,6 @@ using namespace SPIRV;
 using namespace OCLUtil;
 
 namespace SPIRV {
-
-cl::opt<bool> SPIRVRegularizeValidate(
-    "spvregular-validate", cl::init(_SPIRVDBG),
-    cl::desc("Validate module after regularizing LLVM IR "));
 
 static bool SPIRVDbgSaveRegularizedModule = false;
 static std::string RegularizedModuleTmpFile = "regularized.bc";
@@ -95,15 +90,9 @@ bool SPIRVRegularizeLLVM::runOnModule(Module &Module) {
 
   LLVM_DEBUG(dbgs() << "Enter SPIRVRegularizeLLVM:\n");
   regularize();
+  LLVM_DEBUG(dbgs() << "After SPIRVRegularizeLLVM:\n" << *M);
 
-  if (SPIRVRegularizeValidate) {
-    LLVM_DEBUG(dbgs() << "After SPIRVRegularizeLLVM:\n" << *M);
-    std::string Err;
-    raw_string_ostream ErrorOS(Err);
-    if (verifyModule(*M, &ErrorOS)) {
-      LLVM_DEBUG(errs() << "Fails to verify module: " << ErrorOS.str());
-    }
-  }
+  VERIFY_REGULARIZATION_PASS(*M, "SPIRVRegularizeLLVM")
 
   return true;
 }

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -44,7 +44,6 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Operator.h"
-#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
 
 #include <set>
@@ -92,7 +91,7 @@ bool SPIRVRegularizeLLVM::runOnModule(Module &Module) {
   regularize();
   LLVM_DEBUG(dbgs() << "After SPIRVRegularizeLLVM:\n" << *M);
 
-  VERIFY_REGULARIZATION_PASS(*M, "SPIRVRegularizeLLVM")
+  verifyRegularizationPass(*M, "SPIRVRegularizeLLVM");
 
   return true;
 }

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
@@ -39,6 +39,11 @@
 
 #include "SPIRVDebug.h"
 
+#include "llvm/IR/Verifier.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "spirv-regularization"
+
 using namespace SPIRV;
 
 bool SPIRV::SPIRVDbgEnable = false;
@@ -49,4 +54,18 @@ bool SPIRV::SPIRVDbgErrorMsgIncludesSourceInfo = true;
 llvm::cl::opt<bool> SPIRV::VerifyRegularizationPasses(
     "spirv-verify-regularize-passes", llvm::cl::init(_SPIRVDBG),
     llvm::cl::desc(
-        "Validate module after each pass in LLVM regularization phase"));
+        "Verify module after each pass in LLVM regularization phase"));
+
+namespace SPIRV {
+void verifyRegularizationPass(llvm::Module &M, const std::string &PassName) {
+  if (VerifyRegularizationPasses) {
+    std::string Err;
+    llvm::raw_string_ostream ErrorOS(Err);
+    if (llvm::verifyModule(M, &ErrorOS)) {
+      LLVM_DEBUG(llvm::errs()
+                 << "Failed to verify module after pass: " << PassName << "\n"
+                 << ErrorOS.str());
+    }
+  }
+}
+} // namespace SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
@@ -45,3 +45,8 @@ bool SPIRV::SPIRVDbgEnable = false;
 SPIRV::SPIRVDbgErrorHandlingKinds SPIRV::SPIRVDbgError =
     SPIRVDbgErrorHandlingKinds::Exit;
 bool SPIRV::SPIRVDbgErrorMsgIncludesSourceInfo = true;
+
+llvm::cl::opt<bool> SPIRV::VerifyRegularizationPasses(
+    "spirv-verify-regularize-passes", llvm::cl::init(_SPIRVDBG),
+    llvm::cl::desc(
+        "Validate module after each pass in LLVM regularization phase"));

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -41,9 +41,14 @@
 #define SPIRV_LIBSPIRV_SPIRVDEBUG_H
 
 #include "SPIRVUtil.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Debug.h"
+
 #include <iostream>
 
 namespace SPIRV {
+
+extern llvm::cl::opt<bool> VerifyRegularizationPasses;
 
 // Include source file and line number in error message.
 extern bool SPIRVDbgErrorMsgIncludesSourceInfo;
@@ -103,6 +108,19 @@ inline dev_null_stream &spvdbgs() {
 }
 
 #endif
+
+#define VERIFY_REGULARIZATION_PASS(Module, PassName)                           \
+  {                                                                            \
+    if (VerifyRegularizationPasses) {                                          \
+      std::string Err;                                                         \
+      raw_string_ostream ErrorOS(Err);                                         \
+      if (verifyModule(Module, &ErrorOS)) {                                    \
+        LLVM_DEBUG(errs() << "Failed to verify module after pass: "            \
+                          << PassName << "\n"                                  \
+                          << ErrorOS.str());                                   \
+      }                                                                        \
+    }                                                                          \
+  }
 
 } // namespace SPIRV
 #endif // SPIRV_LIBSPIRV_SPIRVDEBUG_H

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -45,23 +45,30 @@
 
 namespace SPIRV {
 
-#define _SPIRVDBG
-#ifdef _SPIRVDBG
-
-#define SPIRVDBG(x)                                                            \
-  if (SPIRVDbgEnable) {                                                        \
-    x;                                                                         \
-  }
-
-// Enable debug output.
-extern bool SPIRVDbgEnable;
-
 // Include source file and line number in error message.
 extern bool SPIRVDbgErrorMsgIncludesSourceInfo;
 
 // Enable assert or exit on error
 enum class SPIRVDbgErrorHandlingKinds { Abort, Exit, Ignore };
 extern SPIRVDbgErrorHandlingKinds SPIRVDbgError;
+
+// Enable debug output.
+extern bool SPIRVDbgEnable;
+
+#ifndef _SPIRVDBG
+#if !defined(NDEBUG) || defined (_DEBUG)
+#define _SPIRVDBG true
+#else
+#define _SPIRVDBG false
+#endif
+#endif
+
+#if _SPIRVDBG
+
+#define SPIRVDBG(x)                                                            \
+  if (SPIRVDbgEnable) {                                                        \
+    x;                                                                         \
+  }
 
 // Output stream for SPIRV debug information.
 inline spv_ostream &spvdbgs() {
@@ -71,6 +78,29 @@ inline spv_ostream &spvdbgs() {
 #else
 
 #define SPIRVDBG(x)
+
+// Minimal std::basic_ostream mock that ignores everything being printed via
+// operator<<
+class dev_null_stream {
+public:
+  void flush() {}
+};
+
+template <typename T>
+dev_null_stream &operator<<(dev_null_stream &Out, const T &) {
+  return Out;
+}
+
+template <typename T>
+const dev_null_stream &&operator<<(dev_null_stream &&Out, const T &) {
+  return Out;
+}
+
+// Output stream for SPIRV debug information.
+inline dev_null_stream &spvdbgs() {
+  static dev_null_stream Out;
+  return Out;
+}
 
 #endif
 

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -61,7 +61,7 @@ extern SPIRVDbgErrorHandlingKinds SPIRVDbgError;
 extern bool SPIRVDbgEnable;
 
 #ifndef _SPIRVDBG
-#if !defined(NDEBUG) || defined (_DEBUG)
+#if !defined(NDEBUG) || defined(_DEBUG)
 #define _SPIRVDBG true
 #else
 #define _SPIRVDBG false
@@ -92,12 +92,12 @@ public:
 };
 
 template <typename T>
-dev_null_stream &operator<<(dev_null_stream &Out, const T &) {
+const dev_null_stream &operator<<(const dev_null_stream &Out, const T &) {
   return Out;
 }
 
 template <typename T>
-const dev_null_stream &&operator<<(dev_null_stream &&Out, const T &) {
+const dev_null_stream &&operator<<(const dev_null_stream &&Out, const T &) {
   return Out;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -41,10 +41,12 @@
 #define SPIRV_LIBSPIRV_SPIRVDEBUG_H
 
 #include "SPIRVUtil.h"
+#include "llvm/IR/Module.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 #include <iostream>
+#include <string>
 
 namespace SPIRV {
 
@@ -59,6 +61,8 @@ extern SPIRVDbgErrorHandlingKinds SPIRVDbgError;
 
 // Enable debug output.
 extern bool SPIRVDbgEnable;
+
+void verifyRegularizationPass(llvm::Module &, const std::string &);
 
 #ifndef _SPIRVDBG
 #if !defined(NDEBUG) || defined(_DEBUG)
@@ -98,7 +102,7 @@ const dev_null_stream &operator<<(const dev_null_stream &Out, const T &) {
 
 template <typename T>
 const dev_null_stream &&operator<<(const dev_null_stream &&Out, const T &) {
-  return Out;
+  return std::move(Out);
 }
 
 // Output stream for SPIRV debug information.
@@ -108,19 +112,6 @@ inline dev_null_stream &spvdbgs() {
 }
 
 #endif
-
-#define VERIFY_REGULARIZATION_PASS(Module, PassName)                           \
-  {                                                                            \
-    if (VerifyRegularizationPasses) {                                          \
-      std::string Err;                                                         \
-      raw_string_ostream ErrorOS(Err);                                         \
-      if (verifyModule(Module, &ErrorOS)) {                                    \
-        LLVM_DEBUG(errs() << "Failed to verify module after pass: "            \
-                          << PassName << "\n"                                  \
-                          << ErrorOS.str());                                   \
-      }                                                                        \
-    }                                                                          \
-  }
 
 } // namespace SPIRV
 #endif // SPIRV_LIBSPIRV_SPIRVDEBUG_H

--- a/lib/SPIRV/libSPIRV/SPIRVError.h
+++ b/lib/SPIRV/libSPIRV/SPIRVError.h
@@ -41,8 +41,8 @@
 
 #include "SPIRVDebug.h"
 #include "SPIRVUtil.h"
-#include <sstream>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 namespace SPIRV {

--- a/lib/SPIRV/libSPIRV/SPIRVError.h
+++ b/lib/SPIRV/libSPIRV/SPIRVError.h
@@ -42,6 +42,7 @@
 #include "SPIRVDebug.h"
 #include "SPIRVUtil.h"
 #include <sstream>
+#include <iostream>
 #include <string>
 
 namespace SPIRV {
@@ -115,16 +116,17 @@ inline bool SPIRVErrorLog::checkError(bool Cond, SPIRVErrorCode ErrCode,
   setError(ErrCode, SS.str());
   switch (SPIRVDbgError) {
   case SPIRVDbgErrorHandlingKinds::Abort:
-    spvdbgs() << SS.str() << '\n';
-    spvdbgs().flush();
+    std::cerr << SS.str() << std::endl;
     abort();
     break;
   case SPIRVDbgErrorHandlingKinds::Exit:
-    spvdbgs() << SS.str() << '\n';
-    spvdbgs().flush();
+    std::cerr << SS.str() << std::endl;
     std::exit(ErrCode);
     break;
   case SPIRVDbgErrorHandlingKinds::Ignore:
+    // Still print info about the error into debug output stream
+    spvdbgs() << SS.str() << '\n';
+    spvdbgs().flush();
     break;
   }
   return Cond;


### PR DESCRIPTION
This is achieved by guarding most (only covered LLVM IR -> SPIR-V passes)
`verifyModule` calls by corresponding command line options, which are
disabled/enabled in accordance with _SPIRVDBG define.

Made _SPIRVDBG define disabled in release builds by default