### PR TITLE
Fix a crash when alias metadata is attached to a call to lifetime inrinsic

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -133,8 +133,8 @@ static bool shouldTryToAddMemAliasingDecoration(Instruction *Inst) {
   CallInst *CI = dyn_cast<CallInst>(Inst);
   if (!CI)
     return true;
-  // Calls to intrinsics are skipped with an exception of lifetime start/end
-  // which are handled separately
+  // Calls to intrinsics are skipped. At some point lifetime start/end will be
+  // handled separately, but specification isn't ready.
   if (Function *Fun = CI->getCalledFunction())
     if (Fun->isIntrinsic())
       return false;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -122,6 +122,25 @@ static SPIRVMemoryModelKind getMemoryModel(Module &M) {
   return SPIRVMemoryModelKind::MemoryModelMax;
 }
 
+static bool shouldTryToAddMemAliasingDecoration(Instruction *Inst) {
+  // Limit translation of aliasing metadata with only this set of instructions
+  // gracefully considering others as compilation mistakes and ignoring them
+  if (!Inst->mayReadOrWriteMemory())
+    return false;
+  // Loads and Stores are handled during memory access mask addition
+  if (isa<StoreInst>(Inst) || isa<LoadInst>(Inst))
+    return false;
+  CallInst *CI = dyn_cast<CallInst>(Inst);
+  if (!CI)
+    return true;
+  // Calls to intrinsics are skipped with an exception of lifetime start/end
+  // which are handled separately
+  if (Function *Fun = CI->getCalledFunction())
+    if (Fun->isIntrinsic())
+      return false;
+  return true;
+}
+
 LLVMToSPIRVBase::LLVMToSPIRVBase(SPIRVModule *SMod)
     : M(nullptr), Ctx(nullptr), BM(SMod), SrcLang(0), SrcLangVer(0) {
   DbgTran = std::make_unique<LLVMToSPIRVDbgTran>(nullptr, SMod, this);
@@ -1956,7 +1975,9 @@ bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
         BV->setFPFastMathMode(M);
     }
   }
-  transMemAliasingINTELDecorations(V, BV);
+  if (Instruction *Inst = dyn_cast<Instruction>(V))
+    if (shouldTryToAddMemAliasingDecoration(Inst))
+      transMemAliasingINTELDecorations(Inst, BV);
 
   if (auto *CI = dyn_cast<CallInst>(V)) {
     auto OC = BV->getOpCode();
@@ -1984,19 +2005,11 @@ bool LLVMToSPIRVBase::transAlign(Value *V, SPIRVValue *BV) {
 
 // Apply aliasing decorations to instructions annotated with aliasing metadata.
 // Do it for any instruction but loads and stores.
-void LLVMToSPIRVBase::transMemAliasingINTELDecorations(Value *V,
+void LLVMToSPIRVBase::transMemAliasingINTELDecorations(Instruction *Inst,
                                                        SPIRVValue *BV) {
   if (!BM->isAllowedToUseExtension(
          ExtensionID::SPV_INTEL_memory_access_aliasing))
     return;
-  // Loads and Stores are handled during memory access mask addition
-  if (isa<StoreInst>(V) || isa<LoadInst>(V))
-    return;
-
-  Instruction *Inst = dyn_cast<Instruction>(V);
-  if (!Inst)
-    return;
-
   if (MDNode *AliasingListMD =
           Inst->getMetadata(LLVMContext::MD_alias_scope)) {
     auto *MemAliasList =

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -102,7 +102,7 @@ public:
   SPIRVValue *transAsmINTEL(InlineAsm *Asm);
   SPIRVValue *transAsmCallINTEL(CallInst *Call, SPIRVBasicBlock *BB);
   bool transDecoration(Value *V, SPIRVValue *BV);
-  void transMemAliasingINTELDecorations(Value *V, SPIRVValue *BV);
+  void transMemAliasingINTELDecorations(Instruction *V, SPIRVValue *BV);
   SPIRVWord transFunctionControlMask(Function *);
   SPIRVFunction *transFunctionDecl(Function *F);
   void transVectorComputeMetadata(Function *F);

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-lifetime.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-lifetime.ll
@@ -1,0 +1,48 @@
+; The test checks if the translator won't crash
+; TODO need to figure out how to translate the alias.scope/noalias metadata
+; in a case when it attached to a call to lifetime intrinsic
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_memory_access_aliasing -o %t.spv
+
+; ModuleID = 'main'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+%class.anon = type { i8 }
+
+; Function Attrs: nounwind
+define spir_kernel void @lifetime_simple()
+{
+  %1 = alloca i32
+  %2 = bitcast i32* %1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2), !noalias !10
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #0
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!opencl.enable.FP_CONTRACT = !{}
+!spirv.Source = !{!6}
+!opencl.spir.version = !{!7}
+!opencl.ocl.version = !{!7}
+!opencl.used.extensions = !{!8}
+!opencl.used.optional.core.features = !{!8}
+!spirv.Generator = !{!9}
+
+!1 = !{i32 1, i32 1, i32 1}
+!2 = !{!"none", !"none", !"none"}
+!3 = !{!"int*", !"int*", !"int*"}
+!4 = !{!"", !"", !""}
+!5 = !{!"int*", !"int*", !"int*"}
+!6 = !{i32 3, i32 102000}
+!7 = !{i32 1, i32 2}
+!8 = !{}
+!9 = !{i16 7, i16 0}
+!10 = !{!11}
+!11 = distinct !{!11, !12}
+!12 = distinct !{!12}

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-lifetime.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-lifetime.ll
@@ -16,7 +16,7 @@ define spir_kernel void @lifetime_simple()
 {
   %1 = alloca i32
   %2 = bitcast i32* %1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2), !noalias !10
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2), !noalias !1
   ret void
 }
 
@@ -24,25 +24,7 @@ define spir_kernel void @lifetime_simple()
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #0
 
 attributes #0 = { nounwind }
-attributes #1 = { nounwind readnone }
 
-!opencl.enable.FP_CONTRACT = !{}
-!spirv.Source = !{!6}
-!opencl.spir.version = !{!7}
-!opencl.ocl.version = !{!7}
-!opencl.used.extensions = !{!8}
-!opencl.used.optional.core.features = !{!8}
-!spirv.Generator = !{!9}
-
-!1 = !{i32 1, i32 1, i32 1}
-!2 = !{!"none", !"none", !"none"}
-!3 = !{!"int*", !"int*", !"int*"}
-!4 = !{!"", !"", !""}
-!5 = !{!"int*", !"int*", !"int*"}
-!6 = !{i32 3, i32 102000}
-!7 = !{i32 1, i32 2}
-!8 = !{}
-!9 = !{i16 7, i16 0}
-!10 = !{!11}
-!11 = distinct !{!11, !12}
-!12 = distinct !{!12}
+!1 = !{!2}
+!2 = distinct !{!2, !3}
+!3 = distinct !{!3}

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-lifetime.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-lifetime.ll
@@ -1,6 +1,6 @@
 ; The test checks if the translator won't crash
 ; TODO need to figure out how to translate the alias.scope/noalias metadata
-; in a case when it attached to a call to lifetime intrinsic
+; in a case when it attached to a call to lifetime intrinsic. Now just skip it.
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_memory_access_aliasing -o %t.spv


### PR DESCRIPTION
The correct translation of this case will be done later, once the spec
is updated.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>