### PR TITLE
Fix TopologicalSort memory leak

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1774,7 +1774,7 @@ public:
   }
 
   ~TopologicalSort() {
-    for (auto F : ForwardPointerSet)
+    for (auto *F : ForwardPointerSet)
       delete F;
   }
 };

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1715,8 +1715,9 @@ class TopologicalSort {
           // cyclic dependency by inserting a forward declaration of that
           // pointer.
           SPIRVTypePointer *Ptr = static_cast<SPIRVTypePointer *>(E);
-          ForwardPointerSet.insert(new SPIRVTypeForwardPointer(
-              E->getModule(), Ptr, Ptr->getPointerStorageClass()));
+          SPIRVModule *BM = E->getModule();
+          ForwardPointerSet.insert(BM->add(new SPIRVTypeForwardPointer(
+              BM, Ptr, Ptr->getPointerStorageClass())));
           return false;
         }
         return true;
@@ -1771,11 +1772,6 @@ public:
     // Append forward pointers vector
     ForwardPointerVec.insert(ForwardPointerVec.end(), ForwardPointerSet.begin(),
                              ForwardPointerSet.end());
-  }
-
-  ~TopologicalSort() {
-    for (auto *F : ForwardPointerSet)
-      delete F;
   }
 };
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1772,6 +1772,11 @@ public:
     ForwardPointerVec.insert(ForwardPointerVec.end(), ForwardPointerSet.begin(),
                              ForwardPointerSet.end());
   }
+
+  ~TopologicalSort() {
+    for (auto F : ForwardPointerSet)
+      delete F;
+  }
 };
 
 spv_ostream &operator<<(spv_ostream &O, const TopologicalSort &S) {


### PR DESCRIPTION
There was memory leak in function `TopologicalSort::visit`. This patch fixes it.
@AlexeySotkin, @svenvh could you please review this fix?