### PR TITLE
Align with LLORG on sret/byval parameter attribute types

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2885,7 +2885,10 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF) {
         AttrTy = cast<PointerType>(I->getType())->getElementType();
       else if (LLVMKind == Attribute::AttrKind::StructRet)
         AttrTy = I->getType();
-      I->addAttr(Attribute::get(*Context, LLVMKind, AttrTy));
+      // Make sure to use a correct constructor for a typed/typeless attribute
+      auto A = AttrTy ? Attribute::get(*Context, LLVMKind, AttrTy)
+                      : Attribute::get(*Context, LLVMKind);
+      I->addAttr(A);
     });
 
     SPIRVWord MaxOffset = 0;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2879,7 +2879,13 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF) {
     BA->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
       if (Kind == FunctionParameterAttributeNoWrite)
         return;
-      F->addAttribute(I->getArgNo() + 1, SPIRSPIRVFuncParamAttrMap::rmap(Kind));
+      Attribute::AttrKind LLVMKind = SPIRSPIRVFuncParamAttrMap::rmap(Kind);
+      Type *AttrTy = nullptr;
+      if (LLVMKind == Attribute::AttrKind::ByVal)
+        AttrTy = cast<PointerType>(I->getType())->getElementType();
+      else if (LLVMKind == Attribute::AttrKind::StructRet)
+        AttrTy = I->getType();
+      I->addAttr(Attribute::get(*Context, LLVMKind, AttrTy));
     });
 
     SPIRVWord MaxOffset = 0;

--- a/test/DebugInfo/Generic/2010-10-01-crash.ll
+++ b/test/DebugInfo/Generic/2010-10-01-crash.ll
@@ -7,7 +7,7 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-define void @CGRectStandardize(i32* sret %agg.result, i32* byval %rect) nounwind ssp !dbg !0 {
+define void @CGRectStandardize(i32* sret(i32*) %agg.result, i32* byval(i32) %rect) nounwind ssp !dbg !0 {
 entry:
   call void @llvm.dbg.declare(metadata i32* %rect, metadata !23, metadata !DIExpression()), !dbg !24
   ret void

--- a/test/DebugInfo/UnknownBaseType.ll
+++ b/test/DebugInfo/UnknownBaseType.ll
@@ -17,7 +17,7 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; Function Attrs: convergent nounwind
-define spir_func void @foo({ float, float }* byval align 4 %f) #0 !dbg !7 {
+define spir_func void @foo({ float, float }* byval({ float, float }) align 4 %f) #0 !dbg !7 {
 entry:
   call void @llvm.dbg.declare(metadata { float, float }* %f, metadata !13, metadata !DIExpression()), !dbg !14
   ret void, !dbg !14

--- a/test/DebugInfo/X86/dbg-byval-parameter.ll
+++ b/test/DebugInfo/X86/dbg-byval-parameter.ll
@@ -11,7 +11,7 @@ target triple = "spir64-unknown-unknown"
 %struct.Pt = type { double, double }
 %struct.Rect = type { %struct.Pt, %struct.Pt }
 
-define double @foo(%struct.Rect* byval %my_r0) nounwind ssp !dbg !1 {
+define double @foo(%struct.Rect* byval(%struct.Rect) %my_r0) nounwind ssp !dbg !1 {
 entry:
   %retval = alloca double                         ; <double*> [#uses=2]
   %0 = alloca double                              ; <double*> [#uses=2]

--- a/test/DebugInfo/X86/dbg-declare-arg.ll
+++ b/test/DebugInfo/X86/dbg-declare-arg.ll
@@ -29,7 +29,7 @@ target triple = "spir64-unknown-unknown"
 
 %class.A = type { i32, i32, i32, i32 }
 
-define void @_Z3fooi(%class.A* sret %agg.result, i32 %i) ssp !dbg !19 {
+define void @_Z3fooi(%class.A* sret(%class.A) %agg.result, i32 %i) ssp !dbg !19 {
 entry:
   %i.addr = alloca i32, align 4
   %j = alloca i32, align 4

--- a/test/DebugInfo/X86/double-declare.ll
+++ b/test/DebugInfo/X86/double-declare.ll
@@ -15,7 +15,7 @@ target triple = "spir64-unknown-unknown"
 
 declare void @llvm.dbg.declare(metadata, metadata, metadata)
 
-define void @f(i32* byval %p, i1 %c) !dbg !5 {
+define void @f(i32* byval(i32) %p, i1 %c) !dbg !5 {
   br i1 %c, label %x, label %y
 
 x:

--- a/test/EnqueueEmptyKernel.ll
+++ b/test/EnqueueEmptyKernel.ll
@@ -38,7 +38,7 @@ define spir_kernel void @test_enqueue_empty() #0 !kernel_arg_addr_space !0 !kern
 entry:
   %tmp = alloca %struct.ndrange_t, align 8
   %call = call spir_func %opencl.queue_t* @_Z17get_default_queuev() #4
-  call spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret %tmp, i64 1) #4
+  call spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp, i64 1) #4
   %0 = call i32 @__enqueue_kernel_basic_events(%opencl.queue_t* %call, i32 1, %struct.ndrange_t* %tmp, i32 0, %opencl.clk_event_t* addrspace(4)* null, %opencl.clk_event_t* addrspace(4)* null, i8 addrspace(4)* addrspacecast (i8* bitcast (void (i8 addrspace(4)*)* @__test_enqueue_empty_block_invoke_kernel to i8*) to i8 addrspace(4)*), i8 addrspace(4)* addrspacecast (i8 addrspace(1)* bitcast ({ i32, i32 } addrspace(1)* @__block_literal_global to i8 addrspace(1)*) to i8 addrspace(4)*))
   ret void
 ; CHECK-SPIRV: Bitcast [[Int8Ptr]] [[Int8PtrBlock:[0-9]+]] [[Block]]
@@ -50,7 +50,7 @@ entry:
 declare spir_func %opencl.queue_t* @_Z17get_default_queuev() #1
 
 ; Function Attrs: convergent
-declare spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret, i64) #1
+declare spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret(%struct.ndrange_t*), i64) #1
 
 ; Function Attrs: convergent nounwind
 define internal spir_func void @__test_enqueue_empty_block_invoke(i8 addrspace(4)* %.block_descriptor) #2 {

--- a/test/llvm-intrinsics/memcpy.align.ll
+++ b/test/llvm-intrinsics/memcpy.align.ll
@@ -41,7 +41,7 @@ target triple = "spir"
 @__const.bar.a = private unnamed_addr addrspace(2) constant %struct.A { i64 0, %struct.B { [2 x i32] [i32 1, i32 2] } }, align 8
 
 ; Function Attrs: convergent nounwind
-define spir_func void @foo(%struct.A* noalias sret %agg.result) #0 {
+define spir_func void @foo(%struct.A* noalias sret(%struct.A*) %agg.result) #0 {
 entry:
   %b = alloca %struct.B, align 4
   %0 = bitcast %struct.B* %b to i8*
@@ -73,7 +73,7 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* nocapture writeonly, i8* nocapture r
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: convergent nounwind
-define spir_func void @bar(%struct.B* noalias sret %agg.result) #0 {
+define spir_func void @bar(%struct.B* noalias sret(%struct.B*) %agg.result) #0 {
 entry:
   %a = alloca %struct.A, align 8
   %0 = bitcast %struct.A* %a to i8*

--- a/test/llvm-intrinsics/memset.ll
+++ b/test/llvm-intrinsics/memset.ll
@@ -63,7 +63,7 @@ target triple = "spir"
 ; CHECK-LLVM: internal unnamed_addr addrspace(2) constant [4 x i8] c"\15\15\15\15"
 
 ; Function Attrs: nounwind
-define spir_func void @_Z5foo11v(%struct.S1 addrspace(4)* noalias nocapture sret %agg.result, i32 %s1, i64 %s2, i8 %v) #0 {
+define spir_func void @_Z5foo11v(%struct.S1 addrspace(4)* noalias nocapture sret(%struct.S1 addrspace(4)*) %agg.result, i32 %s1, i64 %s2, i8 %v) #0 {
   %x = alloca [4 x i8]
   %x.bc = bitcast [4 x i8]* %x to i8*
   %1 = bitcast %struct.S1 addrspace(4)* %agg.result to i8 addrspace(4)*

--- a/test/transcoding/BuildNDRange.ll
+++ b/test/transcoding/BuildNDRange.ll
@@ -22,11 +22,11 @@ target triple = "spir"
 ; Function Attrs: nounwind
 define spir_kernel void @test() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
   %ndrange = alloca %struct.ndrange_t, align 4
-  call spir_func void @_Z10ndrange_1Djj(%struct.ndrange_t* sret %ndrange, i32 123, i32 456)
+  call spir_func void @_Z10ndrange_1Djj(%struct.ndrange_t* sret(%struct.ndrange_t*) %ndrange, i32 123, i32 456)
   ret void
 }
 
-declare spir_func void @_Z10ndrange_1Djj(%struct.ndrange_t* sret, i32, i32) #1
+declare spir_func void @_Z10ndrange_1Djj(%struct.ndrange_t* sret(%struct.ndrange_t*), i32, i32) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/transcoding/BuildNDRange_2.ll
+++ b/test/transcoding/BuildNDRange_2.ll
@@ -71,28 +71,28 @@ entry:
   %0 = bitcast [2 x i64]* %lsize2 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %0, i8* align 8 bitcast ([2 x i64]* @test_ndrange_2D3D.lsize2 to i8*), i64 16, i1 false)
   %arraydecay = getelementptr inbounds [2 x i64], [2 x i64]* %lsize2, i64 0, i64 0
-  call spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret %tmp, i64* %arraydecay) #2
+  call spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp, i64* %arraydecay) #2
   %1 = bitcast [3 x i64]* %lsize3 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %1, i8* align 8 bitcast ([3 x i64]* @test_ndrange_2D3D.lsize3 to i8*), i64 24, i1 false)
   %arraydecay2 = getelementptr inbounds [3 x i64], [3 x i64]* %lsize3, i64 0, i64 0
-  call spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret %tmp3, i64* %arraydecay2) #2
+  call spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp3, i64* %arraydecay2) #2
   ret void
 }
 
 ; Function Attrs: nounwind
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture, i8* nocapture readonly, i64, i1) #2
 
-declare spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret, i64*) #1
+declare spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*), i64*) #1
 
-declare spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret, i64*) #1
+declare spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*), i64*) #1
 
 ; Function Attrs: nounwind
 define spir_func void @test_ndrange_const_2D3D() #0 {
 entry:
   %tmp = alloca %struct.ndrange_t, align 8
   %tmp1 = alloca %struct.ndrange_t, align 8
-  call spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret %tmp, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @test_ndrange_2D3D.lsize2, i64 0, i64 0)) #2
-  call spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret %tmp1, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @test_ndrange_2D3D.lsize3, i64 0, i64 0)) #2
+  call spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @test_ndrange_2D3D.lsize2, i64 0, i64 0)) #2
+  call spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp1, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @test_ndrange_2D3D.lsize3, i64 0, i64 0)) #2
   ret void
 }
 


### PR DESCRIPTION
With the latest community changes, the StructRet/ByVal parameter
attributes are now required to have a type. Fix the build by:
1. updating the LIT IR to match this policy;
2. adding correct attribute types in backwards translation.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>