### PR TITLE
Remove language check assert

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4379,22 +4379,22 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC,
 void SPIRVToLLVM::transSourceLanguage() {
   SPIRVWord Ver = 0;
   SourceLanguage Lang = BM->getSourceLanguage(&Ver);
-  if (Lang == SourceLanguageUnknown || // Allow unknown for debug info test
-      Lang == SourceLanguageOpenCL_C || Lang == SourceLanguageOpenCL_CPP) {
-    unsigned short Major = 0;
-    unsigned char Minor = 0;
-    unsigned char Rev = 0;
-    std::tie(Major, Minor, Rev) = decodeOCLVer(Ver);
-    SPIRVMDBuilder Builder(*M);
-    Builder.addNamedMD(kSPIRVMD::Source).addOp().add(Lang).add(Ver).done();
-    // ToDo: Phasing out usage of old SPIR metadata
-    if (Ver <= kOCLVer::CL12)
-      addOCLVersionMetadata(Context, M, kSPIR2MD::SPIRVer, 1, 2);
-    else
-      addOCLVersionMetadata(Context, M, kSPIR2MD::SPIRVer, 2, 0);
+  if (Lang != SourceLanguageUnknown && // Allow unknown for debug info test
+      Lang != SourceLanguageOpenCL_C && Lang != SourceLanguageOpenCL_CPP)
+    return;
+  unsigned short Major = 0;
+  unsigned char Minor = 0;
+  unsigned char Rev = 0;
+  std::tie(Major, Minor, Rev) = decodeOCLVer(Ver);
+  SPIRVMDBuilder Builder(*M);
+  Builder.addNamedMD(kSPIRVMD::Source).addOp().add(Lang).add(Ver).done();
+  // ToDo: Phasing out usage of old SPIR metadata
+  if (Ver <= kOCLVer::CL12)
+    addOCLVersionMetadata(Context, M, kSPIR2MD::SPIRVer, 1, 2);
+  else
+    addOCLVersionMetadata(Context, M, kSPIR2MD::SPIRVer, 2, 0);
 
-    addOCLVersionMetadata(Context, M, kSPIR2MD::OCLVer, Major, Minor);
-  }
+  addOCLVersionMetadata(Context, M, kSPIR2MD::OCLVer, Major, Minor);
 }
 
 bool SPIRVToLLVM::transSourceExtension() {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3476,8 +3476,7 @@ bool SPIRVToLLVM::translate() {
     return false;
   if (!transFPContractMetadata())
     return false;
-  if (!transSourceLanguage())
-    return false;
+  transSourceLanguage();
   if (!transSourceExtension())
     return false;
   transGeneratorMD();
@@ -4377,26 +4376,25 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC,
 
 // SPIR-V only contains language version. Use OpenCL language version as
 // SPIR version.
-bool SPIRVToLLVM::transSourceLanguage() {
+void SPIRVToLLVM::transSourceLanguage() {
   SPIRVWord Ver = 0;
   SourceLanguage Lang = BM->getSourceLanguage(&Ver);
-  assert((Lang == SourceLanguageUnknown || // Allow unknown for debug info test
-          Lang == SourceLanguageOpenCL_C || Lang == SourceLanguageOpenCL_CPP) &&
-         "Unsupported source language");
-  unsigned short Major = 0;
-  unsigned char Minor = 0;
-  unsigned char Rev = 0;
-  std::tie(Major, Minor, Rev) = decodeOCLVer(Ver);
-  SPIRVMDBuilder Builder(*M);
-  Builder.addNamedMD(kSPIRVMD::Source).addOp().add(Lang).add(Ver).done();
-  // ToDo: Phasing out usage of old SPIR metadata
-  if (Ver <= kOCLVer::CL12)
-    addOCLVersionMetadata(Context, M, kSPIR2MD::SPIRVer, 1, 2);
-  else
-    addOCLVersionMetadata(Context, M, kSPIR2MD::SPIRVer, 2, 0);
+  if (Lang == SourceLanguageUnknown || // Allow unknown for debug info test
+      Lang == SourceLanguageOpenCL_C || Lang == SourceLanguageOpenCL_CPP) {
+    unsigned short Major = 0;
+    unsigned char Minor = 0;
+    unsigned char Rev = 0;
+    std::tie(Major, Minor, Rev) = decodeOCLVer(Ver);
+    SPIRVMDBuilder Builder(*M);
+    Builder.addNamedMD(kSPIRVMD::Source).addOp().add(Lang).add(Ver).done();
+    // ToDo: Phasing out usage of old SPIR metadata
+    if (Ver <= kOCLVer::CL12)
+      addOCLVersionMetadata(Context, M, kSPIR2MD::SPIRVer, 1, 2);
+    else
+      addOCLVersionMetadata(Context, M, kSPIR2MD::SPIRVer, 2, 0);
 
-  addOCLVersionMetadata(Context, M, kSPIR2MD::OCLVer, Major, Minor);
-  return true;
+    addOCLVersionMetadata(Context, M, kSPIR2MD::OCLVer, Major, Minor);
+  }
 }
 
 bool SPIRVToLLVM::transSourceExtension() {

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -115,7 +115,7 @@ public:
   CallInst *transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
                               bool IsBinaryInst = false);
   bool transNonTemporalMetadata(Instruction *I);
-  bool transSourceLanguage();
+  void transSourceLanguage();
   bool transSourceExtension();
   void transGeneratorMD();
   Value *transConvertInst(SPIRVValue *BV, Function *F, BasicBlock *BB);

--- a/test/OpSource.spt
+++ b/test/OpSource.spt
@@ -1,0 +1,38 @@
+119734787 65536 393230 13 0 
+2 Capability Addresses 
+2 Capability Linkage 
+2 Capability Kernel 
+2 Capability Int8 
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 2 2 
+5 EntryPoint 6 8 "test"
+3 ExecutionMode 8 31 
+14 String 12 "kernel_arg_type.test.char,short,int,long,int2,"
+3 Source 12345 67890 
+6 Name 4 "_Z8popcountc"
+3 Name 9 "x8"
+4 Name 10 "entry"
+8 Decorate 4 LinkageAttributes "_Z8popcountc" Import 
+4 TypeInt 2 8 0 
+4 TypeFunction 3 2 2 
+2 TypeVoid 6 
+4 TypeFunction 7 6 2 
+
+
+5 Function 2 4 0 3 
+3 FunctionParameter 2 5 
+
+1 FunctionEnd 
+
+5 Function 6 8 4 7 
+3 FunctionParameter 2 9 
+
+2 Label 10 
+5 FunctionCall 2 11 4 9 
+1 Return 
+
+1 FunctionEnd 
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; Reverse translation shouldn't crash:
+; RUN: llvm-spirv -r %t.spv -o %t.bc


### PR DESCRIPTION
According to specification, OpSource has no semantic impact and can safely be removed from a module. Therefore, such a strict check is not required.

Signed-off-by: amochalo <anastasiya.mochalova@intel.com>