### PR TITLE
[GitHub Actions] Fix paths-ignore

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -18,7 +18,7 @@ on:
       - 'test/**' # tests
       - '**.md'   # README
       - '**.txt'  # CMakeLists.txt
-      - '**/check-**-build.xml' # Other workflows
+      - '**/check-**-build.yml' # Other workflows
 
 env:
   # We need compile command database in order to perform clang-tidy check. So,

--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -14,8 +14,8 @@ on:
     paths-ignore: # no need to check build for:
       - 'docs/**' # documentation
       - '**.md'   # README
-      - '**/check-code-style.xml' # check-code-style workflow
-      - '**/check-out-of-tree-build.xml' # check-out-of-tree-build workflow
+      - '**/check-code-style.yml' # check-code-style workflow
+      - '**/check-out-of-tree-build.yml' # check-out-of-tree-build workflow
   pull_request:
     branches:
       - master
@@ -23,8 +23,8 @@ on:
     paths-ignore: # no need to check build for:
       - 'docs/**' # documentation
       - '**.md'   # README
-      - '**/check-code-style.xml' # check-code-style workflow
-      - '**/check-out-of-tree-build.xml' # check-out-of-tree-build workflow
+      - '**/check-code-style.yml' # check-code-style workflow
+      - '**/check-out-of-tree-build.yml' # check-out-of-tree-build workflow
   schedule:
     # Ideally, we might want to simplify our regular nightly build as we
     # probably don't need every configuration to be built every day: most of

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -14,8 +14,8 @@ on:
     paths-ignore: # no need to check build for:
       - 'docs/**' # documentation
       - '**.md'   # README
-      - '**/check-code-style.xml' # check-code-style workflow
-      - '**/check-in-tree-build.xml' # check-in-tree-build workflow
+      - '**/check-code-style.yml' # check-code-style workflow
+      - '**/check-in-tree-build.yml' # check-in-tree-build workflow
   pull_request:
     branches:
       - master
@@ -23,8 +23,8 @@ on:
     paths-ignore: # no need to check build for:
       - 'docs/**' # documentation
       - '**.md'   # README
-      - '**/check-code-style.xml' # check-code-style workflow
-      - '**/check-in-tree-build.xml' # check-in-tree-build workflow
+      - '**/check-code-style.yml' # check-code-style workflow
+      - '**/check-in-tree-build.yml' # check-in-tree-build workflow
   schedule:
     - cron: 0 0 * * *
 


### PR DESCRIPTION
Changed `xml` -> `yml` to avoid launching some workflows on unrelated
changes, like we don't need to launch out-of-tree build if the only
changed file in the PR is in-tree build configuration.