### PR TITLE
Use Initializer execution mode for global constructors

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -68,6 +68,8 @@ public:
 
   bool runOnModule(Module &M) override;
   void visit(Module *M);
+  void preprocessCXXStructorList(SPIRVMDBuilder::NamedMDWrapper &EM,
+                                 GlobalVariable *V, ExecutionMode EMode);
   void preprocessOCLMetadata(Module *M, SPIRVMDBuilder *B, SPIRVMDWalker *W);
   void preprocessVectorComputeMetadata(Module *M, SPIRVMDBuilder *B,
                                        SPIRVMDWalker *W);
@@ -94,6 +96,24 @@ bool PreprocessMetadata::runOnModule(Module &Module) {
   return true;
 }
 
+void PreprocessMetadata::preprocessCXXStructorList(
+    SPIRVMDBuilder::NamedMDWrapper &EM, GlobalVariable *V,
+    ExecutionMode EMode) {
+  auto *List = dyn_cast_or_null<ConstantArray>(V->getInitializer());
+  if (!List)
+    return;
+
+  for (Value *V : List->operands()) {
+    auto *Structor = cast<ConstantStruct>(V);
+
+    // Each entry in the list is a struct containing 3 members:
+    // (priority, function, data), with function being the entry point.
+    auto *Kernel = cast<Function>(Structor->getOperand(1));
+
+    EM.addOp().add(Kernel).add(EMode).done();
+  }
+}
+
 void PreprocessMetadata::visit(Module *M) {
   SPIRVMDBuilder B(*M);
   SPIRVMDWalker W(*M);
@@ -104,6 +124,10 @@ void PreprocessMetadata::visit(Module *M) {
   // Create metadata representing (empty so far) list
   // of OpExecutionMode instructions
   auto EM = B.addNamedMD(kSPIRVMD::ExecutionMode); // !spirv.ExecutionMode = {}
+
+  // Process special variables in LLVM IR module.
+  if (auto *GV = M->getGlobalVariable("llvm.global_ctors"))
+    preprocessCXXStructorList(EM, GV, spv::ExecutionModeInitializer);
 
   // Add execution modes for kernels. We take it from metadata attached to
   // the kernel functions.

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3673,6 +3673,45 @@ void SPIRVToLLVM::transGlobalCtorDtors(SPIRVVariable *BV) {
   cast<GlobalValue>(V)->setLinkage(GlobalValue::AppendingLinkage);
 }
 
+void SPIRVToLLVM::createCXXStructor(const char *ListName,
+                                    SmallVectorImpl<Function *> &Funcs) {
+  if (Funcs.empty())
+    return;
+
+  // If the SPIR-V input contained a variable for the structor list and it
+  // has already been translated, then don't interfere.
+  if (M->getGlobalVariable(ListName))
+    return;
+
+  // Type of a structor entry: { i32, void ()*, i8* }
+  Type *PriorityTy = Type::getInt32Ty(*Context);
+  PointerType *CtorTy = PointerType::getUnqual(
+      FunctionType::get(Type::getVoidTy(*Context), false));
+  PointerType *ComdatTy = Type::getInt8PtrTy(*Context);
+  StructType *StructorTy = StructType::get(PriorityTy, CtorTy, ComdatTy);
+
+  ArrayType *ArrTy = ArrayType::get(StructorTy, Funcs.size());
+
+  GlobalVariable *GV =
+      cast<GlobalVariable>(M->getOrInsertGlobal(ListName, ArrTy));
+  GV->setLinkage(GlobalValue::AppendingLinkage);
+
+  // Build the initializer.
+  SmallVector<Constant *, 2> ArrayElts;
+  for (auto *F : Funcs) {
+    SmallVector<Constant *, 3> Elts;
+    // SPIR-V does not specify an order between Initializers, so set default
+    // priority.
+    Elts.push_back(ConstantInt::get(PriorityTy, 65535));
+    Elts.push_back(ConstantExpr::getBitCast(F, CtorTy));
+    Elts.push_back(ConstantPointerNull::get(ComdatTy));
+    ArrayElts.push_back(ConstantStruct::get(StructorTy, Elts));
+  }
+
+  Constant *NewArray = ConstantArray::get(ArrTy, ArrayElts);
+  GV->setInitializer(NewArray);
+}
+
 bool SPIRVToLLVM::transFPContractMetadata() {
   bool ContractOff = false;
   for (unsigned I = 0, E = BM->getNumFunctions(); I != E; ++I) {
@@ -3749,6 +3788,7 @@ static bool transKernelArgTypeMedataFromString(LLVMContext *Ctx,
 }
 
 bool SPIRVToLLVM::transMetadata() {
+  SmallVector<Function *, 2> CtorKernels;
   for (unsigned I = 0, E = BM->getNumFunctions(); I != E; ++I) {
     SPIRVFunction *BF = BM->getFunction(I);
     Function *F = static_cast<Function *>(getTranslatedValue(BF));
@@ -3780,6 +3820,10 @@ bool SPIRVToLLVM::transMetadata() {
           ConstantInt::get(Type::getInt32Ty(*Context), 1)));
       F->setMetadata(kSPIR2MD::VecTyHint, MDNode::get(*Context, MetadataVec));
     }
+    // Generate metadata for Initializer.
+    if (BF->getExecutionMode(ExecutionModeInitializer)) {
+      CtorKernels.push_back(F);
+    }
     // Generate metadata for intel_reqd_sub_group_size
     if (auto *EM = BF->getExecutionMode(ExecutionModeSubgroupSize)) {
       auto SizeMD = ConstantAsMetadata::get(getUInt32(M, EM->getLiterals()[0]));
@@ -3810,6 +3854,7 @@ bool SPIRVToLLVM::transMetadata() {
   MemoryModelMD->addOperand(
       getMDTwoInt(Context, static_cast<unsigned>(BM->getAddressingModel()),
                   static_cast<unsigned>(BM->getMemoryModel())));
+  createCXXStructor("llvm.global_ctors", CtorKernels);
   return true;
 }
 

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -271,6 +271,8 @@ private:
   void transUserSemantic(SPIRV::SPIRVFunction *Fun);
   void transGlobalAnnotations();
   void transGlobalCtorDtors(SPIRVVariable *BV);
+  void createCXXStructor(const char *ListName,
+                         SmallVectorImpl<Function *> &Funcs);
   void transIntelFPGADecorations(SPIRVValue *BV, Value *V);
 }; // class SPIRVToLLVM
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3002,10 +3002,19 @@ bool LLVMToSPIRV::transExecutionMode() {
 
       switch (EMode) {
       case spv::ExecutionModeContractionOff:
-      case spv::ExecutionModeInitializer:
-      case spv::ExecutionModeFinalizer:
         BF->addExecutionMode(BM->add(
             new SPIRVExecutionMode(BF, static_cast<ExecutionMode>(EMode))));
+        break;
+      case spv::ExecutionModeInitializer:
+      case spv::ExecutionModeFinalizer:
+        if (BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_1)) {
+          BF->addExecutionMode(BM->add(
+              new SPIRVExecutionMode(BF, static_cast<ExecutionMode>(EMode))));
+        } else {
+          getErrorLog().checkError(false, SPIRVEC_Requires1_1,
+                                   "Initializer/Finalizer Execution Mode");
+          return false;
+        }
         break;
       case spv::ExecutionModeLocalSize:
       case spv::ExecutionModeLocalSizeHint: {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2676,7 +2676,14 @@ bool LLVMToSPIRV::transGlobalVariables() {
   for (auto I = M->global_begin(), E = M->global_end(); I != E; ++I) {
     if ((*I).getName() == "llvm.global.annotations")
       transGlobalAnnotation(&(*I));
-    else if (MDNode *IO = ((*I).getMetadata("io_pipe_id")))
+    else if ((I->getName() == "llvm.global_ctors" ||
+              I->getName() == "llvm.global_dtors") &&
+             !BM->isAllowedToUseExtension(
+                 ExtensionID::SPV_INTEL_function_pointers)) {
+      // Function pointers are required to represent structor lists; do not
+      // translate the variable if function pointers are not available.
+      continue;
+    } else if (MDNode *IO = ((*I).getMetadata("io_pipe_id")))
       transGlobalIOPipeStorage(&(*I), IO);
     else if (!transValue(&(*I), nullptr))
       return false;

--- a/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
@@ -16,3 +16,4 @@ _SPIRV_OP(FunctionPointers, "Can't translate function pointer:\n")
 _SPIRV_OP(InvalidInstruction, "Can't translate llvm instruction:\n")
 _SPIRV_OP(InvalidWordCount,
           "Can't encode instruction with word count greater than 65535:\n")
+_SPIRV_OP(Requires1_1, "Feature requires SPIR-V 1.1 or greater:")

--- a/test/CXX/global-ctor.cl
+++ b/test/CXX/global-ctor.cl
@@ -2,6 +2,7 @@
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 class Something {
   public:
@@ -19,3 +20,6 @@ void kernel work(global int *out) {
 // CHECK-SPIRV-NOT: ExecutionMode [[work]] 33
 // CHECK-SPIRV: EntryPoint 6 [[ctor:[0-9]+]] "_GLOBAL__sub_I_global_ctor.cl"
 // CHECK-SPIRV: ExecutionMode [[ctor]] 33
+
+// CHECK-LLVM: llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 65535, void ()* @[[CTORNAME:_GLOBAL__sub_I[^ ]+]], i8* null }
+// CHECK-LLVM: define spir_kernel void @[[CTORNAME]]

--- a/test/CXX/global-ctor.cl
+++ b/test/CXX/global-ctor.cl
@@ -3,6 +3,7 @@
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: not llvm-spirv %t.bc --spirv-max-version=1.0 2>&1 | FileCheck %s --check-prefix=CHECK-SPV10
 
 class Something {
   public:
@@ -23,3 +24,5 @@ void kernel work(global int *out) {
 
 // CHECK-LLVM: llvm.global_ctors = appending global [1 x { i32, void ()*, i8* }] [{ i32, void ()*, i8* } { i32 65535, void ()* @[[CTORNAME:_GLOBAL__sub_I[^ ]+]], i8* null }
 // CHECK-LLVM: define spir_kernel void @[[CTORNAME]]
+
+// CHECK-SPV10: Feature requires SPIR-V 1.1 or greater: Initializer/Finalizer Execution Mode

--- a/test/CXX/global-ctor.cl
+++ b/test/CXX/global-ctor.cl
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -cl-std=clc++ -emit-llvm-bc -triple spir -O0 %s -o %t.bc
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+class Something {
+  public:
+    Something(int a) : v(a) {}
+    int v;
+};
+
+Something g(33);
+
+void kernel work(global int *out) {
+  *out = g.v;
+}
+
+// CHECK-SPIRV: EntryPoint 6 [[work:[0-9]+]] "work"
+// CHECK-SPIRV-NOT: ExecutionMode [[work]] 33
+// CHECK-SPIRV: EntryPoint 6 [[ctor:[0-9]+]] "_GLOBAL__sub_I_global_ctor.cl"
+// CHECK-SPIRV: ExecutionMode [[ctor]] 33


### PR DESCRIPTION
This PR adds support to translate global constructors from LLVM's `llvm.global_ctors` variable to SPIR-V's `Initializer` execution mode, and vice versa.

* Only emit Initializer and Finalizer from SPIR-V 1.1
* Translate Initializer to llvm.global_ctors
* Set Initializer ExecutionMode for global ctors
* Conditionalize translation of llvm.global_ctors/dtors