### PR TITLE
Implementing VectorComputeCallableFunctionINTEL decoration backport to v10

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3373,6 +3373,8 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
   SPIRVWord SIMTMode = 0;
   if (BF->hasDecorate(DecorationSIMTCallINTEL, 0, &SIMTMode))
     F->addFnAttr(kVCMetadata::VCSIMTCall, std::to_string(SIMTMode));
+  if (BF->hasDecorate(DecorationVectorComputeCallableFunctionINTEL))
+    F->addFnAttr(kVCMetadata::VCCallable);
 
   for (Function::arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E;
        ++I) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -568,6 +568,10 @@ void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
     BF->addDecorate(DecorationSIMTCallINTEL, SIMTMode);
   }
 
+  if (Attrs.hasFnAttribute(kVCMetadata::VCCallable)) {
+    BF->addDecorate(DecorationVectorComputeCallableFunctionINTEL);
+  }
+
   for (Function::arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E;
        ++I) {
     auto ArgNo = I->getArgNo();

--- a/lib/SPIRV/VectorComputeUtil.h
+++ b/lib/SPIRV/VectorComputeUtil.h
@@ -108,6 +108,7 @@ const static char VCGlobalVariable[] = "VCGlobalVariable";
 const static char VCVolatile[] = "VCVolatile";
 const static char VCByteOffset[] = "VCByteOffset";
 const static char VCSIMTCall[] = "VCSIMTCall";
+const static char VCCallable[] = "VCCallable";
 } // namespace kVCMetadata
 
 namespace kVCType {

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -401,6 +401,8 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
                {CapabilityFunctionFloatControlINTEL});
   ADD_VEC_INIT(DecorationFunctionFloatingPointModeINTEL,
                {CapabilityFunctionFloatControlINTEL});
+  ADD_VEC_INIT(DecorationVectorComputeCallableFunctionINTEL,
+               {CapabilityVectorComputeINTEL});
 }
 
 template <> inline void SPIRVMap<BuiltIn, SPIRVCapVec>::init() {

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -429,6 +429,7 @@ inline bool isValid(spv::Decoration V) {
   case DecorationFunctionRoundingModeINTEL:
   case DecorationFunctionDenormModeINTEL:
   case DecorationFunctionFloatingPointModeINTEL:
+  case DecorationVectorComputeCallableFunctionINTEL:
     return true;
   default:
     return false;

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -369,6 +369,8 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationFunctionDenormModeINTEL, "FunctionDenormModeINTEL");
   add(DecorationFunctionFloatingPointModeINTEL,
       "FunctionFloatingPointModeINTEL");
+  add(DecorationVectorComputeCallableFunctionINTEL,
+      "VectorComputeCallableFunctionINTEL");
 }
 SPIRV_DEF_NAMEMAP(Decoration, SPIRVDecorationNameMap)
 

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -514,6 +514,7 @@ enum Decoration {
   DecorationForcePow2DepthINTEL = 5836,
   DecorationIOPipeStorageINTEL = 5944,
   DecorationFunctionFloatingPointModeINTEL = 6080,
+  DecorationVectorComputeCallableFunctionINTEL = 6087,
   DecorationMax = 0x7fffffff,
 };
 

--- a/test/callable-attribute-decoration.ll
+++ b/test/callable-attribute-decoration.ll
@@ -1,0 +1,19 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute
+; RUN: llvm-spirv %t.spv -o %t.spt --to-text
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -o %t.bc -r
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
+target triple = "spir64"
+
+
+define dso_local <4 x i32> @foo(<4 x i32> %a, <4 x i32> %b) #0 {
+entry:
+  ret <4 x i32> %a
+}
+; CHECK-SPIRV: 3 Decorate {{[0-9]+}} VectorComputeCallableFunctionINTEL
+; CHECK-LLVM: attributes
+; CHECK-LLVM-SAME: "VCCallable"
+
+attributes #0 = { "VCCallable" "VCFunction" }


### PR DESCRIPTION
Added following decoration and bidirectional translation it to
"VCCallable" attribute, according to spec: https://github.com/intel/llvm/pull/1612