### PR TITLE
[CherryPick] updates for OpenCL C 3.0

### DIFF
--- a/lib/SPIRV/OCL20ToSPIRV.cpp
+++ b/lib/SPIRV/OCL20ToSPIRV.cpp
@@ -346,7 +346,7 @@ bool OCL20ToSPIRV::runOnModule(Module &Module) {
     return false;
 
   CLVer = std::get<1>(Src);
-  if (CLVer > kOCLVer::CL20)
+  if (CLVer == kOCLVer::CL21)
     return false;
 
   LLVM_DEBUG(dbgs() << "Enter OCL20ToSPIRV:\n");
@@ -426,7 +426,8 @@ void OCL20ToSPIRV::visitCallInst(CallInst &CI) {
         DemangledName == kOCLBuiltinName::AtomicCmpXchgStrong ||
         DemangledName == kOCLBuiltinName::AtomicCmpXchgWeakExplicit ||
         DemangledName == kOCLBuiltinName::AtomicCmpXchgStrongExplicit) {
-      assert(CLVer == kOCLVer::CL20 && "Wrong version of OpenCL");
+      assert((CLVer == kOCLVer::CL20 || CLVer == kOCLVer::CL30) &&
+             "Wrong version of OpenCL");
       PCI = visitCallAtomicCmpXchg(PCI, DemangledName);
     }
     visitCallAtomicLegacy(PCI, MangledName, DemangledName);

--- a/lib/SPIRV/OCL21ToSPIRV.cpp
+++ b/lib/SPIRV/OCL21ToSPIRV.cpp
@@ -109,7 +109,7 @@ bool OCL21ToSPIRV::runOnModule(Module &Module) {
     return false;
 
   CLVer = std::get<1>(Src);
-  if (CLVer < kOCLVer::CL21)
+  if (CLVer != kOCLVer::CL21)
     return false;
 
   LLVM_DEBUG(dbgs() << "Enter OCL21ToSPIRV:\n");

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -253,6 +253,7 @@ namespace kOCLVer {
 const unsigned CL12 = 102000;
 const unsigned CL20 = 200000;
 const unsigned CL21 = 201000;
+const unsigned CL30 = 300000;
 } // namespace kOCLVer
 
 namespace OclExt {

--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -175,8 +175,8 @@ void PreprocessMetadata::preprocessOCLMetadata(Module *M, SPIRVMDBuilder *B,
   // !{x} = !{i32 3, i32 102000}
   B->addNamedMD(kSPIRVMD::Source)
       .addOp()
-      .add(CLVer < kOCLVer::CL21 ? spv::SourceLanguageOpenCL_C
-                                 : spv::SourceLanguageOpenCL_CPP)
+      .add(CLVer == kOCLVer::CL21 ? spv::SourceLanguageOpenCL_CPP
+                                  : spv::SourceLanguageOpenCL_C)
       .add(CLVer)
       .done();
   if (EraseOCLMD)


### PR DESCRIPTION
OpenCL C 3.0 is a derivative of OpenCL C 2.0 and not OpenCL C++.
Run the OpenCL C++ passes for OpenCL 2.1 only, and run similar
OpenCL C 2.0 passes for OpenCL C 3.0.

(cherry picked from commit 9ede94ccc038a54e6b308d594ffa341894f19369)