### PR TITLE
Switch to LLVM main branch

### DIFF
--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: master
+          ref: main
           path: llvm-project
       - name:  Checkout the translator sources
         uses: actions/checkout@v2
@@ -110,7 +110,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: master
+          ref: main
           path: llvm-project
       - name:  Checkout the translator sources
         uses: actions/checkout@v2
@@ -152,7 +152,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: llvm/llvm-project
-          ref: master
+          ref: main
           path: llvm-project
       - name:  Checkout the translator sources
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The files/directories related to the translator:
 ## Build Instructions
 
 The `master` branch of this repo is aimed to be buildable with the latest
-LLVM `master` revision.
+LLVM `main` revision.
 
 ### Build with pre-installed LLVM
 
@@ -187,7 +187,7 @@ More information can be found in
 ## Branching strategy
 
 Code on the master branch in this repository is intended to be compatible with
-the master branch of the [llvm](https://github.com/llvm/llvm-project)
+the main branch of the [llvm](https://github.com/llvm/llvm-project)
 project. That is, for an OpenCL kernel compiled to llvm bitcode by the latest
 git revision of Clang it should be possible to translate it to SPIR-V with the
 llvm-spirv tool.


### PR DESCRIPTION
The LLVM project is renaming the "master" branch to "main" [1].
Update the CI configuration and README for this change.

[1] https://foundation.llvm.org/docs/branch-rename/