### PR TITLE
fix legacy atomic and memory fence memory order and scope

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -187,7 +187,7 @@ public:
 
   /// Transform mem_fence to __spirv_MemoryBarrier.
   /// mem_fence(flag) => __spirv_MemoryBarrier(Workgroup, map(flag))
-  void visitCallMemFence(CallInst *CI);
+  void visitCallMemFence(CallInst *CI, StringRef DemangledName);
 
   void visitCallNDRange(CallInst *CI, StringRef DemangledName);
 
@@ -441,7 +441,7 @@ void OCLToSPIRV::visitCallInst(CallInst &CI) {
   if (DemangledName == kOCLBuiltinName::MemFence ||
       DemangledName == kOCLBuiltinName::ReadMemFence ||
       DemangledName == kOCLBuiltinName::WriteMemFence) {
-    visitCallMemFence(&CI);
+    visitCallMemFence(&CI, DemangledName);
     return;
   }
   if (DemangledName.find(kOCLBuiltinName::ReadImage) == 0) {
@@ -686,11 +686,15 @@ void OCLToSPIRV::visitCallAtomicWorkItemFence(CallInst *CI) {
   transMemoryBarrier(CI, getAtomicWorkItemFenceLiterals(CI));
 }
 
-void OCLToSPIRV::visitCallMemFence(CallInst *CI) {
+void OCLToSPIRV::visitCallMemFence(CallInst *CI, StringRef DemangledName) {
+  OCLMemOrderKind MO = StringSwitch<OCLMemOrderKind>(DemangledName)
+      .Case(kOCLBuiltinName::ReadMemFence, OCLMO_acquire)
+      .Case(kOCLBuiltinName::WriteMemFence, OCLMO_release)
+      .Default(OCLMO_acq_rel);  // kOCLBuiltinName::MemFence
   transMemoryBarrier(
       CI,
       std::make_tuple(cast<ConstantInt>(CI->getArgOperand(0))->getZExtValue(),
-                      OCLMO_relaxed, OCLMS_work_group));
+                      MO, OCLMS_work_group));
 }
 
 void OCLToSPIRV::transMemoryBarrier(CallInst *CI,

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -688,9 +688,9 @@ void OCLToSPIRV::visitCallAtomicWorkItemFence(CallInst *CI) {
 
 void OCLToSPIRV::visitCallMemFence(CallInst *CI, StringRef DemangledName) {
   OCLMemOrderKind MO = StringSwitch<OCLMemOrderKind>(DemangledName)
-      .Case(kOCLBuiltinName::ReadMemFence, OCLMO_acquire)
-      .Case(kOCLBuiltinName::WriteMemFence, OCLMO_release)
-      .Default(OCLMO_acq_rel);  // kOCLBuiltinName::MemFence
+                           .Case(kOCLBuiltinName::ReadMemFence, OCLMO_acquire)
+                           .Case(kOCLBuiltinName::WriteMemFence, OCLMO_release)
+                           .Default(OCLMO_acq_rel); // kOCLBuiltinName::MemFence
   transMemoryBarrier(
       CI,
       std::make_tuple(cast<ConstantInt>(CI->getArgOperand(0))->getZExtValue(),

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -305,10 +305,10 @@ const unsigned int OCLImageChannelOrderOffset = 0x10B0;
 const unsigned int OCLImageChannelDataTypeOffset = 0x10D0;
 
 /// OCL 1.x atomic memory order when translated to 2.0 atomics.
-const OCLMemOrderKind OCLLegacyAtomicMemOrder = OCLMO_seq_cst;
+const OCLMemOrderKind OCLLegacyAtomicMemOrder = OCLMO_relaxed;
 
 /// OCL 1.x atomic memory scope when translated to 2.0 atomics.
-const OCLScopeKind OCLLegacyAtomicMemScope = OCLMS_device;
+const OCLScopeKind OCLLegacyAtomicMemScope = OCLMS_work_group;
 
 enum IntelFPGAMemoryAccessesVal {
   BurstCoalesce = 0x1,

--- a/test/transcoding/OpenCL/atomic_cmpxchg.cl
+++ b/test/transcoding/OpenCL/atomic_cmpxchg.cl
@@ -26,19 +26,19 @@ __kernel void test_atomic_cmpxchg(__global int *p, int cmp, int val) {
 // translator applies some default memory order for it and therefore, constants
 // below include a bit more information than original source
 //
-// 0x1 Device
-// CHECK-SPIRV-DAG: Constant [[UINT]] [[DEVICE_SCOPE:[0-9]+]] 1
+// 0x2 Workgroup
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[WORKGROUP_SCOPE:[0-9]+]] 2
 //
-// 0x10 SequentiallyConsistent
+// 0x0 Relaxed
 // TODO: do we need CrossWorkgroupMemory here as well?
-// CHECK-SPIRV-DAG: Constant [[UINT]] [[SEQ_CST:[0-9]+]] 16
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[RELAXED:[0-9]+]] 0
 //
 // CHECK-SPIRV: Function {{[0-9]+}} [[TEST]]
 // CHECK-SPIRV: FunctionParameter [[UINT_PTR]] [[PTR:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter [[UINT]] [[CMP:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter [[UINT]] [[VAL:[0-9]+]]
-// CHECK-SPIRV: AtomicCompareExchange [[UINT]] {{[0-9]+}} [[PTR]] [[DEVICE_SCOPE]] [[SEQ_CST]] [[SEQ_CST]] [[VAL]] [[CMP]]
-// CHECK-SPIRV: AtomicCompareExchange [[UINT]] {{[0-9]+}} [[PTR]] [[DEVICE_SCOPE]] [[SEQ_CST]] [[SEQ_CST]] [[VAL]] [[CMP]]
+// CHECK-SPIRV: AtomicCompareExchange [[UINT]] {{[0-9]+}} [[PTR]] [[WORKGROUP_SCOPE]] [[RELAXED]] [[RELAXED]] [[VAL]] [[CMP]]
+// CHECK-SPIRV: AtomicCompareExchange [[UINT]] {{[0-9]+}} [[PTR]] [[WORKGROUP_SCOPE]] [[RELAXED]] [[RELAXED]] [[VAL]] [[CMP]]
 //
 //
 // CHECK-LLVM-LABEL: define spir_kernel void @test_atomic_cmpxchg

--- a/test/transcoding/OpenCL/atomic_legacy.cl
+++ b/test/transcoding/OpenCL/atomic_legacy.cl
@@ -1,0 +1,45 @@
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -emit-llvm-bc -fdeclare-opencl-builtins -o %t.bc
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv %t.spv -r --spirv-target-env=CL1.2 -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+// This test checks that the translator is capable to correctly translate
+// legacy atomic OpenCL C 1.2 built-in functions [1] into corresponding SPIR-V
+// instruction and vice-versa.
+
+__kernel void test_legacy_atomics(__global int *p, int val) {
+  atom_add(p, val);     // from cl_khr_global_int32_base_atomics
+  atomic_add(p, val);   // from OpenCL C 1.1
+}
+
+// CHECK-SPIRV: EntryPoint {{[0-9]+}} [[TEST:[0-9]+]] "test_legacy_atomics"
+// CHECK-SPIRV-DAG: TypeInt [[UINT:[0-9]+]] 32 0
+// CHECK-SPIRV-DAG: TypePointer [[UINT_PTR:[0-9]+]] 5 [[UINT]]
+//
+// In SPIR-V, atomic_add is represented as OpAtomicIAdd [2], which also includes
+// memory scope and memory semantic arguments. The translator applies a default
+// memory scope and memory order memory order for it and therefore, constants
+// below include a bit more information than original source
+//
+// 0x2 Workgroup
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[WORKGROUP_SCOPE:[0-9]+]] 2
+//
+// 0x0 Relaxed
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[RELAXED:[0-9]+]] 0
+//
+// CHECK-SPIRV: Function {{[0-9]+}} [[TEST]]
+// CHECK-SPIRV: FunctionParameter [[UINT_PTR]] [[PTR:[0-9]+]]
+// CHECK-SPIRV: FunctionParameter [[UINT]] [[VAL:[0-9]+]]
+// CHECK-SPIRV: AtomicIAdd [[UINT]] {{[0-9]+}} [[PTR]] [[WORKGROUP_SCOPE]] [[RELAXED]] [[VAL]]
+// CHECK-SPIRV: AtomicIAdd [[UINT]] {{[0-9]+}} [[PTR]] [[WORKGROUP_SCOPE]] [[RELAXED]] [[VAL]]
+//
+//
+// CHECK-LLVM-LABEL: define spir_kernel void @test_legacy_atomics
+// Note: the translator generates the OpenCL C 1.1 function name exclusively!
+// CHECK-LLVM: call spir_func i32 @_Z10atomic_addPU3AS1Vii
+// CHECK-LLVM: call spir_func i32 @_Z10atomic_addPU3AS1Vii
+
+// References:
+// [1]: https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#atomic-legacy
+// [2]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpAtomicIAdd

--- a/test/transcoding/OpenCL/atomic_legacy.cl
+++ b/test/transcoding/OpenCL/atomic_legacy.cl
@@ -19,8 +19,8 @@ __kernel void test_legacy_atomics(__global int *p, int val) {
 //
 // In SPIR-V, atomic_add is represented as OpAtomicIAdd [2], which also includes
 // memory scope and memory semantic arguments. The translator applies a default
-// memory scope and memory order memory order for it and therefore, constants
-// below include a bit more information than original source
+// memory scope and memory order for it and therefore, constants below include
+// a bit more information than original source
 //
 // 0x2 Workgroup
 // CHECK-SPIRV-DAG: Constant [[UINT]] [[WORKGROUP_SCOPE:[0-9]+]] 2

--- a/test/transcoding/OpenCL/mem_fence.cl
+++ b/test/transcoding/OpenCL/mem_fence.cl
@@ -62,32 +62,46 @@ __kernel void test_mem_fence_non_const_flags(cl_mem_fence_flags flags) {
 // 0x2 Workgroup
 // CHECK-SPIRV-DAG: Constant [[UINT]] [[WG:[0-9]+]] 2
 //
-// 0x0 Relaxed + 0x100 WorkgroupMemory
-// CHECK-SPIRV-DAG: Constant [[UINT]] [[LOCAL:[0-9]+]] 256
-// 0x0 Relaxed + 0x200 CrossWorkgroupMemory
-// CHECK-SPIRV-DAG: Constant [[UINT]] [[GLOBAL:[0-9]+]] 512
-// 0x0 Relaxed + 0x800 ImageMemory
-// CHECK-SPIRV-DAG: Constant [[UINT]] [[IMAGE:[0-9]+]] 2048
-// 0x0 Relaxed + 0x100 WorkgroupMemory + 0x200 CrossWorkgroupMemory
-// CHECK-SPIRV-DAG: Constant [[UINT]] [[LOCAL_GLOBAL:[0-9]+]] 768
-// 0x0 Relaxed + 0x100 WorkgroupMemory + 0x800 ImageMemory
-// CHECK-SPIRV-DAG: Constant [[UINT]] [[LOCAL_IMAGE:[0-9]+]] 2304
-// 0x0 Relaxed + 0x100 WorkgroupMemory + 0x200 CrossWorkgroupMemory + 0x800 ImageMemory
-// CHECK-SPIRV-DAG: Constant [[UINT]] [[LOCAL_GLOBAL_IMAGE:[0-9]+]] 2816
+// 0x2 Acquire + 0x100 WorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_LOCAL:[0-9]+]] 258
+// 0x2 Acquire + 0x200 CrossWorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_GLOBAL:[0-9]+]] 514
+// 0x2 Acquire + 0x100 WorkgroupMemory + 0x200 CrossWorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_LOCAL_GLOBAL:[0-9]+]] 770
+//
+// 0x4 Release + 0x100 WorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[REL_LOCAL:[0-9]+]] 260
+// 0x4 Release + 0x200 CrossWorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[REL_GLOBAL:[0-9]+]] 516
+// 0x4 Release + 0x100 WorkgroupMemory + 0x200 CrossWorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[REL_LOCAL_GLOBAL:[0-9]+]] 772
+//
+// 0x8 AcquireRelease + 0x100 WorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_REL_LOCAL:[0-9]+]] 264
+// 0x8 AcquireRelease + 0x200 CrossWorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_REL_GLOBAL:[0-9]+]] 520
+// 0x8 AcquireRelease + 0x800 ImageMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_REL_IMAGE:[0-9]+]] 2056
+// 0x8 AcquireRelease + 0x100 WorkgroupMemory + 0x200 CrossWorkgroupMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_REL_LOCAL_GLOBAL:[0-9]+]] 776
+// 0x8 AcquireRelease + 0x100 WorkgroupMemory + 0x800 ImageMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_REL_LOCAL_IMAGE:[0-9]+]] 2312
+// 0x8 AcquireRelease + 0x100 WorkgroupMemory + 0x200 CrossWorkgroupMemory + 0x800 ImageMemory
+// CHECK-SPIRV-DAG: Constant [[UINT]] [[ACQ_REL_LOCAL_GLOBAL_IMAGE:[0-9]+]] 2824
 //
 // CHECK-SPIRV: Function {{[0-9]+}} [[TEST_CONST_FLAGS]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[LOCAL]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[GLOBAL]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[IMAGE]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[LOCAL_GLOBAL]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[LOCAL_IMAGE]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[LOCAL_GLOBAL_IMAGE]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[LOCAL]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[GLOBAL]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[LOCAL_GLOBAL]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[LOCAL]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[GLOBAL]]
-// CHECK-SPIRV: MemoryBarrier [[WG]] [[LOCAL_GLOBAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_REL_LOCAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_REL_GLOBAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_REL_IMAGE]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_REL_LOCAL_GLOBAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_REL_LOCAL_IMAGE]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_REL_LOCAL_GLOBAL_IMAGE]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_LOCAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_GLOBAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[ACQ_LOCAL_GLOBAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[REL_LOCAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[REL_GLOBAL]]
+// CHECK-SPIRV: MemoryBarrier [[WG]] [[REL_LOCAL_GLOBAL]]
 //
 // CHECK-LLVM-LABEL: define spir_kernel void @test_mem_fence_const_flags
 // CHECK-LLVM: call spir_func void @_Z9mem_fencej(i32 1)


### PR DESCRIPTION
This PR fixes the memory scope and memory order for legacy atomics and memory fences.

Fixes #934.