### PR TITLE
Improve OpSpecConstantOp handling and testing for SMod, SConvert, UConvert, BitCast

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2483,7 +2483,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     //   r = srem(a, b)
     //   needs_fixing = ((a < 0) != (b < 0) && r != 0)
     //   result = needs_fixing ? r + b : r
-    IRBuilder<> Builder(BB);
+    IRBuilder<> Builder(*Context);
+    if (BB) {
+      Builder.SetInsertPoint(BB);
+    }
     SPIRVSMod *SMod = static_cast<SPIRVSMod *>(BV);
     auto Dividend = transValue(SMod->getOperand(0), F, BB);
     auto Divisor = transValue(SMod->getOperand(1), F, BB);

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -9,6 +9,8 @@
 ; operations are supported.  Also verify that edge cases such as division
 ; by zero are handled gracefully.
 
+; CHECK: @var_sconvert = addrspace(1) global i8 53
+; CHECK: @var_uconvert = addrspace(1) global i8 53
 ; CHECK: @var_snegate = addrspace(1) global i32 -53
 ; CHECK: @var_not = addrspace(1) global i32 -54
 ; CHECK: @var_iadd = addrspace(1) global i32 49
@@ -43,13 +45,17 @@
 ; CHECK: @var_icmpsle = addrspace(1) global i1 false
 ; CHECK: @var_icmpuge = addrspace(1) global i1 false
 ; CHECK: @var_icmpsge = addrspace(1) global i1 true
+; CHECK: @var_bitcast = addrspace(1) global i32 1065353216
 
                OpCapability Addresses
                OpCapability Linkage
                OpCapability Kernel
+               OpCapability Int8
                OpMemoryModel Physical32 OpenCL
                OpEntryPoint Kernel %15 "foo"
                OpName %entry "entry"
+               OpDecorate %var_sconvert LinkageAttributes "var_sconvert" Export
+               OpDecorate %var_uconvert LinkageAttributes "var_uconvert" Export
                OpDecorate %var_snegate LinkageAttributes "var_snegate" Export
                OpDecorate %var_not LinkageAttributes "var_not" Export
                OpDecorate %var_iadd LinkageAttributes "var_iadd" Export
@@ -83,14 +89,20 @@
                OpDecorate %var_icmpsle LinkageAttributes "var_icmpsle" Export
                OpDecorate %var_icmpuge LinkageAttributes "var_icmpuge" Export
                OpDecorate %var_icmpsge LinkageAttributes "var_icmpsge" Export
+               OpDecorate %var_bitcast LinkageAttributes "var_bitcast" Export
        %bool = OpTypeBool
        %true = OpConstantTrue %bool
       %false = OpConstantFalse %bool
+      %uchar = OpTypeInt 8 0
        %uint = OpTypeInt 32 0
+      %float = OpTypeFloat 32
      %uint_0 = OpConstant %uint 0
      %uint_4 = OpConstant %uint 4
     %uint_53 = OpConstant %uint 53
   %uint_min4 = OpConstant %uint 0xfffffffc
+    %float_1 = OpConstant %float 1.0
+   %sconvert = OpSpecConstantOp %uchar SConvert %uint_53
+   %uconvert = OpSpecConstantOp %uchar UConvert %uint_53
     %snegate = OpSpecConstantOp %uint SNegate %uint_53
         %not = OpSpecConstantOp %uint Not %uint_53
        %iadd = OpSpecConstantOp %uint IAdd %uint_53 %uint_min4
@@ -124,11 +136,15 @@
     %icmpsle = OpSpecConstantOp %bool SLessThanEqual %uint_53 %uint_min4
     %icmpuge = OpSpecConstantOp %bool UGreaterThanEqual %uint_53 %uint_min4
     %icmpsge = OpSpecConstantOp %bool SGreaterThanEqual %uint_53 %uint_min4
+    %bitcast = OpSpecConstantOp %uint Bitcast %float_1
+ %_ptr_uchar = OpTypePointer CrossWorkgroup %uchar
   %_ptr_uint = OpTypePointer CrossWorkgroup %uint
   %_ptr_bool = OpTypePointer CrossWorkgroup %bool
        %void = OpTypeVoid
          %14 = OpTypeFunction %void
 
+%var_sconvert = OpVariable %_ptr_uchar CrossWorkgroup %sconvert
+%var_uconvert = OpVariable %_ptr_uchar CrossWorkgroup %uconvert
 %var_snegate = OpVariable %_ptr_uint CrossWorkgroup %snegate
     %var_not = OpVariable %_ptr_uint CrossWorkgroup %not
    %var_iadd = OpVariable %_ptr_uint CrossWorkgroup %iadd
@@ -162,6 +178,7 @@
 %var_icmpsle = OpVariable %_ptr_bool CrossWorkgroup %icmpsle
 %var_icmpuge = OpVariable %_ptr_bool CrossWorkgroup %icmpuge
 %var_icmpsge = OpVariable %_ptr_bool CrossWorkgroup %icmpsge
+%var_bitcast = OpVariable %_ptr_uint CrossWorkgroup %bitcast
 
          %15 = OpFunction %void Pure %14
       %entry = OpLabel

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -22,7 +22,7 @@
 ; CHECK: @var_sdiv0 = addrspace(1) global i32 poison
 ; CHECK: @var_umod = addrspace(1) global i32 1
 ; CHECK: @var_srem = addrspace(1) global i32 1
-; TODO: smod
+; CHECK: @var_smod = addrspace(1) global i32 -3
 ; CHECK: @var_srl = addrspace(1) global i32 268435455
 ; CHECK: @var_sra = addrspace(1) global i32 -1
 ; CHECK: @var_sll = addrspace(1) global i32 848
@@ -67,6 +67,7 @@
                OpDecorate %var_sdiv0 LinkageAttributes "var_sdiv0" Export
                OpDecorate %var_umod LinkageAttributes "var_umod" Export
                OpDecorate %var_srem LinkageAttributes "var_srem" Export
+               OpDecorate %var_smod LinkageAttributes "var_smod" Export
                OpDecorate %var_srl LinkageAttributes "var_srl" Export
                OpDecorate %var_sra LinkageAttributes "var_sra" Export
                OpDecorate %var_sll LinkageAttributes "var_sll" Export
@@ -114,6 +115,7 @@
       %sdiv0 = OpSpecConstantOp %uint SDiv %uint_53 %uint_0
        %umod = OpSpecConstantOp %uint UMod %uint_53 %uint_4
        %srem = OpSpecConstantOp %uint SRem %uint_53 %uint_min4
+       %smod = OpSpecConstantOp %uint SMod %uint_53 %uint_min4
         %srl = OpSpecConstantOp %uint ShiftRightLogical %uint_min4 %uint_4
         %sra = OpSpecConstantOp %uint ShiftRightArithmetic %uint_min4 %uint_4
         %sll = OpSpecConstantOp %uint ShiftLeftLogical %uint_53 %uint_4
@@ -156,6 +158,7 @@
   %var_sdiv0 = OpVariable %_ptr_uint CrossWorkgroup %sdiv0
    %var_umod = OpVariable %_ptr_uint CrossWorkgroup %umod
    %var_srem = OpVariable %_ptr_uint CrossWorkgroup %srem
+   %var_smod = OpVariable %_ptr_uint CrossWorkgroup %smod
     %var_srl = OpVariable %_ptr_uint CrossWorkgroup %srl
     %var_sra = OpVariable %_ptr_uint CrossWorkgroup %sra
     %var_sll = OpVariable %_ptr_uint CrossWorkgroup %sll


### PR DESCRIPTION
This is a continuation of #1050 to improve OpSpecConstantOp handling.

- Handle OpSpecConstantOp with SMod
- Add tests for SConvert, UConvert, BitCast OpSpecConstantOp, which do not need any further implementation work.