### PR TITLE
Fix spirv-linked programs with program scope variables.

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1672,18 +1672,20 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto Ty = transType(BVar->getType()->getPointerElementType());
     bool IsConst = BVar->isConstant();
     llvm::GlobalValue::LinkageTypes LinkageTy = transLinkageType(BVar);
+    SPIRVStorageClassKind BS = BVar->getStorageClass();
     Constant *Initializer = nullptr;
     SPIRVValue *Init = BVar->getInitializer();
     if (Init)
       Initializer = dyn_cast<Constant>(transValue(Init, F, BB, false));
     else if (LinkageTy == GlobalValue::CommonLinkage)
-      // In LLVM variables with common linkage type must be initilized by 0
+      // In LLVM, variables with common linkage type must be initialized to 0.
       Initializer = Constant::getNullValue(Ty);
-    else if (BVar->getStorageClass() ==
-             SPIRVStorageClassKind::StorageClassWorkgroup)
+    else if (BS == SPIRVStorageClassKind::StorageClassWorkgroup)
       Initializer = dyn_cast<Constant>(UndefValue::get(Ty));
+    else if ((LinkageTy != GlobalValue::ExternalLinkage) &&
+             (BS == SPIRVStorageClassKind::StorageClassCrossWorkgroup))
+      Initializer = Constant::getNullValue(Ty);
 
-    SPIRVStorageClassKind BS = BVar->getStorageClass();
     if (BS == StorageClassFunction && !Init) {
       assert(BB && "Invalid BB");
       return mapValue(BV, new AllocaInst(Ty, 0, BV->getName(), BB));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,11 @@ if(SPIRV_TOOLS_FOUND)
     set(SPIRV_TOOLS_SPIRV_AS_FOUND True)
   endif()
 
+  find_program(SPIRV_TOOLS_SPIRV_LINK NAMES spirv-link PATHS ${SPIRV_TOOLS_PREFIX}/bin)
+  if(SPIRV_TOOLS_SPIRV_LINK)
+    set(SPIRV_TOOLS_SPIRV_LINK_FOUND True)
+  endif()
+
   find_program(SPIRV_TOOLS_SPIRV_VAL NAMES spirv-val PATHS ${SPIRV_TOOLS_PREFIX}/bin)
   if(SPIRV_TOOLS_SPIRV_VAL)
     set(SPIRV_TOOLS_SPIRV_VAL_FOUND True)
@@ -26,6 +31,11 @@ endif()
 if(NOT SPIRV_TOOLS_SPIRV_AS)
   message(WARNING "spirv-as not found! SPIR-V assembly tests will not be run.")
   set(SPIRV_TOOLS_SPIRV_AS_FOUND False)
+endif()
+
+if(NOT SPIRV_TOOLS_SPIRV_LINK)
+  message(WARNING "spirv-link not found! SPIR-V test involving the linker will not be run.")
+  set(SPIRV_TOOLS_SPIRV_LINK_FOUND False)
 endif()
 
 if(NOT SPIRV_TOOLS_SPIRV_VAL)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -60,6 +60,11 @@ if config.spirv_tools_have_spirv_as:
     config.available_features.add('spirv-as')
     using_spirv_tools = True
 
+if config.spirv_tools_have_spirv_link:
+    llvm_config.add_tool_substitutions(['spirv-link'], [config.spirv_tools_bin_dir])
+    config.available_features.add('spirv-link')
+    using_spirv_tools = True
+
 if config.spirv_tools_have_spirv_val:
     llvm_config.add_tool_substitutions(['spirv-val'], [config.spirv_tools_bin_dir])
     using_spirv_tools = True

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -16,6 +16,7 @@ config.host_arch = "@HOST_ARCH@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
 config.spirv_tools_have_spirv_as = @SPIRV_TOOLS_SPIRV_AS_FOUND@
+config.spirv_tools_have_spirv_link = @SPIRV_TOOLS_SPIRV_LINK_FOUND@
 config.spirv_tools_have_spirv_val = @SPIRV_TOOLS_SPIRV_VAL_FOUND@
 config.spirv_tools_bin_dir = "@SPIRV_TOOLS_BINDIR@"
 config.spirv_tools_lib_dir = "@SPIRV_TOOLS_LIBDIR@"

--- a/test/transcoding/linked-program.ll
+++ b/test/transcoding/linked-program.ll
@@ -1,8 +1,5 @@
 ; REQUIRES: spirv-link
 ;
-; FIXME This currently crashes when translating back from SPIR-V.
-; XFAIL: *
-;
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/linked-program.ll
+++ b/test/transcoding/linked-program.ll
@@ -1,0 +1,25 @@
+; REQUIRES: spirv-link
+;
+; FIXME This currently crashes when translating back from SPIR-V.
+; XFAIL: *
+;
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: spirv-link %t.spv -o %t.linked.spv
+; RUN: llvm-spirv -r %t.linked.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
+;
+; This checks that SPIR-V programs with global variables are still consumable
+; after spirv-link.
+
+target triple = "spir-unknown-unknown"
+
+@foo = common dso_local local_unnamed_addr addrspace(1) global i32 0, align 4
+; CHECK: @foo = internal addrspace(1) global i32 0, align 4
+
+define dso_local spir_kernel void @bar() local_unnamed_addr {
+entry:
+  store i32 42, i32 addrspace(1)* @foo, align 4
+  ret void
+}


### PR DESCRIPTION
 * Make spirv-link usable in tests
 * Add default initializer to CrossWorkgroup globals

Patches by @mantognini!