### PR TITLE
[CI] Enable GitHub Actions for builds and tests

### DIFF
--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -1,5 +1,5 @@
-# This workflow is intended to check if PR doesn't introduce any regressions
-# into in-tree build in various configurations.
+# This workflow is intended to check that in-tree build of the translator is
+# healthy and all tests pass. It is used in pre-commits and nightly builds.
 #
 # Documentation for GitHub Actions:
 # [workflow-syntax]: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
@@ -50,13 +50,13 @@ jobs:
           echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
           echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
-          # Linux systems in GitHub Actions already has pre-installed clang is
-          # not needed for the translator as we rely on newer version
+          # Linux systems in GitHub Actions already have a pre-installed clang
+          # that is not needed for the translator as we rely on newer version
           sudo apt-get --purge remove clang-8 clang-9
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \
             spirv-tools
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 1000
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
       - name: Checkout LLVM sources
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -1,0 +1,175 @@
+# This workflow is intended to check if PR doesn't introduce any regressions
+# into in-tree build in various configurations.
+#
+# Documentation for GitHub Actions:
+# [workflow-syntax]: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# [context-and-expression-syntax]: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
+name: In-tree build & tests
+
+on:
+  push:
+    branches:
+      - master
+      - llvm_release_*
+    paths-ignore: # no need to check build for documentation changes
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+      - llvm_release_*
+    paths-ignore: # no need to check build for documentation changes
+      - 'docs/**'
+      - '**.md'
+  schedule:
+    # Ideally, we might want to simplify our regular nightly build as we
+    # probably don't need every configuration to be built every day: most of
+    # them are only necessary in pre-commits to avoid breakages
+    - cron: 0 0 * * *
+
+env:
+  LLVM_VERSION: 12
+
+jobs:
+  build_and_test_linux:
+    name: Linux
+    strategy:
+      matrix:
+        build_type: [Release, Debug]
+        shared_libs: [NoSharedLibs]
+        include:
+          - build_type: Release
+            shared_libs: EnableSharedLibs
+      fail-fast: false
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install dependencies
+        run: |
+          curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
+          curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
+          echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
+          echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          # Linux systems in GitHub Actions already has pre-installed clang is
+          # not needed for the translator as we rely on newer version
+          sudo apt-get --purge remove clang-8 clang-9
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            clang-${{ env.LLVM_VERSION }} \
+            spirv-tools
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 1000
+      - name: Checkout LLVM sources
+        uses: actions/checkout@v2
+        with:
+          repository: llvm/llvm-project
+          ref: master
+          path: llvm-project
+      - name:  Checkout the translator sources
+        uses: actions/checkout@v2
+        with:
+          path: llvm-project/llvm/projects/SPIRV-LLVM-Translator
+      - name: Configure
+        run: |
+          mkdir build && cd build
+          # ON/OFF specifically weren't used as a values for shared_libs matrix
+          # field to improve usability of PR page: instead of (Release, ON) a
+          # job will be displayed as (Release, EnableSharedLibs)
+          SHARED_LIBS=OFF
+          if [[ "${{ matrix.shared_libs }}" == "EnableSharedLibs" ]]; then
+            SHARED_LIBS=ON
+          fi
+          cmake ${{ github.workspace }}/llvm-project/llvm \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DBUILD_SHARED_LIBS=${SHARED_LIBS} \
+            -DLLVM_TARGETS_TO_BUILD="X86" \
+            -DSPIRV_SKIP_CLANG_BUILD=ON \
+            -DSPIRV_SKIP_DEBUG_INFO_TESTS=ON \
+            -DLLVM_LIT_ARGS="-sv --no-progress-bar" \
+            -G "Unix Makefiles"
+      - name: Build
+        run: |
+          cd build
+          make llvm-spirv -j2
+      - name: Build tests & test
+        run: |
+          cd build
+          make check-llvm-spirv -j2
+
+  build_windows:
+    name: Windows
+    strategy:
+      matrix:
+        build_type: [Release]
+      fail-fast: false
+    runs-on: windows-latest
+    steps:
+      - name: Checkout LLVM sources
+        uses: actions/checkout@v2
+        with:
+          repository: llvm/llvm-project
+          ref: master
+          path: llvm-project
+      - name:  Checkout the translator sources
+        uses: actions/checkout@v2
+        with:
+          path: llvm-project\\llvm\\projects\\SPIRV-LLVM-Translator
+      - name: Configure
+        shell: bash
+        run: |
+          mkdir build && cd build
+          cmake ..\\llvm-project\\llvm \
+            -Thost=x64 \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_TARGETS_TO_BUILD="X86" \
+            -DSPIRV_SKIP_CLANG_BUILD=ON \
+            -DSPIRV_SKIP_DEBUG_INFO_TESTS=ON \
+            -DLLVM_LIT_ARGS="-sv --no-progress-bar"
+      - name: Build
+        shell: bash
+        run: |
+          cd build
+          cmake --build . --config ${{ matrix.build_type }} --target llvm-spirv -j2
+          # FIXME: Testing is disabled at the moment as it requires clang to be present
+          #       - name: Build tests & test
+          #         shell: bash
+          #         run: |
+          #           cd build
+          #           cmake --build . --config Release --target check-llvm-spirv -j2
+
+  build_and_test_macosx:
+    name: macOS
+    strategy:
+      matrix:
+        build_type: [Release]
+      fail-fast: false
+    runs-on: macos-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout LLVM sources
+        uses: actions/checkout@v2
+        with:
+          repository: llvm/llvm-project
+          ref: master
+          path: llvm-project
+      - name:  Checkout the translator sources
+        uses: actions/checkout@v2
+        with:
+          path: llvm-project/llvm/projects/SPIRV-LLVM-Translator
+      - name: Configure
+        run: |
+          mkdir build && cd build
+          cmake ${{ github.workspace }}/llvm-project/llvm \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DLLVM_TARGETS_TO_BUILD="X86" \
+            -DSPIRV_SKIP_CLANG_BUILD=ON \
+            -DSPIRV_SKIP_DEBUG_INFO_TESTS=ON \
+            -DLLVM_LIT_ARGS="-sv --no-progress-bar" \
+            -G "Unix Makefiles"
+      - name: Build
+        run: |
+          cd build
+          make llvm-spirv -j2
+          # FIXME: Testing is disabled at the moment as it requires clang to be present
+          # - name: Build tests & test
+          #   run: |
+          #     cd build
+          #     make check-llvm-spirv -j2

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -1,5 +1,5 @@
-# This workflow is intended to check if PR doesn't introduce any regressions
-# into out-of-tree build in various configurations.
+# This workflow is intended to check that out-of-tree build of the translator is
+# healthy and all tests pass. It is used in pre-commits and nightly builds.
 #
 # Documentation for GitHub Actions:
 # [workflow-syntax]: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
@@ -43,15 +43,15 @@ jobs:
           echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
           echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
-          # Linux systems in GitHub Actions already has pre-installed clang is
-          # not needed for the translator as we rely on newer version
+          # Linux systems in GitHub Actions already have a pre-installed clang
+          # that is not needed for the translator as we rely on newer version
           sudo apt-get --purge remove clang-8 clang-9
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \
             llvm-${{ env.LLVM_VERSION }}-dev \
             llvm-${{ env.LLVM_VERSION }}-tools \
             spirv-tools
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 1000
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
       - name:  Checkout the translator sources
         uses: actions/checkout@v2
       - name: Configure

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -1,0 +1,72 @@
+# This workflow is intended to check if PR doesn't introduce any regressions
+# into out-of-tree build in various configurations.
+#
+# Documentation for GitHub Actions:
+# [workflow-syntax]: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# [context-and-expression-syntax]: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions
+name: Out-of-tree build & tests
+
+on:
+  push:
+    branches:
+      - master
+      - llvm_release_*
+    paths-ignore: # no need to check build for documentation changes
+      - 'docs/**'
+      - '**.md'
+  pull_request:
+    branches:
+      - master
+      - llvm_release_*
+    paths-ignore: # no need to check build for documentation changes
+      - 'docs/**'
+      - '**.md'
+  schedule:
+    - cron: 0 0 * * *
+
+env:
+  LLVM_VERSION: 12
+
+jobs:
+  build_and_test:
+    name: Linux
+    strategy:
+      matrix:
+        build_type: [Release, Debug]
+      fail-fast: false
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install dependencies
+        run: |
+          curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
+          curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
+          echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
+          echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
+          # Linux systems in GitHub Actions already has pre-installed clang is
+          # not needed for the translator as we rely on newer version
+          sudo apt-get --purge remove clang-8 clang-9
+          sudo apt-get -yq --no-install-suggests --no-install-recommends install \
+            clang-${{ env.LLVM_VERSION }} \
+            llvm-${{ env.LLVM_VERSION }}-dev \
+            llvm-${{ env.LLVM_VERSION }}-tools \
+            spirv-tools
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 1000
+      - name:  Checkout the translator sources
+        uses: actions/checkout@v2
+      - name: Configure
+        run: |
+          mkdir build && cd build
+          cmake ${{ github.workspace }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DLLVM_INCLUDE_TESTS=ON \
+            -DLLVM_EXTERNAL_LIT="/usr/lib/llvm-${{ env.LLVM_VERSION }}/build/utils/lit/lit.py" \
+            -G "Unix Makefiles"
+      - name: Build
+        run: |
+          cd build
+          make llvm-spirv -j2
+      - name: Build tests & test
+        run: |
+          cd build
+          make check-llvm-spirv -j2


### PR DESCRIPTION
There are two main reasons this PR was created:
1. We have a problem with Travis CI and it has been basically disabled for almost a two weeks for now
2. From my point of view, GitHub Actions provide more features to make our CI jobs even better

(2) is being discussed in #716 and this PR can be considered as a temporary, i.e. if we don't like how GitHub Actions work we can always fallback to Travis CI once it is fixed.

Anyway, this PR features the following:
- two separate workflows for in-tree and out-of-tree builds
- support for master and release branches as well as for nightly builds
- in-tree build is enabled on Linux, Windows (this tries to address #726, at least partially) and macOS
- these workflows are not launched for documentation-only changes

I added links to GitHub Actions documentation and tried to add comments to all potentially confusing places.

There are for sure more thing that could be improved, like adding `-Werror` configuration or adding GitHub Actions badges to README page, but this can be done as follow-up PRs, I think: my main intent here was to unblock commits to the translator by enabling the CI back.

A few obvious downsides:
Each job is now displayed as a separate check, which seems to be an overkill, but there is [no workaround](https://github.community/t/hide-pr-checks-for-skipped-jobs/124881/4) for this at the moment.
Also, we can't control the order in which jobs are launched, which means list of checks on the PR page might be different each time. "Checks" page is better: the order of jobs is fixed there (it follows their appearance in workflow file), but the ordering of workflows is not fixed, which means that you still can't use muscle memory to quickly look at in-tree build results