### PR TITLE
Update dbg-declare-arg test after LLVM change

### DIFF
--- a/test/DebugInfo/X86/dbg-declare-arg.ll
+++ b/test/DebugInfo/X86/dbg-declare-arg.ll
@@ -24,7 +24,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK: DW_AT_name {{.*}}"j"
 ; CHECK: DW_TAG_variable  
 ; CHECK-NEXT:   DW_AT_location [DW_FORM_sec_offset] (
-; CHECK-NEXT:     0x{{.*}}, 0x{{.*}}: DW_OP_breg7 RSP+16, DW_OP_deref)
+; CHECK-NEXT:     0x{{.*}}, 0x{{.*}}: DW_OP_breg7 RSP+8, DW_OP_deref)
 ; CHECK-NEXT:   DW_AT_name {{.*}}"my_a"
 
 %class.A = type { i32, i32, i32, i32 }


### PR DESCRIPTION
Propagate the test change from LLVM commit 55f9f87da2c ("Reapply
Revert "RegAllocFast: Rewrite and improve"", 2020-09-21).