### PR TITLE
[Backport] Added translation of VCFCEntry attribute(#827) branch 100

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -292,6 +292,12 @@ void PreprocessMetadata::preprocessVectorComputeMetadata(Module *M,
           .add(SLMSize)
           .done();
     }
+    if (Attrs.hasFnAttribute(kVCMetadata::VCFCEntry)) {
+      EM.addOp()
+          .add(&F)
+          .add(spv::ExecutionModeVectorComputeFastCompositeKernelINTEL)
+          .done();
+    }
   }
 }
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3375,6 +3375,9 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
     F->addFnAttr(kVCMetadata::VCSIMTCall, std::to_string(SIMTMode));
   if (BF->hasDecorate(DecorationVectorComputeCallableFunctionINTEL))
     F->addFnAttr(kVCMetadata::VCCallable);
+  if (isKernel(BF) &&
+      BF->getExecutionMode(ExecutionModeVectorComputeFastCompositeKernelINTEL))
+    F->addFnAttr(kVCMetadata::VCFCEntry);
 
   for (Function::arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E;
        ++I) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2418,6 +2418,11 @@ bool LLVMToSPIRV::transExecutionMode() {
         BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
             BF, static_cast<ExecutionMode>(EMode), TargetWidth)));
       } break;
+      case spv::ExecutionModeVectorComputeFastCompositeKernelINTEL: {
+        if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
+          BF->addExecutionMode(BM->add(
+              new SPIRVExecutionMode(BF, static_cast<ExecutionMode>(EMode))));
+      } break;
       default:
         llvm_unreachable("invalid execution mode");
       }

--- a/lib/SPIRV/VectorComputeUtil.h
+++ b/lib/SPIRV/VectorComputeUtil.h
@@ -109,6 +109,7 @@ const static char VCVolatile[] = "VCVolatile";
 const static char VCByteOffset[] = "VCByteOffset";
 const static char VCSIMTCall[] = "VCSIMTCall";
 const static char VCCallable[] = "VCCallable";
+const static char VCFCEntry[] = "VCFCEntry";
 } // namespace kVCMetadata
 
 namespace kVCType {

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -256,6 +256,8 @@ template <> inline void SPIRVMap<SPIRVExecutionModeKind, SPIRVCapVec>::init() {
                {CapabilityFloatingPointModeINTEL});
   ADD_VEC_INIT(ExecutionModeSharedLocalMemorySizeINTEL,
                {CapabilityVectorComputeINTEL});
+  ADD_VEC_INIT(ExecutionModeVectorComputeFastCompositeKernelINTEL,
+               {CapabilityVectorComputeINTEL});
 }
 
 template <> inline void SPIRVMap<SPIRVMemoryModelKind, SPIRVCapVec>::init() {

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -171,6 +171,7 @@ enum ExecutionMode {
     ExecutionModeMaxWorkDimINTEL = 5894,
     ExecutionModeNoGlobalOffsetINTEL = 5895,
     ExecutionModeNumSIMDWorkitemsINTEL = 5896,
+    ExecutionModeVectorComputeFastCompositeKernelINTEL = 6088,
     ExecutionModeMax = 0x7fffffff,
 };
 

--- a/test/fast-composit-entry.ll
+++ b/test/fast-composit-entry.ll
@@ -1,0 +1,40 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute
+; RUN: llvm-spirv %t.spv -o %t.spt --to-text
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -o %t.bc -r
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
+
+target triple = "spir64-unknown-unknown"
+
+
+; CHECK-SPIRV: {{[0-9]+}} EntryPoint {{[0-9]+}} [[#FOO_ID:]] "foo"
+; CHECK-SPIRV: {{[0-9]+}} EntryPoint {{[0-9]+}} [[#BAR_ID:]] "bar"
+; CHECK-SPIRV: 3 ExecutionMode [[#FOO_ID]] 6088
+; CHECK-SPIRV-NOT: 3 ExecutionMode [[#BAR_ID]] 6088
+
+; CHECK-LLVM: define spir_kernel void @foo
+; CHECK-LLVM-SAME: #[[#FOO_ATTR_ID:]]
+; CHECK-LLVM: define spir_kernel void @bar
+; CHECK-LLVM-SAME: #[[#BAR_ATTR_ID:]]
+
+; CHECK-LLVM: attributes #[[#FOO_ATTR_ID]]
+; CHECK-LLVM-SAME: "VCFCEntry"
+; CHECK-LLVM: attributes #[[#BAR_ATTR_ID]]
+; CHECK-LLVM-NOT: "VCFCEntry"
+
+
+define spir_kernel void @foo(<4 x i32> %a, <4 x i32> %b) #0 {
+entry:
+  ret void
+}
+
+define spir_kernel void @bar(<4 x i32> %a, <4 x i32> %b) #1 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "VCFCEntry" "VCFloatControl"="0" "VCFunction" }
+attributes #1 = { noinline nounwind "VCFloatControl"="48" "VCFunction" }
+


### PR DESCRIPTION
Added translation of VCFCEntry kernel attribute to execution mode
VectorComputeFastCompositeKernelINTEL

Backport for https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/827