### PR TITLE
Fix memory leak after getAsInstruction

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -125,6 +125,11 @@ LLVMToSPIRVBase::LLVMToSPIRVBase(SPIRVModule *SMod)
   DbgTran = std::make_unique<LLVMToSPIRVDbgTran>(nullptr, SMod, this);
 }
 
+LLVMToSPIRVBase::~LLVMToSPIRVBase() {
+  for (auto *I : UnboundInst)
+    I->deleteValue();
+}
+
 bool LLVMToSPIRVBase::runLLVMToSPIRV(Module &Mod) {
   M = &Mod;
   CG = std::make_unique<CallGraph>(Mod);
@@ -834,6 +839,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
              dbgs() << "Instruction: " << *Inst << '\n';)
     auto BI = transValue(Inst, nullptr, false);
     Inst->dropAllReferences();
+    UnboundInst.push_back(Inst);
     return BI;
   }
 
@@ -1309,6 +1315,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
         Ty = static_cast<PointerType *>(Init->getType());
       }
       Inst->dropAllReferences();
+      UnboundInst.push_back(Inst);
       BVarInit = transValue(Init, nullptr);
     } else if (ST && isa<UndefValue>(Init)) {
       // Undef initializer for LLVM structure be can translated to

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -137,6 +137,7 @@ public:
     OCLTypeToSPIRVPtr = OCLTypeToSPIRV;
   }
   OCLTypeToSPIRVBase *getOCLTypeToSPIRV() { return OCLTypeToSPIRVPtr; }
+  ~LLVMToSPIRVBase();
 
 private:
   Module *M;
@@ -150,6 +151,7 @@ private:
   std::unique_ptr<LLVMToSPIRVDbgTran> DbgTran;
   std::unique_ptr<CallGraph> CG;
   OCLTypeToSPIRVBase *OCLTypeToSPIRVPtr;
+  std::vector<llvm::Instruction *> UnboundInst;
 
   enum class FPContract { UNDEF, DISABLED, ENABLED };
   DenseMap<Function *, FPContract> FPContractMap;


### PR DESCRIPTION
Adding a destructor and a special class field to account for getAsInstruction instruction.
Per LLVM documentation, getAsInstruction doesn't attach the result to any Module/Function/Basic Block and therefore it is not deleted as part of their destructors; basically, any pointers to this memory are lost at the end of corresponding if scopes.

Signed-off-by: amochalo <anastasiya.mochalova@intel.com>

reproduce memory leak on transcoding/PipeStorage.ll test 
valgrind report without patch:
>==5395== Command: llvm-spirv PipeStorage.bc -spirv-text
==5395==
==5395==
==5395== HEAP SUMMARY:
==5395==     in use at exit: 89,374 bytes in 268 blocks
==5395==   total heap usage: 7,784 allocs, 7,516 frees, 644,989 bytes allocated
==5395==
==5395== 96 bytes in 1 blocks are definitely lost in loss record 226 of 244
==5395==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5395==    by 0xBB7BFD: allocateFixedOperandUser (User.cpp:129)
==5395==    by 0xBB7BFD: llvm::User::operator new(unsigned long, unsigned int) (User.cpp:148)
==5395==    by 0x26E7A9: llvm::UnaryInstruction::operator new(unsigned long) (InstrTypes.h:72)
==5395==    by 0xAD9424: llvm::CastInst::Create(llvm::Instruction::CastOps, llvm::Value*, llvm::Type*, llvm::Twine const&, llvm::Instruction*) (Instructions.cpp:2970)
==5395==    by 0x9B92AA: llvm::ConstantExpr::getAsInstruction() const (Constants.cpp:3488)
==5395==    by 0x33653A: SPIRV::LLVMToSPIRVBase::transConstant(llvm::Value*) (SPIRVWriter.cpp:832)
==5395==    by 0x339557: SPIRV::LLVMToSPIRVBase::transValueWithoutDecoration(llvm::Value*, SPIRV::SPIRVBasicBlock*, bool, SPIRV::LLVMToSPIRVBase::FuncTransMode) (SPIRVWriter.cpp:1396)
==5395==    by 0x336863: SPIRV::LLVMToSPIRVBase::transValue(llvm::Value*, SPIRV::SPIRVBasicBlock*, bool, SPIRV::LLVMToSPIRVBase::FuncTransMode) (SPIRVWriter.cpp:862)
==5395==    by 0x33647A: SPIRV::LLVMToSPIRVBase::transConstant(llvm::Value*) (SPIRVWriter.cpp:827)
==5395==    by 0x339557: SPIRV::LLVMToSPIRVBase::transValueWithoutDecoration(llvm::Value*, SPIRV::SPIRVBasicBlock*, bool, SPIRV::LLVMToSPIRVBase::FuncTransMode) (SPIRVWriter.cpp:1396)
==5395==    by 0x336863: SPIRV::LLVMToSPIRVBase::transValue(llvm::Value*, SPIRV::SPIRVBasicBlock*, bool, SPIRV::LLVMToSPIRVBase::FuncTransMode) (SPIRVWriter.cpp:862)
==5395==    by 0x33910B: SPIRV::LLVMToSPIRVBase::transValueWithoutDecoration(llvm::Value*, SPIRV::SPIRVBasicBlock*, bool, SPIRV::LLVMToSPIRVBase::FuncTransMode) (SPIRVWriter.cpp:1346)
==5395==
==5395== LEAK SUMMARY:
==5395==    definitely lost: 96 bytes in 1 blocks
==5395==    indirectly lost: 0 bytes in 0 blocks
==5395==      possibly lost: 0 bytes in 0 blocks
==5395==    still reachable: 89,278 bytes in 267 blocks
==5395==         suppressed: 0 bytes in 0 blocks
==5395== Reachable blocks (those to which a pointer was found) are not shown.




valgrind with patch:
>==5800== Command: llvm-spirv PipeStorage.bc -spirv-text
==5800==
==5800==
==5800== HEAP SUMMARY:
==5800==     in use at exit: 89,278 bytes in 267 blocks
==5800==   total heap usage: 7,785 allocs, 7,518 frees, 645,021 bytes allocated
==5800==
==5800== LEAK SUMMARY:
==5800==    definitely lost: 0 bytes in 0 blocks
==5800==    indirectly lost: 0 bytes in 0 blocks
==5800==      possibly lost: 0 bytes in 0 blocks
==5800==    still reachable: 89,278 bytes in 267 blocks
==5800==         suppressed: 0 bytes in 0 blocks
==5800== Reachable blocks (those to which a pointer was found) are not shown.
