### PR TITLE
Add OpModuleProcessed token handling

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -611,6 +611,12 @@ void SPIRVName::validate() const {
 
 _SPIRV_IMP_ENCDEC2(SPIRVString, Id, Str)
 _SPIRV_IMP_ENCDEC3(SPIRVMemberName, Target, MemberNumber, Str)
+_SPIRV_IMP_ENCDEC1(SPIRVModuleProcessed, Process)
+
+void SPIRVModuleProcessed::validate() const {
+  assert(WordCount == getSizeInWords(Process) + FixedWC &&
+         "Incorrect word count");
+}
 
 void SPIRVLine::encode(spv_ostream &O) const {
   getEncoder(O) << FileName << Line << Column;

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -572,6 +572,23 @@ protected:
   std::string Str;
 };
 
+class SPIRVModuleProcessed : public SPIRVEntryNoId<OpModuleProcessed> {
+  static const SPIRVWord FixedWC = 1;
+
+public:
+  SPIRVModuleProcessed(SPIRVModule *M, const std::string &TheProcess)
+      : SPIRVEntryNoId(M, FixedWC + getSizeInWords(TheProcess)),
+        Process(TheProcess) {
+    validate();
+  }
+  SPIRVModuleProcessed() {}
+
+protected:
+  _SPIRV_DCL_ENCDEC
+  void validate() const override;
+  std::string Process;
+};
+
 class SPIRVString : public SPIRVEntry {
   static const Op OC = OpString;
   static const SPIRVWord FixedWC = 2;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -487,6 +487,7 @@ private:
   typedef std::vector<SPIRVVariable *> SPIRVVariableVec;
   typedef std::vector<SPIRVString *> SPIRVStringVec;
   typedef std::vector<SPIRVMemberName *> SPIRVMemberNameVec;
+  typedef std::vector<SPIRVModuleProcessed *> SPIRVModuleProcessedVec;
   typedef std::vector<SPIRVDecorationGroup *> SPIRVDecGroupVec;
   typedef std::vector<SPIRVGroupDecorateGeneric *> SPIRVGroupDecVec;
   typedef std::vector<SPIRVAsmTargetINTEL *> SPIRVAsmTargetVector;
@@ -514,6 +515,7 @@ private:
   SPIRVIdSet NamedId;
   SPIRVStringVec StringVec;
   SPIRVMemberNameVec MemberNameVec;
+  SPIRVModuleProcessedVec ModuleProcessedVec;
   std::shared_ptr<const SPIRVLine> CurrentLine;
   SPIRVDecorateSet DecorateSet;
   SPIRVDecGroupVec DecGroupVec;
@@ -635,6 +637,9 @@ void SPIRVModuleImpl::layoutEntry(SPIRVEntry *E) {
     break;
   case OpMemberName:
     addTo(MemberNameVec, E);
+    break;
+  case OpModuleProcessed:
+    addTo(ModuleProcessedVec, E);
     break;
   case OpVariable: {
     auto BV = static_cast<SPIRVVariable *>(E);

--- a/test/transcoding/OpModuleProcessed.spt
+++ b/test/transcoding/OpModuleProcessed.spt
@@ -1,0 +1,10 @@
+119734787 65536 393230 9 0
+; RUN: llvm-spirv %s -o %t.spv -to-binary
+; RUN: llvm-spirv %t.spv -o %t.spt -to-text
+; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV
+
+2 Capability Kernel
+3 MemoryModel 2 2
+3 Source 3 102000
+; SPV: 9 ModuleProcessed "Linked_by_SPIR-V_Tools_Linker"
+9 ModuleProcessed "Linked_by_SPIR-V_Tools_Linker"


### PR DESCRIPTION
Translator fails to read module generated by spirv-link, because spirv-link adds OpModuleProcessed token which is not supported. This patch fix the problem.