### PR TITLE
Exchange nullptr by quotes in checkError function

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1554,8 +1554,7 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
 
   if (Instruction *Inst = dyn_cast<Instruction>(V)) {
     BM->getErrorLog().checkError(false, SPIRVEC_InvalidInstruction,
-                                 toString(Inst) + "\n", "", __FILE__,
-                                 __LINE__);
+                                 toString(Inst) + "\n", "", __FILE__, __LINE__);
   }
 
   llvm_unreachable("Not implemented");

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1554,7 +1554,7 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
 
   if (Instruction *Inst = dyn_cast<Instruction>(V)) {
     BM->getErrorLog().checkError(false, SPIRVEC_InvalidInstruction,
-                                 toString(Inst) + "\n", nullptr, __FILE__,
+                                 toString(Inst) + "\n", "", __FILE__,
                                  __LINE__);
   }
 


### PR DESCRIPTION
The nullptr creates a problem then falls into the stream.

Signed-off-by: Aleksander Fadeev <aleksander.fadeev@intel.com>