### PR TITLE
[NFC] Fix a static analysis issue

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -114,7 +114,8 @@ char SPIRVRegularizeLLVM::ID = 0;
 
 std::string SPIRVRegularizeLLVM::lowerLLVMIntrinsicName(IntrinsicInst *II) {
   Function *IntrinsicFunc = II->getCalledFunction();
-  assert(IntrinsicFunc && "Missing function");
+  if (!IntrinsicFunc)
+    return "";
   std::string FuncName = IntrinsicFunc->getName().str();
   std::replace(FuncName.begin(), FuncName.end(), '.', '_');
   FuncName = "spirv." + FuncName;


### PR DESCRIPTION
Fix a potential nullptr dereference issue that static analysis
finds in prod build mode (where assertions are disabled). This
is a follow-up for [KhronosGroup/SPIRV-LLVM-Translator@ee145be].

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>