### PR TITLE
Fix SPIR-V friendly IR for event opcodes

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -694,6 +694,8 @@ bool SPIRVToLLVM::isDirectlyTranslatedToOCL(Op OpCode) const {
     return true;
   if (OpCode == OpImageSampleExplicitLod || OpCode == OpSampledImage)
     return false;
+  if (isEventOpCode(OpCode))
+    return false;
   if (OCLSPIRVBuiltinMap::rfind(OpCode, nullptr)) {
     // Not every spirv opcode which is placed in OCLSPIRVBuiltinMap is
     // translated directly to OCL builtin. Some of them are translated

--- a/lib/SPIRV/libSPIRV/SPIRVOpCode.h
+++ b/lib/SPIRV/libSPIRV/SPIRVOpCode.h
@@ -234,6 +234,10 @@ inline bool isIntelSubgroupOpCode(Op OpCode) {
   return OpSubgroupShuffleINTEL <= OC && OC <= OpSubgroupImageBlockWriteINTEL;
 }
 
+inline bool isEventOpCode(Op OpCode) {
+  return OpRetainEvent <= OpCode && OpCode <= OpCaptureEventProfilingInfo;
+}
+
 } // namespace SPIRV
 
 #endif // SPIRV_LIBSPIRV_SPIRVOPCODE_H

--- a/test/transcoding/clk_event_t.cl
+++ b/test/transcoding/clk_event_t.cl
@@ -3,7 +3,10 @@
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-OCL
+// RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPV
+// RUN: llvm-spirv %t.rev.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 // CHECK-SPIRV: TypeDeviceEvent
 // CHECK-SPIRV: 5 Function
@@ -15,14 +18,23 @@
 // CHECK-SPIRV: ReleaseEvent
 // CHECK-SPIRV: FunctionEnd
 
-// CHECK-LLVM-LABEL: @clk_event_t_test
-// CHECK-LLVM: call spir_func %opencl.clk_event_t* @_Z17create_user_eventv()
-// CHECK-LLVM: call spir_func i1 @_Z14is_valid_event12ocl_clkevent
-// CHECK-LLVM: call spir_func void @_Z12retain_event12ocl_clkevent
-// CHECK-LLVM: call spir_func void @_Z21set_user_event_status12ocl_clkeventi(%opencl.clk_event_t* %{{[a-z]+}}, i32 -42)
-// CHECK-LLVM: call spir_func void @_Z28capture_event_profiling_info12ocl_clkeventiPU3AS1v(%opencl.clk_event_t* %{{[a-z]+}}, i32 1, i8 addrspace(1)* %prof)
-// CHECK-LLVM: call spir_func void @_Z13release_event12ocl_clkevent
-// CHECK-LLVM: ret
+// CHECK-LLVM-OCL-LABEL: @clk_event_t_test
+// CHECK-LLVM-OCL: call spir_func %opencl.clk_event_t* @_Z17create_user_eventv()
+// CHECK-LLVM-OCL: call spir_func i1 @_Z14is_valid_event12ocl_clkevent
+// CHECK-LLVM-OCL: call spir_func void @_Z12retain_event12ocl_clkevent
+// CHECK-LLVM-OCL: call spir_func void @_Z21set_user_event_status12ocl_clkeventi(%opencl.clk_event_t* %{{[a-z]+}}, i32 -42)
+// CHECK-LLVM-OCL: call spir_func void @_Z28capture_event_profiling_info12ocl_clkeventiPU3AS1v(%opencl.clk_event_t* %{{[a-z]+}}, i32 1, i8 addrspace(1)* %prof)
+// CHECK-LLVM-OCL: call spir_func void @_Z13release_event12ocl_clkevent
+// CHECK-LLVM-OCL: ret
+
+// CHECK-LLVM-SPV-LABEL: @clk_event_t_test
+// CHECK-LLVM-SPV: call spir_func %opencl.clk_event_t* @_Z23__spirv_CreateUserEventv()
+// CHECK-LLVM-SPV: call spir_func i1 @_Z20__spirv_IsValidEvent12ocl_clkevent
+// CHECK-LLVM-SPV: call spir_func void @_Z19__spirv_RetainEvent12ocl_clkevent
+// CHECK-LLVM-SPV: call spir_func void @_Z26__spirv_SetUserEventStatus12ocl_clkeventi(%opencl.clk_event_t* %{{[a-z]+}}, i32 -42)
+// CHECK-LLVM-SPV: call spir_func void @_Z33__spirv_CaptureEventProfilingInfo12ocl_clkeventiPU3AS1c(%opencl.clk_event_t* %{{[a-z]+}}, i32 1, i8 addrspace(1)* %prof)
+// CHECK-LLVM-SPV: call spir_func void @_Z20__spirv_ReleaseEvent12ocl_clkevent
+// CHECK-LLVM-SPV: ret
 
 kernel void clk_event_t_test(global int *res, global void *prof) {
   clk_event_t e1 = create_user_event();


### PR DESCRIPTION
This instruction was translated directly to OCL even if SPIR-V
friendly LLVM IR was requested.