### PR TITLE
Improve paths-ignore in our CI workflows

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -13,9 +13,12 @@ on:
     branches:
       - master
       - llvm_release_*
-    paths-ignore: # no need to check formatting for documentation and tests
-      - 'docs/**'
-      - 'test/**'
+    paths-ignore: # no need to check formatting for:
+      - 'docs/**' # documentation
+      - 'test/**' # tests
+      - '**.md'   # README
+      - '**.txt'  # CMakeLists.txt
+      - '**/check-**-build.xml' # Other workflows
 
 env:
   # We need compile command database in order to perform clang-tidy check. So,

--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -11,16 +11,20 @@ on:
     branches:
       - master
       - llvm_release_*
-    paths-ignore: # no need to check build for documentation changes
-      - 'docs/**'
-      - '**.md'
+    paths-ignore: # no need to check build for:
+      - 'docs/**' # documentation
+      - '**.md'   # README
+      - '**/check-code-style.xml' # check-code-style workflow
+      - '**/check-out-of-tree-build.xml' # check-out-of-tree-build workflow
   pull_request:
     branches:
       - master
       - llvm_release_*
-    paths-ignore: # no need to check build for documentation changes
-      - 'docs/**'
-      - '**.md'
+    paths-ignore: # no need to check build for:
+      - 'docs/**' # documentation
+      - '**.md'   # README
+      - '**/check-code-style.xml' # check-code-style workflow
+      - '**/check-out-of-tree-build.xml' # check-out-of-tree-build workflow
   schedule:
     # Ideally, we might want to simplify our regular nightly build as we
     # probably don't need every configuration to be built every day: most of

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -11,16 +11,20 @@ on:
     branches:
       - master
       - llvm_release_*
-    paths-ignore: # no need to check build for documentation changes
-      - 'docs/**'
-      - '**.md'
+    paths-ignore: # no need to check build for:
+      - 'docs/**' # documentation
+      - '**.md'   # README
+      - '**/check-code-style.xml' # check-code-style workflow
+      - '**/check-in-tree-build.xml' # check-in-tree-build workflow
   pull_request:
     branches:
       - master
       - llvm_release_*
-    paths-ignore: # no need to check build for documentation changes
-      - 'docs/**'
-      - '**.md'
+    paths-ignore: # no need to check build for:
+      - 'docs/**' # documentation
+      - '**.md'   # README
+      - '**/check-code-style.xml' # check-code-style workflow
+      - '**/check-in-tree-build.xml' # check-in-tree-build workflow
   schedule:
     - cron: 0 0 * * *
 


### PR DESCRIPTION
There are more reasons to skip particular workflows, like:
- if we change check-code-style workflow, no need to launch builds
- if we change some CMakeLists.txt, no need to launch check-code-style