### PR TITLE
Move SPV_INTEL_fast_composite tokens into internal:: namespace

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -354,7 +354,10 @@ void PreprocessMetadataBase::preprocessVectorComputeMetadata(Module *M,
           .done();
     }
     if (Attrs.hasFnAttribute(kVCMetadata::VCFCEntry)) {
-      EM.addOp().add(&F).add(spv::ExecutionModeFastCompositeKernelINTEL).done();
+      EM.addOp()
+          .add(&F)
+          .add(spv::internal::ExecutionModeFastCompositeKernelINTEL)
+          .done();
     }
   }
 }

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3968,10 +3968,10 @@ bool SPIRVToLLVM::transMetadata() {
     transVectorComputeMetadata(BF);
     transFPGAFunctionMetadata(BF, F);
 
-    if (BF->hasDecorate(DecorationCallableFunctionINTEL))
+    if (BF->hasDecorate(internal::DecorationCallableFunctionINTEL))
       F->addFnAttr(kVCMetadata::VCCallable);
     if (isKernel(BF) &&
-        BF->getExecutionMode(ExecutionModeFastCompositeKernelINTEL))
+        BF->getExecutionMode(internal::ExecutionModeFastCompositeKernelINTEL))
       F->addFnAttr(kVCMetadata::VCFCEntry);
 
     if (F->getCallingConv() != CallingConv::SPIR_KERNEL)

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -632,7 +632,7 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
 
   if (Attrs.hasFnAttribute(kVCMetadata::VCCallable) &&
       BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fast_composite)) {
-    BF->addDecorate(DecorationCallableFunctionINTEL);
+    BF->addDecorate(internal::DecorationCallableFunctionINTEL);
   }
 
   if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
@@ -3585,7 +3585,7 @@ bool LLVMToSPIRVBase::transExecutionMode() {
         BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
             BF, static_cast<ExecutionMode>(EMode), TargetWidth)));
       } break;
-      case spv::ExecutionModeFastCompositeKernelINTEL: {
+      case spv::internal::ExecutionModeFastCompositeKernelINTEL: {
         if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fast_composite))
           BF->addExecutionMode(BM->add(
               new SPIRVExecutionMode(BF, static_cast<ExecutionMode>(EMode))));

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -190,7 +190,7 @@ public:
       return ExtensionID::SPV_INTEL_fpga_cluster_attributes;
     case DecorationFuseLoopsInFunctionINTEL:
       return ExtensionID::SPV_INTEL_loop_fuse;
-    case DecorationCallableFunctionINTEL:
+    case internal::DecorationCallableFunctionINTEL:
       return ExtensionID::SPV_INTEL_fast_composite;
     case internal::DecorationMathOpDSPModeINTEL:
       return ExtensionID::SPV_INTEL_fpga_dsp_control;

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -840,7 +840,7 @@ public:
   }
 
   llvm::Optional<ExtensionID> getRequiredExtension() const override {
-    switch (Kind) {
+    switch (static_cast<unsigned>(Kind)) {
     case CapabilityDenormPreserve:
     case CapabilityDenormFlushToZero:
     case CapabilitySignedZeroInfNanPreserve:
@@ -854,7 +854,7 @@ public:
     case CapabilityVectorComputeINTEL:
     case CapabilityVectorAnyINTEL:
       return ExtensionID::SPV_INTEL_vector_compute;
-    case CapabilityFastCompositeINTEL:
+    case internal::CapabilityFastCompositeINTEL:
       return ExtensionID::SPV_INTEL_fast_composite;
     default:
       return {};

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -259,8 +259,8 @@ template <> inline void SPIRVMap<SPIRVExecutionModeKind, SPIRVCapVec>::init() {
                {CapabilityFloatingPointModeINTEL});
   ADD_VEC_INIT(ExecutionModeSharedLocalMemorySizeINTEL,
                {CapabilityVectorComputeINTEL});
-  ADD_VEC_INIT(ExecutionModeFastCompositeKernelINTEL,
-               {CapabilityFastCompositeINTEL});
+  ADD_VEC_INIT(internal::ExecutionModeFastCompositeKernelINTEL,
+               {internal::CapabilityFastCompositeINTEL});
 }
 
 template <> inline void SPIRVMap<SPIRVMemoryModelKind, SPIRVCapVec>::init() {
@@ -421,7 +421,8 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
                {CapabilityFunctionFloatControlINTEL});
   ADD_VEC_INIT(DecorationSingleElementVectorINTEL,
                {CapabilityVectorComputeINTEL});
-  ADD_VEC_INIT(DecorationCallableFunctionINTEL, {CapabilityFastCompositeINTEL});
+  ADD_VEC_INIT(internal::DecorationCallableFunctionINTEL,
+               {internal::CapabilityFastCompositeINTEL});
   ADD_VEC_INIT(DecorationStallEnableINTEL,
                {CapabilityFPGAClusterAttributesINTEL});
   ADD_VEC_INIT(DecorationFuseLoopsInFunctionINTEL, {CapabilityLoopFuseINTEL});

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -164,7 +164,7 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationFunctionFloatingPointModeINTEL,
       "FunctionFloatingPointModeINTEL");
   add(DecorationSingleElementVectorINTEL, "SingleElementVectorINTEL");
-  add(DecorationCallableFunctionINTEL, "CallableFunctionINTEL");
+  add(internal::DecorationCallableFunctionINTEL, "CallableFunctionINTEL");
   add(DecorationStallEnableINTEL, "StallEnableINTEL");
   add(DecorationFuseLoopsInFunctionINTEL, "FuseLoopsInFunctionINTEL");
   add(internal::DecorationMathOpDSPModeINTEL, "MathOpDSPModeINTEL");
@@ -521,7 +521,7 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilityMax, "Max");
   add(internal::CapabilityFPGADSPControlINTEL, "FPGADSPControlINTEL");
   add(CapabilityLongConstantCompositeINTEL, "LongConstantCompositeINTEL");
-  add(CapabilityFastCompositeINTEL, "FastCompositeINTEL");
+  add(internal::CapabilityFastCompositeINTEL, "FastCompositeINTEL");
   add(internal::CapabilityOptNoneINTEL, "OptNoneINTEL");
   add(internal::CapabilityMemoryAccessAliasingINTEL,
       "MemoryAccessAliasingINTEL");

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -178,7 +178,6 @@ enum ExecutionMode {
     ExecutionModeNoGlobalOffsetINTEL = 5895,
     ExecutionModeNumSIMDWorkitemsINTEL = 5896,
     ExecutionModeSchedulerTargetFmaxMhzINTEL = 5903,
-    ExecutionModeFastCompositeKernelINTEL = 6088,
     ExecutionModeMax = 0x7fffffff,
 };
 
@@ -548,7 +547,6 @@ enum Decoration {
     DecorationIOPipeStorageINTEL = 5944,
     DecorationFunctionFloatingPointModeINTEL = 6080,
     DecorationSingleElementVectorINTEL = 6085,
-    DecorationCallableFunctionINTEL = 6087,
     DecorationMax = 0x7fffffff,
 };
 
@@ -1052,7 +1050,6 @@ enum Capability {
     CapabilityAtomicFloat32AddEXT = 6033,
     CapabilityAtomicFloat64AddEXT = 6034,
     CapabilityLongConstantCompositeINTEL = 6089,
-    CapabilityFastCompositeINTEL = 6093,
     CapabilityMax = 0x7fffffff,
 };
 

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -49,13 +49,15 @@ enum InternalDecoration {
   IDecNoAliasINTEL = 5915,
   IDecInitiationIntervalINTEL = 5917,
   IDecMaxConcurrencyINTEL = 5918,
-  IDecPipelineEnableINTEL = 5919
+  IDecPipelineEnableINTEL = 5919,
+  IDecCallableFunctionINTEL = 6087
 };
 
 enum InternalCapability {
   ICapFPGADSPControlINTEL = 5908,
   ICapMemoryAccessAliasingINTEL = 5910,
   ICapFPGAInvocationPipeliningAttributesINTEL = 5916,
+  ICapFastCompositeINTEL = 6093,
   ICapOptNoneINTEL = 6094,
   ICapTokenTypeINTEL = 6112
 };
@@ -66,6 +68,8 @@ enum InternalMemoryAccessMask {
   IMemAccessAliasScopeINTELMask = 0x10000,
   IMemAccessNoAliasINTELMask = 0x20000
 };
+
+enum InternalExecutionMode { IExecModeFastCompositeKernelINTEL = 6088 };
 
 constexpr LinkageType LinkageTypeInternal =
     static_cast<LinkageType>(ILTInternal);
@@ -87,7 +91,11 @@ constexpr Decoration DecorationMaxConcurrencyINTEL =
     static_cast<Decoration>(IDecMaxConcurrencyINTEL);
 constexpr Decoration DecorationPipelineEnableINTEL =
     static_cast<Decoration>(IDecPipelineEnableINTEL);
+constexpr Decoration DecorationCallableFunctionINTEL =
+    static_cast<Decoration>(IDecCallableFunctionINTEL);
 
+constexpr Capability CapabilityFastCompositeINTEL =
+    static_cast<Capability>(ICapFastCompositeINTEL);
 constexpr Capability CapabilityOptNoneINTEL =
     static_cast<Capability>(ICapOptNoneINTEL);
 constexpr Capability CapabilityFPGADSPControlINTEL =
@@ -109,6 +117,9 @@ constexpr MemoryAccessMask MemoryAccessAliasScopeINTELMask =
     static_cast<MemoryAccessMask>(IMemAccessAliasScopeINTELMask);
 constexpr MemoryAccessMask MemoryAccessNoAliasINTELMask =
     static_cast<MemoryAccessMask>(IMemAccessNoAliasINTELMask);
+
+constexpr ExecutionMode ExecutionModeFastCompositeKernelINTEL =
+    static_cast<ExecutionMode>(IExecModeFastCompositeKernelINTEL);
 
 } // namespace internal
 } // namespace spv


### PR DESCRIPTION
This is being done as one of the migration steps to downloading
spirv.hpp from SPIR-V Registry during the build time.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>