### PR TITLE
Fix using of deprecated CreateInBounds

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1402,7 +1402,7 @@ bool SPIRVToLLVM::postProcessOCLBuiltinWithArrayArguments(
           auto Zero =
               ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
           Value *Index[] = {Zero, Zero};
-          I = GetElementPtrInst::CreateInBounds(Alloca, Index, "", CI);
+          I = GetElementPtrInst::CreateInBounds(nullptr, Alloca, Index, "", CI);
         }
         return Name.str();
       },

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1402,7 +1402,7 @@ bool SPIRVToLLVM::postProcessOCLBuiltinWithArrayArguments(
           auto Zero =
               ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
           Value *Index[] = {Zero, Zero};
-          I = GetElementPtrInst::CreateInBounds(nullptr, Alloca, Index, "", CI);
+          I = GetElementPtrInst::CreateInBounds(T, Alloca, Index, "", CI);
         }
         return Name.str();
       },

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1184,8 +1184,7 @@ Value *getScalarOrArrayConstantInt(Instruction *Pos, Type *T, unsigned Len,
     new StoreInst(CA, Alloca, Pos);
     auto Zero = ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
     Value *Index[] = {Zero, Zero};
-    auto *Ret =
-        GetElementPtrInst::CreateInBounds(nullptr, Alloca, Index, "", Pos);
+    auto *Ret = GetElementPtrInst::CreateInBounds(AT, Alloca, Index, "", Pos);
     LLVM_DEBUG(dbgs() << "[getScalarOrArrayConstantInt] Alloca: " << *Alloca
                       << ", Return: " << *Ret << '\n');
     return Ret;

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1184,7 +1184,8 @@ Value *getScalarOrArrayConstantInt(Instruction *Pos, Type *T, unsigned Len,
     new StoreInst(CA, Alloca, Pos);
     auto Zero = ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
     Value *Index[] = {Zero, Zero};
-    auto Ret = GetElementPtrInst::CreateInBounds(Alloca, Index, "", Pos);
+    auto *Ret =
+        GetElementPtrInst::CreateInBounds(nullptr, Alloca, Index, "", Pos);
     LLVM_DEBUG(dbgs() << "[getScalarOrArrayConstantInt] Alloca: " << *Alloca
                       << ", Return: " << *Ret << '\n');
     return Ret;


### PR DESCRIPTION
Enable using of CreateInBounds with element type due to deprecate
GetElementPtrInst::CreateInBounds without element type.