### PR TITLE
Make LoopControlLoopCoalesceINTELMask parameter be mandatory

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -930,16 +930,17 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
            "Missing loop control parameter!");
   }
   if (LC & LoopControlLoopCoalesceINTELMask) {
-    // If LoopCoalesce has no parameters
-    if (LoopControlParameters.empty()) {
+    // If LoopCoalesce has a parameter of '0'
+    if (!LoopControlParameters[NumParam]) {
       Metadata.push_back(llvm::MDNode::get(
           *Context, getMetadataFromName("llvm.loop.coalesce.enable")));
     } else {
       Metadata.push_back(llvm::MDNode::get(
           *Context,
           getMetadataFromNameAndParameter("llvm.loop.coalesce.count",
-                                          LoopControlParameters[NumParam++])));
+                                          LoopControlParameters[NumParam])));
     }
+    ++NumParam;
     assert(NumParam <= LoopControlParameters.size() &&
            "Missing loop control parameter!");
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1060,6 +1060,8 @@ LLVMToSPIRV::getLoopControl(const BranchInst *Branch,
         } else if (S == "llvm.loop.coalesce.enable") {
           BM->addExtension(ExtensionID::SPV_INTEL_fpga_loop_controls);
           BM->addCapability(CapabilityFPGALoopControlsINTEL);
+          ParametersToSort.emplace_back(spv::LoopControlLoopCoalesceINTELMask,
+                                        0);
           LoopControl |= spv::LoopControlLoopCoalesceINTELMask;
         } else if (S == "llvm.loop.coalesce.count") {
           BM->addExtension(ExtensionID::SPV_INTEL_fpga_loop_controls);

--- a/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGALoopMergeInst.ll
+++ b/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGALoopMergeInst.ll
@@ -341,9 +341,9 @@ while.end:                                        ; preds = %while.cond
   br label %while.cond1
 
 ; Per SPIR-V spec, LoopControlLoopCoalesceINTELMask = 0x100000 (1048576)
-; CHECK-SPIRV: 4 LoopMerge {{[0-9]+}} {{[0-9]+}} 1048576
+; CHECK-SPIRV: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 1048576 0
 ; CHECK-SPIRV-NEXT: 4 BranchConditional {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}
-; CHECK-SPIRV-NEGATIVE-NOT: 4 LoopMerge {{[0-9]+}} {{[0-9]+}} 1048576
+; CHECK-SPIRV-NEGATIVE-NOT: 5 LoopMerge {{[0-9]+}} {{[0-9]+}} 1048576 0
 while.cond1:                                      ; preds = %if.end8, %if.then6, %while.end
   %4 = load i32, i32* %i, align 4
   %5 = load i32, i32* %m, align 4


### PR DESCRIPTION
Otherwise we can't make any assumptions about LoopControl parameters
order.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>