### PR TITLE
Do not truncate subgroup return value

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -381,7 +381,9 @@ std::string SPIRVToOCL::groupOCToOCLBuiltinName(CallInst *CI, Op OC) {
   return FuncName;
 }
 
-static bool extendRetTyToi32(Op OC) {
+/// Return true if the original boolean return type needs to be changed to i32
+/// when mapping the SPIR-V op to an OpenCL builtin.
+static bool needsInt32RetTy(Op OC) {
   return OC == OpGroupAny || OC == OpGroupAll || OC == OpGroupNonUniformAny ||
          OC == OpGroupNonUniformAll || OC == OpGroupNonUniformAllEqual ||
          OC == OpGroupNonUniformElect || OC == OpGroupNonUniformInverseBallot ||
@@ -408,15 +410,17 @@ void SPIRVToOCL::visitCallSPIRVGroupBuiltin(CallInst *CI, Op OC) {
       Args[0] = CastInst::CreateZExtOrBitCast(Args[0], Int32Ty, "", CI);
 
     // Handle function return type
-    if (extendRetTyToi32(OC))
+    if (needsInt32RetTy(OC))
       RetTy = Int32Ty;
 
     return FuncName;
   };
   auto ModifyRetTy = [=](CallInst *CI) -> Instruction * {
-    if (extendRetTyToi32(OC)) {
-      Type *RetTy = Type::getInt1Ty(*Ctx);
-      return CastInst::CreateTruncOrBitCast(CI, RetTy, "", CI->getNextNode());
+    if (needsInt32RetTy(OC)) {
+      // The OpenCL builtin returns a non-zero integer value. Convert to a
+      // boolean value.
+      Constant *Zero = ConstantInt::get(CI->getType(), 0);
+      return new ICmpInst(CI->getNextNode(), CmpInst::ICMP_NE, CI, Zero);
     } else
       return CI;
   };

--- a/test/transcoding/sub_group_ballot.ll
+++ b/test/transcoding/sub_group_ballot.ll
@@ -1054,8 +1054,10 @@ declare dso_local spir_func double @_Z25sub_group_broadcast_firstd(double) local
 
 ; CHECK-LLVM-LABEL: @testBallotOperations
 ; CHECK-LLVM: %[[ballot:[0-9]+]] = call spir_func <4 x i32> @_Z16sub_group_balloti(i32 {{.*}})
-; CHECK-LLVM: call spir_func i32 @_Z24sub_group_inverse_ballotDv4_j(<4 x i32> %[[ballot]])
-; CHECK-LLVM: call spir_func i32 @_Z28sub_group_ballot_bit_extractDv4_jj(<4 x i32> %[[ballot]], i32 0)
+; CHECK-LLVM: %[[inverse_ballot:[0-9]+]] = call spir_func i32 @_Z24sub_group_inverse_ballotDv4_j(<4 x i32> %[[ballot]])
+; CHECK-LLVM-NEXT: icmp ne i32 %[[inverse_ballot]], 0
+; CHECK-LLVM: %[[bit_extract:[0-9]+]] = call spir_func i32 @_Z28sub_group_ballot_bit_extractDv4_jj(<4 x i32> %[[ballot]], i32 0)
+; CHECK-LLVM-NEXT: icmp ne i32 %[[bit_extract]], 0
 ; CHECK-LLVM: call spir_func i32 @_Z26sub_group_ballot_bit_countDv4_j(<4 x i32> %[[ballot]])
 ; CHECK-LLVM: call spir_func i32 @_Z31sub_group_ballot_inclusive_scanDv4_j(<4 x i32> %[[ballot]])
 ; CHECK-LLVM: call spir_func i32 @_Z31sub_group_ballot_exclusive_scanDv4_j(<4 x i32> %[[ballot]])


### PR DESCRIPTION
Various SPIR-V subgroup operations return a boolean value, whereas the
equivalent OpenCL builtins return a zero or non-zero integer value.

Until now, the SPIR-V to OpenCL conversion would yield a truncate to
convert from integer to boolean, which is incorrect because any
non-zero integer value should be treated as a "true" value.  Use a
compare for the conversion instead.

Also rename the helper function to reflect better what it does and add
some comments.