### PR TITLE
Use -fdeclare-opencl-builtins for more .cl tests

### DIFF
--- a/test/event_no_group_cap.cl
+++ b/test/event_no_group_cap.cl
@@ -2,7 +2,7 @@ __kernel void test_fn( const __global char *src)
 {
 	wait_group_events(0, NULL);
 }
-// RUN: %clang_cc1 -triple spir64 -x cl -cl-std=CL2.0 -finclude-default-header -O0 -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir64 -x cl -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -O0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpenCL/atomic_work_item_fence.cl
+++ b/test/transcoding/OpenCL/atomic_work_item_fence.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 //
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
@@ -7,40 +7,7 @@
 
 // This test checks that the translator is capable to correctly translate
 // atomic_work_item_fence OpenCL C 2.0 built-in function [1] into corresponding
-// SPIR-V instruction [3] and vice-versa.
-//
-// Forward declarations and defines below are based on the following sources:
-// - llvm/llvm-project [1]:
-//   - clang/lib/Headers/opencl-c-base.h
-//   - clang/lib/Headers/opencl-c.h
-// - OpenCL C 2.0 reference pages [2]
-// TODO: remove these and switch to using -fdeclare-opencl-builtins once
-// atomic_work_item_fence is supported by this flag
-
-typedef unsigned int cl_mem_fence_flags;
-
-#define CLK_LOCAL_MEM_FENCE 0x01
-#define CLK_GLOBAL_MEM_FENCE 0x02
-#define CLK_IMAGE_MEM_FENCE 0x04
-
-typedef enum memory_scope {
-  memory_scope_work_item = __OPENCL_MEMORY_SCOPE_WORK_ITEM,
-  memory_scope_work_group = __OPENCL_MEMORY_SCOPE_WORK_GROUP,
-  memory_scope_device = __OPENCL_MEMORY_SCOPE_DEVICE,
-  memory_scope_all_svm_devices = __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES,
-  memory_scope_sub_group = __OPENCL_MEMORY_SCOPE_SUB_GROUP
-} memory_scope;
-
-typedef enum memory_order
-{
-  memory_order_relaxed = __ATOMIC_RELAXED,
-  memory_order_acquire = __ATOMIC_ACQUIRE,
-  memory_order_release = __ATOMIC_RELEASE,
-  memory_order_acq_rel = __ATOMIC_ACQ_REL,
-  memory_order_seq_cst = __ATOMIC_SEQ_CST
-} memory_order;
-
-void __attribute__((overloadable)) atomic_work_item_fence(cl_mem_fence_flags, memory_order, memory_scope);
+// SPIR-V instruction [2] and vice-versa.
 
 __kernel void test_mem_fence_const_flags() {
   atomic_work_item_fence(CLK_LOCAL_MEM_FENCE, memory_order_relaxed, memory_scope_work_item);
@@ -102,5 +69,4 @@ __kernel void test_mem_fence_non_const_flags(cl_mem_fence_flags flags, memory_or
 
 // References:
 // [1]: https://www.khronos.org/registry/OpenCL/sdk/2.0/docs/man/xhtml/atomic_work_item_fence.html
-// [2]: https://github.com/llvm/llvm-project
-// [3]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpMemoryBarrier
+// [2]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpMemoryBarrier

--- a/test/transcoding/OpenCL/sub_group_mask.cl
+++ b/test/transcoding/OpenCL/sub_group_mask.cl
@@ -1,14 +1,9 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.spv -r -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
-
-// Taken from clang/lib/Headers/opencl-c{,-base}.h
-// TODO: remove these and switch to -fdeclare-opencl-builtins
-typedef unsigned int uint4 __attribute__((ext_vector_type(4)));
-uint4 __attribute__((overloadable)) get_sub_group_gt_mask(void);
 
 // CHECK-SPIRV: Capability GroupNonUniformBallot
 // CHECK-SPIRV: Decorate {{[0-9]+}} BuiltIn 4418

--- a/test/transcoding/OpenCL/work_group_barrier.cl
+++ b/test/transcoding/OpenCL/work_group_barrier.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
@@ -7,32 +7,6 @@
 // This test checks that the translator is capable to correctly translate
 // sub_group_barrier built-in function [1] from cl_khr_subgroups extension into
 // corresponding SPIR-V instruction and vice-versa.
-//
-// Forward declarations and defines below are based on the following sources:
-// - llvm/llvm-project [2]:
-//   - clang/lib/Headers/opencl-c-base.h
-//   - clang/lib/Headers/opencl-c.h
-// - OpenCL C 2.0 reference pages [1]
-// TODO: remove these and switch to using -fdeclare-opencl-builtins once
-// work_group_barrier is supported by this flag
-
-typedef unsigned int cl_mem_fence_flags;
-
-#define CLK_LOCAL_MEM_FENCE 0x01
-#define CLK_GLOBAL_MEM_FENCE 0x02
-#define CLK_IMAGE_MEM_FENCE 0x04
-
-typedef enum memory_scope {
-  memory_scope_work_item = __OPENCL_MEMORY_SCOPE_WORK_ITEM,
-  memory_scope_work_group = __OPENCL_MEMORY_SCOPE_WORK_GROUP,
-  memory_scope_device = __OPENCL_MEMORY_SCOPE_DEVICE,
-  memory_scope_all_svm_devices = __OPENCL_MEMORY_SCOPE_ALL_SVM_DEVICES,
-  memory_scope_sub_group = __OPENCL_MEMORY_SCOPE_SUB_GROUP
-} memory_scope;
-
-void __attribute__((overloadable)) __attribute__((convergent)) barrier(cl_mem_fence_flags);
-void __attribute__((overloadable)) __attribute__((convergent)) work_group_barrier(cl_mem_fence_flags);
-void __attribute__((overloadable)) __attribute__((convergent)) work_group_barrier(cl_mem_fence_flags, memory_scope);
 
 __kernel void test_barrier_const_flags() {
   work_group_barrier(CLK_LOCAL_MEM_FENCE);
@@ -62,8 +36,8 @@ __kernel void test_barrier_non_const_flags(cl_mem_fence_flags flags, memory_scop
 // CHECK-SPIRV: EntryPoint {{[0-9]+}} [[TEST_CONST_FLAGS:[0-9]+]] "test_barrier_const_flags"
 // CHECK-SPIRV: TypeInt [[UINT:[0-9]+]] 32 0
 //
-// In SPIR-V, barrier is represented as OpControlBarrier [3] and OpenCL
-// cl_mem_fence_flags are represented as part of Memory Semantics [4], which
+// In SPIR-V, barrier is represented as OpControlBarrier [2] and OpenCL
+// cl_mem_fence_flags are represented as part of Memory Semantics [3], which
 // also includes memory order constraints. The translator applies some default
 // memory order for OpControlBarrier and therefore, constants below include a
 // bit more information than original source
@@ -122,6 +96,5 @@ __kernel void test_barrier_non_const_flags(cl_mem_fence_flags flags, memory_scop
 
 // References:
 // [1]: https://www.khronos.org/registry/OpenCL/sdk/2.0/docs/man/xhtml/work_group_barrier.html
-// [2]: https://github.com/llvm/llvm-project
-// [3]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpControlBarrier
-// [4]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_memory_semantics__id_a_memory_semantics_lt_id_gt
+// [2]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpControlBarrier
+// [3]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_memory_semantics__id_a_memory_semantics_lt_id_gt

--- a/test/transcoding/atomic_explicit_arguments.cl
+++ b/test/transcoding/atomic_explicit_arguments.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir -cl-std=cl2.0 %s -finclude-default-header -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 -triple spir -cl-std=cl2.0 %s -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.spv -r --spirv-target-env=CL2.0 -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/atomic_flag.cl
+++ b/test/transcoding/atomic_flag.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/clk_event_t.cl
+++ b/test/transcoding/clk_event_t.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv


### PR DESCRIPTION
Since clang commit 85eb12eefdf6 ("[OpenCL] Add declarations with
enum/typedef args", 2021-02-24), Clang provides most of the OpenCL
builtin functions through the faster `-fdeclare-opencl-builtins` flag.
Update various .cl tests to make use of this flag, to speed up running
of the tests and to avoid maintaining excerpts from `opencl-c.h` in
the tests.