### PR TITLE
Add ReadNone attr for Builtin functions

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4115,6 +4115,8 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC,
     F->setCallingConv(CallingConv::SPIR_FUNC);
     if (isFuncNoUnwind())
       F->addFnAttr(Attribute::NoUnwind);
+    if (isFuncReadNone(UnmangledName))
+      F->addFnAttr(Attribute::ReadNone);
   }
   auto Args = transValue(BC->getValues(BArgs), F, BB);
   SPIRVDBG(dbgs() << "[transOCLBuiltinFromExtInst] Function: " << *F

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4428,3 +4428,32 @@ bool llvm::getSpecConstInfo(std::istream &IS,
   }
   return !IS.fail();
 }
+
+const StringSet<> SPIRVToLLVM::BuiltInConstFunc {
+  "convert", "get_work_dim", "get_global_size", "sub_group_ballot_bit_count",
+  "get_global_id", "get_local_size", "get_local_id", "get_num_groups",
+  "get_group_id", "get_global_offset", "acos", "acosh", "acospi",
+  "asin", "asinh", "asinpi", "atan", "atan2", "atanh", "atanpi",
+  "atan2pi", "cbrt", "ceil", "copysign", "cos", "cosh", "cospi",
+  "erfc", "erf", "exp", "exp2", "exp10", "expm1", "fabs", "fdim",
+  "floor", "fma", "fmax", "fmin", "fmod", "ilogb", "ldexp", "lgamma",
+  "log", "log2", "log10", "log1p", "logb", "mad", "maxmag", "minmag",
+  "nan", "nextafter", "pow", "pown", "powr", "remainder", "rint",
+  "rootn", "round", "rsqrt", "sin", "sinh", "sinpi", "sqrt", "tan",
+  "tanh", "tanpi", "tgamma", "trunc", "half_cos", "half_divide", "half_exp",
+  "half_exp2", "half_exp10", "half_log", "half_log2", "half_log10", "half_powr",
+  "half_recip", "half_rsqrt", "half_sin", "half_sqrt", "half_tan", "native_cos",
+  "native_divide", "native_exp", "native_exp2", "native_exp10", "native_log",
+  "native_log2", "native_log10", "native_powr", "native_recip", "native_rsqrt",
+  "native_sin", "native_sqrt", "native_tan", "abs", "abs_diff", "add_sat", "hadd",
+  "rhadd", "clamp", "clz", "mad_hi", "mad_sat", "max", "min", "mul_hi", "rotate",
+  "sub_sat", "upsample", "popcount", "mad24", "mul24", "degrees", "mix", "radians",
+  "step", "smoothstep", "sign", "cross", "dot", "distance", "length", "normalize",
+  "fast_distance", "fast_length", "fast_normalize", "isequal", "isnotequal",
+  "isgreater", "isgreaterequal", "isless", "islessequal", "islessgreater",
+  "isfinite", "isinf", "isnan", "isnormal", "isordered", "isunordered", "signbit",
+  "any", "all", "bitselect", "select", "shuffle", "shuffle2", "get_image_width",
+  "get_image_height", "get_image_depth", "get_image_channel_data_type",
+  "get_image_channel_order", "get_image_dim", "get_image_array_size",
+  "get_image_array_size", "sub_group_inverse_ballot", "sub_group_ballot_bit_extract",
+  };

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4429,6 +4429,7 @@ bool llvm::getSpecConstInfo(std::istream &IS,
   return !IS.fail();
 }
 
+// clang-format off
 const StringSet<> SPIRVToLLVM::BuiltInConstFunc {
   "convert", "get_work_dim", "get_global_size", "sub_group_ballot_bit_count",
   "get_global_id", "get_local_size", "get_local_id", "get_num_groups",
@@ -4456,4 +4457,5 @@ const StringSet<> SPIRVToLLVM::BuiltInConstFunc {
   "get_image_height", "get_image_depth", "get_image_channel_data_type",
   "get_image_channel_order", "get_image_dim", "get_image_array_size",
   "get_image_array_size", "sub_group_inverse_ballot", "sub_group_ballot_bit_extract",
-  };
+};
+// clang-format on

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -222,7 +222,7 @@ private:
   bool isFuncNoUnwind() const { return true; }
 
   bool isFuncReadNone(const std::string& name) const {
-    if (BuiltInFunc.find(name) != BuiltInFunc.end())
+    if (BuiltInConstFunc.find(name) != BuiltInFunc.end())
       return true;
     else
       return false;

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -44,9 +44,8 @@
 #include "SPIRVModule.h"
 
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
-#include "llvm/IR/Metadata.h"    // llvm::Metadata
 #include "llvm/ADT/StringSet.h"
+#include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
 
 namespace llvm {
 class Module;
@@ -223,7 +222,7 @@ private:
   // Change this if it is no longer true.
   bool isFuncNoUnwind() const { return true; }
 
-  bool isFuncReadNone(const std::string& name) const {
+  bool isFuncReadNone(const std::string &name) const {
     return BuiltInConstFunc.count(name);
   }
 

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -76,6 +76,7 @@ class SPIRVToLLVM {
 public:
   SPIRVToLLVM(Module *LLVMModule, SPIRVModule *TheSPIRVModule);
 
+  static const StringSet<> BuiltInConstFunc;
   std::string getOCLBuiltinName(SPIRVInstruction *BI);
   std::string getOCLConvertBuiltinName(SPIRVInstruction *BI);
   std::string getOCLGenericCastToPtrName(SPIRVInstruction *BI);
@@ -222,41 +223,8 @@ private:
   bool isFuncNoUnwind() const { return true; }
 
   bool isFuncReadNone(const std::string& name) const {
-    if (BuiltInConstFunc.find(name) != BuiltInFunc.end())
-      return true;
-    else
-      return false;
+    return BuiltInConstFunc.count(name);
   }
-
-  std::set<std::string> BuiltInConstFunc{
-  "convert", "get_work_dim", "get_global_size",
-  "get_global_id", "get_local_size", "get_local_id", "get_num_groups",
-  "get_group_id", "get_global_offset", "acos", "acosh", "acospi",
-  "asin", "asinh", "asinpi", "atan", "atan2", "atanh", "atanpi",
-  "atan2pi", "cbrt", "ceil", "copysign", "cos", "cosh", "cospi",
-  "erfc", "erf", "exp", "exp2", "exp10", "expm1", "fabs", "fdim",
-  "floor", "fma", "fmax", "fmin", "fmod", "ilogb", "ldexp", "lgamma",
-  "log", "log2", "log10", "log1p", "logb", "mad", "maxmag", "minmag",
-  "nan", "nextafter", "pow", "pown", "powr", "remainder", "rint",
-  "rootn", "round", "rsqrt", "sin", "sinh", "sinpi", "sqrt", "tan",
-  "tanh", "tanpi", "tgamma", "trunc", "half_cos", "half_divide", "half_exp",
-  "half_exp2", "half_exp10", "half_log", "half_log2", "half_log10", "half_powr",
-  "half_recip", "half_rsqrt", "half_sin", "half_sqrt", "half_tan", "native_cos",
-  "native_divide", "native_exp", "native_exp2", "native_exp10", "native_log",
-  "native_log2", "native_log10", "native_powr", "native_recip", "native_rsqrt",
-  "native_sin", "native_sqrt", "native_tan", "abs", "abs_diff", "add_sat", "hadd",
-  "rhadd", "clamp", "clz", "mad_hi", "mad_sat", "max", "min", "mul_hi", "rotate",
-  "sub_sat", "upsample", "popcount", "mad24", "mul24", "degrees", "mix", "radians",
-  "step", "smoothstep", "sign", "cross", "dot", "distance", "length", "normalize",
-  "fast_distance", "fast_length", "fast_normalize", "isequal", "isnotequal",
-  "isgreater", "isgreaterequal", "isless", "islessequal", "islessgreater",
-  "isfinite", "isinf", "isnan", "isnormal", "isordered", "isunordered", "signbit",
-  "any", "all", "bitselect", "select", "shuffle", "shuffle2", "get_image_width",
-  "get_image_height", "get_image_depth", "get_image_channel_data_type",
-  "get_image_channel_order", "get_image_dim", "get_image_array_size",
-  "get_image_array_size", "sub_group_inverse_ballot", "sub_group_ballot_bit_extract",
-  "sub_group_ballot_bit_count"
-  };
 
   bool isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const;
   bool isDirectlyTranslatedToOCL(Op OpCode) const;

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -46,6 +46,7 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
 #include "llvm/IR/Metadata.h"    // llvm::Metadata
+#include "llvm/ADT/StringSet.h"
 
 namespace llvm {
 class Module;

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -222,8 +222,8 @@ private:
   // Change this if it is no longer true.
   bool isFuncNoUnwind() const { return true; }
 
-  bool isFuncReadNone(const std::string &name) const {
-    return BuiltInConstFunc.count(name);
+  bool isFuncReadNone(const std::string &Name) const {
+    return BuiltInConstFunc.count(Name);
   }
 
   bool isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const;

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -220,6 +220,44 @@ private:
   // OpenCL function always has NoUnwind attribute.
   // Change this if it is no longer true.
   bool isFuncNoUnwind() const { return true; }
+
+  bool isFuncReadNone(const std::string& name) const {
+    if (BuiltInFunc.find(name) != BuiltInFunc.end())
+      return true;
+    else
+      return false;
+  }
+
+  std::set<std::string> BuiltInConstFunc{
+  "convert", "get_work_dim", "get_global_size",
+  "get_global_id", "get_local_size", "get_local_id", "get_num_groups",
+  "get_group_id", "get_global_offset", "acos", "acosh", "acospi",
+  "asin", "asinh", "asinpi", "atan", "atan2", "atanh", "atanpi",
+  "atan2pi", "cbrt", "ceil", "copysign", "cos", "cosh", "cospi",
+  "erfc", "erf", "exp", "exp2", "exp10", "expm1", "fabs", "fdim",
+  "floor", "fma", "fmax", "fmin", "fmod", "ilogb", "ldexp", "lgamma",
+  "log", "log2", "log10", "log1p", "logb", "mad", "maxmag", "minmag",
+  "nan", "nextafter", "pow", "pown", "powr", "remainder", "rint",
+  "rootn", "round", "rsqrt", "sin", "sinh", "sinpi", "sqrt", "tan",
+  "tanh", "tanpi", "tgamma", "trunc", "half_cos", "half_divide", "half_exp",
+  "half_exp2", "half_exp10", "half_log", "half_log2", "half_log10", "half_powr",
+  "half_recip", "half_rsqrt", "half_sin", "half_sqrt", "half_tan", "native_cos",
+  "native_divide", "native_exp", "native_exp2", "native_exp10", "native_log",
+  "native_log2", "native_log10", "native_powr", "native_recip", "native_rsqrt",
+  "native_sin", "native_sqrt", "native_tan", "abs", "abs_diff", "add_sat", "hadd",
+  "rhadd", "clamp", "clz", "mad_hi", "mad_sat", "max", "min", "mul_hi", "rotate",
+  "sub_sat", "upsample", "popcount", "mad24", "mul24", "degrees", "mix", "radians",
+  "step", "smoothstep", "sign", "cross", "dot", "distance", "length", "normalize",
+  "fast_distance", "fast_length", "fast_normalize", "isequal", "isnotequal",
+  "isgreater", "isgreaterequal", "isless", "islessequal", "islessgreater",
+  "isfinite", "isinf", "isnan", "isnormal", "isordered", "isunordered", "signbit",
+  "any", "all", "bitselect", "select", "shuffle", "shuffle2", "get_image_width",
+  "get_image_height", "get_image_depth", "get_image_channel_data_type",
+  "get_image_channel_order", "get_image_dim", "get_image_array_size",
+  "get_image_array_size", "sub_group_inverse_ballot", "sub_group_ballot_bit_extract",
+  "sub_group_ballot_bit_count"
+  };
+
   bool isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const;
   bool isDirectlyTranslatedToOCL(Op OpCode) const;
   bool transOCLBuiltinsFromVariables();

--- a/test/transcoding/builtin_function_readnone_attr.ll
+++ b/test/transcoding/builtin_function_readnone_attr.ll
@@ -1,0 +1,47 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: convergent nofree norecurse nounwind uwtable
+define dso_local spir_kernel void @test_builtin_readnone(double* nocapture readonly %a, double* nocapture %b) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %0 = load double, double* %a, align 8, !tbaa !7
+  %call = tail call double @_Z3expd(double %0) #2
+  store double %call, double* %b, align 8, !tbaa !7
+  %1 = load double, double* %a, align 8, !tbaa !7
+  %call1 = tail call double @_Z3cosd(double %1) #2
+  store double %call1, double* %b, align 8, !tbaa !7
+  ret void
+}
+
+; CHECK-LLVM: ; Function Attrs: nounwind readnone
+; Function Attrs: convergent nounwind readnone
+declare dso_local double @_Z3expd(double) local_unnamed_addr #1
+
+; CHECK-LLVM: ; Function Attrs: nounwind readnone
+; Function Attrs: convergent nounwind readnone
+declare dso_local double @_Z3cosd(double) local_unnamed_addr #1
+
+attributes #0 = { convergent nofree norecurse nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind readnone }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 12.0.0 (https://github.com/intel/llvm 275e05b9dc13deb44eb7c765d23e65358d6bd077)"}
+!3 = !{i32 1, i32 1}
+!4 = !{!"none", !"none"}
+!5 = !{!"double*", !"double*"}
+!6 = !{!"", !""}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"double", !9, i64 0}
+!9 = !{!"omnipotent char", !10, i64 0}
+!10 = !{!"Simple C/C++ TBAA"}

--- a/test/transcoding/builtin_function_readnone_attr.ll
+++ b/test/transcoding/builtin_function_readnone_attr.ll
@@ -19,11 +19,11 @@ entry:
 }
 
 ; Function Attrs: convergent nounwind readnone
-; CHECK-LLVM: @_Z3expd{{.*}}#[[#Attrs:]]
+; CHECK-LLVM: declare{{.*}}@_Z3expd{{.*}}#[[#Attrs:]]
 declare dso_local double @_Z3expd(double) local_unnamed_addr #1
 
 ; Function Attrs: convergent nounwind readnone
-; CHECK-LLVM: @_Z3cosd{{.*}} [[#Attrs]]
+; CHECK-LLVM: declare{{.*}}@_Z3cosd{{.*}}#[[#Attrs]]
 declare dso_local double @_Z3cosd(double) local_unnamed_addr #1
 
 attributes #0 = { convergent nofree norecurse nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/transcoding/builtin_function_readnone_attr.ll
+++ b/test/transcoding/builtin_function_readnone_attr.ll
@@ -18,15 +18,16 @@ entry:
   ret void
 }
 
-; CHECK-LLVM: ; Function Attrs: nounwind readnone
 ; Function Attrs: convergent nounwind readnone
+; CHECK-LLVM: @_Z3expd{{.*}}#[[#Attrs:]]
 declare dso_local double @_Z3expd(double) local_unnamed_addr #1
 
-; CHECK-LLVM: ; Function Attrs: nounwind readnone
 ; Function Attrs: convergent nounwind readnone
+; CHECK-LLVM: @_Z3cosd{{.*}} [[#Attrs]]
 declare dso_local double @_Z3cosd(double) local_unnamed_addr #1
 
 attributes #0 = { convergent nofree norecurse nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
+; CHECK-LLVM: attributes #[[#Attrs]] {{.*}} readnone
 attributes #1 = { convergent nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { convergent nounwind readnone }
 


### PR DESCRIPTION
All constant built in functions should have readnone attribute in LLVM IR. 

Signed-off-by: Aleksander Fadeev <aleksander.fadeev@intel.com>