### PR TITLE
[NFC] Sync spirv.hpp and regenerate SPIRVNameMapEnum.h

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1057,6 +1057,6 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgModule(const DIModule *Module) {
   Ops[ApiNotesIdx] = BM->getString(Module->getAPINotesFile().str())->getId();
   Ops[IsDeclIdx] = Module->getIsDecl();
   BM->addExtension(ExtensionID::SPV_INTEL_debug_module);
-  BM->addCapability(spv::internal::CapabilityDebugInfoModuleINTEL);
+  BM->addCapability(spv::CapabilityDebugInfoModuleINTEL);
   return BM->addDebugInfo(SPIRVDebug::ModuleINTEL, getVoidTy(), Ops);
 }

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -557,10 +557,12 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilityDotProductInput4x8BitPackedKHR,
       "DotProductInput4x8BitPackedKHR");
   add(CapabilityDotProductKHR, "DotProductKHR");
+  add(CapabilityBitInstructions, "BitInstructions");
   add(CapabilityAtomicFloat32AddEXT, "AtomicFloat32AddEXT");
   add(CapabilityAtomicFloat64AddEXT, "AtomicFloat64AddEXT");
   add(CapabilityLongConstantCompositeINTEL, "LongConstantCompositeINTEL");
   add(CapabilityAtomicFloat16AddEXT, "AtomicFloat16AddEXT");
+  add(CapabilityDebugInfoModuleINTEL, "DebugInfoModuleINTEL");
 
   // From spirv_internal.hpp
   add(internal::CapabilityFPGADSPControlINTEL, "FPGADSPControlINTEL");
@@ -572,7 +574,6 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
       "FPGAInvocationPipeliningAttributesINTEL");
   add(internal::CapabilityTokenTypeINTEL, "TokenTypeINTEL");
   add(CapabilityMax, "Max");
-  add(internal::CapabilityDebugInfoModuleINTEL, "DebugInfoModuleINTEL");
 }
 SPIRV_DEF_NAMEMAP(Capability, SPIRVCapabilityNameMap)
 

--- a/lib/SPIRV/libSPIRV/spirv.hpp
+++ b/lib/SPIRV/libSPIRV/spirv.hpp
@@ -1045,10 +1045,12 @@ enum Capability {
     CapabilityDotProductInput4x8BitKHR = 6017,
     CapabilityDotProductInput4x8BitPackedKHR = 6018,
     CapabilityDotProductKHR = 6019,
+    CapabilityBitInstructions = 6025,
     CapabilityAtomicFloat32AddEXT = 6033,
     CapabilityAtomicFloat64AddEXT = 6034,
     CapabilityLongConstantCompositeINTEL = 6089,
     CapabilityAtomicFloat16AddEXT = 6095,
+    CapabilityDebugInfoModuleINTEL = 6114,
     CapabilityMax = 0x7fffffff,
 };
 

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -60,7 +60,6 @@ enum InternalCapability {
   ICapFastCompositeINTEL = 6093,
   ICapOptNoneINTEL = 6094,
   ICapTokenTypeINTEL = 6112,
-  ICapDebugInfoModuleINTEL = 6114
 };
 
 enum InternalFunctionControlMask { IFunctionControlOptNoneINTELMask = 0x10000 };
@@ -109,8 +108,6 @@ constexpr Capability CapabilityFPGAInvocationPipeliningAttributesINTEL =
     static_cast<Capability>(ICapFPGAInvocationPipeliningAttributesINTEL);
 constexpr Capability CapabilityTokenTypeINTEL =
     static_cast<Capability>(ICapTokenTypeINTEL);
-constexpr Capability CapabilityDebugInfoModuleINTEL =
-    static_cast<Capability>(ICapDebugInfoModuleINTEL);
 
 constexpr FunctionControlMask FunctionControlOptNoneINTELMask =
     static_cast<FunctionControlMask>(IFunctionControlOptNoneINTELMask);


### PR DESCRIPTION
Bring spirv.hpp in sync with `ddf3230 ("Merge pull request #222 from
kpet/github-actions", 2021-06-30)` from
github.com/KhronosGroup/SPIRV-Headers .

This brings the `SPV_KHR_bit_instructions` and `SPV_INTEL_debug_module`
extension enum values.  Drop the internal enum value of the latter.