### PR TITLE
Translate empty LLVM module to empty SPIR-V module

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2844,8 +2844,16 @@ void LLVMToSPIRV::transFunction(Function *I) {
   }
 }
 
+bool isEmptyLLVMModule(Module *M) {
+  return M->empty() &&      // No functions
+         M->global_empty(); // No global variables
+}
+
 bool LLVMToSPIRV::translate() {
   BM->setGeneratorVer(KTranslatorVer);
+
+  if (isEmptyLLVMModule(M))
+    BM->addCapability(CapabilityLinkage);
 
   if (!transSourceLanguage())
     return false;
@@ -3581,6 +3589,9 @@ void addPassesForSPIRV(legacy::PassManager &PassMgr,
 bool isValidLLVMModule(Module *M, SPIRVErrorLog &ErrorLog) {
   if (!M)
     return false;
+
+  if (isEmptyLLVMModule(M))
+    return true;
 
   Triple TT(M->getTargetTriple());
   if (!ErrorLog.checkError(isSupportedTriple(TT), SPIRVEC_InvalidTargetTriple,

--- a/test/empty-module.ll
+++ b/test/empty-module.ll
@@ -1,0 +1,12 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+; CHECK: 119734787 {{[0-9]*}} {{[0-9]*}} {{[0-9]*}} 0
+; CHECK: Capability Addresses
+; CHECK: Capability Linkage
+; CHECK: Capability Kernel
+; CHECK: ExtInstImport 1 "OpenCL.std"
+; CHECK: MemoryModel 2 2
+; CHECK: Source 0 0


### PR DESCRIPTION
When translator tool is used in toolchain it is possible that it can
receive an empty LLVM module as an input, just emit an empty SPIR-V module
with Linkage capability in this case.