### PR TITLE
Support 1024-bit constants

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -183,7 +183,12 @@ protected:
   _SPIRV_DEF_ENCDEC3(Id, BitWidth, IsSigned)
   void validate() const override {
     SPIRVEntry::validate();
-    assert(BitWidth > 1 && BitWidth <= 64 && "Invalid bit width");
+    assert(BitWidth > 1 &&
+           (BitWidth <= 64 ||
+            (Module->isAllowedToUseExtension(
+                 ExtensionID::SPV_INTEL_arbitrary_precision_integers) &&
+             BitWidth <= 1024)) &&
+           "Invalid bit width");
   }
 
 private:

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -176,7 +176,7 @@ protected:
   }
   void validate() const override {
     SPIRVValue::validate();
-    assert(NumWords >= 1 && NumWords <= 2 && "Invalid constant size");
+    assert(NumWords >= 1 && NumWords <= 32 && "Invalid constant size");
   }
   void encode(spv_ostream &O) const override {
     getEncoder(O) << Type << Id;
@@ -198,7 +198,7 @@ protected:
     uint64_t UInt64Val;
     float FloatVal;
     double DoubleVal;
-    SPIRVWord Words[2];
+    SPIRVWord Words[32];
     UnionType() { UInt64Val = 0; }
   } Union;
 };

--- a/test/capability-arbitrary-precision-integers.ll
+++ b/test/capability-arbitrary-precision-integers.ll
@@ -15,6 +15,14 @@
 ; CHECK-SPIRV-DAG: TypeInt {{[0-9]+}} 13 0
 ; CHECK-SPIRV-DAG: TypeInt {{[0-9]+}} 58 0
 ; CHECK-SPIRV-DAG: TypeInt {{[0-9]+}} 30 0
+; CHECK-SPIRV-DAG: TypeInt [[#I96:]] 96 0
+; CHECK-SPIRV-DAG: TypeInt [[#I128:]] 128 0
+; CHECK-SPIRV-DAG: TypeInt [[#I256:]] 256 0
+; CHECK-SPIRV-DAG: TypeInt [[#I1024:]] 1024 0
+; CHECK-SPIRV-DAG: Constant [[#I96]] [[#]] 1 0 0
+; CHECK-SPIRV-DAG: Constant [[#I128]] [[#]] 1 0 0 0
+; CHECK-SPIRV-DAG: Constant [[#I256]] [[#]] 1 0 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: Constant [[#I1024]] [[#]] 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
@@ -25,6 +33,10 @@ target triple = "spir64-unknown-unknown"
 @b = addrspace(1) global i58 0, align 8
 ; CHECK-LLVM: @c = addrspace(1) global i48 0, align 8
 @c = addrspace(1) global i48 0, align 8
+@d = addrspace(1) global i96 0, align 8
+@e = addrspace(1) global i128 0, align 8
+@f = addrspace(1) global i256 0, align 8
+@g = addrspace(1) global i1024 0, align 8
 
 ; Function Attrs: noinline nounwind optnone
 ; CHECK-LLVM: void @_Z4funci(i30 %a)
@@ -38,5 +50,13 @@ entry:
   store i30 1, i30* %a.addr, align 4
 ; CHECK-LLVM: store i48 -4294901761, i48 addrspace(1)* @c
   store i48 -4294901761, i48 addrspace(1)* @c, align 8
+  store i96 1, i96 addrspace(1)* @d, align 8
+; CHECK-LLVM: store i96 1, i96 addrspace(1)* @d
+  store i128 1, i128 addrspace(1)* @e, align 8
+; CHECK-LLVM: store i128 1, i128 addrspace(1)* @e
+  store i256 1, i256 addrspace(1)* @f, align 8
+; CHECK-LLVM: store i256 1, i256 addrspace(1)* @f
+  store i1024 1, i1024 addrspace(1)* @g, align 8
+; CHECK-LLVM: store i1024 1, i1024 addrspace(1)* @g
   ret void
 }


### PR DESCRIPTION
Adjusted SPRIVConstantBase class to hold up to 8 SPIR-V words in a
constant.

Motivation for this change is that optimized LLVM IR can represent
types like `[3 x i32]` as `i96` and in combination with
SPV_INTEL_arbitrary_precision_integers extension it generates pretty
valid SPIR-V. However, during its consumption the translator reads more
than 2 SPIR-V words from an input and stores them in array for only 2
SPIR-V words, which causes memory corruption.

Discovered by debugging an issue with SYCL compiler from intel/llvm
project where internal representation of `cl::sycl::vec<int, 8>` class
were transformed into `i256` and stored in a constant.