### PR TITLE
Suppress clang-tidy error about static_cast

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1749,6 +1749,7 @@ public:
   SPIRVFunctionCall(SPIRVId TheId, SPIRVFunction *TheFunction,
                     const std::vector<SPIRVWord> &TheArgs, SPIRVBasicBlock *BB);
   SPIRVFunctionCall() : FunctionId(SPIRVID_INVALID) {}
+  // NOLINTNEXTLINE(clang-diagnostic-error)
   SPIRVFunction *getFunction() const { return get<SPIRVFunction>(FunctionId); }
   _SPIRV_DEF_ENCDEC4(Type, Id, FunctionId, Args)
   void validate() const override;


### PR DESCRIPTION
The same warning didn't show up in regular builds