### PR TITLE
Fix inlined-formal-parameter LIT test after LLVM update

### DIFF
--- a/test/DebugInfo/X86/inlined-formal-parameter.ll
+++ b/test/DebugInfo/X86/inlined-formal-parameter.ll
@@ -23,7 +23,7 @@
 ; CHECK:       DW_TAG_inlined_subroutine
 ; CHECK-NEXT:    DW_AT_abstract_origin {{.*}} "bar"
 ; CHECK:         DW_TAG_formal_parameter
-; CHECK-NEXT:      DW_AT_const_value
+; CHECK-NEXT:      DW_AT_const_value [DW_FORM_sdata]   (0)
 ; CHECK-NEXT:      DW_AT_abstract_origin {{.*}} "a"
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/DebugInfo/X86/inlined-formal-parameter.ll
+++ b/test/DebugInfo/X86/inlined-formal-parameter.ll
@@ -23,8 +23,7 @@
 ; CHECK:       DW_TAG_inlined_subroutine
 ; CHECK-NEXT:    DW_AT_abstract_origin {{.*}} "bar"
 ; CHECK:         DW_TAG_formal_parameter
-; CHECK-NEXT:      DW_AT_location [DW_FORM_data4]	(
-; CHECK-NEXT:        {{.*}}, {{.*}}: DW_OP_consts +0)
+; CHECK-NEXT:      DW_AT_const_value
 ; CHECK-NEXT:      DW_AT_abstract_origin {{.*}} "a"
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
Adjusted the test in accordance with llvm/llvm-project@57d8acac64b87cb4286b00485fb2da7521fc091e