### PR TITLE
[NFC] Remove switch on opcode by inheriting from SPIRVInstTemplateBase

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3838,10 +3838,6 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     return BM->addAsyncGroupCopy(BArgs[0], BArgs[1], BArgs[2], BArgs[3],
                                  BArgs[4], BArgs[5], BB);
   } break;
-  case OpSelect: {
-    auto BArgs = transValue(getArguments(CI), BB);
-    return BM->addSelectInst(BArgs[0], BArgs[1], BArgs[2], BB);
-  }
   case OpSampledImage: {
     // Clang can generate SPIRV-friendly call for OpSampledImage instruction,
     // i.e. __spirv_SampledImage... But it can't generate correct return type

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -244,39 +244,8 @@ SPIRVInstruction *createInstFromSpecConstantOp(SPIRVSpecConstantOp *Inst) {
   assert(isSpecConstantOpAllowedOp(OC) &&
          "Op code not allowed for OpSpecConstantOp");
   Ops.erase(Ops.begin(), Ops.begin() + 1);
-  switch (OC) {
-  case OpVectorShuffle: {
-    std::vector<SPIRVWord> Comp;
-    for (auto I = Ops.begin() + 2, E = Ops.end(); I != E; ++I) {
-      Comp.push_back(*I);
-    }
-    return new SPIRVVectorShuffle(Inst->getId(), Inst->getType(), Ops[0],
-                                  Ops[1], Comp, nullptr, Inst->getModule());
-  }
-  case OpCompositeExtract: {
-    std::vector<SPIRVWord> Indices;
-    for (auto I = Ops.begin() + 1, E = Ops.end(); I != E; ++I) {
-      Indices.push_back(*I);
-    }
-    return new SPIRVCompositeExtract(Inst->getType(), Inst->getId(), Ops[0],
-                                     Indices, nullptr, Inst->getModule());
-  }
-  case OpCompositeInsert: {
-    std::vector<SPIRVWord> Indices;
-    for (auto I = Ops.begin() + 2, E = Ops.end(); I != E; ++I) {
-      Indices.push_back(*I);
-    }
-    return new SPIRVCompositeInsert(Inst->getType(), Inst->getId(), Ops[0],
-                                    Ops[1], Indices, nullptr,
-                                    Inst->getModule());
-  }
-  case OpSelect:
-    return new SPIRVSelect(Inst->getId(), Inst->getType(), Ops[0], Ops[1],
-                           Ops[2], nullptr, Inst->getModule());
-  default:
-    return SPIRVInstTemplateBase::create(OC, Inst->getType(), Inst->getId(),
-                                         Ops, nullptr, Inst->getModule());
-  }
+  return SPIRVInstTemplateBase::create(OC, Inst->getType(), Inst->getId(), Ops,
+                                       nullptr, Inst->getModule());
 }
 
 } // namespace SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -971,27 +971,18 @@ _SPIRV_OP(Ordered)
 _SPIRV_OP(Unordered)
 #undef _SPIRV_OP
 
-class SPIRVSelect : public SPIRVInstruction {
+class SPIRVSelectBase : public SPIRVInstTemplateBase {
 public:
-  // Complete constructor
-  SPIRVSelect(SPIRVId TheId, SPIRVType *TheType, SPIRVId TheCondition,
-              SPIRVId TheOp1, SPIRVId TheOp2, SPIRVBasicBlock *TheBB,
-              SPIRVModule *TheM)
-      : SPIRVInstruction(6, OpSelect, TheType, TheId, TheBB, TheM),
-        Condition(TheCondition), Op1(TheOp1), Op2(TheOp2) {
-    validate();
-  }
-  // Incomplete constructor
-  SPIRVSelect()
-      : SPIRVInstruction(OpSelect), Condition(SPIRVID_INVALID),
-        Op1(SPIRVID_INVALID), Op2(SPIRVID_INVALID) {}
-  SPIRVValue *getCondition() { return getValue(Condition); }
-  SPIRVValue *getTrueValue() { return getValue(Op1); }
-  SPIRVValue *getFalseValue() { return getValue(Op2); }
+  SPIRVValue *getCondition() { return getValue(Ops[0]); }
+  SPIRVValue *getTrueValue() { return getValue(Ops[1]); }
+  SPIRVValue *getFalseValue() { return getValue(Ops[2]); }
 
 protected:
-  _SPIRV_DEF_ENCDEC5(Type, Id, Condition, Op1, Op2)
   void validate() const override {
+    SPIRVId Condition = Ops[0];
+    SPIRVId Op1 = Ops[1];
+    SPIRVId Op2 = Ops[2];
+
     SPIRVInstruction::validate();
     if (getValue(Condition)->isForward() || getValue(Op1)->isForward() ||
         getValue(Op2)->isForward())
@@ -1005,10 +996,9 @@ protected:
     assert(getType() == getValueType(Op1) && getType() == getValueType(Op2) &&
            "Inconsistent type");
   }
-  SPIRVId Condition;
-  SPIRVId Op1;
-  SPIRVId Op2;
 };
+
+typedef SPIRVInstTemplate<SPIRVSelectBase, OpSelect, true, 6> SPIRVSelect;
 
 class SPIRVSelectionMerge : public SPIRVInstruction {
 public:
@@ -1898,86 +1888,57 @@ protected:
   std::vector<SPIRVId> Constituents;
 };
 
-class SPIRVCompositeExtract : public SPIRVInstruction {
+class SPIRVCompositeExtractBase : public SPIRVInstTemplateBase {
 public:
-  const static Op OC = OpCompositeExtract;
-  // Complete constructor
-  SPIRVCompositeExtract(SPIRVType *TheType, SPIRVId TheId, SPIRVId TheComposite,
-                        const std::vector<SPIRVWord> &TheIndices,
-                        SPIRVBasicBlock *TheBB, SPIRVModule *TheM)
-      : SPIRVInstruction(TheIndices.size() + 4, OC, TheType, TheId, TheBB,
-                         TheM),
-        Composite(TheComposite), Indices(TheIndices) {
-    validate();
+  SPIRVValue *getComposite() { return getValue(Ops[0]); }
+  const std::vector<SPIRVWord> getIndices() const {
+    return std::vector<SPIRVWord>(Ops.begin() + 1, Ops.end());
   }
-  // Incomplete constructor
-  SPIRVCompositeExtract() : SPIRVInstruction(OC), Composite(SPIRVID_INVALID) {}
-
-  SPIRVValue *getComposite() { return getValue(Composite); }
-  const std::vector<SPIRVWord> &getIndices() const { return Indices; }
 
 protected:
-  void setWordCount(SPIRVWord TheWordCount) override {
-    SPIRVEntry::setWordCount(TheWordCount);
-    Indices.resize(TheWordCount - 4);
-  }
-  _SPIRV_DEF_ENCDEC4(Type, Id, Composite, Indices)
   // ToDo: validate the result type is consistent with the base type and indices
   // need to trace through the base type for struct types
   void validate() const override {
     SPIRVInstruction::validate();
+    assert(OpCode == OpCompositeExtract);
+    SPIRVId Composite = Ops[0];
+    (void)Composite;
     assert(getValueType(Composite)->isTypeArray() ||
            getValueType(Composite)->isTypeStruct() ||
            getValueType(Composite)->isTypeVector());
   }
-  SPIRVId Composite;
-  std::vector<SPIRVWord> Indices;
 };
 
-class SPIRVCompositeInsert : public SPIRVInstruction {
-public:
-  const static Op OC = OpCompositeInsert;
-  const static SPIRVWord FixedWordCount = 5;
-  // Complete constructor
-  SPIRVCompositeInsert(SPIRVType *TheType, SPIRVId TheId, SPIRVId TheObject,
-                       SPIRVId TheComposite,
-                       const std::vector<SPIRVWord> &TheIndices,
-                       SPIRVBasicBlock *TheBB, SPIRVModule *TheM)
-      : SPIRVInstruction(TheIndices.size() + FixedWordCount, OC, TheType, TheId,
-                         TheBB, TheM),
-        Object(TheObject), Composite(TheComposite), Indices(TheIndices) {
-    validate();
-  }
-  // Incomplete constructor
-  SPIRVCompositeInsert()
-      : SPIRVInstruction(OC), Object(SPIRVID_INVALID),
-        Composite(SPIRVID_INVALID) {}
+typedef SPIRVInstTemplate<SPIRVCompositeExtractBase, OpCompositeExtract, true,
+                          4, true>
+    SPIRVCompositeExtract;
 
-  SPIRVValue *getObject() { return getValue(Object); }
-  SPIRVValue *getComposite() { return getValue(Composite); }
-  const std::vector<SPIRVWord> &getIndices() const { return Indices; }
+class SPIRVCompositeInsertBase : public SPIRVInstTemplateBase {
+public:
+  SPIRVValue *getObject() { return getValue(Ops[0]); }
+  SPIRVValue *getComposite() { return getValue(Ops[1]); }
+  const std::vector<SPIRVWord> getIndices() const {
+    return std::vector<SPIRVWord>(Ops.begin() + 2, Ops.end());
+  }
 
 protected:
-  void setWordCount(SPIRVWord TheWordCount) override {
-    SPIRVEntry::setWordCount(TheWordCount);
-    Indices.resize(TheWordCount - FixedWordCount);
-  }
-  _SPIRV_DEF_ENCDEC5(Type, Id, Object, Composite, Indices)
   // ToDo: validate the object type is consistent with the base type and indices
   // need to trace through the base type for struct types
   void validate() const override {
     SPIRVInstruction::validate();
-    assert(OpCode == OC);
-    assert(WordCount == Indices.size() + FixedWordCount);
+    assert(OpCode == OpCompositeInsert);
+    SPIRVId Composite = Ops[1];
+    (void)Composite;
     assert(getValueType(Composite)->isTypeArray() ||
            getValueType(Composite)->isTypeStruct() ||
            getValueType(Composite)->isTypeVector());
     assert(Type == getValueType(Composite));
   }
-  SPIRVId Object;
-  SPIRVId Composite;
-  std::vector<SPIRVWord> Indices;
 };
+
+typedef SPIRVInstTemplate<SPIRVCompositeInsertBase, OpCompositeInsert, true, 5,
+                          true>
+    SPIRVCompositeInsert;
 
 class SPIRVCopyObject : public SPIRVInstruction {
 public:
@@ -2175,51 +2136,33 @@ protected:
   SPIRVId ComponentId;
 };
 
-class SPIRVVectorShuffle : public SPIRVInstruction {
+class SPIRVVectorShuffleBase : public SPIRVInstTemplateBase {
 public:
-  const static Op OC = OpVectorShuffle;
-  const static SPIRVWord FixedWordCount = 5;
-  // Complete constructor
-  SPIRVVectorShuffle(SPIRVId TheId, SPIRVType *TheType, SPIRVId TheVector1,
-                     SPIRVId TheVector2,
-                     const std::vector<SPIRVWord> &TheComponents,
-                     SPIRVBasicBlock *TheBB, SPIRVModule *TheM)
-      : SPIRVInstruction(TheComponents.size() + FixedWordCount, OC, TheType,
-                         TheId, TheBB, TheM),
-        Vector1(TheVector1), Vector2(TheVector2), Components(TheComponents) {
-    validate();
+  SPIRVValue *getVector1() { return getValue(Ops[0]); }
+  SPIRVValue *getVector2() { return getValue(Ops[1]); }
+  const std::vector<SPIRVWord> getComponents() const {
+    return std::vector<SPIRVWord>(Ops.begin() + 2, Ops.end());
   }
-  // Incomplete constructor
-  SPIRVVectorShuffle()
-      : SPIRVInstruction(OC), Vector1(SPIRVID_INVALID),
-        Vector2(SPIRVID_INVALID) {}
-
-  SPIRVValue *getVector1() { return getValue(Vector1); }
-  SPIRVValue *getVector2() { return getValue(Vector2); }
-  const std::vector<SPIRVWord> &getComponents() const { return Components; }
 
 protected:
-  void setWordCount(SPIRVWord TheWordCount) override {
-    SPIRVEntry::setWordCount(TheWordCount);
-    Components.resize(TheWordCount - FixedWordCount);
-  }
-  _SPIRV_DEF_ENCDEC5(Type, Id, Vector1, Vector2, Components)
   void validate() const override {
     SPIRVInstruction::validate();
-    assert(OpCode == OC);
-    assert(WordCount == Components.size() + FixedWordCount);
+    SPIRVId Vector1 = Ops[0];
+    SPIRVId Vector2 = Ops[1];
+    assert(OpCode == OpVectorShuffle);
     assert(Type->isTypeVector());
     assert(Type->getVectorComponentType() ==
            getValueType(Vector1)->getVectorComponentType());
     if (getValue(Vector1)->isForward() || getValue(Vector2)->isForward())
       return;
     assert(getValueType(Vector1) == getValueType(Vector2));
-    assert(Components.size() == Type->getVectorComponentCount());
+    assert(Ops.size() - 2 == Type->getVectorComponentCount());
   }
-  SPIRVId Vector1;
-  SPIRVId Vector2;
-  std::vector<SPIRVWord> Components;
 };
+
+typedef SPIRVInstTemplate<SPIRVVectorShuffleBase, OpVectorShuffle, true, 5,
+                          true>
+    SPIRVVectorShuffle;
 
 class SPIRVControlBarrier : public SPIRVInstruction {
 public:

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1382,9 +1382,11 @@ SPIRVInstruction *SPIRVModuleImpl::addVectorInsertDynamicInst(
 SPIRVValue *SPIRVModuleImpl::addVectorShuffleInst(
     SPIRVType *Type, SPIRVValue *Vec1, SPIRVValue *Vec2,
     const std::vector<SPIRVWord> &Components, SPIRVBasicBlock *BB) {
-  return addInstruction(new SPIRVVectorShuffle(getId(), Type, Vec1->getId(),
-                                               Vec2->getId(), Components, BB,
-                                               this),
+  std::vector<SPIRVId> Ops{Vec1->getId(), Vec2->getId()};
+  Ops.insert(Ops.end(), Components.begin(), Components.end());
+
+  return addInstruction(SPIRVInstTemplateBase::create(OpVectorShuffle, Type,
+                                                      getId(), Ops, BB, this),
                         BB);
 }
 
@@ -1441,10 +1443,11 @@ SPIRVInstruction *SPIRVModuleImpl::addSelectInst(SPIRVValue *Condition,
                                                  SPIRVValue *Op1,
                                                  SPIRVValue *Op2,
                                                  SPIRVBasicBlock *BB) {
-  return addInstruction(new SPIRVSelect(getId(), Op1->getType(),
-                                        Condition->getId(), Op1->getId(),
-                                        Op2->getId(), BB, this),
-                        BB);
+  return addInstruction(
+      SPIRVInstTemplateBase::create(
+          OpSelect, Op1->getType(), getId(),
+          getVec(Condition->getId(), Op1->getId(), Op2->getId()), BB, this),
+      BB);
 }
 
 SPIRVInstruction *SPIRVModuleImpl::addSelectionMergeInst(
@@ -1526,19 +1529,21 @@ SPIRVInstruction *
 SPIRVModuleImpl::addCompositeExtractInst(SPIRVType *Type, SPIRVValue *TheVector,
                                          const std::vector<SPIRVWord> &Indices,
                                          SPIRVBasicBlock *BB) {
-  return addInstruction(new SPIRVCompositeExtract(Type, getId(),
-                                                  TheVector->getId(), Indices,
-                                                  BB, this),
+  return addInstruction(SPIRVInstTemplateBase::create(
+                            OpCompositeExtract, Type, getId(),
+                            getVec(TheVector->getId(), Indices), BB, this),
                         BB);
 }
 
 SPIRVInstruction *SPIRVModuleImpl::addCompositeInsertInst(
     SPIRVValue *Object, SPIRVValue *Composite,
     const std::vector<SPIRVWord> &Indices, SPIRVBasicBlock *BB) {
-  return addInstruction(
-      new SPIRVCompositeInsert(Composite->getType(), getId(), Object->getId(),
-                               Composite->getId(), Indices, BB, this),
-      BB);
+  std::vector<SPIRVId> Ops{Object->getId(), Composite->getId()};
+  Ops.insert(Ops.end(), Indices.begin(), Indices.end());
+  return addInstruction(SPIRVInstTemplateBase::create(OpCompositeInsert,
+                                                      Composite->getType(),
+                                                      getId(), Ops, BB, this),
+                        BB);
 }
 
 SPIRVInstruction *SPIRVModuleImpl::addCopyObjectInst(SPIRVType *TheType,


### PR DESCRIPTION
Make the following classes inherit from SPIRVInstTemplateBase:
 - SPIRVSelect
 - SPIRVVectorShuffle
 - SPIRVCompositeExtract
 - SPIRVCompositeInsert

This allows removing a switch on opcode in SPIRVInstruction.cpp.

With SPIRVSelect inheriting from SPIRVInstTemplateBase, an
OpSelect case in SPIRVWriter.cpp can now be handled through
the switch default.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1072