### PR TITLE
Add missing atomic include

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -45,6 +45,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/Support/Path.h"
 
+#include <atomic>
 #include <functional>
 #include <tuple>
 #include <type_traits>


### PR DESCRIPTION
`std::memory_order` used in this file is defined in `<atomic>`, which was
not included directly.  This fixes the build for some setups that do not include
`<atomic>` transitively somehow.