### PR TITLE
Removing deprecated "VectorType::getNumElements"

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -1555,7 +1555,7 @@ void OCL20ToSPIRV::visitCallEnqueueKernel(CallInst *CI,
     auto *LocalSizeArray =
         cast<GetElementPtrInst>(CI->getArgOperand(LocalSizeArrayIdx));
     auto *LocalSizeArrayTy =
-        cast<FixedVectorType>(LocalSizeArray->getSourceElementType());
+        cast<ArrayType>(LocalSizeArray->getSourceElementType());
     const uint64_t LocalSizeNum = LocalSizeArrayTy->getNumElements();
     for (unsigned I = 0; I < LocalSizeNum; ++I)
       Args.push_back(GetElementPtrInst::Create(

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -1335,23 +1335,24 @@ void OCL20ToSPIRV::visitCallRelational(CallInst *CI, StringRef DemangledName) {
         if (CI->getOperand(0)->getType()->isVectorTy())
           Ret = FixedVectorType::get(
               Type::getInt1Ty(*Ctx),
-              cast<VectorType>(CI->getOperand(0)->getType())->getNumElements());
+              cast<FixedVectorType>(CI->getOperand(0)->getType())
+                  ->getNumElements());
         return SPIRVName;
       },
       [=](CallInst *NewCI) -> Instruction * {
         Value *False = nullptr, *True = nullptr;
         if (NewCI->getType()->isVectorTy()) {
           Type *IntTy = Type::getInt32Ty(*Ctx);
-          if (cast<VectorType>(NewCI->getOperand(0)->getType())
+          if (cast<FixedVectorType>(NewCI->getOperand(0)->getType())
                   ->getElementType()
                   ->isDoubleTy())
             IntTy = Type::getInt64Ty(*Ctx);
-          if (cast<VectorType>(NewCI->getOperand(0)->getType())
+          if (cast<FixedVectorType>(NewCI->getOperand(0)->getType())
                   ->getElementType()
                   ->isHalfTy())
             IntTy = Type::getInt16Ty(*Ctx);
           Type *VTy = FixedVectorType::get(
-              IntTy, cast<VectorType>(NewCI->getType())->getNumElements());
+              IntTy, cast<FixedVectorType>(NewCI->getType())->getNumElements());
           False = Constant::getNullValue(VTy);
           True = Constant::getAllOnesValue(VTy);
         } else {
@@ -1554,7 +1555,7 @@ void OCL20ToSPIRV::visitCallEnqueueKernel(CallInst *CI,
     auto *LocalSizeArray =
         cast<GetElementPtrInst>(CI->getArgOperand(LocalSizeArrayIdx));
     auto *LocalSizeArrayTy =
-        cast<ArrayType>(LocalSizeArray->getSourceElementType());
+        cast<FixedVectorType>(LocalSizeArray->getSourceElementType());
     const uint64_t LocalSizeNum = LocalSizeArrayTy->getNumElements();
     for (unsigned I = 0; I < LocalSizeNum; ++I)
       Args.push_back(GetElementPtrInst::Create(
@@ -1618,7 +1619,7 @@ static void processSubgroupBlockReadWriteINTEL(CallInst *CI,
                                                OCLBuiltinTransInfo &Info,
                                                const Type *DataTy, Module *M) {
   unsigned VectorNumElements = 1;
-  if (auto *VecTy = dyn_cast<VectorType>(DataTy))
+  if (auto *VecTy = dyn_cast<FixedVectorType>(DataTy))
     VectorNumElements = VecTy->getNumElements();
   unsigned ElementBitSize = DataTy->getScalarSizeInBits();
   Info.Postfix = "_";

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -805,7 +805,7 @@ unsigned encodeVecTypeHint(Type *Ty) {
       llvm_unreachable("invalid integer type");
     }
   }
-  if (VectorType *VecTy = dyn_cast<VectorType>(Ty)) {
+  if (FixedVectorType *VecTy = dyn_cast<FixedVectorType>(Ty)) {
     Type *EleTy = VecTy->getElementType();
     unsigned Size = VecTy->getNumElements();
     return Size << 16 | encodeVecTypeHint(EleTy);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -336,7 +336,7 @@ bool SPIRVToLLVM::transOCLBuiltinFromVariable(GlobalVariable *GV,
     std::vector<Value *> Vectors;
     Loads.push_back(LD);
     if (HasIndexArg) {
-      auto *VecTy = cast<VectorType>(
+      auto *VecTy = cast<FixedVectorType>(
           LD->getPointerOperandType()->getPointerElementType());
       Value *EmptyVec = UndefValue::get(VecTy);
       Vectors.push_back(EmptyVec);
@@ -1937,7 +1937,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     IRBuilder<> Builder(BB);
     auto Scalar = transValue(VTS->getScalar(), F, BB);
     auto Vector = transValue(VTS->getVector(), F, BB);
-    auto *VecTy = cast<VectorType>(Vector->getType());
+    auto *VecTy = cast<FixedVectorType>(Vector->getType());
     unsigned VecSize = VecTy->getNumElements();
     auto NewVec = Builder.CreateVectorSplat(VecSize, Scalar, Scalar->getName());
     NewVec->takeName(Scalar);
@@ -1965,8 +1965,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
     unsigned M = Mat->getType()->getArrayNumElements();
 
-    auto *VecTy = cast<VectorType>(Vec->getType());
-    VectorType *VTy = FixedVectorType::get(VecTy->getElementType(), M);
+    auto *VecTy = cast<FixedVectorType>(Vec->getType());
+    FixedVectorType *VTy = FixedVectorType::get(VecTy->getElementType(), M);
     auto ETy = VTy->getElementType();
     unsigned N = VecTy->getNumElements();
     Value *V = Builder.CreateVectorSplat(M, ConstantFP::get(ETy, 0.0));
@@ -1994,7 +1994,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto Matrix = transValue(MTS->getMatrix(), F, BB);
     uint64_t ColNum = Matrix->getType()->getArrayNumElements();
     auto ColType = cast<ArrayType>(Matrix->getType())->getElementType();
-    auto VecSize = cast<VectorType>(ColType)->getNumElements();
+    auto VecSize = cast<FixedVectorType>(ColType)->getNumElements();
     auto NewVec = Builder.CreateVectorSplat(VecSize, Scalar, Scalar->getName());
     NewVec->takeName(Scalar);
 
@@ -2031,8 +2031,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     // where sum is defined as vector sum.
 
     unsigned M = Mat->getType()->getArrayNumElements();
-    VectorType *VTy =
-        cast<VectorType>(cast<ArrayType>(Mat->getType())->getElementType());
+    FixedVectorType *VTy = cast<FixedVectorType>(
+        cast<ArrayType>(Mat->getType())->getElementType());
     unsigned N = VTy->getNumElements();
     auto ETy = VTy->getElementType();
     Value *V = Builder.CreateVectorSplat(N, ConstantFP::get(ETy, 0.0));
@@ -2086,10 +2086,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
     unsigned C1 = M1->getType()->getArrayNumElements();
     unsigned C2 = M2->getType()->getArrayNumElements();
-    VectorType *V1Ty =
-        cast<VectorType>(cast<ArrayType>(M1->getType())->getElementType());
-    VectorType *V2Ty =
-        cast<VectorType>(cast<ArrayType>(M2->getType())->getElementType());
+    FixedVectorType *V1Ty =
+        cast<FixedVectorType>(cast<ArrayType>(M1->getType())->getElementType());
+    FixedVectorType *V2Ty =
+        cast<FixedVectorType>(cast<ArrayType>(M2->getType())->getElementType());
     unsigned R1 = V1Ty->getNumElements();
     unsigned R2 = V2Ty->getNumElements();
     auto ETy = V1Ty->getElementType();
@@ -2127,8 +2127,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     IRBuilder<> Builder(BB);
     auto Matrix = transValue(TR->getMatrix(), F, BB);
     unsigned ColNum = Matrix->getType()->getArrayNumElements();
-    VectorType *ColTy =
-        cast<VectorType>(cast<ArrayType>(Matrix->getType())->getElementType());
+    FixedVectorType *ColTy = cast<FixedVectorType>(
+        cast<ArrayType>(Matrix->getType())->getElementType());
     unsigned RowNum = ColTy->getNumElements();
 
     auto VTy = FixedVectorType::get(ColTy->getElementType(), ColNum);
@@ -4255,7 +4255,7 @@ Instruction *SPIRVToLLVM::transOCLAllAny(SPIRVInstruction *I, BasicBlock *BB) {
                auto OldArg = CI->getOperand(0);
                auto NewArgTy = FixedVectorType::get(
                    Int32Ty,
-                   cast<VectorType>(OldArg->getType())->getNumElements());
+                   cast<FixedVectorType>(OldArg->getType())->getNumElements());
                auto NewArg =
                    CastInst::CreateSExtOrBitCast(OldArg, NewArgTy, "", CI);
                Args[0] = NewArg;
@@ -4281,16 +4281,17 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
                Type *IntTy = Type::getInt32Ty(*Context);
                RetTy = IntTy;
                if (CI->getType()->isVectorTy()) {
-                 if (cast<VectorType>(CI->getOperand(0)->getType())
+                 if (cast<FixedVectorType>(CI->getOperand(0)->getType())
                          ->getElementType()
                          ->isDoubleTy())
                    IntTy = Type::getInt64Ty(*Context);
-                 if (cast<VectorType>(CI->getOperand(0)->getType())
+                 if (cast<FixedVectorType>(CI->getOperand(0)->getType())
                          ->getElementType()
                          ->isHalfTy())
                    IntTy = Type::getInt16Ty(*Context);
                  RetTy = FixedVectorType::get(
-                     IntTy, cast<VectorType>(CI->getType())->getNumElements());
+                     IntTy,
+                     cast<FixedVectorType>(CI->getType())->getNumElements());
                }
                return CI->getCalledFunction()->getName().str();
              },
@@ -4299,7 +4300,7 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
                if (NewCI->getType()->isVectorTy())
                  RetTy = FixedVectorType::get(
                      Type::getInt1Ty(*Context),
-                     cast<VectorType>(NewCI->getType())->getNumElements());
+                     cast<FixedVectorType>(NewCI->getType())->getNumElements());
                return CastInst::CreateTruncOrBitCast(NewCI, RetTy, "",
                                                      NewCI->getNextNode());
              },

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -190,13 +190,13 @@ void SPIRVToOCL::visitCallSPRIVImageQuerySize(CallInst *CI) {
           GetImageSize,
           FixedVectorType::get(
               CI->getType()->getScalarType(),
-              cast<VectorType>(GetImageSize->getType())->getNumElements()),
+              cast<FixedVectorType>(GetImageSize->getType())->getNumElements()),
           false, CI->getName(), CI);
     }
   }
 
   if (ImgArray || ImgDim == 3) {
-    auto *VecTy = cast<VectorType>(CI->getType());
+    auto *VecTy = cast<FixedVectorType>(CI->getType());
     const unsigned ImgQuerySizeRetEls = VecTy->getNumElements();
 
     if (ImgDim == 1) {
@@ -224,7 +224,7 @@ void SPIRVToOCL::visitCallSPRIVImageQuerySize(CallInst *CI) {
   if (ImgArray) {
     assert((ImgDim == 1 || ImgDim == 2) && "invalid image array type");
     // Insert get_image_array_size to the last position of the resulting vector.
-    auto *VecTy = cast<VectorType>(CI->getType());
+    auto *VecTy = cast<FixedVectorType>(CI->getType());
     Type *SizeTy =
         Type::getIntNTy(*Ctx, M->getDataLayout().getPointerSizeInBits(0));
     Instruction *GetImageArraySize = addCallInst(
@@ -482,7 +482,7 @@ void SPIRVToOCL::visitCallSPIRVImageMediaBlockBuiltin(CallInst *CI, Op OC) {
         else
           assert(0 && "Unsupported texel type!");
 
-        if (auto *VecTy = dyn_cast<VectorType>(RetType)) {
+        if (auto *VecTy = dyn_cast<FixedVectorType>(RetType)) {
           unsigned int NumEl = VecTy->getNumElements();
           assert((NumEl == 2 || NumEl == 4 || NumEl == 8 || NumEl == 16) &&
                  "Wrong function type!");

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -141,7 +141,7 @@ std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed) {
     }
     return SignPrefix + Stem;
   }
-  if (auto VecTy = dyn_cast<VectorType>(Ty)) {
+  if (auto VecTy = dyn_cast<FixedVectorType>(Ty)) {
     Type *EleTy = VecTy->getElementType();
     unsigned Size = VecTy->getNumElements();
     std::stringstream Ss;
@@ -738,7 +738,7 @@ void makeVector(Instruction *InsPos, std::vector<Value *> &Ops,
 void expandVector(Instruction *InsPos, std::vector<Value *> &Ops,
                   size_t VecPos) {
   auto Vec = Ops[VecPos];
-  auto *VT = dyn_cast<VectorType>(Vec->getType());
+  auto *VT = dyn_cast<FixedVectorType>(Vec->getType());
   if (!VT)
     return;
   size_t N = VT->getNumElements();
@@ -1045,7 +1045,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
     return SPIR::RefParamType(new SPIR::PrimitiveType(SPIR::PRIMITIVE_FLOAT));
   if (Ty->isDoubleTy())
     return SPIR::RefParamType(new SPIR::PrimitiveType(SPIR::PRIMITIVE_DOUBLE));
-  if (auto *VecTy = dyn_cast<VectorType>(Ty)) {
+  if (auto *VecTy = dyn_cast<FixedVectorType>(Ty)) {
     return SPIR::RefParamType(new SPIR::VectorType(
         transTypeDesc(VecTy->getElementType(), Info), VecTy->getNumElements()));
   }
@@ -1159,7 +1159,7 @@ Value *getScalarOrArray(Value *V, unsigned Size, Instruction *Pos) {
 Constant *getScalarOrVectorConstantInt(Type *T, uint64_t V, bool IsSigned) {
   if (auto IT = dyn_cast<IntegerType>(T))
     return ConstantInt::get(IT, V);
-  if (auto VT = dyn_cast<VectorType>(T)) {
+  if (auto VT = dyn_cast<FixedVectorType>(T)) {
     std::vector<Constant *> EV(
         VT->getNumElements(),
         getScalarOrVectorConstantInt(VT->getElementType(), V, IsSigned));
@@ -1536,7 +1536,7 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
     if (II->getArgOperand(0)->getType() != Ty)
       return false;
     int NumElems = 1;
-    if (auto *VecTy = dyn_cast<VectorType>(Ty)) {
+    if (auto *VecTy = dyn_cast<FixedVectorType>(Ty)) {
       NumElems = VecTy->getNumElements();
       Ty = VecTy->getElementType();
     }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -372,7 +372,7 @@ SPIRVType *LLVMToSPIRV::transType(Type *T) {
     }
   }
 
-  if (auto *VecTy = dyn_cast<VectorType>(T))
+  if (auto *VecTy = dyn_cast<FixedVectorType>(T))
     return mapType(T, BM->addVectorType(transType(VecTy->getElementType()),
                                         VecTy->getNumElements()));
 
@@ -3438,7 +3438,7 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       auto IsVector = ResultTy->isVectorTy();
       if (IsVector)
         BoolTy = FixedVectorType::get(
-            BoolTy, cast<VectorType>(ResultTy)->getNumElements());
+            BoolTy, cast<FixedVectorType>(ResultTy)->getNumElements());
       auto BBT = transType(BoolTy);
       SPIRVInstruction *Res;
       if (isCmpOpCode(OC)) {


### PR DESCRIPTION
Replacing "VectorType" with a "FixedVectorType"

Fixes #506

Signed-off-by: amochalo <anastasiya.mochalova@intel.com>