### PR TITLE
Update DebugInfo test for LLVM address space change

### DIFF
--- a/test/DebugInfo/DebugDeclareUnused.cl
+++ b/test/DebugInfo/DebugDeclareUnused.cl
@@ -12,4 +12,4 @@ void foo() {
 
 // CHECK-SPIRV: Undef [[#]] [[#Undef:]]
 // CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] DebugDeclare [[#]] [[#Undef]] [[#]]
-// CHECK-LLVM: call void @llvm.dbg.declare(metadata i32* undef, metadata ![[#]], metadata !DIExpression())
+// CHECK-LLVM: call void @llvm.dbg.declare(metadata i32* undef, metadata ![[#]], metadata !DIExpression({{.*}}))


### PR DESCRIPTION
After LLVM commit 333987b04589 ("[OpenCL] Add DWARF address spaces
mapping for SPIR", 2021-06-04), the address space is now part of the
debug info.  Update the pattern to accommodate it.