### PR TITLE
[CI] Improve Clang version selection via manual mode

### DIFF
--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -54,9 +54,6 @@ jobs:
           echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
           echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
-          # Linux systems in GitHub Actions already have a pre-installed clang
-          # that is not needed for the translator as we rely on newer version
-          sudo apt-get --purge remove clang-8 clang-9
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \
             spirv-tools
@@ -95,6 +92,7 @@ jobs:
           make llvm-spirv -j2
       - name: Build tests & test
         run: |
+          export CLANG=/usr/bin/clang-${{ env.LLVM_VERSION }}
           cd build
           make check-llvm-spirv -j2
 

--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -57,6 +57,8 @@ jobs:
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \
             spirv-tools
+          # Linux systems in GitHub Actions already have older versions of clang
+          # pre-installed. Make sure to override these with the relevant version.
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
       - name: Checkout LLVM sources
         uses: actions/checkout@v2
@@ -92,9 +94,6 @@ jobs:
           make llvm-spirv -j2
       - name: Build tests & test
         run: |
-          # Linux systems in GitHub Actions already have older versions of clang
-          # pre-installed. Explicitly rely on the latest version.
-          export CLANG=/usr/bin/clang-${{ env.LLVM_VERSION }}
           cd build
           make check-llvm-spirv -j2
 

--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -60,6 +60,7 @@ jobs:
           # Linux systems in GitHub Actions already have older versions of clang
           # pre-installed. Make sure to override these with the relevant version.
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
+          sudo update-alternatives --set clang /usr/bin/clang-${{ env.LLVM_VERSION }}
       - name: Checkout LLVM sources
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -92,6 +92,8 @@ jobs:
           make llvm-spirv -j2
       - name: Build tests & test
         run: |
+          # Linux systems in GitHub Actions already have older versions of clang
+          # pre-installed. Explicitly rely on the latest version.
           export CLANG=/usr/bin/clang-${{ env.LLVM_VERSION }}
           cd build
           make check-llvm-spirv -j2

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -71,6 +71,8 @@ jobs:
           make llvm-spirv -j2
       - name: Build tests & test
         run: |
+          # Linux systems in GitHub Actions already have older versions of clang
+          # pre-installed. Explicitly rely on the latest version.
           export CLANG=/usr/bin/clang-${{ env.LLVM_VERSION }}
           cd build
           make check-llvm-spirv -j2

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -47,9 +47,6 @@ jobs:
           echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic main" | sudo tee -a /etc/apt/sources.list
           echo "deb https://packages.lunarg.com/vulkan bionic main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
-          # Linux systems in GitHub Actions already have a pre-installed clang
-          # that is not needed for the translator as we rely on newer version
-          sudo apt-get --purge remove clang-8 clang-9
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \
             llvm-${{ env.LLVM_VERSION }}-dev \
@@ -74,5 +71,6 @@ jobs:
           make llvm-spirv -j2
       - name: Build tests & test
         run: |
+          export CLANG=/usr/bin/clang-${{ env.LLVM_VERSION }}
           cd build
           make check-llvm-spirv -j2

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -53,6 +53,8 @@ jobs:
             libomp-${{ env.LLVM_VERSION }}-dev \
             llvm-${{ env.LLVM_VERSION }}-tools \
             spirv-tools
+          # Linux systems in GitHub Actions already have older versions of clang
+          # pre-installed. Make sure to override these with the relevant version.
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
       - name:  Checkout the translator sources
         uses: actions/checkout@v2
@@ -71,8 +73,5 @@ jobs:
           make llvm-spirv -j2
       - name: Build tests & test
         run: |
-          # Linux systems in GitHub Actions already have older versions of clang
-          # pre-installed. Explicitly rely on the latest version.
-          export CLANG=/usr/bin/clang-${{ env.LLVM_VERSION }}
           cd build
           make check-llvm-spirv -j2

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -56,6 +56,7 @@ jobs:
           # Linux systems in GitHub Actions already have older versions of clang
           # pre-installed. Make sure to override these with the relevant version.
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
+          sudo update-alternatives --set clang /usr/bin/clang-${{ env.LLVM_VERSION }}
       - name:  Checkout the translator sources
         uses: actions/checkout@v2
       - name: Configure

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -41,6 +41,8 @@ config.test_exec_root = os.path.join(config.test_run_dir, 'test_output')
 
 llvm_config.use_default_substitutions()
 
+# Explicitly set `use_installed` to alleviate downstream CI pipelines of
+# any additional environment setup for pre-installed Clang usage.
 llvm_config.use_clang(use_installed=True)
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -41,7 +41,7 @@ config.test_exec_root = os.path.join(config.test_run_dir, 'test_output')
 
 llvm_config.use_default_substitutions()
 
-llvm_config.use_clang()
+llvm_config.use_clang(use_installed=True)
 
 config.substitutions.append(('%PATH%', config.environment['PATH']))
 


### PR DESCRIPTION
As per https://linux.die.net/man/8/update-alternatives, usage of the
`--set` action switches the link group into manual mode. This excludes
the slim possibility of a pre-installed Clang version being selected
over the latest compiler.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>