### PR TITLE
Fix LLVM-SPIRV::dbg-value-location.ll test

### DIFF
--- a/test/DebugInfo/X86/dbg-value-location.ll
+++ b/test/DebugInfo/X86/dbg-value-location.ll
@@ -2,8 +2,8 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 
-; RUN: llc -mtriple=%triple -filetype=obj %t.ll -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
-; RUN: llc -mtriple=%triple -filetype=obj %t.ll -regalloc=basic -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
+; RUN: llc -mtriple=x86_64-apple-darwin10.0.0 -filetype=obj %t.ll -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
+; RUN: llc -mtriple=x86_64-apple-darwin10.0.0 -filetype=obj %t.ll -regalloc=basic -o - | llvm-dwarfdump -v -debug-info - | FileCheck %s
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 ; Test that the type for the formal parameter "var" makes it into the debug info.


### PR DESCRIPTION
After recent changes in LLVM, debug info for this test changed for
Windows triple and caused test fail on Windows. Debug info can be
represented in several ways, it may depend on the triple. This test was
originally made for x86_64-apple-darwin10.0.0 triple, so this patch sets
this triple permanently.