### PR TITLE
Fix warning when build by clang

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1718,7 +1718,7 @@ public:
 private:
   OCLExtOpKind ExtOpId;
   ArrayRef<Type *> ArgTys;
-  Type *RetTy;
+  LLVM_ATTRIBUTE_UNUSED Type *RetTy;
 };
 } // namespace
 

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1718,7 +1718,6 @@ public:
 private:
   OCLExtOpKind ExtOpId;
   ArrayRef<Type *> ArgTys;
-  LLVM_ATTRIBUTE_UNUSED Type *RetTy;
 };
 } // namespace
 


### PR DESCRIPTION
Warning message:
private field 'RetTy' is not used [-Werror,-Wunused-private-field]

Signed-off-by: Pavel V Chupin <pavel.v.chupin@intel.com>