### PR TITLE
Remove mapping of NoWrite function parameter attribute on qual metadata

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -104,7 +104,6 @@ static bool DbgSaveTmpLLVM = false;
 static const char *DbgTmpLLVMFileName = "_tmp_llvmbil.ll";
 
 namespace kOCLTypeQualifierName {
-const static char *Const = "const";
 const static char *Volatile = "volatile";
 const static char *Restrict = "restrict";
 const static char *Pipe = "pipe";
@@ -4060,17 +4059,8 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
           Qual = kOCLTypeQualifierName::Volatile;
         Arg->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
           Qual += Qual.empty() ? "" : " ";
-          switch (Kind) {
-          case FunctionParameterAttributeNoAlias:
+          if (Kind == FunctionParameterAttributeNoAlias)
             Qual += kOCLTypeQualifierName::Restrict;
-            break;
-          case FunctionParameterAttributeNoWrite:
-            Qual += kOCLTypeQualifierName::Const;
-            break;
-          default:
-            // do nothing.
-            break;
-          }
         });
         if (Arg->getType()->isTypePipe()) {
           Qual += Qual.empty() ? "" : " ";

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3500,10 +3500,6 @@ bool LLVMToSPIRV::transOCLMetadata() {
               BA->addDecorate(
                   new SPIRVDecorate(DecorationFuncParamAttr, BA,
                                     FunctionParameterAttributeNoAlias));
-            if (Str.find("const") != std::string::npos)
-              BA->addDecorate(
-                  new SPIRVDecorate(DecorationFuncParamAttr, BA,
-                                    FunctionParameterAttributeNoWrite));
           });
     }
     if (auto *KernelArgName = F.getMetadata(SPIR_MD_KERNEL_ARG_NAME)) {

--- a/test/group-decorate.spt
+++ b/test/group-decorate.spt
@@ -13,10 +13,7 @@
 4 Name 11 "entry"
 4 Decorate 13 FuncParamAttr 5 
 2 DecorationGroup 13 
-4 Decorate 14 FuncParamAttr 6 
-2 DecorationGroup 14 
 5 GroupDecorate 13 8 9 10 
-4 GroupDecorate 14 8 9 
 4 TypeInt 3 8 0 
 2 TypeVoid 2 
 4 TypeVector 4 3 4 
@@ -38,6 +35,4 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: define spir_kernel void @test(<4 x i8> addrspace(1)* nocapture %src1, <4 x i8> addrspace(1)* nocapture %src2, <4 x i8> addrspace(1)* nocapture %dst) {{.*}} !kernel_arg_type_qual ![[QUALS:[0-9]+]]
-
-; CHECK-LLVM: ![[QUALS]] = !{!"const", !"const", !""}
+; CHECK-LLVM: define spir_kernel void @test(<4 x i8> addrspace(1)* nocapture %src1, <4 x i8> addrspace(1)* nocapture %src2, <4 x i8> addrspace(1)* nocapture %dst) {{.*}}


### PR DESCRIPTION
The NoWrite SPIR-V function parameter provides an assurance that memory pointed to by a NoWrite pointer
will not be modified through that pointer.

The const qualifier (represented in LLVM IR for kernel functions using kernel_arg_type_qual metadata) does
not provide any such guarantee. There is nothing that prevents a function that takes a pointer to a const
pointee from stripping the const pointer away and modifying the pointee.

As such, it is not appropriate to translate from one to the other, and so the code for doing so should be
removed, so that this translation is not performed either when translating from LLVM IR to SPIR-V, or
when translating from SPIR-V to LLVM IR.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>