### PR TITLE
[NFC] Move FPGA memory access enum definition

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -101,6 +101,13 @@ enum OCLMemOrderKind {
   OCLMO_seq_cst = std::memory_order::memory_order_seq_cst
 };
 
+enum IntelFPGAMemoryAccessesVal {
+  BurstCoalesce = 0x1,
+  CacheSizeFlag = 0x2,
+  DontStaticallyCoalesce = 0x4,
+  PrefetchFlag = 0x8
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 // Types
@@ -310,13 +317,6 @@ const OCLMemOrderKind OCLLegacyAtomicMemOrder = OCLMO_relaxed;
 
 /// OCL 1.x atomic memory scope when translated to 2.0 atomics.
 const OCLScopeKind OCLLegacyAtomicMemScope = OCLMS_work_group;
-
-enum IntelFPGAMemoryAccessesVal {
-  BurstCoalesce = 0x1,
-  CacheSizeFlag = 0x2,
-  DontStaticallyCoalesce = 0x4,
-  PrefetchFlag = 0x8
-};
 
 namespace kOCLVer {
 const unsigned CL12 = 102000;


### PR DESCRIPTION
Since there's a dedicated `// Enums` section in the `OCLUtil.h` header,
move the enum definition there.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>