### PR TITLE
Update DebugInfo test after LLVM change

### DIFF
--- a/test/DebugInfo/X86/dwarf-pubnames-split.ll
+++ b/test/DebugInfo/X86/dwarf-pubnames-split.ll
@@ -14,7 +14,7 @@ target triple = "spir64-unknown-unknown"
 
 ; Check that we get a symbol off of the debug_info section when using split dwarf and pubnames.
 
-; CHECK: .LpubTypes_begin0:
+; CHECK: .LpubTypes_start0:
 ; CHECK-NEXT: .short    2                       # DWARF Version
 ; CHECK-NEXT: .long     .Lcu_begin0             # Offset of Compilation Unit Info
 


### PR DESCRIPTION
Update for LLVM commit d39bc36b1be7 ("[debug-info] refactor
emitDwarfUnitLength", 2021-02-25).