### PR TITLE
[CI] Only check code style in include/ and lib/

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Gather list of changes
       id: gather-list-of-changes
       run: |
-        git diff -U0 --no-color ${{ github.sha }}^ > diff-to-inspect.txt
+        git diff -U0 --no-color ${{ github.sha }}^ -- include lib > diff-to-inspect.txt
         if [ -s diff-to-inspect.txt ]; then
           # Here we set an output of our step, which is used later to either
           # perform or skip further steps, i.e. there is no sense to install


### PR DESCRIPTION
I noticed in https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/879 that the code style check also runs on .cl test files, which doesn't seem desirable.