### PR TITLE
[Backport][branch 80] Update translator for new Fast Composite extension

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -259,6 +259,9 @@ void PreprocessMetadata::preprocessVectorComputeMetadata(Module *M,
           .add(SLMSize)
           .done();
     }
+    if (Attrs.hasFnAttribute(kVCMetadata::VCFCEntry)) {
+      EM.addOp().add(&F).add(spv::ExecutionModeFastCompositeKernelINTEL).done();
+    }
   }
 }
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2518,6 +2518,12 @@ bool SPIRVToLLVM::transMetadata() {
     transOCLMetadata(BF);
     transVectorComputeMetadata(BF);
 
+    if (BF->hasDecorate(DecorationCallableFunctionINTEL))
+      F->addFnAttr(kVCMetadata::VCCallable);
+    if (isKernel(BF) &&
+        BF->getExecutionMode(ExecutionModeFastCompositeKernelINTEL))
+      F->addFnAttr(kVCMetadata::VCFCEntry);
+
     if (F->getCallingConv() != CallingConv::SPIR_KERNEL)
       continue;
 
@@ -2652,8 +2658,6 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
   SPIRVWord SIMTMode = 0;
   if (BF->hasDecorate(DecorationSIMTCallINTEL, 0, &SIMTMode))
     F->addFnAttr(kVCMetadata::VCSIMTCall, std::to_string(SIMTMode));
-  if (BF->hasDecorate(DecorationVectorComputeCallableFunctionINTEL))
-    F->addFnAttr(kVCMetadata::VCCallable);
 
   auto SEVAttr = Attribute::get(*Context, kVCMetadata::VCSingleElementVector);
   if (BF->hasDecorate(DecorationSingleElementVectorINTEL))

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -511,6 +511,9 @@ SPIRVFunction *LLVMToSPIRV::transFunctionDecl(Function *F) {
   if (Attrs.hasAttribute(AttributeList::ReturnIndex, Attribute::SExt))
     BF->addDecorate(DecorationFuncParamAttr, FunctionParameterAttributeSext);
 
+  if (Attrs.hasFnAttribute(kVCMetadata::VCCallable))
+    BF->addDecorate(DecorationCallableFunctionINTEL);
+
   transVectorComputeMetadata(F);
 
   SPIRVDBG(dbgs() << "[transFunction] " << *F << " => ";
@@ -537,10 +540,6 @@ void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
         .getValueAsString()
         .getAsInteger(0, SIMTMode);
     BF->addDecorate(DecorationSIMTCallINTEL, SIMTMode);
-  }
-
-  if (Attrs.hasFnAttribute(kVCMetadata::VCCallable)) {
-    BF->addDecorate(DecorationVectorComputeCallableFunctionINTEL);
   }
 
   if (Attrs.hasAttribute(AttributeList::ReturnIndex,
@@ -1871,6 +1870,10 @@ bool LLVMToSPIRV::transExecutionMode() {
         N.get(TargetWidth);
         BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
             BF, static_cast<ExecutionMode>(EMode), TargetWidth)));
+      } break;
+      case spv::ExecutionModeFastCompositeKernelINTEL: {
+        BF->addExecutionMode(BM->add(
+            new SPIRVExecutionMode(BF, static_cast<ExecutionMode>(EMode))));
       } break;
       default:
         llvm_unreachable("invalid execution mode");

--- a/lib/SPIRV/VectorComputeUtil.h
+++ b/lib/SPIRV/VectorComputeUtil.h
@@ -109,6 +109,7 @@ const static char VCVolatile[] = "VCVolatile";
 const static char VCByteOffset[] = "VCByteOffset";
 const static char VCSIMTCall[] = "VCSIMTCall";
 const static char VCCallable[] = "VCCallable";
+const static char VCFCEntry[] = "VCFCEntry";
 const static char VCSingleElementVector[] = "VCSingleElementVector";
 } // namespace kVCMetadata
 

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -148,6 +148,8 @@ public:
     case DecorationNoSignedWrap:
     case DecorationNoUnsignedWrap:
       return getSet(SPV_KHR_no_integer_wrap_decoration);
+    case DecorationCallableFunctionINTEL:
+      return getSet(SPV_INTEL_fast_composite);
     default:
       return SPIRVExtSet();
     }

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -824,6 +824,8 @@ public:
     case CapabilityVectorComputeINTEL:
     case CapabilityVectorAnyINTEL:
       return getSet(SPV_INTEL_vector_compute);
+    case CapabilityFastCompositeINTEL:
+      return getSet(SPV_INTEL_fast_composite);
     default:
       return SPIRVExtSet();
     }

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -116,7 +116,8 @@ enum SPIRVExtensionKind {
   SPV_INTEL_inline_assembly,
   SPV_KHR_float_controls,
   SPV_INTEL_float_controls2,
-  SPV_INTEL_vector_compute
+  SPV_INTEL_vector_compute,
+  SPV_INTEL_fast_composite,
 };
 
 typedef std::set<SPIRVExtensionKind> SPIRVExtSet;
@@ -130,6 +131,7 @@ template <> inline void SPIRVMap<SPIRVExtensionKind, std::string>::init() {
   add(SPV_KHR_float_controls, "SPV_KHR_float_controls");
   add(SPV_INTEL_float_controls2, "SPV_INTEL_float_controls2");
   add(SPV_INTEL_vector_compute, "SPV_INTEL_vector_compute");
+  add(SPV_INTEL_fast_composite, "SPV_INTEL_fast_composite");
 };
 
 template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
@@ -265,6 +267,8 @@ template <> inline void SPIRVMap<SPIRVExecutionModeKind, SPIRVCapVec>::init() {
                {CapabilityFloatingPointModeINTEL});
   ADD_VEC_INIT(ExecutionModeSharedLocalMemorySizeINTEL,
                {CapabilityVectorComputeINTEL});
+  ADD_VEC_INIT(ExecutionModeFastCompositeKernelINTEL,
+               {CapabilityFastCompositeINTEL});
 }
 
 template <> inline void SPIRVMap<SPIRVMemoryModelKind, SPIRVCapVec>::init() {
@@ -394,8 +398,7 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
                {CapabilityFunctionFloatControlINTEL});
   ADD_VEC_INIT(DecorationSingleElementVectorINTEL,
                {CapabilityVectorComputeINTEL});
-  ADD_VEC_INIT(DecorationVectorComputeCallableFunctionINTEL,
-               {CapabilityVectorComputeINTEL});
+  ADD_VEC_INIT(DecorationCallableFunctionINTEL, {CapabilityFastCompositeINTEL});
 }
 
 template <> inline void SPIRVMap<BuiltIn, SPIRVCapVec>::init() {

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -417,7 +417,7 @@ inline bool isValid(spv::Decoration V) {
   case DecorationFunctionRoundingModeINTEL:
   case DecorationFunctionDenormModeINTEL:
   case DecorationFunctionFloatingPointModeINTEL:
-  case DecorationVectorComputeCallableFunctionINTEL:
+  case DecorationCallableFunctionINTEL:
     return true;
   default:
     return false;

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -355,8 +355,7 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationFunctionFloatingPointModeINTEL,
       "FunctionFloatingPointModeINTEL");
   add(DecorationSingleElementVectorINTEL, "SingleElementVectorINTEL");
-  add(DecorationVectorComputeCallableFunctionINTEL,
-      "VectorComputeCallableFunctionINTEL");
+  add(DecorationCallableFunctionINTEL, "CallableFunctionINTEL");
 }
 SPIRV_DEF_NAMEMAP(Decoration, SPIRVDecorationNameMap)
 
@@ -527,6 +526,7 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
       "GroupNonUniformShuffleRelative");
   add(CapabilityGroupNonUniformClustered, "GroupNonUniformClustered");
   add(CapabilityFunctionFloatControlINTEL, "FunctionFloatControlINTEL");
+  add(CapabilityFastCompositeINTEL, "FastCompositeINTEL");
 }
 SPIRV_DEF_NAMEMAP(Capability, SPIRVCapabilityNameMap)
 

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -151,6 +151,7 @@ enum ExecutionMode {
     ExecutionModeRoundingModeRTNINTEL = 5621,
     ExecutionModeFloatingPointModeALTINTEL = 5622,
     ExecutionModeFloatingPointModeIEEEINTEL = 5623,
+    ExecutionModeFastCompositeKernelINTEL = 6088,
     ExecutionModeMax = 0x7fffffff,
 };
 
@@ -464,7 +465,7 @@ enum Decoration {
   DecorationFunctionDenormModeINTEL = 5823,
   DecorationFunctionFloatingPointModeINTEL = 6080,
   DecorationSingleElementVectorINTEL = 6085,
-  DecorationVectorComputeCallableFunctionINTEL = 6087,
+  DecorationCallableFunctionINTEL = 6087,
   DecorationMax = 0x7fffffff,
 };
 
@@ -890,6 +891,7 @@ enum Capability {
   CapabilityRoundToInfinityINTEL = 5582,
   CapabilityFloatingPointModeINTEL = 5583,
   CapabilityFunctionFloatControlINTEL = 5821,
+  CapabilityFastCompositeINTEL = 6093,
   CapabilityMax = 0x7fffffff,
 };
 

--- a/test/callable-attribute-decoration.ll
+++ b/test/callable-attribute-decoration.ll
@@ -12,7 +12,7 @@ define dso_local <4 x i32> @foo(<4 x i32> %a, <4 x i32> %b) #0 {
 entry:
   ret <4 x i32> %a
 }
-; CHECK-SPIRV: 3 Decorate {{[0-9]+}} VectorComputeCallableFunctionINTEL
+; CHECK-SPIRV: 3 Decorate {{[0-9]+}} CallableFunctionINTEL
 ; CHECK-LLVM: attributes
 ; CHECK-LLVM-SAME: "VCCallable"
 

--- a/test/fast-composit-entry.ll
+++ b/test/fast-composit-entry.ll
@@ -1,0 +1,40 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -o %t.spt --to-text
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -o %t.bc -r
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
+
+target triple = "spir64-unknown-unknown"
+
+
+; CHECK-SPIRV: {{[0-9]+}} EntryPoint {{[0-9]+}} [[FOO_ID:[0-9]+]] "foo"
+; CHECK-SPIRV: {{[0-9]+}} EntryPoint {{[0-9]+}} [[BAR_ID:[0-9]+]] "bar"
+; CHECK-SPIRV: 3 ExecutionMode [[FOO_ID]] 6088
+; CHECK-SPIRV-NOT: 3 ExecutionMode [[BAR_ID]] 6088
+
+; CHECK-LLVM: define spir_kernel void @foo
+; CHECK-LLVM-SAME: #[[FOO_ATTR_ID:[0-9]+]]
+; CHECK-LLVM: define spir_kernel void @bar
+; CHECK-LLVM-SAME: #[[BAR_ATTR_ID:[0-9]+]]
+
+; CHECK-LLVM: attributes #[[FOO_ATTR_ID]]
+; CHECK-LLVM-SAME: "VCFCEntry"
+; CHECK-LLVM: attributes #[[BAR_ATTR_ID]]
+; CHECK-LLVM-NOT: "VCFCEntry"
+
+
+define spir_kernel void @foo(<4 x i32> %a, <4 x i32> %b) #0 {
+entry:
+  ret void
+}
+
+define spir_kernel void @bar(<4 x i32> %a, <4 x i32> %b) #1 {
+entry:
+  ret void
+}
+
+attributes #0 = { noinline nounwind "VCFCEntry" "VCFloatControl"="0" "VCFunction" }
+attributes #1 = { noinline nounwind "VCFloatControl"="48" "VCFunction" }
+


### PR DESCRIPTION
SPV_INTEL_fast_composite extension specification separated some
decorations and execution modes from SPV_INTEL_vector_compute
Spec can be found here: intel/llvm#2882
Original PR to master: #860