### PR TITLE
[NFC] Do not use std::set in getRequiredExtensions

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVAsm.h
+++ b/lib/SPIRV/libSPIRV/SPIRVAsm.h
@@ -38,8 +38,8 @@ public:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityAsmINTEL);
   }
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_inline_assembly);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_inline_assembly;
   }
   const std::string &getTarget() const { return Target; }
 
@@ -75,8 +75,8 @@ public:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityAsmINTEL);
   }
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_inline_assembly);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_inline_assembly;
   }
   const std::string &getInstructions() const { return Instructions; }
   const std::string &getConstraints() const { return Constraints; }
@@ -113,8 +113,8 @@ public:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityAsmINTEL);
   }
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_inline_assembly);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_inline_assembly;
   }
   bool isOperandLiteral(unsigned int Index) const override { return false; }
   void setWordCount(SPIRVWord TheWordCount) override {

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -144,11 +144,11 @@ public:
   // Incomplete constructor
   SPIRVDecorate() : SPIRVDecorateGeneric(OC) {}
 
-  SPIRVExtSet getRequiredExtensions() const override {
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
     switch (Dec) {
     case DecorationNoSignedWrap:
     case DecorationNoUnsignedWrap:
-      return getSet(ExtensionID::SPV_KHR_no_integer_wrap_decoration);
+      return ExtensionID::SPV_KHR_no_integer_wrap_decoration;
     case DecorationRegisterINTEL:
     case DecorationMemoryINTEL:
     case DecorationNumbanksINTEL:
@@ -161,24 +161,24 @@ public:
     case DecorationMergeINTEL:
     case DecorationBankBitsINTEL:
     case DecorationForcePow2DepthINTEL:
-      return getSet(ExtensionID::SPV_INTEL_fpga_memory_attributes);
+      return ExtensionID::SPV_INTEL_fpga_memory_attributes;
     case DecorationBurstCoalesceINTEL:
     case DecorationCacheSizeINTEL:
     case DecorationDontStaticallyCoalesceINTEL:
     case DecorationPrefetchINTEL:
-      return getSet(ExtensionID::SPV_INTEL_fpga_memory_accesses);
+      return ExtensionID::SPV_INTEL_fpga_memory_accesses;
     case DecorationReferencedIndirectlyINTEL:
-      return getSet(ExtensionID::SPV_INTEL_function_pointers);
+      return ExtensionID::SPV_INTEL_function_pointers;
     case DecorationIOPipeStorageINTEL:
-      return getSet(ExtensionID::SPV_INTEL_io_pipes);
+      return ExtensionID::SPV_INTEL_io_pipes;
     case DecorationBufferLocationINTEL:
-      return getSet(ExtensionID::SPV_INTEL_fpga_buffer_location);
+      return ExtensionID::SPV_INTEL_fpga_buffer_location;
     case DecorationFunctionFloatingPointModeINTEL:
     case DecorationFunctionRoundingModeINTEL:
     case DecorationFunctionDenormModeINTEL:
-      return getSet(ExtensionID::SPV_INTEL_float_controls2);
+      return ExtensionID::SPV_INTEL_float_controls2;
     default:
-      return SPIRVExtSet();
+      return {};
     }
   }
 
@@ -258,7 +258,7 @@ public:
   SPIRVMemberDecorate()
       : SPIRVDecorateGeneric(OC), MemberNumber(SPIRVWORD_MAX) {}
 
-  SPIRVExtSet getRequiredExtensions() const override {
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
     switch (Dec) {
     case DecorationRegisterINTEL:
     case DecorationMemoryINTEL:
@@ -272,18 +272,18 @@ public:
     case DecorationMergeINTEL:
     case DecorationBankBitsINTEL:
     case DecorationForcePow2DepthINTEL:
-      return getSet(ExtensionID::SPV_INTEL_fpga_memory_attributes);
+      return ExtensionID::SPV_INTEL_fpga_memory_attributes;
     case DecorationBurstCoalesceINTEL:
     case DecorationCacheSizeINTEL:
     case DecorationDontStaticallyCoalesceINTEL:
     case DecorationPrefetchINTEL:
-      return getSet(ExtensionID::SPV_INTEL_fpga_memory_accesses);
+      return ExtensionID::SPV_INTEL_fpga_memory_accesses;
     case DecorationIOPipeStorageINTEL:
-      return getSet(ExtensionID::SPV_INTEL_io_pipes);
+      return ExtensionID::SPV_INTEL_io_pipes;
     case DecorationBufferLocationINTEL:
-      return getSet(ExtensionID::SPV_INTEL_fpga_buffer_location);
+      return ExtensionID::SPV_INTEL_fpga_buffer_location;
     default:
-      return SPIRVExtSet();
+      return {};
     }
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -44,6 +44,9 @@
 #include "SPIRVEnum.h"
 #include "SPIRVError.h"
 #include "SPIRVIsValidEnum.h"
+
+#include <llvm/ADT/Optional.h>
+
 #include <cassert>
 #include <iostream>
 #include <map>
@@ -289,7 +292,9 @@ public:
   Op getOpCode() const { return OpCode; }
   SPIRVModule *getModule() const { return Module; }
   virtual SPIRVCapVec getRequiredCapability() const { return SPIRVCapVec(); }
-  virtual SPIRVExtSet getRequiredExtensions() const { return SPIRVExtSet(); }
+  virtual llvm::Optional<ExtensionID> getRequiredExtension() const {
+    return {};
+  }
   const std::string &getName() const { return Name; }
   bool hasDecorate(Decoration Kind, size_t Index = 0,
                    SPIRVWord *Result = 0) const;
@@ -822,23 +827,23 @@ public:
     }
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
     switch (Kind) {
     case CapabilityDenormPreserve:
     case CapabilityDenormFlushToZero:
     case CapabilitySignedZeroInfNanPreserve:
     case CapabilityRoundingModeRTE:
     case CapabilityRoundingModeRTZ:
-      return getSet(ExtensionID::SPV_KHR_float_controls);
+      return ExtensionID::SPV_KHR_float_controls;
     case CapabilityRoundToInfinityINTEL:
     case CapabilityFloatingPointModeINTEL:
     case CapabilityFunctionFloatControlINTEL:
-      return getSet(ExtensionID::SPV_INTEL_float_controls2);
+      return ExtensionID::SPV_INTEL_float_controls2;
     case CapabilityVectorComputeINTEL:
     case CapabilityVectorAnyINTEL:
-      return getSet(ExtensionID::SPV_INTEL_vector_compute);
+      return ExtensionID::SPV_INTEL_vector_compute;
     default:
-      return SPIRVExtSet();
+      return {};
     }
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -187,8 +187,8 @@ public:
   SPIRVFunction *getFunction() const { return get<SPIRVFunction>(TheFunction); }
   _SPIRV_DEF_ENCDEC3(Type, Id, TheFunction)
   void validate() const override { SPIRVValue::validate(); }
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_function_pointers);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_function_pointers;
   }
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityFunctionPointersINTEL);

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -879,8 +879,8 @@ public:
     return getVec(CapabilityFPGARegINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_fpga_reg);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_fpga_reg;
   }
 
 protected:
@@ -1680,8 +1680,8 @@ public:
     return getVec(CapabilityUnstructuredLoopControlsINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_unstructured_loop_controls);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_unstructured_loop_controls;
   }
 
   void setWordCount(SPIRVWord TheWordCount) override {
@@ -1772,8 +1772,8 @@ public:
   _SPIRV_DEF_ENCDEC4(Type, Id, CalledValueId, Args)
   void validate() const override;
   bool isOperandLiteral(unsigned Index) const override { return false; }
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_function_pointers);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_function_pointers;
   }
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityFunctionPointersINTEL);
@@ -2621,8 +2621,8 @@ protected:
     return getVec(CapabilityBlockingPipesINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_blocking_pipes);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_blocking_pipes;
   }
 };
 
@@ -2639,8 +2639,8 @@ protected:
     return getVec(CapabilityArbitraryPrecisionFixedPointINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_arbitrary_precision_fixed_point);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_arbitrary_precision_fixed_point;
   }
 };
 
@@ -2666,8 +2666,8 @@ protected:
     return getVec(CapabilityArbitraryPrecisionFloatingPointINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_arbitrary_precision_floating_point);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_arbitrary_precision_floating_point;
   }
 };
 
@@ -2825,8 +2825,8 @@ public:
     return getVec(CapabilityOptimizationHintsINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_optimization_hints);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_optimization_hints;
   }
 
   SPIRVValue *getCondition() const { return getValue(ConditionId); }
@@ -2846,8 +2846,8 @@ protected:
     return getVec(CapabilityOptimizationHintsINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_optimization_hints);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_optimization_hints;
   }
 };
 
@@ -2863,8 +2863,8 @@ protected:
     return getVec(CapabilitySubgroupShuffleINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_subgroups);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_subgroups;
   }
 };
 
@@ -2885,8 +2885,8 @@ protected:
     return getVec(CapabilitySubgroupBufferBlockIOINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_subgroups);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_subgroups;
   }
 };
 
@@ -2905,8 +2905,8 @@ protected:
     return getVec(CapabilitySubgroupImageBlockIOINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_subgroups);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_subgroups;
   }
 };
 
@@ -2925,8 +2925,8 @@ protected:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilitySubgroupImageMediaBlockIOINTEL);
   }
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_media_block_io);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_media_block_io;
   }
 };
 
@@ -2945,8 +2945,8 @@ protected:
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_device_side_avc_motion_estimation);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_device_side_avc_motion_estimation;
   }
 };
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -612,9 +612,9 @@ void SPIRVModuleImpl::addCapability(SPIRVCapabilityKind Cap) {
   if (AutoAddExtensions) {
     // While we are reading existing SPIR-V we need to read it as-is and don't
     // add required extensions for each entry automatically
-    for (auto &E : CapObj->getRequiredExtensions()) {
-      addExtension(E);
-    }
+    auto Ext = CapObj->getRequiredExtension();
+    if (Ext.hasValue())
+      addExtension(Ext.getValue());
   }
 
   CapMap.insert(std::make_pair(Cap, CapObj));
@@ -724,9 +724,9 @@ SPIRVEntry *SPIRVModuleImpl::addEntry(SPIRVEntry *Entry) {
   if (AutoAddExtensions) {
     // While we are reading existing SPIR-V we need to read it as-is and don't
     // add required extensions for each entry automatically
-    for (auto &E : Entry->getRequiredExtensions()) {
-      addExtension(E);
-    }
+    auto Ext = Entry->getRequiredExtension();
+    if (Ext.hasValue())
+      addExtension(Ext.getValue());
   }
 
   return Entry;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -461,16 +461,6 @@ public:
     return TranslationOpts.isAllowedToUseExtension(RequestedExtension);
   }
 
-  virtual bool
-  isAllowedToUseExtensions(const SPIRVExtSet &RequestedExtensions) const final {
-    for (const auto &Ext : RequestedExtensions) {
-      if (!TranslationOpts.isAllowedToUseExtension(Ext))
-        return false;
-    }
-
-    return true;
-  }
-
   virtual bool isGenArgNameMDEnabled() const final {
     return TranslationOpts.isGenArgNameMDEnabled();
   }

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -167,15 +167,15 @@ public:
     }
     return CV;
   }
-  SPIRVExtSet getRequiredExtensions() const override {
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
     switch (BitWidth) {
     case 8:
     case 16:
     case 32:
     case 64:
-      return SPIRVExtSet();
+      return {};
     default:
-      return getSet(ExtensionID::SPV_INTEL_arbitrary_precision_integers);
+      return ExtensionID::SPV_INTEL_arbitrary_precision_integers;
     }
   }
 
@@ -848,8 +848,8 @@ public:
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_device_side_avc_motion_estimation);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_device_side_avc_motion_estimation;
   }
 
 protected:
@@ -903,8 +903,8 @@ public:
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    return getSet(ExtensionID::SPV_INTEL_device_side_avc_motion_estimation);
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_device_side_avc_motion_estimation;
   }
 
   SPIRVValue *getOperand() { return getValue(Opn); }

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -121,12 +121,13 @@ public:
     return Type->getRequiredCapability();
   }
 
-  SPIRVExtSet getRequiredExtensions() const override {
-    SPIRVExtSet EV;
+  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+    llvm::Optional<ExtensionID> EV;
     if (!hasType())
       return EV;
-    EV = Type->getRequiredExtensions();
-    assert(!Module || Module->isAllowedToUseExtensions(EV));
+    EV = Type->getRequiredExtension();
+    assert(Module &&
+           (!EV.hasValue() || Module->isAllowedToUseExtension(EV.getValue())));
     return EV;
   }
 


### PR DESCRIPTION
In all cases what we have encountered so far each instruction has either
zero or one extension that it requires and therefore there is no need to
use `std::set` to store that information.

Replaced `std::set` with `llvm::Optional` and renamed function to
indicate that it can only return a single extension.