### PR TITLE
Treat warnings as errors in out of tree CI builds

### DIFF
--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -64,6 +64,7 @@ jobs:
           mkdir build && cd build
           cmake ${{ github.workspace }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_CXX_FLAGS="-Werror" \
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_EXTERNAL_LIT="/usr/lib/llvm-${{ env.LLVM_VERSION }}/build/utils/lit/lit.py" \
             -G "Unix Makefiles"

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -656,6 +656,7 @@ void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
   if (Attrs.hasAttribute(AttributeList::ReturnIndex,
                          kVCMetadata::VCSingleElementVector)) {
     auto *RT = BF->getType();
+    (void)RT;
     assert((RT->isTypeBool() || RT->isTypeFloat() || RT->isTypeInt() ||
             RT->isTypePointer()) &&
            "This decoration is valid only for Scalar or Pointer types");
@@ -675,6 +676,7 @@ void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
     }
     if (Attrs.hasAttribute(ArgNo + 1, kVCMetadata::VCSingleElementVector)) {
       auto *AT = BA->getType();
+      (void)AT;
       assert((AT->isTypeBool() || AT->isTypeFloat() || AT->isTypeInt() ||
               AT->isTypePointer()) &&
              "This decoration is valid only for Scalar or Pointer types");


### PR DESCRIPTION
Ensure build warnings are not left unnoticed in CI builds.  Only do
this for out of tree builds, such that any warnings from compiling
LLVM sources are not breaking the build unnecessarily.

Fix some unused variable warnings in release builds.