### PR TITLE
Remove alias.scope/noalias exclusive restriction

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1449,14 +1449,12 @@ void SPIRVToLLVM::transAliasingMemAccess(SPIRVInstType *BI, Instruction *I) {
   static_assert(std::is_same<SPIRVInstType, SPIRVStore>::value ||
                 std::is_same<SPIRVInstType, SPIRVLoad>::value,
                 "Only stores and loads can be aliased by memory access mask");
-  bool IsAliasScope = BI->SPIRVMemoryAccess::isAliasScope();
-  bool IsNoAlias = BI->SPIRVMemoryAccess::isNoAlias();
-  if (!(IsAliasScope || IsNoAlias))
-    return;
-  uint32_t AliasMDKind = IsAliasScope ? LLVMContext::MD_alias_scope
-                                      : LLVMContext::MD_noalias;
-  SPIRVId AliasListId = BI->SPIRVMemoryAccess::getAliasing();
-  addMemAliasMetadata(I, AliasListId, AliasMDKind);
+  if (BI->SPIRVMemoryAccess::isNoAlias())
+    addMemAliasMetadata(I, BI->SPIRVMemoryAccess::getNoAliasInstID(),
+                        LLVMContext::MD_noalias);
+  if (BI->SPIRVMemoryAccess::isAliasScope())
+    addMemAliasMetadata(I, BI->SPIRVMemoryAccess::getAliasScopeInstID(),
+                        LLVMContext::MD_alias_scope);
 }
 
 // Create and apply alias.scope/noalias metadata
@@ -1485,10 +1483,9 @@ void SPIRVToLLVM::addMemAliasMetadata(Instruction *I, SPIRVId AliasListId,
     MDScopes.emplace_back(MDAliasScopeMap[ScopeId]);
   }
   // Create and store unique alias.scope/noalias metadata
-  MDAliasListMap.emplace(
-      AliasListId,
-      MDNode::concatenate(I->getMetadata(LLVMContext::MD_alias_scope),
-                          MDNode::get(*Context, MDScopes)));
+  MDAliasListMap.emplace(AliasListId,
+                         MDNode::concatenate(I->getMetadata(AliasMDKind),
+                                             MDNode::get(*Context, MDScopes)));
   I->setMetadata(AliasMDKind, MDAliasListMap[AliasListId]);
 }
 
@@ -3760,21 +3757,22 @@ void SPIRVToLLVM::transMemAliasingINTELDecorations(SPIRVValue *BV, Value *V) {
   Instruction *Inst = dyn_cast<Instruction>(V);
   if (!Inst)
     return;
-  std::vector<SPIRVId> AliasListIds;
-  uint32_t AliasMDKind;
   if (BV->hasDecorateId(internal::DecorationAliasScopeINTEL)) {
-    AliasMDKind = LLVMContext::MD_alias_scope;
+    std::vector<SPIRVId> AliasListIds;
     AliasListIds =
         BV->getDecorationIdLiterals(internal::DecorationAliasScopeINTEL);
-  } else if (BV->hasDecorateId(internal::DecorationNoAliasINTEL)) {
-    AliasMDKind = LLVMContext::MD_noalias;
+    assert(AliasListIds.size() == 1 &&
+           "Memory aliasing decorations must have one argument");
+    addMemAliasMetadata(Inst, AliasListIds[0], LLVMContext::MD_alias_scope);
+  }
+  if (BV->hasDecorateId(internal::DecorationNoAliasINTEL)) {
+    std::vector<SPIRVId> AliasListIds;
     AliasListIds =
         BV->getDecorationIdLiterals(internal::DecorationNoAliasINTEL);
-  } else
-    return;
-  assert(AliasListIds.size() == 1 &&
-         "Memory aliasing decorations must have one argument");
-  addMemAliasMetadata(Inst, AliasListIds[0], AliasMDKind);
+    assert(AliasListIds.size() == 1 &&
+           "Memory aliasing decorations must have one argument");
+    addMemAliasMetadata(Inst, AliasListIds[0], LLVMContext::MD_noalias);
+  }
 }
 
 // Having UserSemantic decoration on Function is against the spec, but we allow

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1474,8 +1474,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     if (MDNode *AliasingListMD = ST->getMetadata(LLVMContext::MD_alias_scope))
       transAliasingMemAccess(BM, AliasingListMD, MemoryAccess,
                              internal::MemoryAccessAliasScopeINTELMask);
-    else if (MDNode *AliasingListMD =
-                 ST->getMetadata(LLVMContext::MD_noalias))
+    if (MDNode *AliasingListMD = ST->getMetadata(LLVMContext::MD_noalias))
       transAliasingMemAccess(BM, AliasingListMD, MemoryAccess,
                              internal::MemoryAccessNoAliasINTELMask);
     if (MemoryAccess.front() == 0)
@@ -1505,9 +1504,8 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       MemoryAccess[0] |= MemoryAccessNontemporalMask;
     if (MDNode *AliasingListMD = LD->getMetadata(LLVMContext::MD_alias_scope))
       transAliasingMemAccess(BM, AliasingListMD, MemoryAccess,
-                            internal::MemoryAccessAliasScopeINTELMask);
-    else if (MDNode *AliasingListMD =
-                 LD->getMetadata(LLVMContext::MD_noalias))
+                             internal::MemoryAccessAliasScopeINTELMask);
+    if (MDNode *AliasingListMD = LD->getMetadata(LLVMContext::MD_noalias))
       transAliasingMemAccess(BM, AliasingListMD, MemoryAccess,
                              internal::MemoryAccessNoAliasINTELMask);
     if (MemoryAccess.front() == 0)
@@ -1931,8 +1929,8 @@ void LLVMToSPIRVBase::transMemAliasingINTELDecorations(Value *V,
       return;
     BV->addDecorate(new SPIRVDecorateId(
           internal::DecorationAliasScopeINTEL, BV, MemAliasList->getId()));
-  } else if (MDNode *AliasingListMD =
-                 Inst->getMetadata(LLVMContext::MD_noalias)) {
+  }
+  if (MDNode *AliasingListMD = Inst->getMetadata(LLVMContext::MD_noalias)) {
     auto *MemAliasList =
         addMemAliasingINTELInstructions(BM, AliasingListMD);
     if (!MemAliasList)

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-load-store.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-load-store.ll
@@ -22,6 +22,7 @@
 ;; with:
 ;; clang++ -fsycl -fsycl-is-device %s -o -
 ;; using https://github.com/intel/llvm.git bb5a2fece7c3315d7c72d8495c34a8a6eabc92d8
+;; with an exception of !16 noalias medata - it doesn't make any sence.
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_memory_access_aliasing -o %t.spv
@@ -39,11 +40,14 @@
 ; CHECK-SPIRV: AliasDomainDeclINTEL [[DOMAIN1:[0-9]+]]
 ; CHECK-SPIRV: AliasScopeDeclINTEL [[SCOPE1:[0-9]+]] [[DOMAIN1]]
 ; CHECK-SPIRV: AliasScopeListDeclINTEL [[LIST1:[0-9]+]] [[SCOPE1]]
+; CHECK-SPIRV: AliasDomainDeclINTEL [[DOMAIN3:[0-9]+]]
+; CHECK-SPIRV: AliasScopeDeclINTEL [[SCOPE3:[0-9]+]] [[DOMAIN3]]
+; CHECK-SPIRV: AliasScopeListDeclINTEL [[LIST3:[0-9]+]] [[SCOPE3]]
 ; CHECK-SPIRV: AliasDomainDeclINTEL [[DOMAIN2:[0-9]+]]
 ; CHECK-SPIRV: AliasScopeDeclINTEL [[SCOPE2:[0-9]+]] [[DOMAIN2]]
 ; CHECK-SPIRV: AliasScopeListDeclINTEL [[LIST2:[0-9]+]] [[SCOPE2]]
 ; CHECK-SPIRV: Load {{.*}} 65538 {{.*}} [[LIST1]]
-; CHECK-SPIRV: Load {{.*}} 65538 {{.*}} [[LIST1]]
+; CHECK-SPIRV: Load {{.*}} 196610 {{.*}} [[LIST1]] [[LIST3]]
 ; CHECK-SPIRV: Store {{.*}} 131074 {{.*}} [[LIST1]]
 ; CHECK-SPIRV: Load {{.*}} 65538 {{.*}} [[LIST2]]
 ; CHECK-SPIRV: Load {{.*}} 65538 {{.*}} [[LIST2]]
@@ -73,9 +77,9 @@ entry:
   %1 = addrspacecast i32 addrspace(1)* %_arg_1 to i32 addrspace(4)*
   %2 = addrspacecast i32 addrspace(1)* %_arg_3 to i32 addrspace(4)*
 ; CHECK-LLVM: load i32, i32 addrspace(4)* {{.*}} !alias.scope ![[LISTMD1:[0-9]+]]
-; CHECK-LLVM: load i32, i32 addrspace(4)* {{.*}} !alias.scope ![[LISTMD1]]
+; CHECK-LLVM: load i32, i32 addrspace(4)* {{.*}} !alias.scope ![[LISTMD1]]{{.*}}!noalias ![[LISTMD2:[0-9]+]]
   %3 = load i32, i32 addrspace(4)* %0, align 4, !tbaa !5, !alias.scope !9
-  %4 = load i32, i32 addrspace(4)* %1, align 4, !tbaa !5, !alias.scope !9
+  %4 = load i32, i32 addrspace(4)* %1, align 4, !tbaa !5, !alias.scope !9, !noalias !16
   %add.i = add nsw i32 %4, %3
 ; CHECK-LLVM: store i32 {{.*}} !noalias ![[LISTMD1]]
   store i32 %add.i, i32 addrspace(4)* %2, align 4, !tbaa !5, !noalias !9
@@ -88,13 +92,13 @@ entry:
   %0 = addrspacecast i32 addrspace(1)* %_arg_ to i32 addrspace(4)*
   %1 = addrspacecast i32 addrspace(1)* %_arg_1 to i32 addrspace(4)*
   %2 = addrspacecast i32 addrspace(1)* %_arg_3 to i32 addrspace(4)*
-; CHECK-LLVM: load i32, i32 addrspace(4)* {{.*}} !alias.scope ![[LISTMD2:[0-9]+]]
-; CHECK-LLVM: load i32, i32 addrspace(4)* {{.*}} !alias.scope ![[LISTMD2]]
+; CHECK-LLVM: load i32, i32 addrspace(4)* {{.*}} !alias.scope ![[LISTMD3:[0-9]+]]
+; CHECK-LLVM: load i32, i32 addrspace(4)* {{.*}} !alias.scope ![[LISTMD3]]
   %3 = load i32, i32 addrspace(4)* %0, align 4, !tbaa !5, !alias.scope !13
   %4 = load i32, i32 addrspace(4)* %1, align 4, !tbaa !5, !alias.scope !13
   %add.i = add i32 %3, %_arg_5
   %add3.i = add i32 %add.i, %4
-; CHECK-LLVM: store i32 {{.*}} !noalias ![[LISTMD2]]
+; CHECK-LLVM: store i32 {{.*}} !noalias ![[LISTMD3]]
   store i32 %add3.i, i32 addrspace(4)* %2, align 4, !tbaa !5, !noalias !13
   ret void
 }
@@ -115,16 +119,23 @@ attributes #0 = { nofree norecurse nounwind willreturn mustprogress "disable-tai
 !6 = !{!"int", !7, i64 0}
 !7 = !{!"omnipotent char", !8, i64 0}
 !8 = !{!"Simple C++ TBAA"}
-; CHECK-LLVM: ![[LISTMD1]] = !{![[SCOPEMD1:[0-9]+]]}
-; CHECK-LLVM: ![[SCOPEMD1]] = distinct !{![[SCOPEMD1]], ![[DOMAINMD1:[0-9]+]]}
-; CHECK-LLVM: ![[DOMAINMD1]] = distinct !{![[DOMAINMD1]]}
 !9 = !{!10}
 !10 = distinct !{!10, !11, !"_ZZ4mainENK3$_0clEv: %this"}
 !11 = distinct !{!11, !"_ZZ4mainENK3$_0clEv"}
 !12 = !{i32 -1, i32 -1, i32 -1, i32 -1}
-; CHECK-LLVM: ![[LISTMD2]] = !{![[SCOPEMD2:[0-9]+]]}
-; CHECK-LLVM: ![[SCOPEMD2]] = distinct !{![[SCOPEMD2]], ![[DOMAINMD2:[0-9]+]]}
-; CHECK-LLVM: ![[DOMAINMD2]] = distinct !{![[DOMAINMD2]]}
 !13 = !{!14}
 !14 = distinct !{!14, !15, !"_ZZ4mainENK3$_2clEv: %this"}
 !15 = distinct !{!15, !"_ZZ4mainENK3$_2clEv"}
+!16 = !{!17}
+!17 = distinct !{!17, !18, !"_ZZ4mainENK3$_0clEv: %this"}
+!18 = distinct !{!18, !"_ZZ4mainENK3$_0clEv"}
+
+; CHECK-LLVM: ![[LISTMD1]] = !{![[SCOPEMD1:[0-9]+]]}
+; CHECK-LLVM: ![[SCOPEMD1]] = distinct !{![[SCOPEMD1]], ![[DOMAINMD1:[0-9]+]]}
+; CHECK-LLVM: ![[DOMAINMD1]] = distinct !{![[DOMAINMD1]]}
+; CHECK-LLVM: ![[LISTMD2]] = !{![[SCOPEMD2:[0-9]+]]}
+; CHECK-LLVM: ![[SCOPEMD2]] = distinct !{![[SCOPEMD2]], ![[DOMAINMD2:[0-9]+]]}
+; CHECK-LLVM: ![[DOMAINMD2]] = distinct !{![[DOMAINMD2]]}
+; CHECK-LLVM: ![[LISTMD3]] = !{![[SCOPEMD3:[0-9]+]]}
+; CHECK-LLVM: ![[SCOPEMD3]] = distinct !{![[SCOPEMD3]], ![[DOMAINMD3:[0-9]+]]}
+; CHECK-LLVM: ![[DOMAINMD3]] = distinct !{![[DOMAINMD3]]}

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-masked-load-store.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-masked-load-store.ll
@@ -44,12 +44,16 @@
 ; CHECK-SPIRV: AliasDomainDeclINTEL [[DOMAIN2:[0-9]+]]
 ; CHECK-SPIRV: AliasScopeDeclINTEL [[SCOPE2:[0-9]+]] [[DOMAIN2]]
 ; CHECK-SPIRV: AliasScopeListDeclINTEL [[LIST2:[0-9]+]] [[SCOPE2]]
+; CHECK-SPIRV: AliasDomainDeclINTEL [[DOMAIN3:[0-9]+]]
+; CHECK-SPIRV: AliasScopeDeclINTEL [[SCOPE3:[0-9]+]] [[DOMAIN3]]
+; CHECK-SPIRV: AliasScopeListDeclINTEL [[LIST3:[0-9]+]] [[SCOPE3]]
 ; CHECK-SPIRV: DecorateId [[TARGET1:[0-9]+]] AliasScopeINTEL [[LIST1]]
 ; CHECK-SPIRV: DecorateId [[TARGET2:[0-9]+]] AliasScopeINTEL [[LIST1]]
-; CHECK-SPIRV: DecorateId [[TARGET3:[0-9]+]] AliasScopeINTEL [[LIST2]]
-; CHECK-SPIRV: DecorateId [[TARGET4:[0-9]+]] AliasScopeINTEL [[LIST2]]
+; CHECK-SPIRV: DecorateId [[TARGET3:[0-9]+]] AliasScopeINTEL [[LIST3]]
+; CHECK-SPIRV: DecorateId [[TARGET4:[0-9]+]] AliasScopeINTEL [[LIST3]]
 ; CHECK-SPIRV: DecorateId [[TARGET5:[0-9]+]] NoAliasINTEL [[LIST1]]
-; CHECK-SPIRV: DecorateId [[TARGET6:[0-9]+]] NoAliasINTEL [[LIST2]]
+; CHECK-SPIRV: DecorateId [[TARGET2]] NoAliasINTEL [[LIST2]]
+; CHECK-SPIRV: DecorateId [[TARGET6:[0-9]+]] NoAliasINTEL [[LIST3]]
 ; CHECK-SPIRV: FunctionCall {{.*}} [[TARGET1]]
 ; CHECK-SPIRV: FunctionCall {{.*}} [[TARGET2]]
 ; CHECK-SPIRV: FunctionCall {{.*}} [[TARGET5]]
@@ -77,9 +81,9 @@ entry:
   %1 = addrspacecast i32 addrspace(1)* %_arg_1 to i32 addrspace(4)*
   %2 = addrspacecast i32 addrspace(1)* %_arg_3 to i32 addrspace(4)*
 ; CHECK-LLVM: call spir_func i32 @wrappedload{{.*}} !alias.scope ![[LISTMD1:[0-9]+]]
-; CHECK-LLVM: call spir_func i32 @wrappedload{{.*}} !alias.scope ![[LISTMD1]]
+; CHECK-LLVM: call spir_func i32 @wrappedload{{.*}} !alias.scope ![[LISTMD1]]{{.*}} ![[LISTMD2:[0-9]+]]
   %3 = call i32 @wrappedload(i32 addrspace(4)* %0), !tbaa !5, !alias.scope !9
-  %4 = call i32 @wrappedload(i32 addrspace(4)* %1), !tbaa !5, !alias.scope !9
+  %4 = call i32 @wrappedload(i32 addrspace(4)* %1), !tbaa !5, !alias.scope !9, !noalias !16
   %add.i = add nsw i32 %4, %3
 ; CHECK-LLVM: call spir_func void @wrappedstore{{.*}} !noalias ![[LISTMD1]]
   call void @wrappedstore(i32 %add.i, i32 addrspace(4)* %2),!tbaa !5, !noalias !9
@@ -92,13 +96,13 @@ entry:
   %0 = addrspacecast i32 addrspace(1)* %_arg_ to i32 addrspace(4)*
   %1 = addrspacecast i32 addrspace(1)* %_arg_1 to i32 addrspace(4)*
   %2 = addrspacecast i32 addrspace(1)* %_arg_3 to i32 addrspace(4)*
-; CHECK-LLVM: call spir_func i32 @wrappedload{{.*}} !alias.scope ![[LISTMD2:[0-9]+]]
-; CHECK-LLVM: call spir_func i32 @wrappedload{{.*}} !alias.scope ![[LISTMD2]]
+; CHECK-LLVM: call spir_func i32 @wrappedload{{.*}} !alias.scope ![[LISTMD3:[0-9]+]]
+; CHECK-LLVM: call spir_func i32 @wrappedload{{.*}} !alias.scope ![[LISTMD3]]
   %3 = call i32 @wrappedload(i32 addrspace(4)* %0), !tbaa !5, !alias.scope !13
   %4 = call i32 @wrappedload(i32 addrspace(4)* %1), !tbaa !5, !alias.scope !13
   %add.i = add i32 %3, %_arg_5
   %add3.i = add i32 %add.i, %4
-; CHECK-LLVM: call spir_func void @wrappedstore{{.*}} !noalias ![[LISTMD2]]
+; CHECK-LLVM: call spir_func void @wrappedstore{{.*}} !noalias ![[LISTMD3]]
   call void @wrappedstore(i32 %add3.i, i32 addrspace(4)* %2),!tbaa !5, !noalias !13
   ret void
 }
@@ -133,16 +137,23 @@ attributes #0 = { nofree norecurse nounwind willreturn mustprogress "disable-tai
 !6 = !{!"int", !7, i64 0}
 !7 = !{!"omnipotent char", !8, i64 0}
 !8 = !{!"Simple C++ TBAA"}
-; CHECK-LLVM: ![[LISTMD1]] = !{![[SCOPEMD1:[0-9]+]]}
-; CHECK-LLVM: ![[SCOPEMD1]] = distinct !{![[SCOPEMD1]], ![[DOMAINMD1:[0-9]+]]}
-; CHECK-LLVM: ![[DOMAINMD1]] = distinct !{![[DOMAINMD1]]}
 !9 = !{!10}
 !10 = distinct !{!10, !11, !"_ZZ4mainENK3$_0clEv: %this"}
 !11 = distinct !{!11, !"_ZZ4mainENK3$_0clEv"}
 !12 = !{i32 -1, i32 -1, i32 -1, i32 -1}
-; CHECK-LLVM: ![[LISTMD2]] = !{![[SCOPEMD2:[0-9]+]]}
-; CHECK-LLVM: ![[SCOPEMD2]] = distinct !{![[SCOPEMD2]], ![[DOMAINMD2:[0-9]+]]}
-; CHECK-LLVM: ![[DOMAINMD2]] = distinct !{![[DOMAINMD2]]}
 !13 = !{!14}
 !14 = distinct !{!14, !15, !"_ZZ4mainENK3$_2clEv: %this"}
 !15 = distinct !{!15, !"_ZZ4mainENK3$_2clEv"}
+!16 = !{!17}
+!17 = distinct !{!17, !18, !"_ZZ4mainENK3$_0clEv: %this"}
+!18 = distinct !{!18, !"_ZZ4mainENK3$_0clEv"}
+
+; CHECK-LLVM: ![[LISTMD1]] = !{![[SCOPEMD1:[0-9]+]]}
+; CHECK-LLVM: ![[SCOPEMD1]] = distinct !{![[SCOPEMD1]], ![[DOMAINMD1:[0-9]+]]}
+; CHECK-LLVM: ![[DOMAINMD1]] = distinct !{![[DOMAINMD1]]}
+; CHECK-LLVM: ![[LISTMD2]] = !{![[SCOPEMD2:[0-9]+]]}
+; CHECK-LLVM: ![[SCOPEMD2]] = distinct !{![[SCOPEMD2]], ![[DOMAINMD2:[0-9]+]]}
+; CHECK-LLVM: ![[DOMAINMD2]] = distinct !{![[DOMAINMD2]]}
+; CHECK-LLVM: ![[LISTMD3]] = !{![[SCOPEMD3:[0-9]+]]}
+; CHECK-LLVM: ![[SCOPEMD3]] = distinct !{![[SCOPEMD3]], ![[DOMAINMD3:[0-9]+]]}
+; CHECK-LLVM: ![[DOMAINMD3]] = distinct !{![[DOMAINMD3]]}


### PR DESCRIPTION
It should be a valid case if alias.scope and noalias mask/decoration
be applied to the same instruction.

The appropriate spec change:
https://github.com/intel/llvm/pull/3426/commits/96cc162703768714cd7e7212c07b19e56f515b2a

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>