### PR TITLE
Add 'willreturn' attribute to OpenCL work-item functions

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -321,6 +321,7 @@ bool SPIRVToLLVM::transOCLBuiltinFromVariable(GlobalVariable *GV,
     Func->setCallingConv(CallingConv::SPIR_FUNC);
     Func->addFnAttr(Attribute::NoUnwind);
     Func->addFnAttr(Attribute::ReadNone);
+    Func->addFnAttr(Attribute::WillReturn);
   }
 
   // Collect instructions in these containers to remove them later.

--- a/test/transcoding/builtin_vars_arithmetics.ll
+++ b/test/transcoding/builtin_vars_arithmetics.ll
@@ -120,6 +120,8 @@ entry:
 
 attributes #0 = { norecurse "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="test.cpp" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 
+; CHECK-LLVM-OCL: attributes #1 = { nounwind readnone willreturn }
+
 !llvm.module.flags = !{!0}
 !opencl.spir.version = !{!1}
 !spirv.Source = !{!2}


### PR DESCRIPTION
These functions will definitely return result, so lets annotate
them with the attribute during reverse translation.

Also, in https://reviews.llvm.org/D96993 behavior of DCE pass was
changed. Now it doesn't remove non-willreturn calls. So for example
in a case when user called get_global_id(dimidx) several times -
redundant calls without 'willreturn' attribute won't be eliminated.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>