### PR TITLE
[SPIR-V] Fix duplicate pointers

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -380,10 +380,19 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
                                   transType(ET)));
       }
     } else {
+      SPIRVType *ElementType = transType(ET);
+      // ET, as a recursive type, may contain exactly the same pointer T, so it
+      // may happen that after translation of ET we already have translated T,
+      // added the translated pointer to the SPIR-V module and mapped T to this
+      // pointer. Now we have to check TypeMap again.
+      LLVMToSPIRVTypeMap::iterator Loc = TypeMap.find(T);
+      if (Loc != TypeMap.end()) {
+        return Loc->second;
+      }
       return mapType(
           T, BM->addPointerType(SPIRSPIRVAddrSpaceMap::map(
                                     static_cast<SPIRAddressSpace>(AddrSpc)),
-                                transType(ET)));
+                                ElementType));
     }
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1685,28 +1685,33 @@ class TopologicalSort {
   // container after visiting all dependent entries(post-order traversal)
   // guarantees that the entry's operands will appear in the container before
   // the entry itslef.
-  void visit(SPIRVEntry *E) {
+  // Returns true if cyclic dependency detected.
+  bool visit(SPIRVEntry *E) {
     DFSState &State = EntryStateMap[E];
-    if (E->getOpCode() == OpTypePointer) {
-      SPIRVTypePointer *Ptr = static_cast<SPIRVTypePointer *>(E);
-      if (EntryStateMap[Ptr->getElementType()] == Discovered) {
-        // We've found a recursive data type, e.g. a structure having a member
-        // which is a pointer to the same structure. In this, case we can break
-        // such cyclic dependency by inserting a forward declaration of that
-        // pointer.
-        ForwardPointerSet.insert(new SPIRVTypeForwardPointer(
-            E->getModule(), Ptr, Ptr->getPointerStorageClass()));
-        return;
-      }
-    }
-    assert(State != Discovered && "Cyclic dependency detected");
     if (State == Visited)
-      return;
+      return false;
+    if (State == Discovered) // Cyclic dependency detected
+      return true;
     State = Discovered;
     for (SPIRVEntry *Op : E->getNonLiteralOperands()) {
-      visit(Op);
+      if (EntryStateMap[Op] == Visited)
+        continue;
+      if (visit(Op)) {
+        // We've found a recursive data type, e.g. a structure having a member
+        // which is a pointer to the same structure.
+        State = Unvisited; // Forget about it
+        if (E->getOpCode() == OpTypePointer) {
+          // If we have a pointer in the recursive chain, we can break the
+          // cyclic dependency by inserting a forward declaration of that
+          // pointer.
+          SPIRVTypePointer *Ptr = static_cast<SPIRVTypePointer *>(E);
+          ForwardPointerSet.insert(new SPIRVTypeForwardPointer(
+              E->getModule(), Ptr, Ptr->getPointerStorageClass()));
+          return false;
+        }
+        return true;
+      }
     }
-    State = Visited;
     Op OC = E->getOpCode();
     if (OC == OpTypeInt)
       TypeIntVec.push_back(static_cast<SPIRVType *>(E));
@@ -1720,6 +1725,8 @@ class TopologicalSort {
       TypeVec.push_back(static_cast<SPIRVType *>(E));
     else
       ConstAndVarVec.push_back(E);
+    State = Visited;
+    return false;
   }
 
 public:
@@ -1747,8 +1754,10 @@ public:
     for (auto *V : VariableVec)
       EntryStateMap[V] = DFSState::Unvisited;
     // Run topoligical sort
-    for (auto ES : EntryStateMap)
-      visit(ES.first);
+    for (auto ES : EntryStateMap) {
+      if (visit(ES.first))
+        llvm_unreachable("Cyclic dependency for types detected");
+    }
     // Append forward pointers vector
     ForwardPointerVec.insert(ForwardPointerVec.end(), ForwardPointerSet.begin(),
                              ForwardPointerSet.end());

--- a/test/pointer_type_mapping.ll
+++ b/test/pointer_type_mapping.ll
@@ -4,11 +4,8 @@
 
 ; CHECK: Name [[#NAME:]] "struct._ZTS6Object.Object"
 ; CHECK-COUNT-1: TypeStruct [[#NAME]]
-; TODO add check count one and remove unused, when the type mapping bug is fixed
 ; CHECK: TypePointer [[#PTRTY:]] {{.*}} [[#NAME]]
-; CHECK: TypePointer [[#UNUSED:]] {{.*}} [[#NAME]]
 ; CHECK: FunctionParameter [[#PTRTY]]
-; CHECK-NOT: FunctionParameter [[#UNUSED]]
 
 ; ModuleID = 'sycl_test.bc'
 source_filename = "sycl_test.cpp"

--- a/test/transcoding/ForwardPtr.ll
+++ b/test/transcoding/ForwardPtr.ll
@@ -3,11 +3,12 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-SPIRV: TypeForwardPointer [[#FwdPtr:]] [[#SC:]]
-; CHECK-SPIRV: TypeFunction [[#]] [[#]] [[#FwdPtr]]
+; CHECK-SPIRV: TypeForwardPointer [[#FwdPtr:]] 8
+; CHECK-SPIRV: TypeStruct [[#FuncArg:]] [[#FwdPtr]]
 ; CHECK-SPIRV: TypeStruct [[#ArgsSec:]] [[#FwdPtr]]
 ; CHECK-SPIRV: TypeStruct [[#A:]] [[#]] [[#ArgsSec:]]
-; CHECK-SPIRV: TypePointer [[#FwdPtr]] [[#SC]] [[#A]]
+; CHECK-SPIRV: TypePointer [[#FwdPtr]] 8 [[#A]]
+; CHECK-SPIRV: TypeFunction [[#]] [[#]] [[#FwdPtr]]
 
 ; CHECK-LLVM: %struct.FuncArg = type { %class.A addrspace(4)* }
 ; CHECK-LLVM: %class.A = type { %class.ArgFirst, %structArgSec }
@@ -20,7 +21,7 @@ target triple = "spir64-unknown-unknown-sycldevice"
 %struct.FuncArg = type { %class.A addrspace(4)* }
 %class.A = type { %class.ArgFirst, %structArgSec }
 %class.ArgFirst = type { void (%class.A addrspace(4)*)* }
-%structArgSec= type { %class.A addrspace(4)* }
+%structArgSec = type { %class.A addrspace(4)* }
 
 declare spir_func i1 @Caller(%struct.FuncArg addrspace(4)* ) align 2
 


### PR DESCRIPTION
Current implementation creates forward pointer only if direct pointee
was already discovered during type traversal. But it is possible to have a
cyclic dependency when pointer points to already discovered type via multiple
intermediate types.

Modified algorithm tracks cyclic dependency case via return value of the
recursive algorithm.

Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>