### PR TITLE
Update for LLVM iterator change

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -542,7 +542,7 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
   if (F->isIntrinsic() && (!BM->isSPIRVAllowUnknownIntrinsicsEnabled() ||
                            isKnownIntrinsic(F->getIntrinsicID()))) {
     // We should not translate LLVM intrinsics as a function
-    assert(none_of(F->user_begin(), F->user_end(),
+    assert(none_of(F->users(),
                    [this](User *U) { return getTranslatedValue(U); }) &&
            "LLVM intrinsics shouldn't be called in SPIRV");
     return nullptr;


### PR DESCRIPTION
Fix the build after LLVM commit `0a92aff721f4 ("Replace uses of
std::iterator with explicit using", 2021-04-12)`.