### PR TITLE
Update spirv.hpp

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -65,12 +65,12 @@ inline bool isValid(spv::ExecutionModel V) {
   case ExecutionModelKernel:
   case ExecutionModelTaskNV:
   case ExecutionModelMeshNV:
-  case ExecutionModelRayGenerationNV:
-  case ExecutionModelIntersectionNV:
-  case ExecutionModelAnyHitNV:
-  case ExecutionModelClosestHitNV:
-  case ExecutionModelMissNV:
-  case ExecutionModelCallableNV:
+  case ExecutionModelRayGenerationKHR:
+  case ExecutionModelIntersectionKHR:
+  case ExecutionModelAnyHitKHR:
+  case ExecutionModelClosestHitKHR:
+  case ExecutionModelMissKHR:
+  case ExecutionModelCallableKHR:
     return true;
   default:
     return false;
@@ -116,13 +116,14 @@ inline bool isValid(spv::StorageClass V) {
   case StorageClassAtomicCounter:
   case StorageClassImage:
   case StorageClassStorageBuffer:
-  case StorageClassCallableDataNV:
-  case StorageClassIncomingCallableDataNV:
-  case StorageClassRayPayloadNV:
-  case StorageClassHitAttributeNV:
-  case StorageClassIncomingRayPayloadNV:
-  case StorageClassShaderRecordBufferNV:
+  case StorageClassCallableDataKHR:
+  case StorageClassIncomingCallableDataKHR:
+  case StorageClassRayPayloadKHR:
+  case StorageClassHitAttributeKHR:
+  case StorageClassIncomingRayPayloadKHR:
+  case StorageClassShaderRecordBufferKHR:
   case StorageClassPhysicalStorageBuffer:
+  case StorageClassCodeSectionINTEL:
   case StorageClassDeviceOnlyINTEL:
   case StorageClassHostOnlyINTEL:
     return true;
@@ -222,8 +223,10 @@ inline bool isValid(spv::BuiltIn V) {
   case BuiltInBaseVertex:
   case BuiltInBaseInstance:
   case BuiltInDrawIndex:
+  case BuiltInPrimitiveShadingRateKHR:
   case BuiltInDeviceIndex:
   case BuiltInViewIndex:
+  case BuiltInShadingRateKHR:
   case BuiltInBaryCoordNoPerspAMD:
   case BuiltInBaryCoordNoPerspCentroidAMD:
   case BuiltInBaryCoordNoPerspSampleAMD:
@@ -250,20 +253,21 @@ inline bool isValid(spv::BuiltIn V) {
   case BuiltInBaryCoordNoPerspNV:
   case BuiltInFragSizeEXT:
   case BuiltInFragInvocationCountEXT:
-  case BuiltInLaunchIdNV:
-  case BuiltInLaunchSizeNV:
-  case BuiltInWorldRayOriginNV:
-  case BuiltInWorldRayDirectionNV:
-  case BuiltInObjectRayOriginNV:
-  case BuiltInObjectRayDirectionNV:
-  case BuiltInRayTminNV:
-  case BuiltInRayTmaxNV:
-  case BuiltInInstanceCustomIndexNV:
-  case BuiltInObjectToWorldNV:
-  case BuiltInWorldToObjectNV:
+  case BuiltInLaunchIdKHR:
+  case BuiltInLaunchSizeKHR:
+  case BuiltInWorldRayOriginKHR:
+  case BuiltInWorldRayDirectionKHR:
+  case BuiltInObjectRayOriginKHR:
+  case BuiltInObjectRayDirectionKHR:
+  case BuiltInRayTminKHR:
+  case BuiltInRayTmaxKHR:
+  case BuiltInInstanceCustomIndexKHR:
+  case BuiltInObjectToWorldKHR:
+  case BuiltInWorldToObjectKHR:
   case BuiltInHitTNV:
-  case BuiltInHitKindNV:
-  case BuiltInIncomingRayFlagsNV:
+  case BuiltInHitKindKHR:
+  case BuiltInIncomingRayFlagsKHR:
+  case BuiltInRayGeometryIndexKHR:
   case BuiltInWarpsPerSMNV:
   case BuiltInSMCountNV:
   case BuiltInWarpIDNV:

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -130,6 +130,7 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationAliasedPointerEXT, "AliasedPointerEXT");
   add(DecorationSIMTCallINTEL, "SIMTCallINTEL");
   add(DecorationReferencedIndirectlyINTEL, "ReferencedIndirectlyINTEL");
+  add(DecorationClobberINTEL, "ClobberINTEL");
   add(DecorationSideEffectsINTEL, "SideEffectsINTEL");
   add(DecorationVectorComputeVariableINTEL, "VectorComputeVariableINTEL");
   add(DecorationFuncParamIOKindINTEL, "FuncParamIOKind");
@@ -159,20 +160,25 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationCacheSizeINTEL, "CacheSizeINTEL");
   add(DecorationDontStaticallyCoalesceINTEL, "DontStaticallyCoalesceINTEL");
   add(DecorationPrefetchINTEL, "PrefetchINTEL");
+  add(DecorationStallEnableINTEL, "StallEnableINTEL");
+  add(DecorationFuseLoopsInFunctionINTEL, "FuseLoopsInFunctionINTEL");
   add(DecorationBufferLocationINTEL, "BufferLocationINTEL");
   add(DecorationIOPipeStorageINTEL, "IOPipeStorageINTEL");
   add(DecorationFunctionFloatingPointModeINTEL,
       "FunctionFloatingPointModeINTEL");
   add(DecorationSingleElementVectorINTEL, "SingleElementVectorINTEL");
+  add(DecorationVectorComputeCallableFunctionINTEL,
+      "VectorComputeCallableFunctionINTEL");
+
+  // From spirv_internal.hpp
   add(internal::DecorationCallableFunctionINTEL, "CallableFunctionINTEL");
-  add(DecorationStallEnableINTEL, "StallEnableINTEL");
-  add(DecorationFuseLoopsInFunctionINTEL, "FuseLoopsInFunctionINTEL");
   add(internal::DecorationMathOpDSPModeINTEL, "MathOpDSPModeINTEL");
   add(internal::DecorationAliasScopeINTEL, "AliasScopeINTEL");
   add(internal::DecorationNoAliasINTEL, "NoAliasINTEL");
   add(internal::DecorationInitiationIntervalINTEL, "InitiationIntervalINTEL");
   add(internal::DecorationMaxConcurrencyINTEL, "MaxConcurrencyINTEL");
   add(internal::DecorationPipelineEnableINTEL, "PipelineEnableINTEL");
+
   add(DecorationMax, "Max");
 }
 SPIRV_DEF_NAMEMAP(Decoration, SPIRVDecorationNameMap)
@@ -232,8 +238,10 @@ template <> inline void SPIRVMap<BuiltIn, std::string>::init() {
   add(BuiltInBaseVertex, "BuiltInBaseVertex");
   add(BuiltInBaseInstance, "BuiltInBaseInstance");
   add(BuiltInDrawIndex, "BuiltInDrawIndex");
+  add(BuiltInPrimitiveShadingRateKHR, "BuiltInPrimitiveShadingRateKHR");
   add(BuiltInDeviceIndex, "BuiltInDeviceIndex");
   add(BuiltInViewIndex, "BuiltInViewIndex");
+  add(BuiltInShadingRateKHR, "BuiltInShadingRateKHR");
   add(BuiltInBaryCoordNoPerspAMD, "BuiltInBaryCoordNoPerspAMD");
   add(BuiltInBaryCoordNoPerspCentroidAMD, "BuiltInBaryCoordNoPerspCentroidAMD");
   add(BuiltInBaryCoordNoPerspSampleAMD, "BuiltInBaryCoordNoPerspSampleAMD");
@@ -262,20 +270,34 @@ template <> inline void SPIRVMap<BuiltIn, std::string>::init() {
   add(BuiltInFragmentSizeNV, "BuiltInFragmentSizeNV");
   add(BuiltInFragInvocationCountEXT, "BuiltInFragInvocationCountEXT");
   add(BuiltInInvocationsPerPixelNV, "BuiltInInvocationsPerPixelNV");
+  add(BuiltInLaunchIdKHR, "BuiltInLaunchIdKHR");
   add(BuiltInLaunchIdNV, "BuiltInLaunchIdNV");
+  add(BuiltInLaunchSizeKHR, "BuiltInLaunchSizeKHR");
   add(BuiltInLaunchSizeNV, "BuiltInLaunchSizeNV");
+  add(BuiltInWorldRayOriginKHR, "BuiltInWorldRayOriginKHR");
   add(BuiltInWorldRayOriginNV, "BuiltInWorldRayOriginNV");
+  add(BuiltInWorldRayDirectionKHR, "BuiltInWorldRayDirectionKHR");
   add(BuiltInWorldRayDirectionNV, "BuiltInWorldRayDirectionNV");
+  add(BuiltInObjectRayOriginKHR, "BuiltInObjectRayOriginKHR");
   add(BuiltInObjectRayOriginNV, "BuiltInObjectRayOriginNV");
+  add(BuiltInObjectRayDirectionKHR, "BuiltInObjectRayDirectionKHR");
   add(BuiltInObjectRayDirectionNV, "BuiltInObjectRayDirectionNV");
+  add(BuiltInRayTminKHR, "BuiltInRayTminKHR");
   add(BuiltInRayTminNV, "BuiltInRayTminNV");
+  add(BuiltInRayTmaxKHR, "BuiltInRayTmaxKHR");
   add(BuiltInRayTmaxNV, "BuiltInRayTmaxNV");
+  add(BuiltInInstanceCustomIndexKHR, "BuiltInInstanceCustomIndexKHR");
   add(BuiltInInstanceCustomIndexNV, "BuiltInInstanceCustomIndexNV");
+  add(BuiltInObjectToWorldKHR, "BuiltInObjectToWorldKHR");
   add(BuiltInObjectToWorldNV, "BuiltInObjectToWorldNV");
+  add(BuiltInWorldToObjectKHR, "BuiltInWorldToObjectKHR");
   add(BuiltInWorldToObjectNV, "BuiltInWorldToObjectNV");
   add(BuiltInHitTNV, "BuiltInHitTNV");
+  add(BuiltInHitKindKHR, "BuiltInHitKindKHR");
   add(BuiltInHitKindNV, "BuiltInHitKindNV");
+  add(BuiltInIncomingRayFlagsKHR, "BuiltInIncomingRayFlagsKHR");
   add(BuiltInIncomingRayFlagsNV, "BuiltInIncomingRayFlagsNV");
+  add(BuiltInRayGeometryIndexKHR, "BuiltInRayGeometryIndexKHR");
   add(BuiltInWarpsPerSMNV, "BuiltInWarpsPerSMNV");
   add(BuiltInSMCountNV, "BuiltInSMCountNV");
   add(BuiltInWarpIDNV, "BuiltInWarpIDNV");
@@ -360,8 +382,15 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilityGroupNonUniformQuad, "GroupNonUniformQuad");
   add(CapabilityShaderLayer, "ShaderLayer");
   add(CapabilityShaderViewportIndex, "ShaderViewportIndex");
+  add(CapabilityFragmentShadingRateKHR, "FragmentShadingRateKHR");
   add(CapabilitySubgroupBallotKHR, "SubgroupBallotKHR");
   add(CapabilityDrawParameters, "DrawParameters");
+  add(CapabilityWorkgroupMemoryExplicitLayoutKHR,
+      "WorkgroupMemoryExplicitLayoutKHR");
+  add(CapabilityWorkgroupMemoryExplicitLayout8BitAccessKHR,
+      "WorkgroupMemoryExplicitLayout8BitAccessKHR");
+  add(CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR,
+      "WorkgroupMemoryExplicitLayout16BitAccessKHR");
   add(CapabilitySubgroupVoteKHR, "SubgroupVoteKHR");
   add(CapabilityStorageBuffer16BitAccess, "StorageBuffer16BitAccess");
   add(CapabilityStorageUniformBufferBlock16, "StorageUniformBufferBlock16");
@@ -385,11 +414,17 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilitySignedZeroInfNanPreserve, "SignedZeroInfNanPreserve");
   add(CapabilityRoundingModeRTE, "RoundingModeRTE");
   add(CapabilityRoundingModeRTZ, "RoundingModeRTZ");
+  add(CapabilityRayQueryProvisionalKHR, "RayQueryProvisionalKHR");
+  add(CapabilityRayQueryKHR, "RayQueryKHR");
+  add(CapabilityRayTraversalPrimitiveCullingKHR,
+      "RayTraversalPrimitiveCullingKHR");
+  add(CapabilityRayTracingKHR, "RayTracingKHR");
   add(CapabilityFloat16ImageAMD, "Float16ImageAMD");
   add(CapabilityImageGatherBiasLodAMD, "ImageGatherBiasLodAMD");
   add(CapabilityFragmentMaskAMD, "FragmentMaskAMD");
   add(CapabilityStencilExportEXT, "StencilExportEXT");
   add(CapabilityImageReadWriteLodAMD, "ImageReadWriteLodAMD");
+  add(CapabilityInt64ImageEXT, "Int64ImageEXT");
   add(CapabilityShaderClockKHR, "ShaderClockKHR");
   add(CapabilitySampleMaskOverrideCoverageNV, "SampleMaskOverrideCoverageNV");
   add(CapabilityGeometryShaderPassthroughNV, "GeometryShaderPassthroughNV");
@@ -460,13 +495,9 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
       "PhysicalStorageBufferAddresses");
   add(CapabilityPhysicalStorageBufferAddressesEXT,
       "PhysicalStorageBufferAddressesEXT");
-  add(CapabilityAtomicFloat32AddEXT, "AtomicFloat32AddEXT");
-  add(CapabilityAtomicFloat64AddEXT, "AtomicFloat64AddEXT");
-  add(CapabilityAtomicFloat32MinMaxEXT, "AtomicFloat32MinMaxEXT");
-  add(CapabilityAtomicFloat64MinMaxEXT, "AtomicFloat64MinMaxEXT");
-  add(CapabilityAtomicFloat16MinMaxEXT, "AtomicFloat16MinMaxEXT");
   add(CapabilityComputeDerivativeGroupLinearNV,
       "ComputeDerivativeGroupLinearNV");
+  add(CapabilityRayTracingProvisionalKHR, "RayTracingProvisionalKHR");
   add(CapabilityCooperativeMatrixNV, "CooperativeMatrixNV");
   add(CapabilityFragmentShaderSampleInterlockEXT,
       "FragmentShaderSampleInterlockEXT");
@@ -487,6 +518,9 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilityFunctionPointersINTEL, "FunctionPointersINTEL");
   add(CapabilityIndirectReferencesINTEL, "IndirectReferencesINTEL");
   add(CapabilityAsmINTEL, "AsmINTEL");
+  add(CapabilityAtomicFloat32MinMaxEXT, "AtomicFloat32MinMaxEXT");
+  add(CapabilityAtomicFloat64MinMaxEXT, "AtomicFloat64MinMaxEXT");
+  add(CapabilityAtomicFloat16MinMaxEXT, "AtomicFloat16MinMaxEXT");
   add(CapabilityVectorComputeINTEL, "VectorComputeINTEL");
   add(CapabilityVectorAnyINTEL, "VectorAnyINTEL");
   add(CapabilityExpectAssumeKHR, "ExpectAssumeKHR");
@@ -506,21 +540,30 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
       "ArbitraryPrecisionFloatingPointINTEL");
   add(CapabilityUnstructuredLoopControlsINTEL, "UnstructuredLoopControlsINTEL");
   add(CapabilityFPGALoopControlsINTEL, "FPGALoopControlsINTEL");
-  add(CapabilityBlockingPipesINTEL, "BlockingPipesINTEL");
-  add(CapabilityFPGARegINTEL, "FPGARegINTEL");
   add(CapabilityKernelAttributesINTEL, "KernelAttributesINTEL");
   add(CapabilityFPGAKernelAttributesINTEL, "FPGAKernelAttributesINTEL");
+  add(CapabilityFPGAMemoryAccessesINTEL, "FPGAMemoryAccessesINTEL");
+  add(CapabilityFPGAClusterAttributesINTEL, "FPGAClusterAttributesINTEL");
+  add(CapabilityLoopFuseINTEL, "LoopFuseINTEL");
   add(CapabilityFPGABufferLocationINTEL, "FPGABufferLocationINTEL");
   add(CapabilityArbitraryPrecisionFixedPointINTEL,
       "ArbitraryPrecisionFixedPointINTEL");
   add(CapabilityUSMStorageClassesINTEL, "USMStorageClassesINTEL");
-  add(CapabilityFPGAMemoryAccessesINTEL, "FPGAMemoryAccessesINTEL");
   add(CapabilityIOPipesINTEL, "IOPipeINTEL");
-  add(CapabilityFPGAClusterAttributesINTEL, "FPGAClusterAttributesINTEL");
-  add(CapabilityLoopFuseINTEL, "LoopFuseINTEL");
-  add(CapabilityMax, "Max");
-  add(internal::CapabilityFPGADSPControlINTEL, "FPGADSPControlINTEL");
+  add(CapabilityBlockingPipesINTEL, "BlockingPipesINTEL");
+  add(CapabilityFPGARegINTEL, "FPGARegINTEL");
+  add(CapabilityDotProductInputAllKHR, "DotProductInputAllKHR");
+  add(CapabilityDotProductInput4x8BitKHR, "DotProductInput4x8BitKHR");
+  add(CapabilityDotProductInput4x8BitPackedKHR,
+      "DotProductInput4x8BitPackedKHR");
+  add(CapabilityDotProductKHR, "DotProductKHR");
+  add(CapabilityAtomicFloat32AddEXT, "AtomicFloat32AddEXT");
+  add(CapabilityAtomicFloat64AddEXT, "AtomicFloat64AddEXT");
   add(CapabilityLongConstantCompositeINTEL, "LongConstantCompositeINTEL");
+  add(CapabilityAtomicFloat16AddEXT, "AtomicFloat16AddEXT");
+
+  // From spirv_internal.hpp
+  add(internal::CapabilityFPGADSPControlINTEL, "FPGADSPControlINTEL");
   add(internal::CapabilityFastCompositeINTEL, "FastCompositeINTEL");
   add(internal::CapabilityOptNoneINTEL, "OptNoneINTEL");
   add(internal::CapabilityMemoryAccessAliasingINTEL,
@@ -528,6 +571,8 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(internal::CapabilityFPGAInvocationPipeliningAttributesINTEL,
       "FPGAInvocationPipeliningAttributesINTEL");
   add(internal::CapabilityTokenTypeINTEL, "TokenTypeINTEL");
+
+  add(CapabilityMax, "Max");
 }
 SPIRV_DEF_NAMEMAP(Capability, SPIRVCapabilityNameMap)
 

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -65,6 +65,7 @@ enum SourceLanguage {
     SourceLanguageOpenCL_C = 3,
     SourceLanguageOpenCL_CPP = 4,
     SourceLanguageHLSL = 5,
+    SourceLanguageCPP_for_OpenCL = 6,
     SourceLanguageMax = 0x7fffffff,
 };
 
@@ -150,6 +151,7 @@ enum ExecutionMode {
     ExecutionModeSubgroupsPerWorkgroupId = 37,
     ExecutionModeLocalSizeId = 38,
     ExecutionModeLocalSizeHintId = 39,
+    ExecutionModeSubgroupUniformControlFlowKHR = 4421,
     ExecutionModePostDepthCoverage = 4446,
     ExecutionModeDenormPreserve = 4459,
     ExecutionModeDenormFlushToZero = 4460,
@@ -406,18 +408,6 @@ enum FPRoundingMode {
     FPRoundingModeMax = 0x7fffffff,
 };
 
-enum FPDenormMode {
-    FPDenormModePreserve = 0,
-    FPDenormModeFlushToZero = 1,
-    FPDenormModeMax = 0x7fffffff,
-};
-
-enum FPOperationMode {
-    FPOperationModeIEEE = 0,
-    FPOperationModeALT = 1,
-    FPOperationModeMax = 0x7fffffff,
-};
-
 enum LinkageType {
     LinkageTypeExport = 0,
     LinkageTypeImport = 1,
@@ -547,6 +537,7 @@ enum Decoration {
     DecorationIOPipeStorageINTEL = 5944,
     DecorationFunctionFloatingPointModeINTEL = 6080,
     DecorationSingleElementVectorINTEL = 6085,
+    DecorationVectorComputeCallableFunctionINTEL = 6087,
     DecorationMax = 0x7fffffff,
 };
 
@@ -923,6 +914,9 @@ enum Capability {
     CapabilityFragmentShadingRateKHR = 4422,
     CapabilitySubgroupBallotKHR = 4423,
     CapabilityDrawParameters = 4427,
+    CapabilityWorkgroupMemoryExplicitLayoutKHR = 4428,
+    CapabilityWorkgroupMemoryExplicitLayout8BitAccessKHR = 4429,
+    CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR = 4430,
     CapabilitySubgroupVoteKHR = 4431,
     CapabilityStorageBuffer16BitAccess = 4433,
     CapabilityStorageUniformBufferBlock16 = 4433,
@@ -1047,9 +1041,14 @@ enum Capability {
     CapabilityIOPipesINTEL = 5943,
     CapabilityBlockingPipesINTEL = 5945,
     CapabilityFPGARegINTEL = 5948,
+    CapabilityDotProductInputAllKHR = 6016,
+    CapabilityDotProductInput4x8BitKHR = 6017,
+    CapabilityDotProductInput4x8BitPackedKHR = 6018,
+    CapabilityDotProductKHR = 6019,
     CapabilityAtomicFloat32AddEXT = 6033,
     CapabilityAtomicFloat64AddEXT = 6034,
     CapabilityLongConstantCompositeINTEL = 6089,
+    CapabilityAtomicFloat16AddEXT = 6095,
     CapabilityMax = 0x7fffffff,
 };
 
@@ -1114,6 +1113,43 @@ enum FragmentShadingRateMask {
     FragmentShadingRateVertical4PixelsMask = 0x00000002,
     FragmentShadingRateHorizontal2PixelsMask = 0x00000004,
     FragmentShadingRateHorizontal4PixelsMask = 0x00000008,
+};
+
+enum FPDenormMode {
+    FPDenormModePreserve = 0,
+    FPDenormModeFlushToZero = 1,
+    FPDenormModeMax = 0x7fffffff,
+};
+
+enum FPOperationMode {
+    FPOperationModeIEEE = 0,
+    FPOperationModeALT = 1,
+    FPOperationModeMax = 0x7fffffff,
+};
+
+enum QuantizationModes {
+    QuantizationModesTRN = 0,
+    QuantizationModesTRN_ZERO = 1,
+    QuantizationModesRND = 2,
+    QuantizationModesRND_ZERO = 3,
+    QuantizationModesRND_INF = 4,
+    QuantizationModesRND_MIN_INF = 5,
+    QuantizationModesRND_CONV = 6,
+    QuantizationModesRND_CONV_ODD = 7,
+    QuantizationModesMax = 0x7fffffff,
+};
+
+enum OverflowModes {
+    OverflowModesWRAP = 0,
+    OverflowModesSAT = 1,
+    OverflowModesSAT_ZERO = 2,
+    OverflowModesSAT_SYM = 3,
+    OverflowModesMax = 0x7fffffff,
+};
+
+enum PackedVectorFormat {
+    PackedVectorFormatPackedVectorFormat4x8BitKHR = 0,
+    PackedVectorFormatMax = 0x7fffffff,
 };
 
 enum Op {
@@ -1473,6 +1509,12 @@ enum Op {
     OpConvertUToAccelerationStructureKHR = 4447,
     OpIgnoreIntersectionKHR = 4448,
     OpTerminateRayKHR = 4449,
+    OpSDotKHR = 4450,
+    OpUDotKHR = 4451,
+    OpSUDotKHR = 4452,
+    OpSDotAccSatKHR = 4453,
+    OpUDotAccSatKHR = 4454,
+    OpSUDotAccSatKHR = 4455,
     OpTypeRayQueryKHR = 4472,
     OpRayQueryInitializeKHR = 4473,
     OpRayQueryTerminateKHR = 4474,
@@ -1785,7 +1827,6 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpTypeArray: *hasResult = true; *hasResultType = false; break;
     case OpTypeRuntimeArray: *hasResult = true; *hasResultType = false; break;
     case OpTypeStruct: *hasResult = true; *hasResultType = false; break;
-    case OpTypeStructContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     case OpTypeOpaque: *hasResult = true; *hasResultType = false; break;
     case OpTypePointer: *hasResult = true; *hasResultType = false; break;
     case OpTypeFunction: *hasResult = true; *hasResultType = false; break;
@@ -1799,8 +1840,6 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpConstantFalse: *hasResult = true; *hasResultType = true; break;
     case OpConstant: *hasResult = true; *hasResultType = true; break;
     case OpConstantComposite: *hasResult = true; *hasResultType = true; break;
-    case OpConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
-    case OpSpecConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     case OpConstantSampler: *hasResult = true; *hasResultType = true; break;
     case OpConstantNull: *hasResult = true; *hasResultType = true; break;
     case OpSpecConstantTrue: *hasResult = true; *hasResultType = true; break;
@@ -2116,6 +2155,12 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpConvertUToAccelerationStructureKHR: *hasResult = true; *hasResultType = true; break;
     case OpIgnoreIntersectionKHR: *hasResult = false; *hasResultType = false; break;
     case OpTerminateRayKHR: *hasResult = false; *hasResultType = false; break;
+    case OpSDotKHR: *hasResult = true; *hasResultType = true; break;
+    case OpUDotKHR: *hasResult = true; *hasResultType = true; break;
+    case OpSUDotKHR: *hasResult = true; *hasResultType = true; break;
+    case OpSDotAccSatKHR: *hasResult = true; *hasResultType = true; break;
+    case OpUDotAccSatKHR: *hasResult = true; *hasResultType = true; break;
+    case OpSUDotAccSatKHR: *hasResult = true; *hasResultType = true; break;
     case OpTypeRayQueryKHR: *hasResult = true; *hasResultType = false; break;
     case OpRayQueryInitializeKHR: *hasResult = false; *hasResultType = false; break;
     case OpRayQueryTerminateKHR: *hasResult = false; *hasResultType = false; break;
@@ -2183,6 +2228,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpAsmCallINTEL: *hasResult = true; *hasResultType = true; break;
     case OpAtomicFMinEXT: *hasResult = true; *hasResultType = true; break;
     case OpAtomicFMaxEXT: *hasResult = true; *hasResultType = true; break;
+    case OpAssumeTrueKHR: *hasResult = false; *hasResultType = false; break;
+    case OpExpectKHR: *hasResult = true; *hasResultType = true; break;
     case OpDecorateString: *hasResult = false; *hasResultType = false; break;
     case OpMemberDecorateString: *hasResult = false; *hasResultType = false; break;
     case OpVmeImageINTEL: *hasResult = true; *hasResultType = true; break;
@@ -2348,8 +2395,6 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpArbitraryFloatPowRINTEL: *hasResult = true; *hasResultType = true; break;
     case OpArbitraryFloatPowNINTEL: *hasResult = true; *hasResultType = true; break;
     case OpLoopControlINTEL: *hasResult = false; *hasResultType = false; break;
-    case OpPtrCastToCrossWorkgroupINTEL: *hasResult = true; *hasResultType = true; break;
-    case OpCrossWorkgroupCastToPtrINTEL: *hasResult = true; *hasResultType = true; break;
     case OpFixedSqrtINTEL: *hasResult = true; *hasResultType = true; break;
     case OpFixedRecipINTEL: *hasResult = true; *hasResultType = true; break;
     case OpFixedRsqrtINTEL: *hasResult = true; *hasResultType = true; break;
@@ -2361,6 +2406,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpFixedSinCosPiINTEL: *hasResult = true; *hasResultType = true; break;
     case OpFixedLogINTEL: *hasResult = true; *hasResultType = true; break;
     case OpFixedExpINTEL: *hasResult = true; *hasResultType = true; break;
+    case OpPtrCastToCrossWorkgroupINTEL: *hasResult = true; *hasResultType = true; break;
+    case OpCrossWorkgroupCastToPtrINTEL: *hasResult = true; *hasResultType = true; break;
     case OpReadPipeBlockingINTEL: *hasResult = true; *hasResultType = true; break;
     case OpWritePipeBlockingINTEL: *hasResult = true; *hasResultType = true; break;
     case OpFPGARegINTEL: *hasResult = true; *hasResultType = true; break;
@@ -2383,6 +2430,9 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
     case OpRayQueryGetIntersectionWorldToObjectKHR: *hasResult = true; *hasResultType = true; break;
     case OpAtomicFAddEXT: *hasResult = true; *hasResultType = true; break;
     case OpTypeBufferSurfaceINTEL: *hasResult = true; *hasResultType = false; break;
+    case OpTypeStructContinuedINTEL: *hasResult = false; *hasResultType = false; break;
+    case OpConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
+    case OpSpecConstantCompositeContinuedINTEL: *hasResult = false; *hasResultType = false; break;
     }
 }
 #endif /* SPV_ENABLE_UTILITY_CODE */

--- a/tools/spirv-tool/gen_spirv.bash
+++ b/tools/spirv-tool/gen_spirv.bash
@@ -164,6 +164,7 @@ genFile() {
 
 #include \"SPIRVEnum.h\"
 #include \"spirv.hpp\"
+#include \"spirv_internal.hpp\"
 
 using namespace spv;
 


### PR DESCRIPTION
Bring spirv.hpp in sync with `f95c3b3 ("Merge pull request #219 from cmarcelo/SPV_EXT_shader_atomic_float16_add", 2021-06-23)` from github.com/KhronosGroup/SPIRV-Headers .

Notably, this brings the `SPV_KHR_integer_dot_product` extension enum
values and `CPP_for_OpenCL` source language enum value, together with
other additions.  There are some reorderings too.

Regenerate SPIRVIsValidEnum.h and SPIRVNameMapEnum.h using
tools/spirv-tool/gen_spirv.bash and manually fix the following:

 - `internal::` values are not handled by the script, so they had to be added manually
   again.  Move all internal values to the end of the generated
   enum/function, so that they are together.

 - `NameMap` entries for `IOPipesINTEL` and `FuncParamIOKindINTEL` do not
   follow the convention of the other values, so they had to be
   changed back to their original values.