### PR TITLE
Only fail getSpecConstInfo if badbit is set

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4704,7 +4704,7 @@ bool llvm::getSpecConstInfo(std::istream &IS,
       D.ignoreInstruction();
     }
   }
-  return !IS.fail();
+  return !IS.bad();
 }
 
 // clang-format off


### PR DESCRIPTION
Attempting to read past EOF may set both the `eofbit` and the
`failbit`, neither of which should be fatal in this case.  This could
cause test/OpSpecConstant.spvasm to fail spuriously.