### PR TITLE
Improve ignoring of vim swap files by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ build/
 # Byte compiled python modules.
 *.pyc
 # vim swap files
-.*.swp
+.*.sw?
 .sw?
 #OS X specific files.
 .DS_store


### PR DESCRIPTION
When a file opened in vim multiple times, vim starts producing swap
files with different extensions, for example .swo. Add them to gitignore
so git doesn't highlight them.