### PR TITLE
Fix SPIR-V friendly IR for OpGroupAsyncCopy and OpGroupWaitEvents

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -684,6 +684,8 @@ bool SPIRVToLLVM::isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const {
   return isCmpOpCode(OC) && !(OC >= OpLessOrGreater && OC <= OpUnordered);
 }
 
+// TODO: Instead of direct translation to OCL we should always produce SPIR-V
+// friendly IR and apply lowering later if needed
 bool SPIRVToLLVM::isDirectlyTranslatedToOCL(Op OpCode) const {
   if (isSubgroupAvcINTELInstructionOpCode(OpCode) ||
       isIntelSubgroupOpCode(OpCode))
@@ -696,7 +698,8 @@ bool SPIRVToLLVM::isDirectlyTranslatedToOCL(Op OpCode) const {
     // clang-consistent format in SPIRVToOCL pass.
     return !(isAtomicOpCode(OpCode) || isGroupOpCode(OpCode) ||
              isGroupNonUniformOpcode(OpCode) || isPipeOpCode(OpCode) ||
-             isMediaBlockINTELOpcode(OpCode));
+             isMediaBlockINTELOpcode(OpCode) || OpCode == OpGroupAsyncCopy ||
+             OpCode == OpGroupWaitEvents);
   }
   return false;
 }

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -104,6 +104,15 @@ public:
   ///   convert_uchar2_sat(int2)
   void visitCallSPIRVCvtBuiltin(CallInst *CI, Op OC, StringRef DemangledName);
 
+  /// Transform
+  ///   __spirv_AsyncGroupCopy(ScopeWorkGroup, dst, src, n, stride, event)
+  ///   => async_work_group_strided_copy(dst, src, n, stride, event)
+  void visitCallAsyncWorkGroupCopy(CallInst *CI, Op OC);
+
+  /// Transform __spirv_GroupWaitEvents(Scope, NumEvents, EventsList)
+  ///   => wait_group_events(NumEvents, EventsList)
+  void visitCallGroupWaitEvents(CallInst *CI, Op OC);
+
   /// Transform __spirv_* builtins to OCL 2.0 builtins.
   /// No change with arguments.
   void visitCallSPIRVBuiltin(CallInst *CI, Op OC);

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -298,35 +298,26 @@ public:
                                : getValue(Ops[I]);
   }
 
-  // Get the offset of operands.
-  // Some instructions skip literals when returning operands.
-  size_t getOperandOffset() const {
-    if (hasExecScope() && !isGroupOpCode(OpCode) && !isPipeOpCode(OpCode))
-      return 1;
-    return 0;
-  }
-
   // Get operands which are values.
   // Drop execution scope and group operation literals.
   // Return other literals as uint32 constants.
   std::vector<SPIRVValue *> getOperands() override {
     std::vector<SPIRVValue *> VOps;
-    auto Offset = getOperandOffset();
-    for (size_t I = 0, E = Ops.size() - Offset; I != E; ++I)
+    for (size_t I = 0, E = Ops.size(); I != E; ++I)
       VOps.push_back(getOperand(I));
     return VOps;
   }
 
   std::vector<SPIRVEntry *> getNonLiteralOperands() const override {
     std::vector<SPIRVEntry *> Operands;
-    for (size_t I = getOperandOffset(), E = Ops.size(); I < E; ++I)
+    for (size_t I = 0, E = Ops.size(); I < E; ++I)
       if (!isOperandLiteral(I))
         Operands.push_back(getEntry(Ops[I]));
     return Operands;
   }
 
   virtual SPIRVValue *getOperand(unsigned I) {
-    return getOpValue(I + getOperandOffset());
+    return getOpValue(I);
   }
 
   bool hasExecScope() const { return SPIRV::hasExecScope(OpCode); }
@@ -2379,6 +2370,7 @@ public:
   SPIRVValue *getEvent() const { return getValue(Event); }
   std::vector<SPIRVValue *> getOperands() override {
     std::vector<SPIRVId> Operands;
+    Operands.push_back(ExecScope);
     Operands.push_back(Destination);
     Operands.push_back(Source);
     Operands.push_back(NumElements);

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -298,9 +298,6 @@ public:
                                : getValue(Ops[I]);
   }
 
-  // Get operands which are values.
-  // Drop execution scope and group operation literals.
-  // Return other literals as uint32 constants.
   std::vector<SPIRVValue *> getOperands() override {
     std::vector<SPIRVValue *> VOps;
     for (size_t I = 0, E = Ops.size(); I != E; ++I)

--- a/test/transcoding/OpGroupAsyncCopy.ll
+++ b/test/transcoding/OpGroupAsyncCopy.ll
@@ -4,8 +4,18 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 
 ; CHECK-LLVM: call spir_func %opencl.event_t{{.*}}* @_Z29async_work_group_strided_copyPU3AS1Dv2_hPU3AS3KS_jj9ocl_event(
+; CHECK-LLVM: call spir_func void @_Z17wait_group_eventsiPU3AS49ocl_event(
+; CHECK-LLVM: declare spir_func %opencl.event_t* @_Z29async_work_group_strided_copyPU3AS1Dv2_hPU3AS3KS_jj9ocl_event(<2 x i8> addrspace(1)*, <2 x i8> addrspace(3)*, i32, i32, %opencl.event_t*)
+; CHECK-LLVM: declare spir_func void @_Z17wait_group_eventsiPU3AS49ocl_event(i32, %opencl.event_t* addrspace(4)*)
+
+; CHECK-SPV-IR: call spir_func %opencl.event_t{{.*}}* @_Z22__spirv_GroupAsyncCopyiPU3AS1Dv2_cPU3AS3S_ii9ocl_event(i32 2
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_GroupWaitEventsiiPU3AS49ocl_event(i32 2
+; CHECK-SPV-IR: declare spir_func %opencl.event_t* @_Z22__spirv_GroupAsyncCopyiPU3AS1Dv2_cPU3AS3S_ii9ocl_event(i32, <2 x i8> addrspace(1)*, <2 x i8> addrspace(3)*, i32, i32, %opencl.event_t*)
+; CHECK-SPV-IR: declare spir_func void @_Z23__spirv_GroupWaitEventsiiPU3AS49ocl_event(i32, i32, %opencl.event_t* addrspace(4)*)
 
 ; CHECK-SPIRV-DAG: GroupAsyncCopy {{[0-9]+}} {{[0-9]+}} [[Scope:[0-9]+]]
 ; CHECK-SPIRV-DAG: Constant {{[0-9]+}} [[Scope]]


### PR DESCRIPTION
These instructions were translated directly to OCL even if SPIR-V
friendly LLVM IR was requested.