### PR TITLE
travis: report llvm revision for non-external builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ script:
       mkdir llvm-spirv
       mv * llvm-spirv
       git clone https://github.com/llvm/llvm-project --depth 1
+      git -C llvm-project log --oneline -1
       mv llvm-spirv llvm-project/llvm-spirv
     fi
   - |


### PR DESCRIPTION
The build log did not contain the llvm-project repository revision
being built for `BUILD_EXTERNAL=0` builds.  Add it to ease debugging
of build failures.