### PR TITLE
[NFC] Disable Travis CI on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ git:
 
 branches:
   only:
-    - master
     - /llvm_release_\d+$/
 # From https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches
 # "Note that safelisting also prevents tagged commits from being built.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # LLVM/SPIR-V Bi-Directional Translator
 
-[![Build Status](https://travis-ci.org/KhronosGroup/SPIRV-LLVM-Translator.svg?branch=master)](https://travis-ci.org/KhronosGroup/SPIRV-LLVM-Translator)
-
 [![Out-of-tree build & tests](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/workflows/Out-of-tree%20build%20&%20tests/badge.svg?branch=master&event=schedule)](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/actions?query=workflow%3A%22Out-of-tree+build+%26+tests%22+event%3Aschedule)
 [![In-tree build & tests](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/workflows/In-tree%20build%20&%20tests/badge.svg?branch=master&event=schedule)](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/actions?query=workflow%3A%22In-tree+build+%26+tests%22+event%3Aschedule)
 


### PR DESCRIPTION
We have GitHub Actions configured and there is no need to use two CI
systems at the same time.

The .travis.yml config file is not removed completed yet as we haven't
swithed to use GitHub Actions on release branches - this file will be
kept as some kind of reference for now.