### PR TITLE
Handle OpSpecConstantOp with VectorShuffle, CompositeExtract, and CompositeInsert

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2317,17 +2317,21 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpCompositeExtract: {
     SPIRVCompositeExtract *CE = static_cast<SPIRVCompositeExtract *>(BV);
+    IRBuilder<> Builder(*Context);
+    if (BB) {
+      Builder.SetInsertPoint(BB);
+    }
     if (CE->getComposite()->getType()->isTypeVector()) {
       assert(CE->getIndices().size() == 1 && "Invalid index");
       return mapValue(
-          BV, ExtractElementInst::Create(
+          BV, Builder.CreateExtractElement(
                   transValue(CE->getComposite(), F, BB),
                   ConstantInt::get(*Context, APInt(32, CE->getIndices()[0])),
-                  BV->getName(), BB));
+                  BV->getName()));
     }
     return mapValue(
-        BV, ExtractValueInst::Create(transValue(CE->getComposite(), F, BB),
-                                     CE->getIndices(), BV->getName(), BB));
+        BV, Builder.CreateExtractValue(transValue(CE->getComposite(), F, BB),
+                                       CE->getIndices(), BV->getName()));
   }
 
   case OpVectorExtractDynamic: {
@@ -2340,19 +2344,23 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpCompositeInsert: {
     auto CI = static_cast<SPIRVCompositeInsert *>(BV);
+    IRBuilder<> Builder(*Context);
+    if (BB) {
+      Builder.SetInsertPoint(BB);
+    }
     if (CI->getComposite()->getType()->isTypeVector()) {
       assert(CI->getIndices().size() == 1 && "Invalid index");
       return mapValue(
-          BV, InsertElementInst::Create(
+          BV, Builder.CreateInsertElement(
                   transValue(CI->getComposite(), F, BB),
                   transValue(CI->getObject(), F, BB),
                   ConstantInt::get(*Context, APInt(32, CI->getIndices()[0])),
-                  BV->getName(), BB));
+                  BV->getName()));
     }
     return mapValue(
-        BV, InsertValueInst::Create(transValue(CI->getComposite(), F, BB),
-                                    transValue(CI->getObject(), F, BB),
-                                    CI->getIndices(), BV->getName(), BB));
+        BV, Builder.CreateInsertValue(transValue(CI->getComposite(), F, BB),
+                                      transValue(CI->getObject(), F, BB),
+                                      CI->getIndices(), BV->getName()));
   }
 
   case OpVectorInsertDynamic: {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2374,11 +2374,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       else
         Components.push_back(ConstantInt::get(Int32Ty, I));
     }
-    return mapValue(BV,
-                    new ShuffleVectorInst(transValue(VS->getVector1(), F, BB),
-                                          transValue(VS->getVector2(), F, BB),
-                                          ConstantVector::get(Components),
-                                          BV->getName(), BB));
+    IRBuilder<> Builder(*Context);
+    if (BB) {
+      Builder.SetInsertPoint(BB);
+    }
+    return mapValue(BV, Builder.CreateShuffleVector(
+                            transValue(VS->getVector1(), F, BB),
+                            transValue(VS->getVector2(), F, BB),
+                            ConstantVector::get(Components), BV->getName()));
   }
 
   case OpBitReverse: {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -253,6 +253,23 @@ SPIRVInstruction *createInstFromSpecConstantOp(SPIRVSpecConstantOp *Inst) {
     return new SPIRVVectorShuffle(Inst->getId(), Inst->getType(), Ops[0],
                                   Ops[1], Comp, nullptr, Inst->getModule());
   }
+  case OpCompositeExtract: {
+    std::vector<SPIRVWord> Indices;
+    for (auto I = Ops.begin() + 1, E = Ops.end(); I != E; ++I) {
+      Indices.push_back(*I);
+    }
+    return new SPIRVCompositeExtract(Inst->getType(), Inst->getId(), Ops[0],
+                                     Indices, nullptr, Inst->getModule());
+  }
+  case OpCompositeInsert: {
+    std::vector<SPIRVWord> Indices;
+    for (auto I = Ops.begin() + 2, E = Ops.end(); I != E; ++I) {
+      Indices.push_back(*I);
+    }
+    return new SPIRVCompositeInsert(Inst->getType(), Inst->getId(), Ops[0],
+                                    Ops[1], Indices, nullptr,
+                                    Inst->getModule());
+  }
   case OpSelect:
     return new SPIRVSelect(Inst->getId(), Inst->getType(), Ops[0], Ops[1],
                            Ops[2], nullptr, Inst->getModule());

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -245,6 +245,14 @@ SPIRVInstruction *createInstFromSpecConstantOp(SPIRVSpecConstantOp *Inst) {
          "Op code not allowed for OpSpecConstantOp");
   Ops.erase(Ops.begin(), Ops.begin() + 1);
   switch (OC) {
+  case OpVectorShuffle: {
+    std::vector<SPIRVWord> Comp;
+    for (auto I = Ops.begin() + 2, E = Ops.end(); I != E; ++I) {
+      Comp.push_back(*I);
+    }
+    return new SPIRVVectorShuffle(Inst->getId(), Inst->getType(), Ops[0],
+                                  Ops[1], Comp, nullptr, Inst->getModule());
+  }
   case OpSelect:
     return new SPIRVSelect(Inst->getId(), Inst->getType(), Ops[0], Ops[1],
                            Ops[2], nullptr, Inst->getModule());

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1898,14 +1898,13 @@ class SPIRVCompositeExtract : public SPIRVInstruction {
 public:
   const static Op OC = OpCompositeExtract;
   // Complete constructor
-  SPIRVCompositeExtract(SPIRVType *TheType, SPIRVId TheId,
-                        SPIRVValue *TheComposite,
+  SPIRVCompositeExtract(SPIRVType *TheType, SPIRVId TheId, SPIRVId TheComposite,
                         const std::vector<SPIRVWord> &TheIndices,
-                        SPIRVBasicBlock *TheBB)
-      : SPIRVInstruction(TheIndices.size() + 4, OC, TheType, TheId, TheBB),
-        Composite(TheComposite->getId()), Indices(TheIndices) {
+                        SPIRVBasicBlock *TheBB, SPIRVModule *TheM)
+      : SPIRVInstruction(TheIndices.size() + 4, OC, TheType, TheId, TheBB,
+                         TheM),
+        Composite(TheComposite), Indices(TheIndices) {
     validate();
-    assert(TheBB && "Invalid BB");
   }
   // Incomplete constructor
   SPIRVCompositeExtract() : SPIRVInstruction(OC), Composite(SPIRVID_INVALID) {}
@@ -1936,16 +1935,14 @@ public:
   const static Op OC = OpCompositeInsert;
   const static SPIRVWord FixedWordCount = 5;
   // Complete constructor
-  SPIRVCompositeInsert(SPIRVId TheId, SPIRVValue *TheObject,
-                       SPIRVValue *TheComposite,
+  SPIRVCompositeInsert(SPIRVType *TheType, SPIRVId TheId, SPIRVId TheObject,
+                       SPIRVId TheComposite,
                        const std::vector<SPIRVWord> &TheIndices,
-                       SPIRVBasicBlock *TheBB)
-      : SPIRVInstruction(TheIndices.size() + FixedWordCount, OC,
-                         TheComposite->getType(), TheId, TheBB),
-        Object(TheObject->getId()), Composite(TheComposite->getId()),
-        Indices(TheIndices) {
+                       SPIRVBasicBlock *TheBB, SPIRVModule *TheM)
+      : SPIRVInstruction(TheIndices.size() + FixedWordCount, OC, TheType, TheId,
+                         TheBB, TheM),
+        Object(TheObject), Composite(TheComposite), Indices(TheIndices) {
     validate();
-    assert(TheBB && "Invalid BB");
   }
   // Incomplete constructor
   SPIRVCompositeInsert()

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2179,16 +2179,14 @@ public:
   const static Op OC = OpVectorShuffle;
   const static SPIRVWord FixedWordCount = 5;
   // Complete constructor
-  SPIRVVectorShuffle(SPIRVId TheId, SPIRVType *TheType, SPIRVValue *TheVector1,
-                     SPIRVValue *TheVector2,
+  SPIRVVectorShuffle(SPIRVId TheId, SPIRVType *TheType, SPIRVId TheVector1,
+                     SPIRVId TheVector2,
                      const std::vector<SPIRVWord> &TheComponents,
-                     SPIRVBasicBlock *TheBB)
+                     SPIRVBasicBlock *TheBB, SPIRVModule *TheM)
       : SPIRVInstruction(TheComponents.size() + FixedWordCount, OC, TheType,
-                         TheId, TheBB),
-        Vector1(TheVector1->getId()), Vector2(TheVector2->getId()),
-        Components(TheComponents) {
+                         TheId, TheBB, TheM),
+        Vector1(TheVector1), Vector2(TheVector2), Components(TheComponents) {
     validate();
-    assert(TheBB && "Invalid BB");
   }
   // Incomplete constructor
   SPIRVVectorShuffle()

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1379,8 +1379,10 @@ SPIRVInstruction *SPIRVModuleImpl::addVectorInsertDynamicInst(
 SPIRVValue *SPIRVModuleImpl::addVectorShuffleInst(
     SPIRVType *Type, SPIRVValue *Vec1, SPIRVValue *Vec2,
     const std::vector<SPIRVWord> &Components, SPIRVBasicBlock *BB) {
-  return addInstruction(
-      new SPIRVVectorShuffle(getId(), Type, Vec1, Vec2, Components, BB), BB);
+  return addInstruction(new SPIRVVectorShuffle(getId(), Type, Vec1->getId(),
+                                               Vec2->getId(), Components, BB,
+                                               this),
+                        BB);
 }
 
 SPIRVInstruction *SPIRVModuleImpl::addBranchInst(SPIRVLabel *TargetLabel,

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1523,15 +1523,19 @@ SPIRVInstruction *
 SPIRVModuleImpl::addCompositeExtractInst(SPIRVType *Type, SPIRVValue *TheVector,
                                          const std::vector<SPIRVWord> &Indices,
                                          SPIRVBasicBlock *BB) {
-  return addInstruction(
-      new SPIRVCompositeExtract(Type, getId(), TheVector, Indices, BB), BB);
+  return addInstruction(new SPIRVCompositeExtract(Type, getId(),
+                                                  TheVector->getId(), Indices,
+                                                  BB, this),
+                        BB);
 }
 
 SPIRVInstruction *SPIRVModuleImpl::addCompositeInsertInst(
     SPIRVValue *Object, SPIRVValue *Composite,
     const std::vector<SPIRVWord> &Indices, SPIRVBasicBlock *BB) {
   return addInstruction(
-      new SPIRVCompositeInsert(getId(), Object, Composite, Indices, BB), BB);
+      new SPIRVCompositeInsert(Composite->getType(), getId(), Object->getId(),
+                               Composite->getId(), Indices, BB, this),
+      BB);
 }
 
 SPIRVInstruction *SPIRVModuleImpl::addCopyObjectInst(SPIRVType *TheType,

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -30,6 +30,7 @@
 ; CHECK: @var_bitor = addrspace(1) global i32 -3
 ; CHECK: @var_bitxor = addrspace(1) global i32 -55
 ; CHECK: @var_bitand = addrspace(1) global i32 52
+; CHECK: @var_vecshuf = addrspace(1) global <2 x i32> <i32 4, i32 53>
 ; CHECK: @var_logor = addrspace(1) global i1 true
 ; CHECK: @var_logand = addrspace(1) global i1 false
 ; CHECK: @var_lognot = addrspace(1) global i1 false
@@ -76,6 +77,7 @@
                OpDecorate %var_bitor LinkageAttributes "var_bitor" Export
                OpDecorate %var_bitxor LinkageAttributes "var_bitxor" Export
                OpDecorate %var_bitand LinkageAttributes "var_bitand" Export
+               OpDecorate %var_vecshuf LinkageAttributes "var_vecshuf" Export
                OpDecorate %var_logor LinkageAttributes "var_logor" Export
                OpDecorate %var_logand LinkageAttributes "var_logand" Export
                OpDecorate %var_lognot LinkageAttributes "var_lognot" Export
@@ -99,11 +101,14 @@
       %uchar = OpTypeInt 8 0
        %uint = OpTypeInt 32 0
       %float = OpTypeFloat 32
+      %v2i32 = OpTypeVector %uint 2
      %uint_0 = OpConstant %uint 0
      %uint_4 = OpConstant %uint 4
     %uint_53 = OpConstant %uint 53
   %uint_min4 = OpConstant %uint 0xfffffffc
     %float_1 = OpConstant %float 1.0
+   %vec_53_0 = OpConstantComposite %v2i32 %uint_53 %uint_0
+    %vec_4_4 = OpConstantComposite %v2i32 %uint_4 %uint_4
    %sconvert = OpSpecConstantOp %uchar SConvert %uint_53
    %uconvert = OpSpecConstantOp %uchar UConvert %uint_53
     %snegate = OpSpecConstantOp %uint SNegate %uint_53
@@ -125,6 +130,7 @@
       %bitor = OpSpecConstantOp %uint BitwiseOr %uint_53 %uint_min4
      %bitxor = OpSpecConstantOp %uint BitwiseXor %uint_53 %uint_min4
      %bitand = OpSpecConstantOp %uint BitwiseAnd %uint_53 %uint_min4
+    %vecshuf = OpSpecConstantOp %v2i32 VectorShuffle %vec_53_0 %vec_4_4 2 0
       %logor = OpSpecConstantOp %bool LogicalOr %true %false
      %logand = OpSpecConstantOp %bool LogicalAnd %true %false
      %lognot = OpSpecConstantOp %bool LogicalNot %true
@@ -145,6 +151,7 @@
  %_ptr_uchar = OpTypePointer CrossWorkgroup %uchar
   %_ptr_uint = OpTypePointer CrossWorkgroup %uint
   %_ptr_bool = OpTypePointer CrossWorkgroup %bool
+ %_ptr_v2i32 = OpTypePointer CrossWorkgroup %v2i32
        %void = OpTypeVoid
          %14 = OpTypeFunction %void
 
@@ -169,6 +176,7 @@
   %var_bitor = OpVariable %_ptr_uint CrossWorkgroup %bitor
  %var_bitxor = OpVariable %_ptr_uint CrossWorkgroup %bitxor
  %var_bitand = OpVariable %_ptr_uint CrossWorkgroup %bitand
+%var_vecshuf = OpVariable %_ptr_v2i32 CrossWorkgroup %vecshuf
   %var_logor = OpVariable %_ptr_bool CrossWorkgroup %logor
  %var_logand = OpVariable %_ptr_bool CrossWorkgroup %logand
  %var_lognot = OpVariable %_ptr_bool CrossWorkgroup %lognot

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -31,6 +31,8 @@
 ; CHECK: @var_bitxor = addrspace(1) global i32 -55
 ; CHECK: @var_bitand = addrspace(1) global i32 52
 ; CHECK: @var_vecshuf = addrspace(1) global <2 x i32> <i32 4, i32 53>
+; CHECK: @var_compext = addrspace(1) global i32 53
+; CHECK: @var_compins = addrspace(1) global <2 x i32> <i32 53, i32 53>
 ; CHECK: @var_logor = addrspace(1) global i1 true
 ; CHECK: @var_logand = addrspace(1) global i1 false
 ; CHECK: @var_lognot = addrspace(1) global i1 false
@@ -78,6 +80,8 @@
                OpDecorate %var_bitxor LinkageAttributes "var_bitxor" Export
                OpDecorate %var_bitand LinkageAttributes "var_bitand" Export
                OpDecorate %var_vecshuf LinkageAttributes "var_vecshuf" Export
+               OpDecorate %var_compext LinkageAttributes "var_compext" Export
+               OpDecorate %var_compins LinkageAttributes "var_compins" Export
                OpDecorate %var_logor LinkageAttributes "var_logor" Export
                OpDecorate %var_logand LinkageAttributes "var_logand" Export
                OpDecorate %var_lognot LinkageAttributes "var_lognot" Export
@@ -131,6 +135,8 @@
      %bitxor = OpSpecConstantOp %uint BitwiseXor %uint_53 %uint_min4
      %bitand = OpSpecConstantOp %uint BitwiseAnd %uint_53 %uint_min4
     %vecshuf = OpSpecConstantOp %v2i32 VectorShuffle %vec_53_0 %vec_4_4 2 0
+    %compext = OpSpecConstantOp %uint CompositeExtract %vec_53_0 0
+    %compins = OpSpecConstantOp %v2i32 CompositeInsert %uint_53 %vec_53_0 1
       %logor = OpSpecConstantOp %bool LogicalOr %true %false
      %logand = OpSpecConstantOp %bool LogicalAnd %true %false
      %lognot = OpSpecConstantOp %bool LogicalNot %true
@@ -177,6 +183,8 @@
  %var_bitxor = OpVariable %_ptr_uint CrossWorkgroup %bitxor
  %var_bitand = OpVariable %_ptr_uint CrossWorkgroup %bitand
 %var_vecshuf = OpVariable %_ptr_v2i32 CrossWorkgroup %vecshuf
+%var_compext = OpVariable %_ptr_uint CrossWorkgroup %compext
+%var_compins = OpVariable %_ptr_v2i32 CrossWorkgroup %compins
   %var_logor = OpVariable %_ptr_bool CrossWorkgroup %logor
  %var_logand = OpVariable %_ptr_bool CrossWorkgroup %logand
  %var_lognot = OpVariable %_ptr_bool CrossWorkgroup %lognot

--- a/test/opundef.spt
+++ b/test/opundef.spt
@@ -16,25 +16,25 @@
 4 TypeInt 7 32 0 
 4 Constant 7 10 1 
 2 TypeVoid 2 
-3 TypeFunction 3 2 
 3 TypeFloat 8 32 
 4 TypeStruct 6 7 8 
+3 TypeFunction 3 6
 
-5 Function 2 4 0 3 
+5 Function 6 4 0 3
 
 2 Label 5 
 3 Undef 6 9 
 6 CompositeInsert 6 11 10 9 0 
-1 Return 
+2 ReturnValue 11
 
 1 FunctionEnd 
 
-5 Function 2 12 0 3 
+5 Function 6 12 0 3
 
 2 Label 13 
 3 Undef 6 15 
 6 CompositeInsert 6 14 10 15 0 
-1 Return 
+2 ReturnValue 14
 
 1 FunctionEnd 
 
@@ -43,14 +43,12 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s
 
-; CHECK: define spir_func void @foo() #0 {
+; CHECK: define spir_func %structtype @foo() #0 {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: %agg1 = insertvalue %{{[0-9a-z\.]*}} undef
-; CHECK-NEXT: ret void
+; CHECK-NEXT: ret %structtype { i32 1, float undef }
 ; CHECK-NEXT: }
-; CHECK: define spir_func void @bar() #0 {
+; CHECK: define spir_func %structtype @bar() #0 {
 ; CHECK-NEXT: entry:
-; CHECK-NEXT: %agg2 = insertvalue %{{[0-9a-z\.]*}} undef
-; CHECK-NEXT: ret void
+; CHECK-NEXT: ret %structtype { i32 1, float undef }
 ; CHECK-NEXT: }
 


### PR DESCRIPTION
This is (hopefully) the last PR in a series to improve `OpSpecConstantOp`
handling with integer operators.

Modify the constructors to allow passing a `nullptr` basic block (as is
the case for variable initializers).

Modify the constructors to take `SPIRVId`s instead of `SPIRVValue`s,
which better reflects what is stored in the class, and saves us an
unnecessary ID-to-Value-to-ID round trip in
`createInstFromSpecConstantOp`.

Use an IRBuilder when translating, so that the resulting
expression will be created as a constant expression (and
possibly constant-folded) where possible.

Modify `test/opundef.spt` to return the constructed value, so that it
does not get optimized out.