### PR TITLE
Fix names of some instructions in SPIR-V friendly IR

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1305,9 +1305,11 @@ Instruction *mutateCallInstOCL(
     Module *M, CallInst *CI,
     std::function<std::string(CallInst *, std::vector<Value *> &, Type *&RetTy)>
         ArgMutate,
-    std::function<Instruction *(CallInst *)> RetMutate, AttributeList *Attrs) {
+    std::function<Instruction *(CallInst *)> RetMutate, AttributeList *Attrs,
+    bool TakeFuncName) {
   OCLBuiltinFuncMangleInfo BtnInfo(CI->getCalledFunction());
-  return mutateCallInst(M, CI, ArgMutate, RetMutate, &BtnInfo, Attrs);
+  return mutateCallInst(M, CI, ArgMutate, RetMutate, &BtnInfo, Attrs,
+                        TakeFuncName);
 }
 
 static std::pair<StringRef, StringRef>

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -468,7 +468,7 @@ Instruction *mutateCallInstOCL(
     std::function<std::string(CallInst *, std::vector<Value *> &, Type *&RetTy)>
         ArgMutate,
     std::function<Instruction *(CallInst *)> RetMutate,
-    AttributeList *Attrs = nullptr);
+    AttributeList *Attrs = nullptr, bool TakeFuncName = false);
 
 /// Check if instruction is bitcast from spirv.ConstantSampler to spirv.Sampler
 bool isSamplerInitializer(Instruction *Inst);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2385,6 +2385,13 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
                                           BV->getName(), BB));
   }
 
+  case OpImageQuerySize:
+  case OpImageQuerySizeLod: {
+    return mapValue(
+        BV, transSPIRVBuiltinFromInst(static_cast<SPIRVInstruction *>(BV), BB,
+                                      /*AddRetTypePostfix=*/true));
+  }
+
   case OpBitReverse: {
     auto *BR = static_cast<SPIRVUnary *>(BV);
     auto Ty = transType(BV->getType());
@@ -3372,9 +3379,7 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromInst(SPIRVInstruction *BI,
   return transBuiltinFromInst(FuncName, BI, BB);
 }
 
-Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
-                                                    BasicBlock *BB) {
-  assert(BB && "Invalid BB");
+std::string getSPIRVFuncSuffix(SPIRVInstruction *BI) {
   string Suffix = "";
   if (BI->getOpCode() == OpCreatePipeFromPipeStorage) {
     auto CPFPS = static_cast<SPIRVCreatePipeFromPipeStorage *>(BI);
@@ -3394,9 +3399,22 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
       break;
     }
   }
+  return Suffix;
+}
 
-  return transBuiltinFromInst(getSPIRVFuncName(BI->getOpCode(), Suffix), BI,
-                              BB);
+Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
+                                                    BasicBlock *BB,
+                                                    bool AddRetTypePostfix) {
+  assert(BB && "Invalid BB");
+  if (AddRetTypePostfix) {
+    const Type *RetTy =
+        BI->hasType() ? transType(BI->getType()) : Type::getVoidTy(*Context);
+    return transBuiltinFromInst(getSPIRVFuncName(BI->getOpCode(), RetTy) +
+                                    getSPIRVFuncSuffix(BI),
+                                BI, BB);
+  }
+  return transBuiltinFromInst(
+      getSPIRVFuncName(BI->getOpCode(), getSPIRVFuncSuffix(BI)), BI, BB);
 }
 
 bool SPIRVToLLVM::translate() {
@@ -4462,13 +4480,13 @@ Instruction *SPIRVToLLVM::transOCLAllAny(SPIRVInstruction *I, BasicBlock *BB) {
                    CastInst::CreateSExtOrBitCast(OldArg, NewArgTy, "", CI);
                Args[0] = NewArg;
                RetTy = Int32Ty;
-               return CI->getCalledFunction()->getName().str();
+               return getSPIRVFuncName(I->getOpCode(), getSPIRVFuncSuffix(I));
              },
              [=](CallInst *NewCI) -> Instruction * {
                return CastInst::CreateTruncOrBitCast(
                    NewCI, Type::getInt1Ty(*Context), "", NewCI->getNextNode());
              },
-             &Attrs)));
+             &Attrs, /*TakeFuncName=*/true)));
 }
 
 Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
@@ -4495,7 +4513,7 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
                      IntTy,
                      cast<FixedVectorType>(CI->getType())->getNumElements());
                }
-               return CI->getCalledFunction()->getName().str();
+               return getSPIRVFuncName(I->getOpCode(), getSPIRVFuncSuffix(I));
              },
              [=](CallInst *NewCI) -> Instruction * {
                Type *RetTy = Type::getInt1Ty(*Context);
@@ -4506,7 +4524,7 @@ Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
                return CastInst::CreateTruncOrBitCast(NewCI, RetTy, "",
                                                      NewCI->getNextNode());
              },
-             &Attrs)));
+             &Attrs, /*TakeFuncName=*/true)));
 }
 
 std::unique_ptr<SPIRVModule> readSpirvModule(std::istream &IS,

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -122,7 +122,8 @@ public:
   Instruction *transBuiltinFromInst(const std::string &FuncName,
                                     SPIRVInstruction *BI, BasicBlock *BB);
   Instruction *transOCLBuiltinFromInst(SPIRVInstruction *BI, BasicBlock *BB);
-  Instruction *transSPIRVBuiltinFromInst(SPIRVInstruction *BI, BasicBlock *BB);
+  Instruction *transSPIRVBuiltinFromInst(SPIRVInstruction *BI, BasicBlock *BB,
+                                         bool AddRetTypePostfix = false);
   void transOCLVectorLoadStore(std::string &UnmangledName,
                                std::vector<SPIRVWord> &BArgs);
 

--- a/test/relationals.ll
+++ b/test/relationals.ll
@@ -2,6 +2,8 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-LLVM
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"
@@ -11,6 +13,18 @@ declare dso_local spir_func <4 x i8> @_Z13__spirv_IsInfIDv4_aDv4_fET_T0_(<4 x fl
 declare dso_local spir_func <4 x i8> @_Z16__spirv_IsFiniteIDv4_aDv4_fET_T0_(<4 x float>)
 declare dso_local spir_func <4 x i8> @_Z16__spirv_IsNormalIDv4_aDv4_fET_T0_(<4 x float>)
 declare dso_local spir_func <4 x i8> @_Z18__spirv_SignBitSetIDv4_aDv4_fET_T0_(<4 x float>)
+
+; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z13__spirv_IsNanDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z13__spirv_IsInfDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z16__spirv_IsFiniteDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z16__spirv_IsNormalDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z18__spirv_SignBitSetDv4_f
+
+; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z13__spirv_IsNanDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z13__spirv_IsInfDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z16__spirv_IsFiniteDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z16__spirv_IsNormalDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z18__spirv_SignBitSetDv4_f(<4 x float>)
 
 ; CHECK-SPIRV: {{[0-9]+}} TypeBool [[TBool:[0-9]+]]
 ; CHECK-SPIRV: {{[0-9]+}} TypeVector [[TBoolVec:[0-9]+]] [[TBool]]

--- a/test/transcoding/OpAllAny.ll
+++ b/test/transcoding/OpAllAny.ll
@@ -4,9 +4,17 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-LLVM
 
 ; CHECK-LLVM: call spir_func i32 @_Z3allDv2_i(
 ; CHECK-LLVM: call spir_func i32 @_Z3anyDv2_i(
+
+; CHECK-SPV-LLVM: call spir_func i32 @_Z11__spirv_AllDv2_i(
+; CHECK-SPV-LLVM: call spir_func i32 @_Z11__spirv_AnyDv2_i(
+
+; CHECK-SPV-LLVM: declare spir_func i32 @_Z11__spirv_AllDv2_i(<2 x i32>)
+; CHECK-SPV-LLVM: declare spir_func i32 @_Z11__spirv_AnyDv2_i(<2 x i32>)
 
 ; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
 ; CHECK-SPIRV: 4 All [[BoolTypeID]]

--- a/test/transcoding/check_ro_qualifier.ll
+++ b/test/transcoding/check_ro_qualifier.ll
@@ -2,6 +2,8 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-LLVM
 
 ; CHECK-LLVM: opencl.image2d_array_ro_t = type opaque
 ; CHECK-LLVM: define spir_kernel void @sample_kernel(%opencl.image2d_array_ro_t addrspace(1)
@@ -13,6 +15,11 @@
 ; CHECK-LLVM: call spir_func i64 @_Z20get_image_array_size20ocl_image2d_array_ro(%opencl.image2d_array_ro_t addrspace(1)
 ; CHECK-LLVM: declare spir_func <2 x i32> @_Z13get_image_dim20ocl_image2d_array_ro(%opencl.image2d_array_ro_t addrspace(1)
 ; CHECK-LLVM: declare spir_func i64 @_Z20get_image_array_size20ocl_image2d_array_ro(%opencl.image2d_array_ro_t addrspace(1)
+
+; CHECK-SPV-LLVM: call spir_func <3 x i32> @_Z32__spirv_ImageQuerySizeLod_Ruint320ocl_image2d_array_roi(%opencl.image2d_array_ro_t addrspace(1)
+; CHECK-SPV-LLVM: call spir_func <3 x i64> @_Z33__spirv_ImageQuerySizeLod_Rulong320ocl_image2d_array_roi(%opencl.image2d_array_ro_t addrspace(1)
+; CHECK-SPV-LLVM: declare spir_func <3 x i32> @_Z32__spirv_ImageQuerySizeLod_Ruint320ocl_image2d_array_roi(%opencl.image2d_array_ro_t addrspace(1)
+; CHECK-SPV-LLVM: declare spir_func <3 x i64> @_Z33__spirv_ImageQuerySizeLod_Rulong320ocl_image2d_array_roi(%opencl.image2d_array_ro_t addrspace(1)
 
 ; CHECK-LLVM-DAG: [[AQ]] = !{!"read_only"}
 ; CHECK-LLVM-DAG: [[TYPE]] = !{!"image2d_array_t"}


### PR DESCRIPTION
Remove double mangling for OpAll/OpAny and relational instructions. Add
return type to name of function which corresponds to
OpImageQuerySizeLod/OpImageQuerySize instructions.