### PR TITLE
Add HandleLLVMOptions to main CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
       ${LLVM_SPIRV_VERSION}
     LANGUAGES
       CXX
+      C
   )
 
   set(CMAKE_CXX_STANDARD 14)
@@ -47,6 +48,7 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
     ${LLVM_CMAKE_DIR}
   )
   include(AddLLVM)
+  include(HandleLLVMOptions)
 
   message(STATUS "Found LLVM: ${LLVM_VERSION}")
 

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -941,7 +941,7 @@ SPIRVExtInst *LLVMToSPIRVDbgTran::getSource(const T *DIEntry) {
   Ops[FileIdx] = BM->getString(FileName)->getId();
   DIFile *F = DIEntry ? DIEntry->getFile() : nullptr;
   if (F && F->getRawChecksum()) {
-    const auto &CheckSum = F->getChecksum().getValue();
+    auto CheckSum = F->getChecksum().getValue();
     Ops[TextIdx] = BM->getString("//__" + CheckSum.getKindAsString().str() +
                                  ":" + CheckSum.Value.str())
                        ->getId();

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -667,7 +667,7 @@ void LLVMToSPIRV::transVectorComputeMetadata(Function *F) {
     auto ArgNo = I->getArgNo();
     SPIRVFunctionParameter *BA = BF->getArgument(ArgNo);
     if (Attrs.hasAttribute(ArgNo + 1, kVCMetadata::VCArgumentIOKind)) {
-      SPIRVWord Kind;
+      SPIRVWord Kind = {};
       Attrs.getAttribute(ArgNo + 1, kVCMetadata::VCArgumentIOKind)
           .getValueAsString()
           .getAsInteger(0, Kind);
@@ -1325,7 +1325,7 @@ SPIRVValue *LLVMToSPIRV::transValueWithoutDecoration(Value *V,
     if (IsVectorCompute) {
       BVar->addDecorate(DecorationVectorComputeVariableINTEL);
       if (GV->hasAttribute(kVCMetadata::VCByteOffset)) {
-        SPIRVWord Offset;
+        SPIRVWord Offset = {};
         GV->getAttribute(kVCMetadata::VCByteOffset)
             .getValueAsString()
             .getAsInteger(0, Offset);

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -240,7 +240,7 @@ SPIRVEntry *SPIRVDecoder::getEntry() {
 
   if (OpExtension == OpCode) {
     auto *OpExt = static_cast<SPIRVExtension *>(Entry);
-    ExtensionID ExtID;
+    ExtensionID ExtID = {};
     bool ExtIsKnown = SPIRVMap<ExtensionID, std::string>::rfind(
         OpExt->getExtensionName(), &ExtID);
     if (!M.getErrorLog().checkError(

--- a/lib/SPIRV/libSPIRV/SPIRVUtil.h
+++ b/lib/SPIRV/libSPIRV/SPIRVUtil.h
@@ -86,7 +86,7 @@ public:
   void init();
 
   static Ty2 map(Ty1 Key) {
-    Ty2 Val;
+    Ty2 Val = {};
     bool Found = find(Key, &Val);
     (void)Found;
     assert(Found && "Invalid key");
@@ -94,7 +94,7 @@ public:
   }
 
   static Ty1 rmap(Ty2 Key) {
-    Ty1 Val;
+    Ty1 Val = {};
     bool Found = rfind(Key, &Val);
     (void)Found;
     assert(Found && "Invalid key");


### PR DESCRIPTION
MERGE WITHOUT SQUASHING
1. Fix Fix uninitialized variables warnings, which come into place after importing HandleLLVMOptions
2. Import HandleLLVMOptions to main CMakeLists.txt to propagate configuration flags. In particular, this enables Multi-threaded option in MSVC (instead of Multi-threaded DLL)
