### PR TITLE
Fix access specifiers in debug info

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -437,6 +437,21 @@ SPIRVWord transDebugFlags(const DINode *DN) {
   return Flags;
 }
 
+/// Clang doesn't emit access flags for members with default access specifier
+/// See clang/lib/CodeGen/CGDebugInfo.cpp: getAccessFlag()
+/// In SPIR-V we set the flags even for members with default access specifier
+SPIRVWord adjustAccessFlags(DIScope *Scope, SPIRVWord Flags) {
+  if (Scope && (Flags & SPIRVDebug::FlagAccess) == 0) {
+    unsigned Tag = Scope->getTag();
+    if (Tag == dwarf::DW_TAG_class_type)
+      Flags |= SPIRVDebug::FlagIsPrivate;
+    else if (Tag == dwarf::DW_TAG_structure_type ||
+             Tag == dwarf::DW_TAG_union_type)
+      Flags |= SPIRVDebug::FlagIsPublic;
+  }
+  return Flags;
+}
+
 /// The following methods (till the end of the file) implement translation of
 /// debug instrtuctions described in the spec.
 
@@ -666,7 +681,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgMemberType(const DIDerivedType *MT) {
   Ops[OffsetIdx] = SPIRVWriter->transValue(Offset, nullptr)->getId();
   ConstantInt *Size = getUInt(M, MT->getSizeInBits());
   Ops[SizeIdx] = SPIRVWriter->transValue(Size, nullptr)->getId();
-  Ops[FlagsIdx] = transDebugFlags(MT);
+  Ops[FlagsIdx] = adjustAccessFlags(MT->getScope(), transDebugFlags(MT));
   if (MT->isStaticMember()) {
     if (llvm::Constant *C = MT->getConstant()) {
       SPIRVValue *Val = SPIRVWriter->transValue(C, nullptr);
@@ -816,7 +831,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgFunction(const DISubprogram *Func) {
   else
     Ops[ParentIdx] = getScope(Scope)->getId();
   Ops[LinkageNameIdx] = BM->getString(Func->getLinkageName().str())->getId();
-  Ops[FlagsIdx] = transDebugFlags(Func);
+  Ops[FlagsIdx] = adjustAccessFlags(Scope, transDebugFlags(Func));
 
   SPIRVEntry *DebugFunc = nullptr;
   if (!Func->isDefinition()) {

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -50,8 +50,8 @@ enum Instruction {
 };
 
 enum Flag {
-  FlagIsPrivate           = 1 << 0,
-  FlagIsProtected         = 1 << 1,
+  FlagIsProtected         = 1 << 0,
+  FlagIsPrivate           = 1 << 1,
   FlagIsPublic            = FlagIsPrivate | FlagIsProtected,
   FlagAccess              = FlagIsPublic,
   FlagIsLocal             = 1 << 2,

--- a/test/DebugInfo/X86/debug-info-access.ll
+++ b/test/DebugInfo/X86/debug-info-access.ll
@@ -40,12 +40,12 @@
 
 ; CHECK: DW_TAG_member
 ; CHECK:     DW_AT_name {{.*}}"pub_default_static")
-; CHECK-NOT: DW_AT_accessibility
+; CHECK: DW_AT_accessibility
 ; CHECK-NOT: DW_TAG
 ;
 ; CHECK: DW_TAG_subprogram
 ; CHECK:     DW_AT_name {{.*}}"pub_default")
-; CHECK-NOT: DW_AT_accessibility
+; CHECK: DW_AT_accessibility
 ; CHECK: DW_TAG
 ;
 ; CHECK: DW_TAG_inheritance
@@ -69,7 +69,7 @@
 ;
 ; CHECK: DW_TAG_subprogram
 ; CHECK:     DW_AT_name {{.*}}"priv_default")
-; CHECK-NOT: DW_AT_accessibility
+; CHECK: DW_AT_accessibility
 ; CHECK: DW_TAG
 ;
 ; CHECK: DW_TAG_member
@@ -79,7 +79,7 @@
 ;
 ; CHECK: DW_TAG_subprogram
 ; CHECK:     DW_AT_name {{.*}}"union_pub_default")
-; CHECK-NOT: DW_AT_accessibility
+; CHECK: DW_AT_accessibility
 ; CHECK: DW_TAG
 ;
 ; CHECK: DW_TAG_subprogram

--- a/test/DebugInfo/X86/dwarf-public-names.ll
+++ b/test/DebugInfo/X86/dwarf-public-names.ll
@@ -50,7 +50,7 @@ target triple = "spir64-unknown-unknown"
 
 ; Skip the output to the header of the pubnames section.
 ; LINUX: debug_pubnames
-; LINUX-NEXT: unit_size = 0x00000128
+; LINUX-NEXT: unit_size = 0x0000012b
 
 ; Check for each name in the output.
 ; LINUX-DAG: "ns"


### PR DESCRIPTION
This commit fixes two issues:

1. FlagIsProtected and FlagIsPrivate had wrong values.

2. Set access flags for class/struct/union members which don't have sccess
   flags set in input LLVM IR, because Clang "optimized" them out in case the
   flags match with default access specifier of the containing type.
   This change also required adjustment of LIT tests to reflect the fact that
   now in DWARF we emit DW_AT_accessibility attribute even for members with
   deafult access specifier.

Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>