### PR TITLE
[SYCL][FPGA] Update ArbitraryFloatCastTo/FromInt processing

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2772,21 +2772,23 @@ CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
 
   // Format of instruction CastFromInt:
   //   LLVM arbitrary floating point functions return value: iN
-  //   Arguments: A(iN), Mout(i32), EnableSubnormals(i32),
+  //   Arguments: A(iN), Mout(i32), FromSign(bool), EnableSubnormals(i32),
   //              RoundingMode(i32), RoundingAccuracy(i32)
   //   where A and return values are of arbitrary precision integer type.
   //   SPIR-V arbitrary floating point instruction layout:
-  //   <id>ResTy Res<id> A<id> Literal Mout Literal EnableSubnormals
-  //       Literal RoundingMode Literal RoundingAccuracy
+  //   <id>ResTy Res<id> A<id> Literal Mout Literal FromSign
+  //       Literal EnableSubnormals Literal RoundingMode
+  //       Literal RoundingAccuracy
 
   // Format of instruction CastToInt:
   //   LLVM arbitrary floating point functions return value: iN
-  //   Arguments: A(iN), MA(i32), EnableSubnormals(i32), RoundingMode(i32),
-  //              RoundingAccuracy(i32)
+  //   Arguments: A(iN), MA(i32), ToSign(bool), EnableSubnormals(i32),
+  //              RoundingMode(i32), RoundingAccuracy(i32)
   //   where A and return values are of arbitrary precision integer type.
   //   SPIR-V arbitrary floating point instruction layout:
-  //   <id>ResTy Res<id> A<id> Literal MA Literal EnableSubnormals
-  //       Literal RoundingMode Literal RoundingAccuracy
+  //   <id>ResTy Res<id> A<id> Literal MA Literal ToSign
+  //       Literal EnableSubnormals Literal RoundingMode
+  //       Literal RoundingAccuracy
 
   // Format of other instructions:
   //   LLVM arbitrary floating point functions return value: iN
@@ -2798,7 +2800,7 @@ CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   //       Literal RoundingMode Literal RoundingAccuracy
 
   Type *RetTy = transType(BI->getType());
-  IntegerType *Int32Ty = IntegerType::get(*Context, 32);
+  IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
   auto Inst = static_cast<SPIRVArbFloatIntelInst *>(BI);
 
@@ -2806,7 +2808,7 @@ CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   Type *BTy = nullptr;
 
   // Words contain:
-  // A<id> [Literal MA] [B<id>] [Literal MB] [Literal Mout]
+  // A<id> [Literal MA] [B<id>] [Literal MB] [Literal Mout] [Literal Sign]
   //   [Literal EnableSubnormals Literal RoundingMode Literal RoundingAccuracy]
   const std::vector<SPIRVWord> Words = Inst->getOpWords();
   auto WordsItr = Words.begin() + 1; /* Skip word for A input id */
@@ -2815,6 +2817,14 @@ CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   std::vector<Value *> Args = {
       transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
       ConstantInt::get(Int32Ty, *WordsItr++) /* MA/Mout - width of mantissa */};
+
+  Op OC = Inst->getOpCode();
+  if (OC == OpArbitraryFloatCastFromIntINTEL ||
+      OC == OpArbitraryFloatCastToIntINTEL) {
+    IntegerType *Int1Ty = Type::getInt1Ty(*Context);
+    ArgTys.push_back(Int1Ty);
+    Args.push_back(ConstantInt::get(Int1Ty, *WordsItr++)); /* ToSign/FromSign */
+  }
 
   if (IsBinaryInst) {
     /* B - input */
@@ -2831,8 +2841,8 @@ CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
                  });
 
   FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
-  std::string FuncName = SPIRVArbFloatIntelMap::rmap(Inst->getOpCode()) +
-                         getFuncAPIntSuffix(RetTy, ATy, BTy);
+  std::string FuncName =
+      SPIRVArbFloatIntelMap::rmap(OC) + getFuncAPIntSuffix(RetTy, ATy, BTy);
   FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
 
   auto *Func = cast<Function>(FCallee.getCallee());

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3668,21 +3668,23 @@ LLVMToSPIRV::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     // Format of instruction CastFromInt:
     //   LLVM arbitrary floating point functions return value type:
     //       iN (arbitrary precision integer of N bits length)
-    //   Arguments: A(iN), Mout(i32), EnableSubnormals(i32), RoundingMode(i32),
-    //              RoundingAccuracy(i32)
+    //   Arguments: A(iN), Mout(i32), FromSign(bool), EnableSubnormals(i32),
+    //              RoundingMode(i32), RoundingAccuracy(i32)
     //   where A and return values are of arbitrary precision integer type.
     //   SPIR-V arbitrary floating point instruction layout:
-    //   <id>ResTy Res<id> A<id> Literal Mout Literal EnableSubnormals
-    //       Literal RoundingMode Literal RoundingAccuracy
+    //   <id>ResTy Res<id> A<id> Literal Mout Literal FromSign
+    //       Literal EnableSubnormals Literal RoundingMode
+    //       Literal RoundingAccuracy
 
     // Format of instruction CastToInt:
     //   LLVM arbitrary floating point functions return value: iN
-    //   Arguments: A(iN), MA(i32), EnableSubnormals(i32), RoundingMode(i32),
-    //              RoundingAccuracy(i32)
+    //   Arguments: A(iN), MA(i32), ToSign(bool), EnableSubnormals(i32),
+    //              RoundingMode(i32), RoundingAccuracy(i32)
     //   where A and return values are of arbitrary precision integer type.
     //   SPIR-V arbitrary floating point instruction layout:
-    //   <id>ResTy Res<id> A<id> Literal MA Literal EnableSubnormals
-    //       Literal RoundingMode Literal RoundingAccuracy
+    //   <id>ResTy Res<id> A<id> Literal MA Literal ToSign
+    //       Literal EnableSubnormals Literal RoundingMode
+    //       Literal RoundingAccuracy
 
     // Format of other instructions:
     //   LLVM arbitrary floating point functions return value: iN

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2677,8 +2677,8 @@ protected:
                             OpArbitraryFloat##x##INTEL, __VA_ARGS__>           \
       SPIRVArbitraryFloat##x##INTEL;
 _SPIRV_OP(Cast, true, 9)
-_SPIRV_OP(CastFromInt, true, 8)
-_SPIRV_OP(CastToInt, true, 8)
+_SPIRV_OP(CastFromInt, true, 9)
+_SPIRV_OP(CastToInt, true, 9)
 _SPIRV_OP(Add, true, 11)
 _SPIRV_OP(Sub, true, 11)
 _SPIRV_OP(Mul, true, 11)

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1477,7 +1477,7 @@ SPIRVInstruction *SPIRVModuleImpl::addArbFloatPointIntelInst(
     Op OC, SPIRVType *ResTy, SPIRVValue *InA, SPIRVValue *InB,
     const std::vector<SPIRVWord> &Ops, SPIRVBasicBlock *BB) {
   // SPIR-V format:
-  //   A<id> [Literal MA] [B<id>] [Literal MB] [Literal Mout]
+  //   A<id> [Literal MA] [B<id>] [Literal MB] [Literal Mout] [Literal Sign]
   //   [Literal EnableSubnormals Literal RoundingMode Literal RoundingAccuracy]
   auto OpsItr = Ops.begin();
   std::vector<SPIRVWord> TheOps = getVec(InA->getId(), *OpsItr++);


### PR DESCRIPTION
Add processing of a new parameter To/FromSign that specifies if integer value
to cast to/from is signed or not for ArbitraryFloatCastTo/FromInt functions.

See spec update (intel/llvm#1934): https://github.com/intel/llvm/blob/ea96f3ccee007e04074af6e275dbfce4fce13717/sycl/doc/extensions/SPIRV/SPV_INTEL_arbitrary_precision_floating_point.asciidoc

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>