### PR TITLE
Support atomic ordering for LLVM load/store instructions

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1116,6 +1116,32 @@ LLVMToSPIRV::getLoopControl(const BranchInst *Branch,
   return static_cast<spv::LoopControlMask>(LoopControl);
 }
 
+static int transAtomicOrdering(llvm::AtomicOrdering Ordering) {
+  return OCLMemOrderMap::map(
+      static_cast<OCLMemOrderKind>(llvm::toCABI(Ordering)));
+}
+
+SPIRVValue *LLVMToSPIRV::transAtomicStore(StoreInst *ST, SPIRVBasicBlock *BB) {
+  std::vector<Value *> Ops{ST->getPointerOperand(),
+                           getUInt32(M, spv::ScopeDevice),
+                           getUInt32(M, transAtomicOrdering(ST->getOrdering())),
+                           ST->getValueOperand()};
+  std::vector<SPIRVValue *> SPIRVOps = transValue(Ops, BB);
+
+  return mapValue(ST, BM->addInstTemplate(OpAtomicStore, BM->getIds(SPIRVOps),
+                                          BB, nullptr));
+}
+
+SPIRVValue *LLVMToSPIRV::transAtomicLoad(LoadInst *LD, SPIRVBasicBlock *BB) {
+  std::vector<Value *> Ops{
+      LD->getPointerOperand(), getUInt32(M, spv::ScopeDevice),
+      getUInt32(M, transAtomicOrdering(LD->getOrdering()))};
+  std::vector<SPIRVValue *> SPIRVOps = transValue(Ops, BB);
+
+  return mapValue(LD, BM->addInstTemplate(OpAtomicLoad, BM->getIds(SPIRVOps),
+                                          BB, transType(LD->getType())));
+}
+
 /// An instruction may use an instruction from another BB which has not been
 /// translated. SPIRVForward should be created as place holder for these
 /// instructions and replaced later by the real instructions.
@@ -1260,6 +1286,9 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
     return mapValue(V, BM->addForward(transType(V->getType())));
 
   if (StoreInst *ST = dyn_cast<StoreInst>(V)) {
+    if (ST->isAtomic())
+      return transAtomicStore(ST, BB);
+
     std::vector<SPIRVWord> MemoryAccess(1, 0);
     if (ST->isVolatile())
       MemoryAccess[0] |= MemoryAccessVolatileMask;
@@ -1280,6 +1309,9 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
   }
 
   if (LoadInst *LD = dyn_cast<LoadInst>(V)) {
+    if (LD->isAtomic())
+      return transAtomicLoad(LD, BB);
+
     std::vector<SPIRVWord> MemoryAccess(1, 0);
     if (LD->isVolatile())
       MemoryAccess[0] |= MemoryAccessVolatileMask;

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -173,6 +173,9 @@ private:
   SPIRVInstruction *transLifetimeIntrinsicInst(Op OC, IntrinsicInst *Intrinsic,
                                                SPIRVBasicBlock *BB);
 
+  SPIRVValue *transAtomicStore(StoreInst *ST, SPIRVBasicBlock *BB);
+  SPIRVValue *transAtomicLoad(LoadInst *LD, SPIRVBasicBlock *BB);
+
   void dumpUsers(Value *V);
 
   template <class ExtInstKind>

--- a/test/atomic-load-store.ll
+++ b/test/atomic-load-store.ll
@@ -1,0 +1,35 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s
+
+; CHECK-DAG: Constant [[#]] [[#Relaxed:]] 0
+; CHECK-DAG: Constant [[#]] [[#DeviceScope:]] 1
+; CHECK-DAG: Constant [[#]] [[#Acquire:]] 2
+; CHECK-DAG: Constant [[#]] [[#Release:]] 4
+; CHECK-DAG: Constant [[#]] [[#SequentiallyConsistent:]] 16
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+; Function Attrs: nounwind
+define dso_local spir_func void @test() {
+entry:
+; CHECK: Variable [[#]] [[#PTR:]]
+  %0 = alloca i32
+
+; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#Relaxed]] [[#]]
+  store atomic i32 0, i32* %0 monotonic, align 4
+; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#Release]] [[#]]
+  store atomic i32 0, i32* %0 release, align 4
+; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#SequentiallyConsistent]] [[#]]
+  store atomic i32 0, i32* %0 seq_cst, align 4
+
+; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#Relaxed]]
+  %1 = load atomic i32, i32* %0 monotonic, align 4
+; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#Acquire]]
+  %2 = load atomic i32, i32* %0 acquire, align 4
+; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#SequentiallyConsistent]]
+  %3 = load atomic i32, i32* %0 seq_cst, align 4
+  ret void
+}

--- a/test/transcoding/atomics.spt
+++ b/test/transcoding/atomics.spt
@@ -94,3 +94,25 @@
 ; CHECK-LLVM-20: call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(i32 addrspace(4)* %object.as14, i32 %desired, i32 5, i32 2) [[attr]]
 ; CHECK-LLVM-20: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(i32 addrspace(4)* %object.as15, i32 5, i32 2) [[attr]]
 ; CHECK-LLVM-20: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(i32 addrspace(4)* %object.as16, i32 5, i32 2) [[attr]]
+
+; RUN: llvm-spirv -r %t1.spv -o %t2.bc --spirv-target-env="SPV-IR"
+; RUN: llvm-dis < %t2.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPV-IR
+
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z24__spirv_AtomicIIncrementPU3AS1iii(i32 addrspace(1)* %dst, i32 1, i32 16) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z24__spirv_AtomicIDecrementPU3AS1iii(i32 addrspace(1)* %dst, i32 1, i32 16) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z18__spirv_AtomicSMaxPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 0) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z18__spirv_AtomicUMaxPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 0) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z18__spirv_AtomicSMinPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 0) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z18__spirv_AtomicUMinPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 0) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z18__spirv_AtomicIAddPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 1) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z18__spirv_AtomicISubPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 1) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z16__spirv_AtomicOrPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 1) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z17__spirv_AtomicXorPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 1) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z17__spirv_AtomicAndPU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 1) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z29__spirv_AtomicCompareExchangePU3AS1iiiiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 16, i32 1, i32 0) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z22__spirv_AtomicExchangePU3AS1iiii(i32 addrspace(1)* %dst, i32 1, i32 16, i32 1) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i32 @_Z18__spirv_AtomicLoadPU3AS1iii(i32 addrspace(1)* %object, i32 1, i32 16) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func void @_Z19__spirv_AtomicStorePU3AS1iiii(i32 addrspace(1)* %object, i32 1, i32 16, i32 %desired) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func i1 @_Z28__spirv_AtomicFlagTestAndSetPU3AS1iii(i32 addrspace(1)* %object, i32 1, i32 16) #[[#attr:]]
+; CHECK-LLVM-SPV-IR: call spir_func void @_Z23__spirv_AtomicFlagClearPU3AS1iii(i32 addrspace(1)* %object, i32 1, i32 16) #[[#attr:]]
+


### PR DESCRIPTION
LLVM IR `store atomic` and `load atomic` instructions are now lowered
to the corresponding SPIR-V atomics.

Signed-off-by: Andrew Savonichev <andrew.savonichev@intel.com>
Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>