### PR TITLE
Fix translation of APInt constants

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -667,8 +667,17 @@ SPIRVValue *LLVMToSPIRV::transConstant(Value *V) {
     return BM->addNullConstant(transType(AggType));
   }
 
-  if (auto ConstI = dyn_cast<ConstantInt>(V))
+  if (auto ConstI = dyn_cast<ConstantInt>(V)) {
+    unsigned BitWidth = ConstI->getType()->getBitWidth();
+    if (BitWidth > 64) {
+      BM->getErrorLog().checkError(
+          BM->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_arbitrary_precision_integers),
+          SPIRVEC_InvalidBitWidth, std::to_string(BitWidth));
+      return BM->addConstant(transType(V->getType()), ConstI->getValue());
+    }
     return BM->addConstant(transType(V->getType()), ConstI->getZExtValue());
+  }
 
   if (auto ConstFP = dyn_cast<ConstantFP>(V)) {
     auto BT = static_cast<SPIRVType *>(transType(V->getType()));

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -48,6 +48,8 @@
 #include "SPIRVType.h"
 #include "SPIRVValue.h"
 
+#include "llvm/ADT/APInt.h"
+
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -261,6 +263,7 @@ public:
                                            SPIRVFunction *F) override;
   SPIRVValue *addConstant(SPIRVValue *) override;
   SPIRVValue *addConstant(SPIRVType *, uint64_t) override;
+  SPIRVValue *addConstant(SPIRVType *, llvm::APInt) override;
   SPIRVValue *addSpecConstant(SPIRVType *, uint64_t) override;
   SPIRVValue *addDoubleConstant(SPIRVTypeFloat *, double) override;
   SPIRVValue *addFloatConstant(SPIRVTypeFloat *, float) override;
@@ -1018,6 +1021,25 @@ SPIRVValue *SPIRVModuleImpl::addConstant(SPIRVType *Ty, uint64_t V) {
   }
   if (Ty->isTypeInt())
     return addIntegerConstant(static_cast<SPIRVTypeInt *>(Ty), V);
+  return addConstant(new SPIRVConstant(this, Ty, getId(), V));
+}
+
+// Complete constructor for AP integer constant
+template <spv::Op OC>
+SPIRVConstantBase<OC>::SPIRVConstantBase(SPIRVModule *M, SPIRVType *TheType,
+                                         SPIRVId TheId, llvm::APInt &TheValue)
+    : SPIRVValue(M, 0, OC, TheType, TheId) {
+  const uint64_t *BigValArr = TheValue.getRawData();
+  for (size_t I = 0; I != TheValue.getNumWords(); ++I) {
+    Union.Words[I * 2 + 1] =
+        (uint32_t)((BigValArr[I] & 0xFFFFFFFF00000000LL) >> 32);
+    Union.Words[I * 2] = (uint32_t)(BigValArr[I] & 0xFFFFFFFFLL);
+  }
+  recalculateWordCount();
+  validate();
+}
+
+SPIRVValue *SPIRVModuleImpl::addConstant(SPIRVType *Ty, llvm::APInt V) {
   return addConstant(new SPIRVConstant(this, Ty, getId(), V));
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -50,6 +50,10 @@
 #include <unordered_set>
 #include <vector>
 
+namespace llvm {
+class APInt;
+} // namespace llvm
+
 namespace SPIRV {
 
 template <Op> class SPIRVConstantBase;
@@ -254,6 +258,7 @@ public:
                                                    SPIRVFunction *F) = 0;
   virtual SPIRVValue *addConstant(SPIRVValue *) = 0;
   virtual SPIRVValue *addConstant(SPIRVType *, uint64_t) = 0;
+  virtual SPIRVValue *addConstant(SPIRVType *, llvm::APInt) = 0;
   virtual SPIRVValue *addSpecConstant(SPIRVType *, uint64_t) = 0;
   virtual SPIRVValue *addDoubleConstant(SPIRVTypeFloat *, double) = 0;
   virtual SPIRVValue *addFloatConstant(SPIRVTypeFloat *, float) = 0;

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -187,7 +187,7 @@ protected:
            (BitWidth <= 64 ||
             (Module->isAllowedToUseExtension(
                  ExtensionID::SPV_INTEL_arbitrary_precision_integers) &&
-             BitWidth <= 1024)) &&
+             BitWidth <= 2048)) &&
            "Invalid bit width");
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -47,6 +47,10 @@
 #include "SPIRVEntry.h"
 #include "SPIRVType.h"
 
+namespace llvm {
+class APInt;
+} // namespace llvm
+
 #include <iostream>
 #include <map>
 #include <memory>
@@ -148,6 +152,9 @@ public:
     recalculateWordCount();
     validate();
   }
+  // Incomplete constructor for AP integer constant
+  SPIRVConstantBase(SPIRVModule *M, SPIRVType *TheType, SPIRVId TheId,
+                    llvm::APInt &TheValue);
   // Complete constructor for float constant
   SPIRVConstantBase(SPIRVModule *M, SPIRVType *TheType, SPIRVId TheId,
                     float TheValue)
@@ -169,6 +176,8 @@ public:
   uint64_t getZExtIntValue() const { return Union.UInt64Val; }
   float getFloatValue() const { return Union.FloatVal; }
   double getDoubleValue() const { return Union.DoubleVal; }
+  unsigned getNumWords() const { return NumWords; }
+  SPIRVWord *getSPIRVWords() { return Union.Words; }
 
 protected:
   void recalculateWordCount() {
@@ -177,7 +186,7 @@ protected:
   }
   void validate() const override {
     SPIRVValue::validate();
-    assert(NumWords >= 1 && NumWords <= 32 && "Invalid constant size");
+    assert(NumWords >= 1 && NumWords <= 64 && "Invalid constant size");
   }
   void encode(spv_ostream &O) const override {
     getEncoder(O) << Type << Id;
@@ -199,7 +208,7 @@ protected:
     uint64_t UInt64Val;
     float FloatVal;
     double DoubleVal;
-    SPIRVWord Words[32];
+    SPIRVWord Words[64];
     UnionType() { UInt64Val = 0; }
   } Union;
 };

--- a/test/capability-arbitrary-precision-integers.ll
+++ b/test/capability-arbitrary-precision-integers.ll
@@ -18,11 +18,11 @@
 ; CHECK-SPIRV-DAG: TypeInt [[#I96:]] 96 0
 ; CHECK-SPIRV-DAG: TypeInt [[#I128:]] 128 0
 ; CHECK-SPIRV-DAG: TypeInt [[#I256:]] 256 0
-; CHECK-SPIRV-DAG: TypeInt [[#I1024:]] 1024 0
-; CHECK-SPIRV-DAG: Constant [[#I96]] [[#]] 1 0 0
+; CHECK-SPIRV-DAG: TypeInt [[#I2048:]] 2048 0
+; CHECK-SPIRV-DAG: Constant [[#I96]] [[#]] 4 0 1
 ; CHECK-SPIRV-DAG: Constant [[#I128]] [[#]] 1 0 0 0
 ; CHECK-SPIRV-DAG: Constant [[#I256]] [[#]] 1 0 0 0 0 0 0 0
-; CHECK-SPIRV-DAG: Constant [[#I1024]] [[#]] 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+; CHECK-SPIRV-DAG: Constant [[#I2048]] [[#]] 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
@@ -36,7 +36,7 @@ target triple = "spir64-unknown-unknown"
 @d = addrspace(1) global i96 0, align 8
 @e = addrspace(1) global i128 0, align 8
 @f = addrspace(1) global i256 0, align 8
-@g = addrspace(1) global i1024 0, align 8
+@g = addrspace(1) global i2048 0, align 8
 
 ; Function Attrs: noinline nounwind optnone
 ; CHECK-LLVM: void @_Z4funci(i30 %a)
@@ -50,13 +50,13 @@ entry:
   store i30 1, i30* %a.addr, align 4
 ; CHECK-LLVM: store i48 -4294901761, i48 addrspace(1)* @c
   store i48 -4294901761, i48 addrspace(1)* @c, align 8
-  store i96 1, i96 addrspace(1)* @d, align 8
-; CHECK-LLVM: store i96 1, i96 addrspace(1)* @d
+  store i96 18446744073709551620, i96 addrspace(1)* @d, align 8
+; CHECK-LLVM: store i96 18446744073709551620, i96 addrspace(1)* @d
   store i128 1, i128 addrspace(1)* @e, align 8
 ; CHECK-LLVM: store i128 1, i128 addrspace(1)* @e
   store i256 1, i256 addrspace(1)* @f, align 8
 ; CHECK-LLVM: store i256 1, i256 addrspace(1)* @f
-  store i1024 1, i1024 addrspace(1)* @g, align 8
-; CHECK-LLVM: store i1024 1, i1024 addrspace(1)* @g
+  store i2048 1, i2048 addrspace(1)* @g, align 8
+; CHECK-LLVM: store i2048 1, i2048 addrspace(1)* @g
   ret void
 }


### PR DESCRIPTION
Previously APInt constants were being stored into uint64_t value
with following encoding/decoding. Now they are being packed into
SPIRVWords array directly.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>