### PR TITLE
Cleanup includes

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -39,6 +39,7 @@
 #include "SPIRVWriter.h"
 
 #include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
 
 using namespace SPIRV;
 

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -43,8 +43,6 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/Module.h"
 
-#include <memory>
-
 using namespace llvm;
 
 namespace SPIRV {

--- a/lib/SPIRV/Mangler/Mangler.cpp
+++ b/lib/SPIRV/Mangler/Mangler.cpp
@@ -14,7 +14,6 @@
 #include "ManglingUtils.h"
 #include "NameMangleAPI.h"
 #include "ParameterType.h"
-#include "SPIRVInternal.h"
 #include <algorithm>
 #include <map>
 #include <sstream>

--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -49,6 +49,7 @@
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
 
 #include <algorithm>
 #include <set>

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -46,6 +46,7 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
 
 #include <set>
 

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -41,7 +41,6 @@
 
 #include "SPIRVInternal.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/IR/DebugInfoMetadata.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/Path.h"

--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -49,6 +49,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -49,6 +49,7 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
 
 #include <list>
 #include <set>

--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
@@ -51,6 +51,7 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/SourceMgr.h"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -45,9 +45,9 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
-#include "llvm/IR/Metadata.h"    // llvm::Metadata
 
 namespace llvm {
+class Metadata;
 class Module;
 class Type;
 class Instruction;

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -45,6 +45,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Operator.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/Debug.h"
 
 #include <set>
 #include <vector>

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -40,7 +40,6 @@
 #define SPIRVTOLLVMDBGTRAN_H
 
 #include "SPIRVInstruction.h"
-#include "SPIRVModule.h"
 
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DebugLoc.h"

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -43,7 +43,7 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/Pass.h"
 
-#include <cstring>
+#include <string>
 
 namespace SPIRV {
 class SPIRVToOCL : public ModulePass, public InstVisitor<SPIRVToOCL> {

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
@@ -40,6 +40,7 @@
 #include "SPIRVDebug.h"
 
 #include "llvm/IR/Verifier.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
 #define DEBUG_TYPE "spirv-regularization"
@@ -51,12 +52,12 @@ SPIRV::SPIRVDbgErrorHandlingKinds SPIRV::SPIRVDbgError =
     SPIRVDbgErrorHandlingKinds::Exit;
 bool SPIRV::SPIRVDbgErrorMsgIncludesSourceInfo = true;
 
-llvm::cl::opt<bool> SPIRV::VerifyRegularizationPasses(
+namespace SPIRV {
+llvm::cl::opt<bool> VerifyRegularizationPasses(
     "spirv-verify-regularize-passes", llvm::cl::init(_SPIRVDBG),
     llvm::cl::desc(
         "Verify module after each pass in LLVM regularization phase"));
 
-namespace SPIRV {
 void verifyRegularizationPass(llvm::Module &M, const std::string &PassName) {
   if (VerifyRegularizationPasses) {
     std::string Err;

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -41,16 +41,15 @@
 #define SPIRV_LIBSPIRV_SPIRVDEBUG_H
 
 #include "SPIRVUtil.h"
-#include "llvm/IR/Module.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
 
 #include <iostream>
 #include <string>
 
-namespace SPIRV {
+namespace llvm {
+class Module;
+}
 
-extern llvm::cl::opt<bool> VerifyRegularizationPasses;
+namespace SPIRV {
 
 // Include source file and line number in error message.
 extern bool SPIRVDbgErrorMsgIncludesSourceInfo;

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -48,10 +48,8 @@
 #include "SPIRVValue.h"
 
 #include <cassert>
-#include <cstdint>
 #include <functional>
 #include <iostream>
-#include <map>
 #include <unordered_set>
 #include <utility>
 #include <vector>

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -46,8 +46,6 @@
 #include <iostream>
 #include <set>
 #include <string>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 namespace SPIRV {

--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -43,11 +43,9 @@
 #include "SPIRVDebug.h"
 #include "SPIRVExtInst.h"
 #include "SPIRVModule.h"
-#include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <iostream>
-#include <iterator>
 #include <string>
 #include <vector>
 

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -48,8 +48,6 @@
 #include "SPIRVStream.h"
 
 #include <cassert>
-#include <iostream>
-#include <map>
 #include <tuple>
 #include <vector>
 

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -48,8 +48,6 @@
 #include "SPIRVType.h"
 
 #include <iostream>
-#include <map>
-#include <memory>
 
 namespace SPIRV {
 


### PR DESCRIPTION
Remove unused includes.

Move some includes from SPIRVDebug.h to .cpp files.

Header files should only include the minimum required, to keep build times reasonable.