### PR TITLE
Fix test/DebugInfo/X86/static_member_array.ll

### DIFF
--- a/test/DebugInfo/X86/static_member_array.ll
+++ b/test/DebugInfo/X86/static_member_array.ll
@@ -20,7 +20,7 @@
 ; CHECK: DW_TAG_member
 ; CHECK: DW_TAG_member
 ; CHECK-NEXT:   DW_AT_name {{.*}} "smem"
-; CHECK-NEXT:   DW_AT_type {{.*}} {0x[[GENERIC:[0-9]+]]}
+; CHECK-NEXT:   DW_AT_type {{.*}} {0x[[GENERIC:[0-9a-f]+]]}
 ;
 ; CHECK: 0x[[GENERIC]]: DW_TAG_array_type
 ; CHECK-NOT:  DW_TAG
@@ -31,7 +31,7 @@
 ;
 ; CHECK: DW_TAG_variable
 ; CHECK-NEXT: DW_AT_specification {{.*}}"smem"
-; CHECK-NEXT: DW_AT_type {{.*}} {0x[[SPECIFIC:[0-9]+]]}
+; CHECK-NEXT: DW_AT_type {{.*}} {0x[[SPECIFIC:[0-9a-f]+]]}
 ;
 ; CHECK: 0x[[SPECIFIC]]: DW_TAG_array_type
 ; CHECK-NOT:  DW_TAG


### PR DESCRIPTION
This patch fixes static_member_array.ll test which fails on Windows. The
reason why it failed is the missing a-f letters in hex number from regex
in test.