### PR TITLE
Tolerate more inputs during alias.scope/noalias MD translation

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1220,14 +1220,16 @@ SPIRVValue *LLVMToSPIRV::transAtomicLoad(LoadInst *LD, SPIRVBasicBlock *BB) {
 // TODO: add support for an optional string operand.
 SPIRVEntry *addMemAliasingINTELInstructions(SPIRVModule *M,
                                             MDNode *AliasingListMD) {
-  assert(AliasingListMD->getNumOperands() > 0 &&
-         "Aliasing list MD must have at least one operand");
+  if (AliasingListMD->getNumOperands() == 0)
+    return nullptr;
   std::vector<SPIRVId> ListId;
   for (const MDOperand &MDListOp : AliasingListMD->operands()) {
     if (MDNode *ScopeMD = dyn_cast<MDNode>(MDListOp)) {
-      assert(ScopeMD->getNumOperands() > 1 &&
-             "Aliasing scope MD must have at least two operands");
-      MDNode *DomainMD = cast<MDNode>(ScopeMD->getOperand(1));
+      if (ScopeMD->getNumOperands() < 2)
+        return nullptr;
+      MDNode *DomainMD = dyn_cast<MDNode>(ScopeMD->getOperand(1));
+      if (!DomainMD)
+        return nullptr;
       auto *Domain =
           M->getOrAddAliasDomainDeclINTELInst(std::vector<SPIRVId>(), DomainMD);
       auto *Scope =
@@ -1249,6 +1251,8 @@ void transAliasingMemAccess(SPIRVModule *BM, MDNode *AliasingListMD,
     return;
   MemoryAccess[0] |= MemAccessMask;
   auto *MemAliasList = addMemAliasingINTELInstructions(BM, AliasingListMD);
+  if (!MemAliasList)
+    return;
   MemoryAccess.push_back(MemAliasList->getId());
 }
 
@@ -1866,12 +1870,16 @@ void LLVMToSPIRV::transMemAliasingINTELDecorations(Value *V, SPIRVValue *BV) {
           Inst->getMetadata(LLVMContext::MD_alias_scope)) {
     auto *MemAliasList =
         addMemAliasingINTELInstructions(BM, AliasingListMD);
+    if (!MemAliasList)
+      return;
     BV->addDecorate(new SPIRVDecorateId(
           internal::DecorationAliasScopeINTEL, BV, MemAliasList->getId()));
   } else if (MDNode *AliasingListMD =
                  Inst->getMetadata(LLVMContext::MD_noalias)) {
     auto *MemAliasList =
         addMemAliasingINTELInstructions(BM, AliasingListMD);
+    if (!MemAliasList)
+      return;
     BV->addDecorate(new SPIRVDecorateId(
           internal::DecorationNoAliasINTEL, BV, MemAliasList->getId()));
   }


### PR DESCRIPTION
According to https://llvm.org/docs/LangRef.html aliasing metadata
must have following layout:
List { MD Node Scope1, (other scopes) ... }
Scope1 { MD Node Scope1, MD Node Domain1, (optional MD String) }
... (other scopes)
Domain1 { MD Node Domain1, (optional MD String) }
... (other domains)

and this pattern is actually being checked in LLVM's
ScopedNoAliasAA.cpp.

But in a harsh reality LLVM opt have bugs, which can result in this
pattern violation. So lets be more tolerant to the input IR module.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>