### PR TITLE
Fix for ParseChecksum function

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1007,7 +1007,8 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
          "DebugSource instruction is expected");
   SPIRVWordVec SourceArgs = Source->getArguments();
   assert(SourceArgs.size() == OperandCount && "Invalid number of operands");
-  auto ChecksumStr = !getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
+  string ChecksumStr =
+      !getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
                          ? getString(SourceArgs[TextIdx])
                          : "";
   StringRef Checksum(ChecksumStr);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1037,15 +1037,18 @@ SPIRVToLLVMDbgTran::ParseChecksum(StringRef Text) {
   // Example of "Text" variable:
   // "SomeInfo//__CSK_MD5:7bb56387968a9caa6e9e35fff94eaf7b:OtherInfo"
   Optional<DIFile::ChecksumInfo<StringRef>> CS;
-  auto KindPos = Text.find(SPIRVDebug::ChecksumKindPrefx);
-  if (KindPos != StringRef::npos) {
-    auto ColonPos = Text.find(":", KindPos);
-    KindPos += string("//__").size();
-    auto KindStr = Text.substr(KindPos, ColonPos - KindPos);
-    auto Checksum = Text.substr(ColonPos).ltrim(':');
-    if (auto Kind = DIFile::getChecksumKind(KindStr)) {
-      size_t ChecksumEndPos = Checksum.find_if_not(llvm::isHexDigit);
-      CS.emplace(Kind.getValue(), Checksum.substr(0, ChecksumEndPos));
+  if (Text.size() > SPIRVDebug::ChecksumKindPrefx.size() &&
+      Text.front() != '\0') {
+    auto KindPos = Text.find(SPIRVDebug::ChecksumKindPrefx);
+    if (KindPos != StringRef::npos) {
+      auto ColonPos = Text.find(":", KindPos);
+      KindPos += string("//__").size();
+      auto KindStr = Text.substr(KindPos, ColonPos - KindPos);
+      auto Checksum = Text.substr(ColonPos).ltrim(':');
+      if (auto Kind = DIFile::getChecksumKind(KindStr)) {
+        size_t ChecksumEndPos = Checksum.find_if_not(llvm::isHexDigit);
+        CS.emplace(Kind.getValue(), Checksum.substr(0, ChecksumEndPos));
+      }
     }
   }
   return CS;

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1007,8 +1007,7 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
          "DebugSource instruction is expected");
   SPIRVWordVec SourceArgs = Source->getArguments();
   assert(SourceArgs.size() == OperandCount && "Invalid number of operands");
-  auto ChecksumStr =
-	  !getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
+  auto ChecksumStr = !getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
                          ? getString(SourceArgs[TextIdx])
                          : "";
   StringRef Checksum(ChecksumStr);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1011,8 +1011,7 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
       getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
           ? ""
           : getString(SourceArgs[TextIdx]);
-  StringRef Checksum(ChecksumStr);
-  return getDIFile(getString(SourceArgs[FileIdx]), ParseChecksum(Checksum));
+  return getDIFile(getString(SourceArgs[FileIdx]), ParseChecksum(ChecksumStr));
 }
 
 SPIRVToLLVMDbgTran::SplitFileName::SplitFileName(const string &FileName) {

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1008,9 +1008,9 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
   SPIRVWordVec SourceArgs = Source->getArguments();
   assert(SourceArgs.size() == OperandCount && "Invalid number of operands");
   std::string ChecksumStr =
-      !getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
-          ? getString(SourceArgs[TextIdx])
-          : "";
+      getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
+          ? ""
+          : getString(SourceArgs[TextIdx]);
   StringRef Checksum(ChecksumStr);
   return getDIFile(getString(SourceArgs[FileIdx]), ParseChecksum(Checksum));
 }

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1007,7 +1007,7 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
          "DebugSource instruction is expected");
   SPIRVWordVec SourceArgs = Source->getArguments();
   assert(SourceArgs.size() == OperandCount && "Invalid number of operands");
-  string ChecksumStr =
+  std::string ChecksumStr =
       !getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
           ? getString(SourceArgs[TextIdx])
           : "";

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1009,8 +1009,8 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
   assert(SourceArgs.size() == OperandCount && "Invalid number of operands");
   string ChecksumStr =
       !getDbgInst<SPIRVDebug::DebugInfoNone>(SourceArgs[TextIdx])
-                         ? getString(SourceArgs[TextIdx])
-                         : "";
+          ? getString(SourceArgs[TextIdx])
+          : "";
   StringRef Checksum(ChecksumStr);
   return getDIFile(getString(SourceArgs[FileIdx]), ParseChecksum(Checksum));
 }


### PR DESCRIPTION
This is a patch to fix failure, caused by bringing as argument of ParseChecksum
StringRef with non-zero length, but with empty data.