### PR TITLE
Redesign handling of forward pointers

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3335,7 +3335,6 @@ bool LLVMToSPIRVBase::translate() {
     return false;
 
   BM->resolveUnknownStructFields();
-  BM->createForwardPointers();
   DbgTran->transDebugMetadata();
   return true;
 }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -249,7 +249,6 @@ public:
   SPIRVTypeQueue *addQueueType() override;
   SPIRVTypePipe *addPipeType() override;
   SPIRVTypeVoid *addVoidType() override;
-  void createForwardPointers() override;
   SPIRVType *addSubgroupAvcINTELType(Op) override;
   SPIRVTypeVmeImageINTEL *addVmeImageINTELType(SPIRVTypeImage *T) override;
   SPIRVTypeBufferSurfaceINTEL *
@@ -931,32 +930,6 @@ SPIRVTypePipeStorage *SPIRVModuleImpl::addPipeStorageType() {
 
 SPIRVTypeSampledImage *SPIRVModuleImpl::addSampledImageType(SPIRVTypeImage *T) {
   return addType(new SPIRVTypeSampledImage(this, getId(), T));
-}
-
-void SPIRVModuleImpl::createForwardPointers() {
-  std::unordered_set<SPIRVId> Seen;
-
-  for (auto *T : TypeVec) {
-    if (T->hasId())
-      Seen.insert(T->getId());
-
-    if (!T->isTypeStruct())
-      continue;
-
-    auto ST = static_cast<SPIRVTypeStruct *>(T);
-
-    for (unsigned I = 0; I < ST->getStructMemberCount(); ++I) {
-      auto MemberTy = ST->getStructMemberType(I);
-      if (!MemberTy->isTypePointer())
-        continue;
-      auto Ptr = static_cast<SPIRVTypePointer *>(MemberTy);
-
-      if (Seen.find(Ptr->getId()) == Seen.end()) {
-        ForwardPointerVec.push_back(new SPIRVTypeForwardPointer(
-            this, Ptr, Ptr->getPointerStorageClass()));
-      }
-    }
-  }
 }
 
 SPIRVTypeVmeImageINTEL *
@@ -1692,14 +1665,22 @@ class TopologicalSort {
   typedef std::vector<SPIRVVariable *> SPIRVVariableVec;
   typedef std::vector<SPIRVEntry *> SPIRVConstAndVarVec;
   typedef std::vector<SPIRVTypeForwardPointer *> SPIRVForwardPointerVec;
-  typedef std::function<bool(SPIRVEntry *, SPIRVEntry *)> IdComp;
-  typedef std::map<SPIRVEntry *, DFSState, IdComp> EntryStateMapTy;
+  typedef std::function<bool(SPIRVEntry *, SPIRVEntry *)> Comp;
+  typedef std::map<SPIRVEntry *, DFSState, Comp> EntryStateMapTy;
+  typedef std::function<bool(const SPIRVTypeForwardPointer *,
+                             const SPIRVTypeForwardPointer *)>
+      Equal;
+  typedef std::function<size_t(const SPIRVTypeForwardPointer *)> Hash;
+  // We may create forward pointers as we go through the types. We use
+  // unordered set to avoid duplicates.
+  typedef std::unordered_set<SPIRVTypeForwardPointer *, Hash, Equal>
+      SPIRVForwardPointerSet;
 
   SPIRVTypeVec TypeIntVec;
   SPIRVConstantVector ConstIntVec;
   SPIRVTypeVec TypeVec;
   SPIRVConstAndVarVec ConstAndVarVec;
-  const SPIRVForwardPointerVec &ForwardPointerVec;
+  SPIRVForwardPointerSet ForwardPointerSet;
   EntryStateMapTy EntryStateMap;
 
   friend spv_ostream &operator<<(spv_ostream &O, const TopologicalSort &S);
@@ -1711,19 +1692,23 @@ class TopologicalSort {
   // the entry itslef.
   void visit(SPIRVEntry *E) {
     DFSState &State = EntryStateMap[E];
+    if (E->getOpCode() == OpTypePointer) {
+      SPIRVTypePointer *Ptr = static_cast<SPIRVTypePointer *>(E);
+      if (EntryStateMap[Ptr->getElementType()] == Discovered) {
+        // We've found a recursive data type, e.g. a structure having a member
+        // which is a pointer to the same structure. In this, case we can break
+        // such cyclic dependency by inserting a forward declaration of that
+        // pointer.
+        ForwardPointerSet.insert(new SPIRVTypeForwardPointer(
+            E->getModule(), Ptr, Ptr->getPointerStorageClass()));
+        return;
+      }
+    }
     assert(State != Discovered && "Cyclic dependency detected");
     if (State == Visited)
       return;
     State = Discovered;
     for (SPIRVEntry *Op : E->getNonLiteralOperands()) {
-      auto Comp = [&Op](SPIRVTypeForwardPointer *FwdPtr) {
-        return FwdPtr->getPointer() == Op;
-      };
-      // Skip forward referenced pointers
-      if (Op->getOpCode() == OpTypePointer &&
-          find_if(ForwardPointerVec.begin(), ForwardPointerVec.end(), Comp) !=
-              ForwardPointerVec.end())
-        continue;
       visit(Op);
     }
     State = Visited;
@@ -1746,8 +1731,16 @@ public:
   TopologicalSort(const SPIRVTypeVec &TypeVec,
                   const SPIRVConstantVector &ConstVec,
                   const SPIRVVariableVec &VariableVec,
-                  const SPIRVForwardPointerVec &ForwardPointerVec)
-      : ForwardPointerVec(ForwardPointerVec),
+                  SPIRVForwardPointerVec &ForwardPointerVec)
+      : ForwardPointerSet(
+            16, // bucket count
+            [](const SPIRVTypeForwardPointer *Ptr) {
+              return std::hash<SPIRVId>()(Ptr->getPointer()->getId());
+            },
+            [](const SPIRVTypeForwardPointer *Ptr1,
+               const SPIRVTypeForwardPointer *Ptr2) {
+              return Ptr1->getPointer()->getId() == Ptr2->getPointer()->getId();
+            }),
         EntryStateMap([](SPIRVEntry *A, SPIRVEntry *B) -> bool {
           return A->getId() < B->getId();
         }) {
@@ -1761,6 +1754,9 @@ public:
     // Run topoligical sort
     for (auto ES : EntryStateMap)
       visit(ES.first);
+    // Append forward pointers vector
+    ForwardPointerVec.insert(ForwardPointerVec.end(), ForwardPointerSet.begin(),
+                             ForwardPointerSet.end());
   }
 };
 
@@ -1829,10 +1825,11 @@ spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M) {
     O << SPIRVNL() << MI.AliasInstMDVec;
   }
 
+  TopologicalSort TS(MI.TypeVec, MI.ConstVec, MI.VariableVec,
+                     MI.ForwardPointerVec);
+
   O << MI.MemberNameVec << MI.ModuleProcessedVec << MI.DecGroupVec
-    << MI.DecorateSet << MI.GroupDecVec << MI.ForwardPointerVec
-    << TopologicalSort(MI.TypeVec, MI.ConstVec, MI.VariableVec,
-                       MI.ForwardPointerVec);
+    << MI.DecorateSet << MI.GroupDecVec << MI.ForwardPointerVec << TS;
 
   if (M.isAllowedToUseExtension(ExtensionID::SPV_INTEL_inline_assembly)) {
     O << SPIRVNL() << MI.AsmTargetVec << MI.AsmVec;
@@ -1997,7 +1994,6 @@ std::istream &operator>>(std::istream &I, SPIRVModule &M) {
   }
 
   MI.resolveUnknownStructFields();
-  MI.createForwardPointers();
   return I;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -250,7 +250,6 @@ public:
   virtual SPIRVTypeVmeImageINTEL *addVmeImageINTELType(SPIRVTypeImage *) = 0;
   virtual SPIRVTypeBufferSurfaceINTEL *
   addBufferSurfaceINTELType(SPIRVAccessQualifierKind Access) = 0;
-  virtual void createForwardPointers() = 0;
 
   // Constants creation functions
   virtual SPIRVValue *

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -718,37 +718,44 @@ public:
   SPIRVTypeFunction(SPIRVModule *M, SPIRVId TheId, SPIRVType *TheReturnType,
                     const std::vector<SPIRVType *> &TheParameterTypes)
       : SPIRVType(M, 3 + TheParameterTypes.size(), OpTypeFunction, TheId),
-        ReturnType(TheReturnType), ParamTypeVec(TheParameterTypes) {
+        ReturnType(TheReturnType) {
+    for (const SPIRVType *T : TheParameterTypes) {
+      ParamTypeIdVec.push_back(T->getId());
+    }
     validate();
   }
   // Incomplete constructor
   SPIRVTypeFunction() : SPIRVType(OpTypeFunction), ReturnType(NULL) {}
 
   SPIRVType *getReturnType() const { return ReturnType; }
-  SPIRVWord getNumParameters() const { return ParamTypeVec.size(); }
-  SPIRVType *getParameterType(unsigned I) const { return ParamTypeVec[I]; }
+  SPIRVWord getNumParameters() const { return ParamTypeIdVec.size(); }
+  SPIRVType *getParameterType(unsigned I) const {
+    return static_cast<SPIRVType *>(getEntry(ParamTypeIdVec[I]));
+  }
+
   std::vector<SPIRVEntry *> getNonLiteralOperands() const override {
-    std::vector<SPIRVEntry *> Operands(1 + ParamTypeVec.size(), ReturnType);
-    std::copy(ParamTypeVec.begin(), ParamTypeVec.end(), ++Operands.begin());
+    std::vector<SPIRVEntry *> Operands = {ReturnType};
+    for (SPIRVId I : ParamTypeIdVec)
+      Operands.push_back(getEntry(I));
     return Operands;
   }
 
 protected:
-  _SPIRV_DEF_ENCDEC3(Id, ReturnType, ParamTypeVec)
+  _SPIRV_DEF_ENCDEC3(Id, ReturnType, ParamTypeIdVec)
   void setWordCount(SPIRVWord WordCount) override {
     SPIRVType::setWordCount(WordCount);
-    ParamTypeVec.resize(WordCount - 3);
+    ParamTypeIdVec.resize(WordCount - 3);
   }
   void validate() const override {
     SPIRVEntry::validate();
     ReturnType->validate();
-    for (auto T : ParamTypeVec)
-      T->validate();
+    for (auto I : ParamTypeIdVec)
+      getEntry(I)->validate();
   }
 
 private:
-  SPIRVType *ReturnType;                 // Return Type
-  std::vector<SPIRVType *> ParamTypeVec; // Parameter Types
+  SPIRVType *ReturnType;               // Return Type
+  std::vector<SPIRVId> ParamTypeIdVec; // Parameter Type Ids
 };
 
 class SPIRVTypeOpaqueGeneric : public SPIRVType {

--- a/test/transcoding/ForwardPtr.ll
+++ b/test/transcoding/ForwardPtr.ll
@@ -1,0 +1,32 @@
+; RUN: llvm-as < %s | llvm-spirv -spirv-ext=+all -o %t.spv
+; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: TypeForwardPointer [[#FwdPtr:]] [[#SC:]]
+; CHECK-SPIRV: TypeFunction [[#]] [[#]] [[#FwdPtr]]
+; CHECK-SPIRV: TypeStruct [[#ArgsSec:]] [[#FwdPtr]]
+; CHECK-SPIRV: TypeStruct [[#A:]] [[#]] [[#ArgsSec:]]
+; CHECK-SPIRV: TypePointer [[#FwdPtr]] [[#SC]] [[#A]]
+
+; CHECK-LLVM: %struct.FuncArg = type { %class.A addrspace(4)* }
+; CHECK-LLVM: %class.A = type { %class.ArgFirst, %structArgSec }
+; CHECK-LLVM: %class.ArgFirst = type { void (%class.A addrspace(4)*)* }
+; CHECK-LLVM: %structArgSec = type { %class.A addrspace(4)* }
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown-sycldevice"
+
+%struct.FuncArg = type { %class.A addrspace(4)* }
+%class.A = type { %class.ArgFirst, %structArgSec }
+%class.ArgFirst = type { void (%class.A addrspace(4)*)* }
+%structArgSec= type { %class.A addrspace(4)* }
+
+declare spir_func i1 @Caller(%struct.FuncArg addrspace(4)* ) align 2
+
+define spir_func void @MainFunc(%struct.FuncArg addrspace(4)* %context) {
+  entry:
+  %call = call spir_func zeroext i1 @Caller( %struct.FuncArg addrspace(4)* undef) 
+  ret void
+}
+

--- a/test/transcoding/RecursiveType.ll
+++ b/test/transcoding/RecursiveType.ll
@@ -13,15 +13,15 @@ target triple = "spir-unknown-unknown"
 %struct.B = type { i32, %struct.A addrspace(4)* }
 %struct.Node = type { %struct.Node addrspace(1)*, i32 }
 
-; CHECK-SPIRV: 3 TypeForwardPointer [[AFwdPtr:[0-9]+]] [[ASC:[0-9]+]]
-; CHECK-SPIRV: 3 TypeForwardPointer [[NodeFwdPtr:[0-9]+]] [[NodeSC:[0-9]+]]
+; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[NodeFwdPtr:[0-9]+]] 5
+; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[AFwdPtr:[0-9]+]] 8
 ; CHECK-SPIRV: 4 TypeInt [[IntID:[0-9]+]] 32 0
 ; CHECK-SPIRV: 4 TypeStruct [[BID:[0-9]+]] {{[0-9]+}} [[AFwdPtr]]
 ; CHECK-SPIRV: 4 TypeStruct [[CID:[0-9]+]] {{[0-9]+}} [[BID]]
 ; CHECK-SPIRV: 4 TypeStruct [[AID:[0-9]+]] {{[0-9]+}} [[CID]]
-; CHECK-SPIRV: 4 TypePointer [[AFwdPtr]] [[ASC]] [[AID:[0-9]+]]
+; CHECK-SPIRV: 4 TypePointer [[AFwdPtr]] 8 [[AID:[0-9]+]]
 ; CHECK-SPIRV: 4 TypeStruct [[NodeID:[0-9]+]] [[NodeFwdPtr]]
-; CHECK-SPIRV: 4 TypePointer [[NodeFwdPtr]] [[NodeSC]] [[NodeID]]
+; CHECK-SPIRV: 4 TypePointer [[NodeFwdPtr]] 5 [[NodeID]]
 
 ; CHECK-LLVM: %struct.A = type { i32, %struct.C }
 ; CHECK-LLVM: %struct.C = type { i32, %struct.B }

--- a/test/transcoding/SPV_INTEL_function_pointers/fp-in-recusive-type.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/fp-in-recusive-type.ll
@@ -30,14 +30,15 @@
 ;
 ; virtual SPIRV::SPIRVEntry* SPIRV::SPIRVModuleImpl::getEntry(SPIRV::SPIRVId) const: Assertion `Loc != IdEntryMap.end() && "Id is not in map"' failed.
 ;
+; CHECK-SPIRV: TypeForwardPointer [[TYPEPTRTY:[0-9]+]]
 ; CHECK-SPIRV: TypeInt [[INTTY:[0-9]+]] 32 0
 ; CHECK-SPIRV: TypeVoid [[VOIDTY:[0-9]+]]
-; CHECK-SPIRV: TypeStruct [[TYPETY:[0-9]+]] [[INTTY]] [[FPTRTY:[0-9]+]]
-; CHECK-SPIRV: TypeStruct [[DESCTY:[0-9]+]] [[INTTY]] [[TYPEPTRTY:[0-9]+]]
-; CHECK-SPIRV: TypePointer [[TYPEPTRTY]] {{[0-9]+}} [[TYPETY]]
+; CHECK-SPIRV: TypeStruct [[DESCTY:[0-9]+]] [[INTTY]] [[TYPEPTRTY]]
 ; CHECK-SPIRV: TypePointer [[DESCPTRTY:[0-9]+]] {{[0-9]+}} [[DESCTY]]
 ; CHECK-SPIRV: TypeFunction [[FTY:[0-9]+]] [[VOIDTY]] [[DESCPTRTY]]
-; CHECK-SPIRV: TypePointer [[FPTRTY]] {{[0-9]+}} [[FTY]]
+; CHECK-SPIRV: TypePointer [[FPTRTY:[0-9]+]] {{[0-9]+}} [[FTY]]
+; CHECK-SPIRV: TypeStruct [[TYPETY:[0-9]+]] [[INTTY]] [[FPTRTY]]
+; CHECK-SPIRV: TypePointer [[TYPEPTRTY]] {{[0-9]+}} [[TYPETY]]
 ; CHECK-SPIRV: TypePointer [[DESCPTR1TY:[0-9]+]] {{[0-9]+}} [[TYPETY]]
 ; CHECK-SPIRV: TypeFunction [[F2TY:[0-9]+]] [[DESCPTRTY]]
 ; CHECK-SPIRV: TypePointer [[FPTR2TY:[0-9]+]] {{[0-9]+}} [[F2TY]]


### PR DESCRIPTION
In some cases the current implementation doesn't create forward pointers
when they are required. New approach is to create forward pointers
during sorting the type instructions.

TODO:
- [x]  Add a LIT test

Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>