### PR TITLE
[Doc] Update the test build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ on `clang` binary, which makes clang a required dependency (search for
 Building clang from sources takes time and resources and it can be avoided:
 - if you are not interested in launching unit-tests for the translator after
   build, you can disable generation of test targets by passing
-  `-DLLVM_INCLUDE_TESTS=OFF` option.
+  `-DLLVM_SPIRV_INCLUDE_TESTS=OFF` option.
 - if you are interested in launching unit-tests, but don't want to build clang
   you can pass `-DSPIRV_SKIP_CLANG_BUILD` cmake option to avoid adding `clang`
   as dependency for `check-llvm-spirv` target. However, LIT will search for
@@ -102,12 +102,13 @@ Execute the following command inside the build directory to run translator tests
 ```
 make test
 ```
-This requires that the `-DLLVM_INCLUDE_TESTS=ON` and
-`-DLLVM_EXTERNAL_LIT="/usr/lib/llvm-12/build/utils/lit/lit.py"` arguments were
-passed to CMake during the build step.
+This requires that the `-DLLVM_SPIRV_INCLUDE_TESTS=ON` argument is
+passed to CMake during the build step. Additionally,
+`-DLLVM_EXTERNAL_LIT="/usr/lib/llvm-12/build/utils/lit/lit.py"` is
+needed when building with a pre-installed version of LLVM.
 
 The translator test suite can be disabled by passing
-`-DLLVM_SPIRV_INCLUDE_TESTS=OFF` to cmake.
+`-DLLVM_SPIRV_INCLUDE_TESTS=OFF` to CMake.
 
 ## Run Instructions for `llvm-spirv`
 


### PR DESCRIPTION
- Ensure correct naming of `LLVM_SPIRV_INCLUDE_TESTS` in the
  documentation;
- Clarify the usage scenario of the `LLVM_EXTERNAL_LIT` variable.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>