### PR TITLE
Improve OpSpecConstantOp handling for unary and integer comparison operators

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2443,10 +2443,16 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpSNegate: {
+    IRBuilder<> Builder(*Context);
+    if (BB) {
+      Builder.SetInsertPoint(BB);
+    }
     SPIRVUnary *BC = static_cast<SPIRVUnary *>(BV);
-    auto Neg = BinaryOperator::CreateNeg(transValue(BC->getOperand(0), F, BB),
-                                         BV->getName(), BB);
-    applyNoIntegerWrapDecorations(BV, Neg);
+    auto Neg =
+        Builder.CreateNeg(transValue(BC->getOperand(0), F, BB), BV->getName());
+    if (auto *NegInst = dyn_cast<Instruction>(Neg)) {
+      applyNoIntegerWrapDecorations(BV, NegInst);
+    }
     return mapValue(BV, Neg);
   }
 
@@ -2499,10 +2505,13 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpNot:
   case OpLogicalNot: {
+    IRBuilder<> Builder(*Context);
+    if (BB) {
+      Builder.SetInsertPoint(BB);
+    }
     SPIRVUnary *BC = static_cast<SPIRVUnary *>(BV);
-    return mapValue(
-        BV, BinaryOperator::CreateNot(transValue(BC->getOperand(0), F, BB),
-                                      BV->getName(), BB));
+    return mapValue(BV, Builder.CreateNot(transValue(BC->getOperand(0), F, BB),
+                                          BV->getName()));
   }
 
   case OpAll:

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -232,7 +232,7 @@ private:
   Type *transFPType(SPIRVType *T);
   Value *transShiftLogicalBitwiseInst(SPIRVValue *BV, BasicBlock *BB,
                                       Function *F);
-  Instruction *transCmpInst(SPIRVValue *BV, BasicBlock *BB, Function *F);
+  Value *transCmpInst(SPIRVValue *BV, BasicBlock *BB, Function *F);
   void transOCLBuiltinFromInstPreproc(SPIRVInstruction *BI, Type *&RetTy,
                                       std::vector<SPIRVValue *> &Args);
   Instruction *transOCLBuiltinPostproc(SPIRVInstruction *BI, CallInst *CI,

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -207,6 +207,7 @@ bool isSpecConstantOpAllowedOp(Op OC) {
       OpLogicalNotEqual,
       OpSelect,
       OpIEqual,
+      OpINotEqual,
       OpULessThan,
       OpSLessThan,
       OpUGreaterThan,

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -9,6 +9,8 @@
 ; operations are supported.  Also verify that edge cases such as division
 ; by zero are handled gracefully.
 
+; CHECK: @var_snegate = addrspace(1) global i32 -53
+; CHECK: @var_not = addrspace(1) global i32 -54
 ; CHECK: @var_iadd = addrspace(1) global i32 49
 ; CHECK: @var_isub = addrspace(1) global i32 57
 ; CHECK: @var_imul = addrspace(1) global i32 -212
@@ -28,6 +30,7 @@
 ; CHECK: @var_bitand = addrspace(1) global i32 52
 ; CHECK: @var_logor = addrspace(1) global i1 true
 ; CHECK: @var_logand = addrspace(1) global i1 false
+; CHECK: @var_lognot = addrspace(1) global i1 false
 
                OpCapability Addresses
                OpCapability Linkage
@@ -35,6 +38,8 @@
                OpMemoryModel Physical32 OpenCL
                OpEntryPoint Kernel %15 "foo"
                OpName %entry "entry"
+               OpDecorate %var_snegate LinkageAttributes "var_snegate" Export
+               OpDecorate %var_not LinkageAttributes "var_not" Export
                OpDecorate %var_iadd LinkageAttributes "var_iadd" Export
                OpDecorate %var_isub LinkageAttributes "var_isub" Export
                OpDecorate %var_imul LinkageAttributes "var_imul" Export
@@ -53,6 +58,7 @@
                OpDecorate %var_bitand LinkageAttributes "var_bitand" Export
                OpDecorate %var_logor LinkageAttributes "var_logor" Export
                OpDecorate %var_logand LinkageAttributes "var_logand" Export
+               OpDecorate %var_lognot LinkageAttributes "var_lognot" Export
        %bool = OpTypeBool
        %true = OpConstantTrue %bool
       %false = OpConstantFalse %bool
@@ -61,6 +67,8 @@
      %uint_4 = OpConstant %uint 4
     %uint_53 = OpConstant %uint 53
   %uint_min4 = OpConstant %uint 0xfffffffc
+    %snegate = OpSpecConstantOp %uint SNegate %uint_53
+        %not = OpSpecConstantOp %uint Not %uint_53
        %iadd = OpSpecConstantOp %uint IAdd %uint_53 %uint_min4
        %isub = OpSpecConstantOp %uint ISub %uint_53 %uint_min4
        %imul = OpSpecConstantOp %uint IMul %uint_53 %uint_min4
@@ -79,11 +87,14 @@
      %bitand = OpSpecConstantOp %uint BitwiseAnd %uint_53 %uint_min4
       %logor = OpSpecConstantOp %bool LogicalOr %true %false
      %logand = OpSpecConstantOp %bool LogicalAnd %true %false
+     %lognot = OpSpecConstantOp %bool LogicalNot %true
   %_ptr_uint = OpTypePointer CrossWorkgroup %uint
   %_ptr_bool = OpTypePointer CrossWorkgroup %bool
        %void = OpTypeVoid
          %14 = OpTypeFunction %void
 
+%var_snegate = OpVariable %_ptr_uint CrossWorkgroup %snegate
+    %var_not = OpVariable %_ptr_uint CrossWorkgroup %not
    %var_iadd = OpVariable %_ptr_uint CrossWorkgroup %iadd
    %var_isub = OpVariable %_ptr_uint CrossWorkgroup %isub
    %var_imul = OpVariable %_ptr_uint CrossWorkgroup %imul
@@ -102,6 +113,7 @@
  %var_bitand = OpVariable %_ptr_uint CrossWorkgroup %bitand
   %var_logor = OpVariable %_ptr_bool CrossWorkgroup %logor
  %var_logand = OpVariable %_ptr_bool CrossWorkgroup %logand
+ %var_lognot = OpVariable %_ptr_bool CrossWorkgroup %lognot
 
          %15 = OpFunction %void Pure %14
       %entry = OpLabel

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -5,28 +5,103 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis %t.bc -o - | FileCheck %s
 
-; Verify that an OpVariable initializer containing an OpSpecConstantOp is supported.
+; Verify that OpVariable initializers containing various OpSpecConstantOp
+; operations are supported.  Also verify that edge cases such as division
+; by zero are handled gracefully.
 
-; CHECK: @var = addrspace(2) constant i32 8, align 4
+; CHECK: @var_iadd = addrspace(1) global i32 49
+; CHECK: @var_isub = addrspace(1) global i32 57
+; CHECK: @var_imul = addrspace(1) global i32 -212
+; CHECK: @var_udiv = addrspace(1) global i32 81037118
+; CHECK: @var_udiv0 = addrspace(1) global i32 poison
+; CHECK: @var_sdiv = addrspace(1) global i32 -13
+; CHECK: @var_sdiv0 = addrspace(1) global i32 poison
+; CHECK: @var_umod = addrspace(1) global i32 1
+; CHECK: @var_srem = addrspace(1) global i32 1
+; TODO: smod
+; CHECK: @var_srl = addrspace(1) global i32 268435455
+; CHECK: @var_sra = addrspace(1) global i32 -1
+; CHECK: @var_sll = addrspace(1) global i32 848
+; CHECK: @var_sll_big = addrspace(1) global i32 poison
+; CHECK: @var_bitor = addrspace(1) global i32 -3
+; CHECK: @var_bitxor = addrspace(1) global i32 -55
+; CHECK: @var_bitand = addrspace(1) global i32 52
+; CHECK: @var_logor = addrspace(1) global i1 true
+; CHECK: @var_logand = addrspace(1) global i1 false
 
                OpCapability Addresses
                OpCapability Linkage
                OpCapability Kernel
                OpMemoryModel Physical32 OpenCL
                OpEntryPoint Kernel %15 "foo"
-               OpName %var "var"
                OpName %entry "entry"
-               OpDecorate %var Constant
-               OpDecorate %var LinkageAttributes "var" Export
-               OpDecorate %var Alignment 4
+               OpDecorate %var_iadd LinkageAttributes "var_iadd" Export
+               OpDecorate %var_isub LinkageAttributes "var_isub" Export
+               OpDecorate %var_imul LinkageAttributes "var_imul" Export
+               OpDecorate %var_udiv LinkageAttributes "var_udiv" Export
+               OpDecorate %var_udiv0 LinkageAttributes "var_udiv0" Export
+               OpDecorate %var_sdiv LinkageAttributes "var_sdiv" Export
+               OpDecorate %var_sdiv0 LinkageAttributes "var_sdiv0" Export
+               OpDecorate %var_umod LinkageAttributes "var_umod" Export
+               OpDecorate %var_srem LinkageAttributes "var_srem" Export
+               OpDecorate %var_srl LinkageAttributes "var_srl" Export
+               OpDecorate %var_sra LinkageAttributes "var_sra" Export
+               OpDecorate %var_sll LinkageAttributes "var_sll" Export
+               OpDecorate %var_sll_big LinkageAttributes "var_sll_big" Export
+               OpDecorate %var_bitor LinkageAttributes "var_bitor" Export
+               OpDecorate %var_bitxor LinkageAttributes "var_bitxor" Export
+               OpDecorate %var_bitand LinkageAttributes "var_bitand" Export
+               OpDecorate %var_logor LinkageAttributes "var_logor" Export
+               OpDecorate %var_logand LinkageAttributes "var_logand" Export
+       %bool = OpTypeBool
+       %true = OpConstantTrue %bool
+      %false = OpConstantFalse %bool
        %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
      %uint_4 = OpConstant %uint 4
-     %uint_8 = OpSpecConstantOp %uint IAdd %uint_4 %uint_4
-  %_ptr_uint = OpTypePointer UniformConstant %uint
+    %uint_53 = OpConstant %uint 53
+  %uint_min4 = OpConstant %uint 0xfffffffc
+       %iadd = OpSpecConstantOp %uint IAdd %uint_53 %uint_min4
+       %isub = OpSpecConstantOp %uint ISub %uint_53 %uint_min4
+       %imul = OpSpecConstantOp %uint IMul %uint_53 %uint_min4
+       %udiv = OpSpecConstantOp %uint UDiv %uint_min4 %uint_53
+      %udiv0 = OpSpecConstantOp %uint UDiv %uint_min4 %uint_0
+       %sdiv = OpSpecConstantOp %uint SDiv %uint_53 %uint_min4
+      %sdiv0 = OpSpecConstantOp %uint SDiv %uint_53 %uint_0
+       %umod = OpSpecConstantOp %uint UMod %uint_53 %uint_4
+       %srem = OpSpecConstantOp %uint SRem %uint_53 %uint_min4
+        %srl = OpSpecConstantOp %uint ShiftRightLogical %uint_min4 %uint_4
+        %sra = OpSpecConstantOp %uint ShiftRightArithmetic %uint_min4 %uint_4
+        %sll = OpSpecConstantOp %uint ShiftLeftLogical %uint_53 %uint_4
+    %sll_big = OpSpecConstantOp %uint ShiftLeftLogical %uint_4 %uint_53
+      %bitor = OpSpecConstantOp %uint BitwiseOr %uint_53 %uint_min4
+     %bitxor = OpSpecConstantOp %uint BitwiseXor %uint_53 %uint_min4
+     %bitand = OpSpecConstantOp %uint BitwiseAnd %uint_53 %uint_min4
+      %logor = OpSpecConstantOp %bool LogicalOr %true %false
+     %logand = OpSpecConstantOp %bool LogicalAnd %true %false
+  %_ptr_uint = OpTypePointer CrossWorkgroup %uint
+  %_ptr_bool = OpTypePointer CrossWorkgroup %bool
        %void = OpTypeVoid
          %14 = OpTypeFunction %void
 
-        %var = OpVariable %_ptr_uint UniformConstant %uint_8
+   %var_iadd = OpVariable %_ptr_uint CrossWorkgroup %iadd
+   %var_isub = OpVariable %_ptr_uint CrossWorkgroup %isub
+   %var_imul = OpVariable %_ptr_uint CrossWorkgroup %imul
+   %var_udiv = OpVariable %_ptr_uint CrossWorkgroup %udiv
+  %var_udiv0 = OpVariable %_ptr_uint CrossWorkgroup %udiv0
+   %var_sdiv = OpVariable %_ptr_uint CrossWorkgroup %sdiv
+  %var_sdiv0 = OpVariable %_ptr_uint CrossWorkgroup %sdiv0
+   %var_umod = OpVariable %_ptr_uint CrossWorkgroup %umod
+   %var_srem = OpVariable %_ptr_uint CrossWorkgroup %srem
+    %var_srl = OpVariable %_ptr_uint CrossWorkgroup %srl
+    %var_sra = OpVariable %_ptr_uint CrossWorkgroup %sra
+    %var_sll = OpVariable %_ptr_uint CrossWorkgroup %sll
+%var_sll_big = OpVariable %_ptr_uint CrossWorkgroup %sll_big
+  %var_bitor = OpVariable %_ptr_uint CrossWorkgroup %bitor
+ %var_bitxor = OpVariable %_ptr_uint CrossWorkgroup %bitxor
+ %var_bitand = OpVariable %_ptr_uint CrossWorkgroup %bitand
+  %var_logor = OpVariable %_ptr_bool CrossWorkgroup %logor
+ %var_logand = OpVariable %_ptr_bool CrossWorkgroup %logand
 
          %15 = OpFunction %void Pure %14
       %entry = OpLabel

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -31,6 +31,18 @@
 ; CHECK: @var_logor = addrspace(1) global i1 true
 ; CHECK: @var_logand = addrspace(1) global i1 false
 ; CHECK: @var_lognot = addrspace(1) global i1 false
+; CHECK: @var_logeq = addrspace(1) global i1 false
+; CHECK: @var_logne = addrspace(1) global i1 true
+; CHECK: @var_icmpeq = addrspace(1) global i1 false
+; CHECK: @var_icmpne = addrspace(1) global i1 true
+; CHECK: @var_icmpult = addrspace(1) global i1 true
+; CHECK: @var_icmpslt = addrspace(1) global i1 false
+; CHECK: @var_icmpugt = addrspace(1) global i1 false
+; CHECK: @var_icmpsgt = addrspace(1) global i1 true
+; CHECK: @var_icmpule = addrspace(1) global i1 true
+; CHECK: @var_icmpsle = addrspace(1) global i1 false
+; CHECK: @var_icmpuge = addrspace(1) global i1 false
+; CHECK: @var_icmpsge = addrspace(1) global i1 true
 
                OpCapability Addresses
                OpCapability Linkage
@@ -59,6 +71,18 @@
                OpDecorate %var_logor LinkageAttributes "var_logor" Export
                OpDecorate %var_logand LinkageAttributes "var_logand" Export
                OpDecorate %var_lognot LinkageAttributes "var_lognot" Export
+               OpDecorate %var_logeq LinkageAttributes "var_logeq" Export
+               OpDecorate %var_logne LinkageAttributes "var_logne" Export
+               OpDecorate %var_icmpeq LinkageAttributes "var_icmpeq" Export
+               OpDecorate %var_icmpne LinkageAttributes "var_icmpne" Export
+               OpDecorate %var_icmpult LinkageAttributes "var_icmpult" Export
+               OpDecorate %var_icmpslt LinkageAttributes "var_icmpslt" Export
+               OpDecorate %var_icmpugt LinkageAttributes "var_icmpugt" Export
+               OpDecorate %var_icmpsgt LinkageAttributes "var_icmpsgt" Export
+               OpDecorate %var_icmpule LinkageAttributes "var_icmpule" Export
+               OpDecorate %var_icmpsle LinkageAttributes "var_icmpsle" Export
+               OpDecorate %var_icmpuge LinkageAttributes "var_icmpuge" Export
+               OpDecorate %var_icmpsge LinkageAttributes "var_icmpsge" Export
        %bool = OpTypeBool
        %true = OpConstantTrue %bool
       %false = OpConstantFalse %bool
@@ -88,6 +112,18 @@
       %logor = OpSpecConstantOp %bool LogicalOr %true %false
      %logand = OpSpecConstantOp %bool LogicalAnd %true %false
      %lognot = OpSpecConstantOp %bool LogicalNot %true
+      %logeq = OpSpecConstantOp %bool LogicalEqual %true %false
+      %logne = OpSpecConstantOp %bool LogicalNotEqual %true %false
+     %icmpeq = OpSpecConstantOp %bool IEqual %uint_53 %uint_min4
+     %icmpne = OpSpecConstantOp %bool INotEqual %uint_53 %uint_min4
+    %icmpult = OpSpecConstantOp %bool ULessThan %uint_53 %uint_min4
+    %icmpslt = OpSpecConstantOp %bool SLessThan %uint_53 %uint_min4
+    %icmpugt = OpSpecConstantOp %bool UGreaterThan %uint_53 %uint_min4
+    %icmpsgt = OpSpecConstantOp %bool SGreaterThan %uint_53 %uint_min4
+    %icmpule = OpSpecConstantOp %bool ULessThanEqual %uint_53 %uint_min4
+    %icmpsle = OpSpecConstantOp %bool SLessThanEqual %uint_53 %uint_min4
+    %icmpuge = OpSpecConstantOp %bool UGreaterThanEqual %uint_53 %uint_min4
+    %icmpsge = OpSpecConstantOp %bool SGreaterThanEqual %uint_53 %uint_min4
   %_ptr_uint = OpTypePointer CrossWorkgroup %uint
   %_ptr_bool = OpTypePointer CrossWorkgroup %bool
        %void = OpTypeVoid
@@ -114,6 +150,18 @@
   %var_logor = OpVariable %_ptr_bool CrossWorkgroup %logor
  %var_logand = OpVariable %_ptr_bool CrossWorkgroup %logand
  %var_lognot = OpVariable %_ptr_bool CrossWorkgroup %lognot
+  %var_logeq = OpVariable %_ptr_bool CrossWorkgroup %logeq
+  %var_logne = OpVariable %_ptr_bool CrossWorkgroup %logne
+ %var_icmpeq = OpVariable %_ptr_bool CrossWorkgroup %icmpeq
+ %var_icmpne = OpVariable %_ptr_bool CrossWorkgroup %icmpne
+%var_icmpult = OpVariable %_ptr_bool CrossWorkgroup %icmpult
+%var_icmpslt = OpVariable %_ptr_bool CrossWorkgroup %icmpslt
+%var_icmpugt = OpVariable %_ptr_bool CrossWorkgroup %icmpugt
+%var_icmpsgt = OpVariable %_ptr_bool CrossWorkgroup %icmpsgt
+%var_icmpule = OpVariable %_ptr_bool CrossWorkgroup %icmpule
+%var_icmpsle = OpVariable %_ptr_bool CrossWorkgroup %icmpsle
+%var_icmpuge = OpVariable %_ptr_bool CrossWorkgroup %icmpuge
+%var_icmpsge = OpVariable %_ptr_bool CrossWorkgroup %icmpsge
 
          %15 = OpFunction %void Pure %14
       %entry = OpLabel


### PR DESCRIPTION
This is a continuation of #1037 to improve OpSpecConstantOp handling.

#### Handle OpSpecConstantOp for integer comparisons
This revealed that OpINotEqual was missing from
isSpecConstantOpAllowedOp.

#### Handle OpSpecConstantOp for SNegate, Not, and LogicalNot
Use an IRBuilder to get automatic folding where possible.

#### Extend OpSpecConstantOp testing for initializers
Co-authored-by: @StuartDBrady 

#### Use IRBuilder for folding
Rely on the IRBuilder to fold into constant expressions if possible.