### PR TITLE
Reduce amount of noise from clang-tidy

### DIFF
--- a/include/LLVMSPIRVExtensions.inc
+++ b/include/LLVMSPIRVExtensions.inc
@@ -1,5 +1,5 @@
 #ifndef EXT
-  #define EXT(X)
+#define EXT(X)
 #endif
 
 EXT(SPV_EXT_shader_atomic_float_add)

--- a/include/LLVMSPIRVExtensions.inc
+++ b/include/LLVMSPIRVExtensions.inc
@@ -1,6 +1,5 @@
-
 #ifndef EXT
-  #error "EXT macro must be defined"
+  #define EXT(X)
 #endif
 
 EXT(SPV_EXT_shader_atomic_float_add)


### PR DESCRIPTION
When we do some changes to `include/LLVMSPIRVExtension.inc`, clang-tidy
complains about undefined `EXT` macro, because it looks at the file
alone, while it was designed to be included from another file where
`EXT` is defined.

In order to fix this constant complain, let's add a dummy definition of
`EXT` macro instead of using `#error` directive.

An example of noisy output from clang-tidy: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/actions/runs/381033219