### PR TITLE
Add SchedulerTargetFmaxMhzINTEL execution mode

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -219,6 +219,17 @@ void PreprocessMetadata::visit(Module *M) {
           .add(getMDOperandAsInt(NumSIMDWorkitemsINTEL, 0))
           .done();
     }
+
+    // !{void (i32 addrspace(1)*)* @kernel, i32 scheduler_target_fmax_mhz,
+    //   i32 num}
+    if (MDNode *SchedulerTargetFmaxMhzINTEL =
+            Kernel.getMetadata(kSPIR2MD::FmaxMhz)) {
+      EM.addOp()
+          .add(&Kernel)
+          .add(spv::ExecutionModeSchedulerTargetFmaxMhzINTEL)
+          .add(getMDOperandAsInt(SchedulerTargetFmaxMhzINTEL, 0))
+          .done();
+    }
   }
 }
 

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -399,6 +399,7 @@ const static char NoGlobalOffset[] = "no_global_work_offset";
 const static char MaxWGDim[] = "max_global_work_dim";
 const static char NumSIMD[] = "num_simd_work_items";
 const static char StallEnable[] = "stall_enable";
+const static char FmaxMhz[] = "scheduler_target_fmax_mhz";
 } // namespace kSPIR2MD
 
 enum Spir2SamplerKind {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3928,6 +3928,12 @@ bool SPIRVToLLVM::transMetadata() {
       F->setMetadata(kSPIR2MD::NumSIMD,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
+    // Generate metadata for scheduler_target_fmax_mhz
+    if (auto EM =
+            BF->getExecutionMode(ExecutionModeSchedulerTargetFmaxMhzINTEL)) {
+      F->setMetadata(kSPIR2MD::FmaxMhz,
+                     getMDNodeStringIntVec(Context, EM->getLiterals()));
+    }
   }
   NamedMDNode *MemoryModelMD =
       M->getOrInsertNamedMetadata(kSPIRVMD::MemoryModel);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3175,16 +3175,8 @@ bool LLVMToSPIRV::transExecutionMode() {
         BF->addExecutionMode(BM->add(
             new SPIRVExecutionMode(BF, static_cast<ExecutionMode>(EMode), X)));
       } break;
-      case spv::ExecutionModeNumSIMDWorkitemsINTEL: {
-        if (BM->isAllowedToUseExtension(
-                ExtensionID::SPV_INTEL_kernel_attributes)) {
-          unsigned X;
-          N.get(X);
-          BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
-              BF, static_cast<ExecutionMode>(EMode), X)));
-          BM->addCapability(CapabilityFPGAKernelAttributesINTEL);
-        }
-      } break;
+      case spv::ExecutionModeNumSIMDWorkitemsINTEL:
+      case spv::ExecutionModeSchedulerTargetFmaxMhzINTEL:
       case spv::ExecutionModeMaxWorkDimINTEL: {
         if (BM->isAllowedToUseExtension(
                 ExtensionID::SPV_INTEL_kernel_attributes)) {

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -511,6 +511,7 @@ void SPIRVExecutionMode::decode(std::istream &I) {
   case ExecutionModeSubgroupSize:
   case ExecutionModeMaxWorkDimINTEL:
   case ExecutionModeNumSIMDWorkitemsINTEL:
+  case ExecutionModeSchedulerTargetFmaxMhzINTEL:
     WordLiterals.resize(1);
     break;
   default:

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -172,6 +172,7 @@ enum ExecutionMode {
     ExecutionModeMaxWorkDimINTEL = 5894,
     ExecutionModeNoGlobalOffsetINTEL = 5895,
     ExecutionModeNumSIMDWorkitemsINTEL = 5896,
+    ExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
     ExecutionModeVectorComputeFastCompositeKernelINTEL = 8088,
     ExecutionModeMax = 0x7fffffff,
 };

--- a/test/transcoding/IntelFPGAFunctionAttributes.ll
+++ b/test/transcoding/IntelFPGAFunctionAttributes.ll
@@ -6,6 +6,7 @@
 ;;     intel::max_work_group_size(1,1,1),
 ;;     intel::num_simd_work_items(8)
 ;;     intel::stall_enable]] void operator()() {}
+;;     intel::scheduler_target_fmax_mhz(1000)]] void operator()() {}
 ;; };
 ;;
 ;; template <typename name, typename Func>
@@ -37,15 +38,17 @@
 ; CHECK-SPIRV: 4 ExecutionMode [[FUNCENTRY]] 5894 1
 ; CHECK-SPIRV: 3 ExecutionMode [[FUNCENTRY]] 5895
 ; CHECK-SPIRV: 4 ExecutionMode [[FUNCENTRY]] 5896 8
+; CHECK-SPIRV: 4 ExecutionMode [[FUNCENTRY]] 5903 1000
 ; CHECK-SPIRV: 3 Decorate [[FUNCENTRY]] StallEnableINTEL
 ; CHECK-SPIRV: 5 Function {{.*}} [[FUNCENTRY]] {{.*}}
 
-; CHECK-LLVM: define spir_kernel void {{.*}}kernel_name() {{.*}} !stall_enable ![[ONEMD:[0-9]+]] !max_work_group_size ![[MAXWG:[0-9]+]] !no_global_work_offset ![[OFFSET:[0-9]+]] !max_global_work_dim ![[ONEMD:[0-9]+]] !num_simd_work_items ![[NUMSIMD:[0-9]+]]
+; CHECK-LLVM: define spir_kernel void {{.*}}kernel_name() {{.*}} !stall_enable ![[ONEMD:[0-9]+]] !max_work_group_size ![[MAXWG:[0-9]+]] !no_global_work_offset ![[OFFSET:[0-9]+]] !max_global_work_dim ![[ONEMD:[0-9]+]] !num_simd_work_items ![[NUMSIMD:[0-9]+]] !scheduler_target_fmax_mhz ![[MAXMHZ:[0-9]+]]
 ; CHECK-LLVM-NOT: define spir_kernel void {{.*}}kernel_name2 {{.*}} !no_global_work_offset {{.*}}
 ; CHECK-LLVM: ![[OFFSET]] = !{}
 ; CHECK-LLVM: ![[ONEMD]] = !{i32 1}
 ; CHECK-LLVM: ![[MAXWG]] = !{i32 1, i32 1, i32 1}
 ; CHECK-LLVM: ![[NUMSIMD]] = !{i32 8}
+; CHECK-LLVM: ![[MAXMHZ]] = !{i32 1000}
 
 ; ModuleID = 'kernel-attrs.cpp'
 source_filename = "kernel-attrs.cpp"
@@ -58,7 +61,7 @@ target triple = "spir64-unknown-linux-sycldevice"
 $_ZN3FooclEv = comdat any
 
 ; Function Attrs: nounwind
-define spir_kernel void @_ZTSZ3barvE11kernel_name() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 !num_simd_work_items !5 !max_work_group_size !6 !max_global_work_dim !7 !no_global_work_offset !4 !stall_enable !7 {
+define spir_kernel void @_ZTSZ3barvE11kernel_name() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 !num_simd_work_items !5 !max_work_group_size !6 !max_global_work_dim !7 !no_global_work_offset !4 !stall_enable !7 !scheduler_target_fmax_mhz !12 {
 entry:
   %Foo = alloca %class._ZTS3Foo.Foo, align 1
   %0 = bitcast %class._ZTS3Foo.Foo* %Foo to i8*
@@ -128,3 +131,4 @@ attributes #4 = { nounwind }
 !9 = !{!"any pointer", !10, i64 0}
 !10 = !{!"omnipotent char", !11, i64 0}
 !11 = !{!"Simple C++ TBAA"}
+!12 = !{i32 1000}


### PR DESCRIPTION
Indicates the target clock frequency (Fmax) for the kernel, in MHz.
Only valid with the Kernel Execution Model.

Spec:
https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>