### PR TITLE
Implement support for dynamic memmove

### DIFF
--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -130,8 +130,7 @@ public:
         continue;
 
       if (F.getIntrinsicID() == Intrinsic::memmove)
-        if (expandMemMoveIntrinsicUses(F))
-          Changed = true;
+        Changed |= expandMemMoveIntrinsicUses(F);
     }
 
     verifyRegularizationPass(M, "SPIRVLowerMemmove");

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -108,7 +108,7 @@ public:
   bool expandMemMoveIntrinsicUses(Function &F) {
     bool Changed = false;
 
-    for (User *U : F.users()) {
+    for (User *U : make_early_inc_range(F.users())) {
       MemMoveInst *Inst = cast<MemMoveInst>(U);
       if (!isa<ConstantInt>(Inst->getLength())) {
         expandMemMoveAsLoop(Inst);

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -46,17 +46,17 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
+#include "llvm/Transforms/Utils/LowerMemIntrinsics.h"
 
 using namespace llvm;
 using namespace SPIRV;
 
 namespace SPIRV {
 
-class SPIRVLowerMemmoveBase : public InstVisitor<SPIRVLowerMemmoveBase> {
+class SPIRVLowerMemmoveBase {
 public:
-  SPIRVLowerMemmoveBase() : Context(nullptr) {}
-  virtual ~SPIRVLowerMemmoveBase() {}
-  virtual void visitMemMoveInst(MemMoveInst &I) {
+  SPIRVLowerMemmoveBase() : Context(nullptr), Mod(nullptr) {}
+  void LowerMemMoveInst(MemMoveInst &I) {
     IRBuilder<> Builder(I.getParent());
     Builder.SetInsertPoint(&I);
     auto *Dest = I.getRawDest();
@@ -65,11 +65,6 @@ public:
       report_fatal_error("llvm.memmove of PHI instruction result not supported",
                          false);
     auto *SrcTy = Src->getType();
-    if (!isa<ConstantInt>(I.getLength()))
-      // ToDo: for non-constant length, could use a loop to copy a
-      // fixed length chunk at a time. For now simply fail
-      report_fatal_error("llvm.memmove of non-constant length not supported",
-                         false);
     auto *Length = cast<ConstantInt>(I.getLength());
     auto *S = Src;
     // The source could be bit-cast or addrspacecast from another type,
@@ -111,13 +106,38 @@ public:
     I.dropAllReferences();
     I.eraseFromParent();
   }
+  bool expandMemIntrinsicUses(Function &F) {
+    bool Changed = false;
+
+    for (auto I = F.user_begin(), E = F.user_end(); I != E;) {
+      MemMoveInst *Inst = cast<MemMoveInst>(*I);
+      ++I;
+      if (!isa<ConstantInt>(Inst->getLength())) {
+        expandMemMoveAsLoop(Inst);
+        Inst->eraseFromParent();
+      } else {
+        LowerMemMoveInst(*Inst);
+      }
+      Changed = true;
+    }
+    return Changed;
+  }
   bool runLowerMemmove(Module &M) {
     Context = &M.getContext();
     Mod = &M;
-    visit(M);
+    bool Changed = false;
+
+    for (Function &F : M) {
+      if (!F.isDeclaration())
+        continue;
+
+      if (F.getIntrinsicID() == Intrinsic::memmove)
+        if (expandMemIntrinsicUses(F))
+          Changed = true;
+    }
 
     verifyRegularizationPass(M, "SPIRVLowerMemmove");
-    return true;
+    return Changed;
   }
 
 private:

--- a/test/llvm-intrinsics/dynamic-memmove.ll
+++ b/test/llvm-intrinsics/dynamic-memmove.ll
@@ -15,37 +15,15 @@ declare void @llvm.memmove.p1i8.p1i8.i64(i8 addrspace(1)* nocapture, i8 addrspac
 define spir_func void @memmove_caller(i8 addrspace(1)* %dst, i8 addrspace(1)* %src, i64 %n) {
 entry:
   call void @llvm.memmove.p1i8.p1i8.i64(i8 addrspace(1)* %dst, i8 addrspace(1)* %src, i64 %n, i1 false)
+  call void @llvm.memmove.p1i8.p1i8.i64(i8 addrspace(1)* %dst, i8 addrspace(1)* %src, i64 %n, i1 false)
+  call void @llvm.memmove.p1i8.p1i8.i64(i8 addrspace(1)* %dst, i8 addrspace(1)* %src, i64 %n, i1 false)
   ret void
 
 ; CHECK-LLVM: @memmove_caller(i8 addrspace(1)* [[DST:%.*]], i8 addrspace(1)* [[SRC:%.*]], i64 [[N:%.*]])
-; CHECK-LLVM:  [[SRC_CMP:%.*]] = ptrtoint i8 addrspace(1)* %src to i64
-; CHECK-LLVM:  [[DST_CMP:%.*]] = ptrtoint i8 addrspace(1)* %dst to i64
+; CHECK-LLVM:  [[SRC_CMP:%.*]] = ptrtoint i8 addrspace(1)* [[SRC]] to i64
+; CHECK-LLVM:  [[DST_CMP:%.*]] = ptrtoint i8 addrspace(1)* [[DST]] to i64
 ; CHECK-LLVM: [[COMPARE_SRC_DST:%.*]] = icmp ult i64 [[SRC_CMP]], [[DST_CMP]]
 ; CHECK-LLVM-NEXT: [[COMPARE_N_TO_0:%.*]] = icmp eq i64 [[N]], 0
-; CHECK-LLVM-NEXT: br i1 [[COMPARE_SRC_DST]], label [[COPY_BACKWARDS:%.*]], label [[COPY_FORWARD:%.*]]
-; CHECK-LLVM: copy_backwards:
-; CHECK-LLVM-NEXT: br i1 [[COMPARE_N_TO_0]], label [[MEMMOVE_DONE:%.*]], label [[COPY_BACKWARDS_LOOP:%.*]]
-; CHECK-LLVM: copy_backwards_loop:
-; CHECK-LLVM-NEXT: [[TMP1:%.*]] = phi i64 [ [[INDEX_PTR:%.*]], [[COPY_BACKWARDS_LOOP]] ], [ [[N]], [[COPY_BACKWARDS]] ]
-; CHECK-LLVM-NEXT: [[INDEX_PTR]] = sub i64 [[TMP1]], 1
-; CHECK-LLVM-NEXT: [[TMP2:%.*]] = getelementptr inbounds i8, i8 addrspace(1)* [[SRC]], i64 [[INDEX_PTR]]
-; CHECK-LLVM-NEXT: [[ELEMENT:%.*]] = load i8, i8 addrspace(1)* [[TMP2]], align 1
-; CHECK-LLVM-NEXT: [[TMP3:%.*]] = getelementptr inbounds i8, i8 addrspace(1)* [[DST]], i64 [[INDEX_PTR]]
-; CHECK-LLVM-NEXT: store i8 [[ELEMENT]], i8 addrspace(1)* [[TMP3]], align 1
-; CHECK-LLVM-NEXT: [[TMP4:%.*]] = icmp eq i64 [[INDEX_PTR]], 0
-; CHECK-LLVM-NEXT: br i1 [[TMP4]], label [[MEMMOVE_DONE]], label [[COPY_BACKWARDS_LOOP]]
-; CHECK-LLVM: copy_forward:
-; CHECK-LLVM-NEXT: br i1 [[COMPARE_N_TO_0]], label [[MEMMOVE_DONE]], label [[COPY_FORWARD_LOOP:%.*]]
-; CHECK-LLVM: copy_forward_loop:
-; CHECK-LLVM-NEXT: [[INDEX_PTR1:%.*]] = phi i64 [ [[INDEX_INCREMENT:%.*]], [[COPY_FORWARD_LOOP]] ], [ 0, [[COPY_FORWARD]] ]
-; CHECK-LLVM-NEXT: [[TMP5:%.*]] = getelementptr inbounds i8, i8 addrspace(1)* [[SRC]], i64 [[INDEX_PTR1]]
-; CHECK-LLVM-NEXT: [[ELEMENT2:%.*]] = load i8, i8 addrspace(1)* [[TMP5]], align 1
-; CHECK-LLVM-NEXT: [[TMP6:%.*]] = getelementptr inbounds i8, i8 addrspace(1)* [[DST]], i64 [[INDEX_PTR1]]
-; CHECK-LLVM-NEXT: store i8 [[ELEMENT2]], i8 addrspace(1)* [[TMP6]], align 1
-; CHECK-LLVM-NEXT: [[INDEX_INCREMENT]] = add i64 [[INDEX_PTR1]], 1
-; CHECK-LLVM-NEXT: [[TMP7:%.*]] = icmp eq i64 [[INDEX_INCREMENT]], [[N]]
-; CHECK-LLVM-NEXT: br i1 [[TMP7]], label [[MEMMOVE_DONE]], label [[COPY_FORWARD_LOOP]]
-; CHECK-LLVM: memmove_done:
-; CHECK-LLVM-NEXT: ret void
-
+; CHECK-LLVM-NEXT: br i1 [[COMPARE_SRC_DST]], label %[[COPY_BACKWARDS:.*]], label %[[COPY_FORWARD:.*]]
+; CHECK-LLVM: [[COPY_BACKWARDS]]:
 }

--- a/test/llvm-intrinsics/dynamic-memmove.ll
+++ b/test/llvm-intrinsics/dynamic-memmove.ll
@@ -1,0 +1,51 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-NOT: llvm.memmove
+
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+declare void @llvm.memmove.p1i8.p1i8.i64(i8 addrspace(1)* nocapture, i8 addrspace(1)* nocapture readonly, i64, i1)
+
+define spir_func void @memmove_caller(i8 addrspace(1)* %dst, i8 addrspace(1)* %src, i64 %n) {
+entry:
+  call void @llvm.memmove.p1i8.p1i8.i64(i8 addrspace(1)* %dst, i8 addrspace(1)* %src, i64 %n, i1 false)
+  ret void
+
+; CHECK-LLVM: @memmove_caller(i8 addrspace(1)* [[DST:%.*]], i8 addrspace(1)* [[SRC:%.*]], i64 [[N:%.*]])
+; CHECK-LLVM:  [[SRC_CMP:%.*]] = ptrtoint i8 addrspace(1)* %src to i64
+; CHECK-LLVM:  [[DST_CMP:%.*]] = ptrtoint i8 addrspace(1)* %dst to i64
+; CHECK-LLVM: [[COMPARE_SRC_DST:%.*]] = icmp ult i64 [[SRC_CMP]], [[DST_CMP]]
+; CHECK-LLVM-NEXT: [[COMPARE_N_TO_0:%.*]] = icmp eq i64 [[N]], 0
+; CHECK-LLVM-NEXT: br i1 [[COMPARE_SRC_DST]], label [[COPY_BACKWARDS:%.*]], label [[COPY_FORWARD:%.*]]
+; CHECK-LLVM: copy_backwards:
+; CHECK-LLVM-NEXT: br i1 [[COMPARE_N_TO_0]], label [[MEMMOVE_DONE:%.*]], label [[COPY_BACKWARDS_LOOP:%.*]]
+; CHECK-LLVM: copy_backwards_loop:
+; CHECK-LLVM-NEXT: [[TMP1:%.*]] = phi i64 [ [[INDEX_PTR:%.*]], [[COPY_BACKWARDS_LOOP]] ], [ [[N]], [[COPY_BACKWARDS]] ]
+; CHECK-LLVM-NEXT: [[INDEX_PTR]] = sub i64 [[TMP1]], 1
+; CHECK-LLVM-NEXT: [[TMP2:%.*]] = getelementptr inbounds i8, i8 addrspace(1)* [[SRC]], i64 [[INDEX_PTR]]
+; CHECK-LLVM-NEXT: [[ELEMENT:%.*]] = load i8, i8 addrspace(1)* [[TMP2]], align 1
+; CHECK-LLVM-NEXT: [[TMP3:%.*]] = getelementptr inbounds i8, i8 addrspace(1)* [[DST]], i64 [[INDEX_PTR]]
+; CHECK-LLVM-NEXT: store i8 [[ELEMENT]], i8 addrspace(1)* [[TMP3]], align 1
+; CHECK-LLVM-NEXT: [[TMP4:%.*]] = icmp eq i64 [[INDEX_PTR]], 0
+; CHECK-LLVM-NEXT: br i1 [[TMP4]], label [[MEMMOVE_DONE]], label [[COPY_BACKWARDS_LOOP]]
+; CHECK-LLVM: copy_forward:
+; CHECK-LLVM-NEXT: br i1 [[COMPARE_N_TO_0]], label [[MEMMOVE_DONE]], label [[COPY_FORWARD_LOOP:%.*]]
+; CHECK-LLVM: copy_forward_loop:
+; CHECK-LLVM-NEXT: [[INDEX_PTR1:%.*]] = phi i64 [ [[INDEX_INCREMENT:%.*]], [[COPY_FORWARD_LOOP]] ], [ 0, [[COPY_FORWARD]] ]
+; CHECK-LLVM-NEXT: [[TMP5:%.*]] = getelementptr inbounds i8, i8 addrspace(1)* [[SRC]], i64 [[INDEX_PTR1]]
+; CHECK-LLVM-NEXT: [[ELEMENT2:%.*]] = load i8, i8 addrspace(1)* [[TMP5]], align 1
+; CHECK-LLVM-NEXT: [[TMP6:%.*]] = getelementptr inbounds i8, i8 addrspace(1)* [[DST]], i64 [[INDEX_PTR1]]
+; CHECK-LLVM-NEXT: store i8 [[ELEMENT2]], i8 addrspace(1)* [[TMP6]], align 1
+; CHECK-LLVM-NEXT: [[INDEX_INCREMENT]] = add i64 [[INDEX_PTR1]], 1
+; CHECK-LLVM-NEXT: [[TMP7:%.*]] = icmp eq i64 [[INDEX_INCREMENT]], [[N]]
+; CHECK-LLVM-NEXT: br i1 [[TMP7]], label [[MEMMOVE_DONE]], label [[COPY_FORWARD_LOOP]]
+; CHECK-LLVM: memmove_done:
+; CHECK-LLVM-NEXT: ret void
+
+}


### PR DESCRIPTION
Use LLVM `expandMemMoveAsLoop` function in case memmove intrinsic use has
non-constant length.