### PR TITLE
[NFC] Replace some std containers with llvm ones

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -48,6 +48,9 @@
 #include "SPIRVType.h"
 #include "SPIRVValue.h"
 
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/DenseSet.h>
+
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -451,9 +454,9 @@ private:
   SPIRVAddressingModelKind AddrModel;
   SPIRVMemoryModelKind MemoryModel;
 
-  typedef std::map<SPIRVId, SPIRVEntry *> SPIRVIdToEntryMap;
+  typedef llvm::DenseMap<SPIRVId, SPIRVEntry *> SPIRVIdToEntryMap;
   typedef std::set<SPIRVEntry *> SPIRVEntrySet;
-  typedef std::set<SPIRVId> SPIRVIdSet;
+  typedef llvm::DenseSet<SPIRVId> SPIRVIdSet;
   typedef std::vector<SPIRVId> SPIRVIdVec;
   typedef std::vector<SPIRVFunction *> SPIRVFunctionVector;
   typedef std::vector<SPIRVTypeForwardPointer *> SPIRVForwardPointerVec;


### PR DESCRIPTION
This change aims to improve performance of the translator.

Tested this patch on the following example: 
[1024_512_256_source.zip](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/files/5157501/1024_512_256_source.zip) contains 20 MB of auto-generated LLVM bitcode from SYCL application. I wrapped content of `llvm::writeSpirv` function into a loop with 50 iterations and this patch speeds up LLVM -> SPIR-V translation by ~30%

Using `std::unordered_map` & `std_unordered_set` for these two types gives only ~15% improvement on the test case mentioned above