### PR TITLE
Fix isSpirvBinary signature

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -75,7 +75,7 @@ namespace SPIRV {
 class SPIRVModule;
 
 /// \brief Check if a string contains SPIR-V binary.
-bool isSpirvBinary(std::string &Img);
+bool isSpirvBinary(const std::string &Img);
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
 /// \brief Convert SPIR-V between binary and internal textual formats.


### PR DESCRIPTION
While checking in-memory spirv binary I've tried using `isSpirvBinary` api and hit a linking failure:
undefined reference to `SPIRV::isSpirvBinary(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)'

Looks like a signature inconsistency, as the cpp has const ref:
`lib/SPIRV/libSPIRV/SPIRVModule.cpp:bool isSpirvBinary(const std::string &Img)`

So, fixing the issue.