### PR TITLE
[Backport] Support missing DWARF opcodes on llvm_release_90 branch

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -148,6 +148,14 @@ public:
     SPIRVAllowUnknownIntrinsics = AllowUnknownIntrinsics;
   }
 
+  bool allowExtraDIExpressions() const noexcept {
+    return AllowExtraDIExpressions;
+  }
+
+  void setAllowExtraDIExpressionsEnabled(bool Allow) noexcept {
+    AllowExtraDIExpressions = Allow;
+  }
+
   DebugInfoEIS getDebugInfoEIS() const { return DebugInfoVersion; }
 
   void setDebugInfoEIS(DebugInfoEIS EIS) { DebugInfoVersion = EIS; }
@@ -179,6 +187,10 @@ private:
   // Unknown LLVM intrinsics will be translated as external function calls in
   // SPIR-V
   bool SPIRVAllowUnknownIntrinsics = false;
+
+  // Enable support for extra DIExpression opcodes not listed in the SPIR-V
+  // DebugInfo specification.
+  bool AllowExtraDIExpressions = false;
 
   DebugInfoEIS DebugInfoVersion = DebugInfoEIS::SPIRV_Debug;
 };

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -935,10 +935,14 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgExpression(const DIExpression *Expr) {
   for (unsigned I = 0, N = Expr->getNumElements(); I < N; ++I) {
     using namespace SPIRVDebug::Operand::Operation;
     auto DWARFOpCode = static_cast<dwarf::LocationAtom>(Expr->getElement(I));
+
     SPIRVDebug::ExpressionOpCode OC =
         SPIRV::DbgExpressionOpCodeMap::map(DWARFOpCode);
-    assert(OpCountMap.find(OC) != OpCountMap.end() &&
-           "unhandled opcode found in DIExpression");
+    if (OpCountMap.find(OC) == OpCountMap.end())
+      report_fatal_error("unknown opcode found in DIExpression");
+    if (OC > SPIRVDebug::Fragment && !BM->allowExtraDIExpressions())
+      report_fatal_error("unsupported opcode found in DIExpression");
+
     unsigned OpCount = OpCountMap[OC];
     SPIRVWordVec Op(OpCount);
     Op[OpCodeIdx] = OC;

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -105,7 +105,162 @@ enum ExpressionOpCode {
   Xderef     = 6,
   StackValue = 7,
   Constu     = 8,
-  Fragment   = 9
+  Fragment   = 9,
+  Convert    = 10,
+  Addr       = 11,
+  Const1u    = 12,
+  Const1s    = 13,
+  Const2u    = 14,
+  Const2s    = 15,
+  Const4u    = 16,
+  Const4s    = 17,
+  Const8u    = 18,
+  Const8s    = 19,
+  Consts     = 20,
+  Dup        = 21,
+  Drop       = 22,
+  Over       = 23,
+  Pick       = 24,
+  Rot        = 25,
+  Abs        = 26,
+  And        = 27,
+  Div        = 28,
+  Mod        = 29,
+  Mul        = 30,
+  Neg        = 31,
+  Not        = 32,
+  Or         = 33,
+  Shl        = 34,
+  Shr        = 35,
+  Shra       = 36,
+  Xor        = 37,
+  Bra        = 38,
+  Eq         = 39,
+  Ge         = 40,
+  Gt         = 41,
+  Le         = 42,
+  Lt         = 43,
+  Ne         = 44,
+  Skip       = 45,
+  Lit0       = 46,
+  Lit1       = 47,
+  Lit2       = 48,
+  Lit3       = 49,
+  Lit4       = 50,
+  Lit5       = 51,
+  Lit6       = 52,
+  Lit7       = 53,
+  Lit8       = 54,
+  Lit9       = 55,
+  Lit10      = 56,
+  Lit11      = 57,
+  Lit12      = 58,
+  Lit13      = 59,
+  Lit14      = 60,
+  Lit15      = 61,
+  Lit16      = 62,
+  Lit17      = 63,
+  Lit18      = 64,
+  Lit19      = 65,
+  Lit20      = 66,
+  Lit21      = 67,
+  Lit22      = 68,
+  Lit23      = 69,
+  Lit24      = 70,
+  Lit25      = 71,
+  Lit26      = 72,
+  Lit27      = 73,
+  Lit28      = 74,
+  Lit29      = 75,
+  Lit30      = 76,
+  Lit31      = 77,
+  Reg0       = 78,
+  Reg1       = 79,
+  Reg2       = 80,
+  Reg3       = 81,
+  Reg4       = 82,
+  Reg5       = 83,
+  Reg6       = 84,
+  Reg7       = 85,
+  Reg8       = 86,
+  Reg9       = 87,
+  Reg10      = 88,
+  Reg11      = 89,
+  Reg12      = 90,
+  Reg13      = 91,
+  Reg14      = 92,
+  Reg15      = 93,
+  Reg16      = 94,
+  Reg17      = 95,
+  Reg18      = 96,
+  Reg19      = 97,
+  Reg20      = 98,
+  Reg21      = 99,
+  Reg22      = 100,
+  Reg23      = 101,
+  Reg24      = 102,
+  Reg25      = 103,
+  Reg26      = 104,
+  Reg27      = 105,
+  Reg28      = 106,
+  Reg29      = 107,
+  Reg30      = 108,
+  Reg31      = 109,
+  Breg0      = 110,
+  Breg1      = 111,
+  Breg2      = 112,
+  Breg3      = 113,
+  Breg4      = 114,
+  Breg5      = 115,
+  Breg6      = 116,
+  Breg7      = 117,
+  Breg8      = 118,
+  Breg9      = 119,
+  Breg10     = 120,
+  Breg11     = 121,
+  Breg12     = 122,
+  Breg13     = 123,
+  Breg14     = 124,
+  Breg15     = 125,
+  Breg16     = 126,
+  Breg17     = 127,
+  Breg18     = 128,
+  Breg19     = 129,
+  Breg20     = 130,
+  Breg21     = 131,
+  Breg22     = 132,
+  Breg23     = 133,
+  Breg24     = 134,
+  Breg25     = 135,
+  Breg26     = 136,
+  Breg27     = 137,
+  Breg28     = 138,
+  Breg29     = 139,
+  Breg30     = 140,
+  Breg31     = 141,
+  Regx       = 142,
+  Fbreg      = 143,
+  Bregx      = 144,
+  Piece      = 145,
+  DerefSize  = 146,
+  XderefSize = 147,
+  Nop        = 148,
+  PushObjectAddress = 149,
+  Call2             = 150,
+  Call4             = 151,
+  CallRef           = 152,
+  FormTlsAddress    = 153,
+  CallFrameCfa      = 154,
+  ImplicitValue     = 155,
+  ImplicitPointer   = 156,
+  Addrx             = 157,
+  Constx            = 158,
+  EntryValue        = 159,
+  ConstTypeOp       = 160,
+  RegvalType        = 161,
+  DerefType         = 162,
+  XderefType        = 163,
+  Reinterpret       = 164
 };
 
 enum ImportedEntityTag {
@@ -432,16 +587,171 @@ enum {
   OpCodeIdx = 0
 };
 static std::map<ExpressionOpCode, unsigned> OpCountMap {
-  { Deref,      1 },
-  { Plus,       1 },
-  { Minus,      1 },
-  { PlusUconst, 2 },
-  { BitPiece,   3 },
-  { Swap,       1 },
-  { Xderef,     1 },
-  { StackValue, 1 },
-  { Constu,     2 },
-  { Fragment,   3 }
+  { Deref,              1 },
+  { Plus,               1 },
+  { Minus,              1 },
+  { PlusUconst,         2 },
+  { BitPiece,           3 },
+  { Swap,               1 },
+  { Xderef,             1 },
+  { StackValue,         1 },
+  { Constu,             2 },
+  { Fragment,           3 },
+  { Convert,            3 },
+  // { Addr,               2 }, /* not implemented */
+  // { Const1u,            2 },
+  // { Const1s,            2 },
+  // { Const2u,            2 },
+  // { Const2s,            2 },
+  // { Const4u,            2 },
+  // { Const4s,            2 },
+  // { Const8u,            2 },
+  // { Const8s,            2 },
+  { Consts,             2 },
+  { Dup,                1 },
+  { Drop,               1 },
+  { Over,               1 },
+  { Pick,               1 },
+  { Rot,                1 },
+  { Abs,                1 },
+  { And,                1 },
+  { Div,                1 },
+  { Mod,                1 },
+  { Mul,                1 },
+  { Neg,                1 },
+  { Not,                1 },
+  { Or,                 1 },
+  { Shl,                1 },
+  { Shr,                1 },
+  { Shra,               1 },
+  { Xor,                1 },
+  // { Bra,                2 }, /* not implemented */
+  { Eq,                 1 },
+  { Ge,                 1 },
+  { Gt,                 1 },
+  { Le,                 1 },
+  { Lt,                 1 },
+  { Ne,                 1 },
+  // { Skip,               2 }, /* not implemented */
+  { Lit0,               1 },
+  { Lit1,               1 },
+  { Lit2,               1 },
+  { Lit3,               1 },
+  { Lit4,               1 },
+  { Lit5,               1 },
+  { Lit6,               1 },
+  { Lit7,               1 },
+  { Lit8,               1 },
+  { Lit9,               1 },
+  { Lit10,              1 },
+  { Lit11,              1 },
+  { Lit12,              1 },
+  { Lit13,              1 },
+  { Lit14,              1 },
+  { Lit15,              1 },
+  { Lit16,              1 },
+  { Lit17,              1 },
+  { Lit18,              1 },
+  { Lit19,              1 },
+  { Lit20,              1 },
+  { Lit21,              1 },
+  { Lit22,              1 },
+  { Lit23,              1 },
+  { Lit24,              1 },
+  { Lit25,              1 },
+  { Lit26,              1 },
+  { Lit27,              1 },
+  { Lit28,              1 },
+  { Lit29,              1 },
+  { Lit30,              1 },
+  { Lit31,              1 },
+  { Reg0,               1 },
+  { Reg1,               1 },
+  { Reg2,               1 },
+  { Reg3,               1 },
+  { Reg4,               1 },
+  { Reg5,               1 },
+  { Reg6,               1 },
+  { Reg7,               1 },
+  { Reg8,               1 },
+  { Reg9,               1 },
+  { Reg10,              1 },
+  { Reg11,              1 },
+  { Reg12,              1 },
+  { Reg13,              1 },
+  { Reg14,              1 },
+  { Reg15,              1 },
+  { Reg16,              1 },
+  { Reg17,              1 },
+  { Reg18,              1 },
+  { Reg19,              1 },
+  { Reg20,              1 },
+  { Reg21,              1 },
+  { Reg22,              1 },
+  { Reg23,              1 },
+  { Reg24,              1 },
+  { Reg25,              1 },
+  { Reg26,              1 },
+  { Reg27,              1 },
+  { Reg28,              1 },
+  { Reg29,              1 },
+  { Reg30,              1 },
+  { Reg31,              1 },
+  { Breg0,              2 },
+  { Breg1,              2 },
+  { Breg2,              2 },
+  { Breg3,              2 },
+  { Breg4,              2 },
+  { Breg5,              2 },
+  { Breg6,              2 },
+  { Breg7,              2 },
+  { Breg8,              2 },
+  { Breg9,              2 },
+  { Breg10,             2 },
+  { Breg11,             2 },
+  { Breg12,             2 },
+  { Breg13,             2 },
+  { Breg14,             2 },
+  { Breg15,             2 },
+  { Breg16,             2 },
+  { Breg17,             2 },
+  { Breg18,             2 },
+  { Breg19,             2 },
+  { Breg20,             2 },
+  { Breg21,             2 },
+  { Breg22,             2 },
+  { Breg23,             2 },
+  { Breg24,             2 },
+  { Breg25,             2 },
+  { Breg26,             2 },
+  { Breg27,             2 },
+  { Breg28,             2 },
+  { Breg29,             2 },
+  { Breg30,             2 },
+  { Breg31,             2 },
+  { Regx,               2 },
+  // { Fbreg,              1 }, /* not implemented */
+  { Bregx,              3 },
+  // { Piece,              2 }, /* not implemented */
+  { DerefSize,          2 },
+  { XderefSize,         2 },
+  { Nop,                1 },
+  { PushObjectAddress,  1 },
+  // { Call2,              2 }, /* not implemented */
+  // { Call4,              2 },
+  // { CallRef,            2 },
+  // { FormTlsAddress,     1 },
+  // { CallFrameCfa,       1 },
+  // { ImplicitValue,      3 },
+  // { ImplicitPointer,    3 },
+  // { Addrx,              2 },
+  // { Constx,             2 },
+  // { EntryValue,         3 },
+  // { ConstTypeOp,        4 },
+  // { RegvalType,         3 },
+  // { DerefType,          3 },
+  // { XderefType,         3 },
+  // { Reinterpret,        2 },
 };
 }
 
@@ -498,16 +808,144 @@ typedef SPIRVMap<dwarf::LocationAtom, SPIRVDebug::ExpressionOpCode>
   DbgExpressionOpCodeMap;
 template <>
 inline void DbgExpressionOpCodeMap::init() {
-  add(dwarf::DW_OP_deref,         SPIRVDebug::Deref);
-  add(dwarf::DW_OP_plus,          SPIRVDebug::Plus);
-  add(dwarf::DW_OP_minus,         SPIRVDebug::Minus);
-  add(dwarf::DW_OP_plus_uconst,   SPIRVDebug::PlusUconst);
-  add(dwarf::DW_OP_bit_piece,     SPIRVDebug::BitPiece);
-  add(dwarf::DW_OP_swap,          SPIRVDebug::Swap);
-  add(dwarf::DW_OP_xderef,        SPIRVDebug::Xderef);
-  add(dwarf::DW_OP_stack_value,   SPIRVDebug::StackValue);
-  add(dwarf::DW_OP_constu,        SPIRVDebug::Constu);
-  add(dwarf::DW_OP_LLVM_fragment, SPIRVDebug::Fragment);
+  add(dwarf::DW_OP_deref,               SPIRVDebug::Deref);
+  add(dwarf::DW_OP_plus,                SPIRVDebug::Plus);
+  add(dwarf::DW_OP_minus,               SPIRVDebug::Minus);
+  add(dwarf::DW_OP_plus_uconst,         SPIRVDebug::PlusUconst);
+  add(dwarf::DW_OP_bit_piece,           SPIRVDebug::BitPiece);
+  add(dwarf::DW_OP_swap,                SPIRVDebug::Swap);
+  add(dwarf::DW_OP_xderef,              SPIRVDebug::Xderef);
+  add(dwarf::DW_OP_stack_value,         SPIRVDebug::StackValue);
+  add(dwarf::DW_OP_constu,              SPIRVDebug::Constu);
+  add(dwarf::DW_OP_LLVM_fragment,       SPIRVDebug::Fragment);
+  add(dwarf::DW_OP_LLVM_convert,        SPIRVDebug::Convert);
+  add(dwarf::DW_OP_consts,              SPIRVDebug::Consts);
+  add(dwarf::DW_OP_dup,                 SPIRVDebug::Dup);
+  add(dwarf::DW_OP_drop,                SPIRVDebug::Drop);
+  add(dwarf::DW_OP_over,                SPIRVDebug::Over);
+  add(dwarf::DW_OP_pick,                SPIRVDebug::Pick);
+  add(dwarf::DW_OP_rot,                 SPIRVDebug::Rot);
+  add(dwarf::DW_OP_abs,                 SPIRVDebug::Abs);
+  add(dwarf::DW_OP_and,                 SPIRVDebug::And);
+  add(dwarf::DW_OP_div,                 SPIRVDebug::Div);
+  add(dwarf::DW_OP_mod,                 SPIRVDebug::Mod);
+  add(dwarf::DW_OP_mul,                 SPIRVDebug::Mul);
+  add(dwarf::DW_OP_neg,                 SPIRVDebug::Neg);
+  add(dwarf::DW_OP_not,                 SPIRVDebug::Not);
+  add(dwarf::DW_OP_or,                  SPIRVDebug::Or);
+  add(dwarf::DW_OP_shl,                 SPIRVDebug::Shl);
+  add(dwarf::DW_OP_shr,                 SPIRVDebug::Shr);
+  add(dwarf::DW_OP_shra,                SPIRVDebug::Shra);
+  add(dwarf::DW_OP_xor,                 SPIRVDebug::Xor);
+  add(dwarf::DW_OP_bra,                 SPIRVDebug::Bra);
+  add(dwarf::DW_OP_eq,                  SPIRVDebug::Eq);
+  add(dwarf::DW_OP_ge,                  SPIRVDebug::Ge);
+  add(dwarf::DW_OP_gt,                  SPIRVDebug::Gt);
+  add(dwarf::DW_OP_le,                  SPIRVDebug::Le);
+  add(dwarf::DW_OP_lt,                  SPIRVDebug::Lt);
+  add(dwarf::DW_OP_ne,                  SPIRVDebug::Ne);
+  add(dwarf::DW_OP_lit0,                SPIRVDebug::Lit0);
+  add(dwarf::DW_OP_lit1,                SPIRVDebug::Lit1);
+  add(dwarf::DW_OP_lit2,                SPIRVDebug::Lit2);
+  add(dwarf::DW_OP_lit3,                SPIRVDebug::Lit3);
+  add(dwarf::DW_OP_lit4,                SPIRVDebug::Lit4);
+  add(dwarf::DW_OP_lit5,                SPIRVDebug::Lit5);
+  add(dwarf::DW_OP_lit6,                SPIRVDebug::Lit6);
+  add(dwarf::DW_OP_lit7,                SPIRVDebug::Lit7);
+  add(dwarf::DW_OP_lit8,                SPIRVDebug::Lit8);
+  add(dwarf::DW_OP_lit9,                SPIRVDebug::Lit9);
+  add(dwarf::DW_OP_lit10,               SPIRVDebug::Lit10);
+  add(dwarf::DW_OP_lit11,               SPIRVDebug::Lit11);
+  add(dwarf::DW_OP_lit12,               SPIRVDebug::Lit12);
+  add(dwarf::DW_OP_lit13,               SPIRVDebug::Lit13);
+  add(dwarf::DW_OP_lit14,               SPIRVDebug::Lit14);
+  add(dwarf::DW_OP_lit15,               SPIRVDebug::Lit15);
+  add(dwarf::DW_OP_lit16,               SPIRVDebug::Lit16);
+  add(dwarf::DW_OP_lit17,               SPIRVDebug::Lit17);
+  add(dwarf::DW_OP_lit18,               SPIRVDebug::Lit18);
+  add(dwarf::DW_OP_lit19,               SPIRVDebug::Lit19);
+  add(dwarf::DW_OP_lit20,               SPIRVDebug::Lit20);
+  add(dwarf::DW_OP_lit21,               SPIRVDebug::Lit21);
+  add(dwarf::DW_OP_lit22,               SPIRVDebug::Lit22);
+  add(dwarf::DW_OP_lit23,               SPIRVDebug::Lit23);
+  add(dwarf::DW_OP_lit24,               SPIRVDebug::Lit24);
+  add(dwarf::DW_OP_lit25,               SPIRVDebug::Lit25);
+  add(dwarf::DW_OP_lit26,               SPIRVDebug::Lit26);
+  add(dwarf::DW_OP_lit27,               SPIRVDebug::Lit27);
+  add(dwarf::DW_OP_lit28,               SPIRVDebug::Lit28);
+  add(dwarf::DW_OP_lit29,               SPIRVDebug::Lit29);
+  add(dwarf::DW_OP_lit30,               SPIRVDebug::Lit30);
+  add(dwarf::DW_OP_lit31,               SPIRVDebug::Lit31);
+  add(dwarf::DW_OP_reg0,                SPIRVDebug::Reg0);
+  add(dwarf::DW_OP_reg1,                SPIRVDebug::Reg1);
+  add(dwarf::DW_OP_reg2,                SPIRVDebug::Reg2);
+  add(dwarf::DW_OP_reg3,                SPIRVDebug::Reg3);
+  add(dwarf::DW_OP_reg4,                SPIRVDebug::Reg4);
+  add(dwarf::DW_OP_reg5,                SPIRVDebug::Reg5);
+  add(dwarf::DW_OP_reg6,                SPIRVDebug::Reg6);
+  add(dwarf::DW_OP_reg7,                SPIRVDebug::Reg7);
+  add(dwarf::DW_OP_reg8,                SPIRVDebug::Reg8);
+  add(dwarf::DW_OP_reg9,                SPIRVDebug::Reg9);
+  add(dwarf::DW_OP_reg10,               SPIRVDebug::Reg10);
+  add(dwarf::DW_OP_reg11,               SPIRVDebug::Reg11);
+  add(dwarf::DW_OP_reg12,               SPIRVDebug::Reg12);
+  add(dwarf::DW_OP_reg13,               SPIRVDebug::Reg13);
+  add(dwarf::DW_OP_reg14,               SPIRVDebug::Reg14);
+  add(dwarf::DW_OP_reg15,               SPIRVDebug::Reg15);
+  add(dwarf::DW_OP_reg16,               SPIRVDebug::Reg16);
+  add(dwarf::DW_OP_reg17,               SPIRVDebug::Reg17);
+  add(dwarf::DW_OP_reg18,               SPIRVDebug::Reg18);
+  add(dwarf::DW_OP_reg19,               SPIRVDebug::Reg19);
+  add(dwarf::DW_OP_reg20,               SPIRVDebug::Reg20);
+  add(dwarf::DW_OP_reg21,               SPIRVDebug::Reg21);
+  add(dwarf::DW_OP_reg22,               SPIRVDebug::Reg22);
+  add(dwarf::DW_OP_reg23,               SPIRVDebug::Reg23);
+  add(dwarf::DW_OP_reg24,               SPIRVDebug::Reg24);
+  add(dwarf::DW_OP_reg25,               SPIRVDebug::Reg25);
+  add(dwarf::DW_OP_reg26,               SPIRVDebug::Reg26);
+  add(dwarf::DW_OP_reg27,               SPIRVDebug::Reg27);
+  add(dwarf::DW_OP_reg28,               SPIRVDebug::Reg28);
+  add(dwarf::DW_OP_reg29,               SPIRVDebug::Reg29);
+  add(dwarf::DW_OP_reg30,               SPIRVDebug::Reg30);
+  add(dwarf::DW_OP_reg31,               SPIRVDebug::Reg31);
+  add(dwarf::DW_OP_breg0,               SPIRVDebug::Breg0);
+  add(dwarf::DW_OP_breg1,               SPIRVDebug::Breg1);
+  add(dwarf::DW_OP_breg2,               SPIRVDebug::Breg2);
+  add(dwarf::DW_OP_breg3,               SPIRVDebug::Breg3);
+  add(dwarf::DW_OP_breg4,               SPIRVDebug::Breg4);
+  add(dwarf::DW_OP_breg5,               SPIRVDebug::Breg5);
+  add(dwarf::DW_OP_breg6,               SPIRVDebug::Breg6);
+  add(dwarf::DW_OP_breg7,               SPIRVDebug::Breg7);
+  add(dwarf::DW_OP_breg8,               SPIRVDebug::Breg8);
+  add(dwarf::DW_OP_breg9,               SPIRVDebug::Breg9);
+  add(dwarf::DW_OP_breg10,              SPIRVDebug::Breg10);
+  add(dwarf::DW_OP_breg11,              SPIRVDebug::Breg11);
+  add(dwarf::DW_OP_breg12,              SPIRVDebug::Breg12);
+  add(dwarf::DW_OP_breg13,              SPIRVDebug::Breg13);
+  add(dwarf::DW_OP_breg14,              SPIRVDebug::Breg14);
+  add(dwarf::DW_OP_breg15,              SPIRVDebug::Breg15);
+  add(dwarf::DW_OP_breg16,              SPIRVDebug::Breg16);
+  add(dwarf::DW_OP_breg17,              SPIRVDebug::Breg17);
+  add(dwarf::DW_OP_breg18,              SPIRVDebug::Breg18);
+  add(dwarf::DW_OP_breg19,              SPIRVDebug::Breg19);
+  add(dwarf::DW_OP_breg20,              SPIRVDebug::Breg20);
+  add(dwarf::DW_OP_breg21,              SPIRVDebug::Breg21);
+  add(dwarf::DW_OP_breg22,              SPIRVDebug::Breg22);
+  add(dwarf::DW_OP_breg23,              SPIRVDebug::Breg23);
+  add(dwarf::DW_OP_breg24,              SPIRVDebug::Breg24);
+  add(dwarf::DW_OP_breg25,              SPIRVDebug::Breg25);
+  add(dwarf::DW_OP_breg26,              SPIRVDebug::Breg26);
+  add(dwarf::DW_OP_breg27,              SPIRVDebug::Breg27);
+  add(dwarf::DW_OP_breg28,              SPIRVDebug::Breg28);
+  add(dwarf::DW_OP_breg29,              SPIRVDebug::Breg29);
+  add(dwarf::DW_OP_breg30,              SPIRVDebug::Breg30);
+  add(dwarf::DW_OP_breg31,              SPIRVDebug::Breg31);
+  add(dwarf::DW_OP_regx,                SPIRVDebug::Regx);
+  add(dwarf::DW_OP_bregx,               SPIRVDebug::Bregx);
+  add(dwarf::DW_OP_deref_size,          SPIRVDebug::DerefSize );
+  add(dwarf::DW_OP_xderef_size,         SPIRVDebug::XderefSize );
+  add(dwarf::DW_OP_nop,                 SPIRVDebug::Nop);
+  add(dwarf::DW_OP_push_object_address, SPIRVDebug::PushObjectAddress );
 }
 
 typedef SPIRVMap<dwarf::Tag, SPIRVDebug::ImportedEntityTag>

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -456,6 +456,10 @@ public:
     return TranslationOpts.isSPIRVAllowUnknownIntrinsicsEnabled();
   }
 
+  bool allowExtraDIExpressions() const noexcept {
+    return TranslationOpts.allowExtraDIExpressions();
+  }
+
   SPIRVExtInstSetKind getDebugInfoEIS() const {
     switch (TranslationOpts.getDebugInfoEIS()) {
     case DebugInfoEIS::SPIRV_Debug:

--- a/test/DebugInfo/X86/convert-debugloc.ll
+++ b/test/DebugInfo/X86/convert-debugloc.ll
@@ -1,0 +1,87 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
+
+; RUN: llc -mtriple=%triple -dwarf-version=5 -filetype=obj -O0 < %t.ll | llvm-dwarfdump - \
+; RUN:   | FileCheck %s --check-prefix=DW5 "--implicit-check-not={{DW_TAG|NULL}}"
+; RUN: llc -mtriple=%triple -dwarf-version=4 -filetype=obj -O0 < %t.ll | llvm-dwarfdump - \
+; RUN:   | FileCheck %s --check-prefix=DW4 "--implicit-check-not={{DW_TAG|NULL}}"
+
+; DW5: .debug_info contents:
+; DW5: DW_TAG_compile_unit
+; DW5:[[SIG8:.*]]:   DW_TAG_base_type
+; DW5-NEXT:DW_AT_name ("DW_ATE_signed_8")
+; DW5-NEXT:DW_AT_encoding (DW_ATE_signed)
+; DW5-NEXT:DW_AT_byte_size (0x01)
+; DW5-NOT: DW_AT
+; DW5:[[SIG32:.*]]:   DW_TAG_base_type
+; DW5-NEXT:DW_AT_name ("DW_ATE_signed_32")
+; DW5-NEXT:DW_AT_encoding (DW_ATE_signed)
+; DW5-NEXT:DW_AT_byte_size (0x04)
+; DW5-NOT: DW_AT
+; DW5:   DW_TAG_subprogram
+; DW5:     DW_TAG_formal_parameter
+; DW5:     DW_TAG_variable
+; DW5:       DW_AT_location (
+; DW5:         {{.*}}, DW_OP_convert ([[SIG8]]) "DW_ATE_signed_8", DW_OP_convert ([[SIG32]]) "DW_ATE_signed_32", DW_OP_stack_value)
+; DW5:       DW_AT_name ("y")
+; DW5:     NULL
+; DW5:   DW_TAG_base_type
+; DW5:     DW_AT_name ("signed char")
+; DW5:   DW_TAG_base_type
+; DW5:     DW_AT_name ("int")
+; DW5:   NULL
+
+; DW4: .debug_info contents:
+; DW4: DW_TAG_compile_unit
+; DW4:   DW_TAG_subprogram
+; DW4:     DW_TAG_formal_parameter
+; DW4:     DW_TAG_variable
+; DW4:       DW_AT_location (
+; DW4:         {{.*}}, DW_OP_dup, DW_OP_constu 0x7, DW_OP_shr, DW_OP_lit0, DW_OP_not, DW_OP_mul, DW_OP_constu 0x8, DW_OP_shl, DW_OP_or, DW_OP_stack_value)
+; DW4:       DW_AT_name ("y")
+; DW4:     NULL
+; DW4:   DW_TAG_base_type
+; DW4:     DW_AT_name ("signed char")
+; DW4:   DW_TAG_base_type
+; DW4:     DW_AT_name ("int")
+; DW4:   NULL
+
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local signext i8 @foo(i8 signext %x) !dbg !7 {
+entry:
+  call void @llvm.dbg.value(metadata i8 %x, metadata !11, metadata !DIExpression()), !dbg !12
+  call void @llvm.dbg.value(metadata i8 32, metadata !13, metadata !DIExpression(DW_OP_LLVM_convert, 8, DW_ATE_signed, DW_OP_LLVM_convert, 32, DW_ATE_signed, DW_OP_stack_value)), !dbg !15
+  ret i8 %x, !dbg !16
+}
+
+; Function Attrs: nounwind readnone speculatable
+declare void @llvm.dbg.declare(metadata, metadata, metadata)
+
+; Function Attrs: nounwind readnone speculatable
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (trunk 353791) (llvm/trunk 353801)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "dbg.c", directory: "/tmp", checksumkind: CSK_MD5, checksum: "2a034da6937f5b9cf6dd2d89127f57fd")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 5}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang version 9.0.0 (trunk 353791) (llvm/trunk 353801)"}
+!7 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !8, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10, !10}
+!10 = !DIBasicType(name: "signed char", size: 8, encoding: DW_ATE_signed_char)
+!11 = !DILocalVariable(name: "x", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!12 = !DILocation(line: 1, column: 29, scope: !7)
+!13 = !DILocalVariable(name: "y", scope: !7, file: !1, line: 3, type: !14)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 3, column: 14, scope: !7)
+!16 = !DILocation(line: 4, column: 3, scope: !7)

--- a/test/DebugInfo/expr-opcode.ll
+++ b/test/DebugInfo/expr-opcode.ll
@@ -1,0 +1,68 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llc -mtriple=%triple -dwarf-version=5 -filetype=obj -O0 < %t.rev.ll
+; RUN: llc -mtriple=%triple -dwarf-version=4 -filetype=obj -O0 < %t.rev.ll
+
+; CHECK: DW_OP_constu, 42
+; CHECK: DW_OP_plus_uconst, 42
+; CHECK: DW_OP_plus
+; CHECK: DW_OP_minus
+; CHECK: DW_OP_mul
+; CHECK: DW_OP_div
+; CHECK: DW_OP_mod
+; CHECK: DW_OP_or
+; CHECK: DW_OP_and
+; CHECK: DW_OP_xor
+; CHECK: DW_OP_shl
+; CHECK: DW_OP_shr
+; CHECK: DW_OP_shra
+; CHECK: DW_OP_deref
+; CHECK: DW_OP_deref_size, 4
+; CHECK: DW_OP_xderef
+; CHECK: DW_OP_lit0
+; CHECK: DW_OP_not
+; CHECK: DW_OP_dup
+; CHECK: DW_OP_swap
+; CHECK: DW_OP_stack_value
+
+target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: noinline nounwind uwtable
+define dso_local signext i8 @foo(i8 signext %x) !dbg !7 {
+entry:
+  call void @llvm.dbg.value(metadata i8 %x, metadata !11, metadata !DIExpression()), !dbg !12
+  call void @llvm.dbg.value(metadata i8 32, metadata !13, metadata !DIExpression(DW_OP_constu, 42, DW_OP_plus_uconst, 42, DW_OP_plus, DW_OP_minus, DW_OP_mul, DW_OP_div, DW_OP_mod, DW_OP_or, DW_OP_and, DW_OP_xor, DW_OP_shl, DW_OP_shr, DW_OP_shra, DW_OP_deref, DW_OP_deref_size, 4, DW_OP_xderef, DW_OP_lit0, DW_OP_not, DW_OP_dup, DW_OP_swap, DW_OP_stack_value)), !dbg !15
+  ret i8 %x, !dbg !16
+}
+
+; Function Attrs: nounwind readnone speculatable
+declare void @llvm.dbg.declare(metadata, metadata, metadata)
+
+; Function Attrs: nounwind readnone speculatable
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4, !5}
+!llvm.ident = !{!6}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "clang version 9.0.0 (trunk 353791) (llvm/trunk 353801)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "dbg.c", directory: "/tmp", checksumkind: CSK_MD5, checksum: "2a034da6937f5b9cf6dd2d89127f57fd")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 5}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{i32 1, !"wchar_size", i32 4}
+!6 = !{!"clang version 9.0.0 (trunk 353791) (llvm/trunk 353801)"}
+!7 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !8, scopeLine: 2, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10, !10}
+!10 = !DIBasicType(name: "signed char", size: 8, encoding: DW_ATE_signed_char)
+!11 = !DILocalVariable(name: "x", arg: 1, scope: !7, file: !1, line: 1, type: !10)
+!12 = !DILocation(line: 1, column: 29, scope: !7)
+!13 = !DILocalVariable(name: "y", scope: !7, file: !1, line: 3, type: !14)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !DILocation(line: 3, column: 14, scope: !7)
+!16 = !DILocation(line: 4, column: 3, scope: !7)

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -183,6 +183,12 @@ cl::opt<bool> SPIRVAllowUnknownIntrinsics(
     cl::desc("Unknown LLVM intrinsics will be translated as external function "
              "calls in SPIR-V"));
 
+static cl::opt<bool> SPIRVAllowExtraDIExpressions(
+    "spirv-allow-extra-diexpressions", cl::init(false),
+    cl::desc("Allow DWARF operations not listed in the OpenCL.DebugInfo.100 "
+             "specification (experimental, may produce incompatible SPIR-V "
+             "module)"));
+
 static cl::opt<SPIRV::DebugInfoEIS> DebugEIS(
     "spirv-debug-info-version", cl::desc("Set SPIR-V debug info version:"),
     cl::init(SPIRV::DebugInfoEIS::SPIRV_Debug),
@@ -561,6 +567,10 @@ int main(int Ac, char **Av) {
     } else {
       Opts.setSPIRVAllowUnknownIntrinsicsEnabled(SPIRVAllowUnknownIntrinsics);
     }
+  }
+
+  if (SPIRVAllowExtraDIExpressions.getNumOccurrences() != 0) {
+    Opts.setAllowExtraDIExpressionsEnabled(SPIRVAllowExtraDIExpressions);
   }
 
   if (DebugEIS.getNumOccurrences() != 0) {


### PR DESCRIPTION
Experimental support of extra DWARF operations

As this functionality is not documented by any formal SPIR-V extension or SPIR-V
extended instruction set specification, it is disabled by default and in order
to enable generation of extra debug information, user needs to pass
`spirv-allow-extra-diexpressions` command line option to the
translator.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>