### PR TITLE
Revert "Remove mapping of NoWrite function parameter attribute on qua…

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -104,6 +104,7 @@ static bool DbgSaveTmpLLVM = false;
 static const char *DbgTmpLLVMFileName = "_tmp_llvmbil.ll";
 
 namespace kOCLTypeQualifierName {
+const static char *Const = "const";
 const static char *Volatile = "volatile";
 const static char *Restrict = "restrict";
 const static char *Pipe = "pipe";
@@ -4007,8 +4008,17 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
           Qual = kOCLTypeQualifierName::Volatile;
         Arg->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
           Qual += Qual.empty() ? "" : " ";
-          if (Kind == FunctionParameterAttributeNoAlias)
+          switch (Kind) {
+          case FunctionParameterAttributeNoAlias:
             Qual += kOCLTypeQualifierName::Restrict;
+            break;
+          case FunctionParameterAttributeNoWrite:
+            Qual += kOCLTypeQualifierName::Const;
+            break;
+          default:
+            // do nothing.
+            break;
+          }
         });
         if (Arg->getType()->isTypePipe()) {
           Qual += Qual.empty() ? "" : " ";

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3374,6 +3374,10 @@ bool LLVMToSPIRVBase::transOCLMetadata() {
               BA->addDecorate(
                   new SPIRVDecorate(DecorationFuncParamAttr, BA,
                                     FunctionParameterAttributeNoAlias));
+            if (Str.find("const") != std::string::npos)
+              BA->addDecorate(
+                  new SPIRVDecorate(DecorationFuncParamAttr, BA,
+                                    FunctionParameterAttributeNoWrite));
           });
     }
     if (auto *KernelArgName = F.getMetadata(SPIR_MD_KERNEL_ARG_NAME)) {

--- a/test/group-decorate.spt
+++ b/test/group-decorate.spt
@@ -13,7 +13,10 @@
 4 Name 11 "entry"
 4 Decorate 13 FuncParamAttr 5 
 2 DecorationGroup 13 
+4 Decorate 14 FuncParamAttr 6 
+2 DecorationGroup 14 
 5 GroupDecorate 13 8 9 10 
+4 GroupDecorate 14 8 9 
 4 TypeInt 3 8 0 
 2 TypeVoid 2 
 4 TypeVector 4 3 4 
@@ -35,4 +38,6 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: define spir_kernel void @test(<4 x i8> addrspace(1)* nocapture %src1, <4 x i8> addrspace(1)* nocapture %src2, <4 x i8> addrspace(1)* nocapture %dst) {{.*}}
+; CHECK-LLVM: define spir_kernel void @test(<4 x i8> addrspace(1)* nocapture %src1, <4 x i8> addrspace(1)* nocapture %src2, <4 x i8> addrspace(1)* nocapture %dst) {{.*}} !kernel_arg_type_qual ![[QUALS:[0-9]+]]
+
+; CHECK-LLVM: ![[QUALS]] = !{!"const", !"const", !""}


### PR DESCRIPTION
…l metadata"

This reverts commit 9b2cc0c6b11ed43d4a57ea426cfdfb83bd078846.

This change is needed for Intel Compute stack with LLVM 11 conformance ([compute-runtime](https://github.com/intel/compute-runtime), [intel-graphics-compiler](https://github.com/intel/intel-graphics-compiler), [opencl-clang](https://github.com/intel/opencl-clang)), since it breaks an [unit test related to `readonly` function parameter](https://github.com/intel/compute-runtime/blob/master/opencl/test/unit_test/kernel/kernel_tests.cpp#L422) in [this kernel](https://github.com/intel/compute-runtime/blob/master/opencl/test/unit_test/test_files/simple_kernels.cl#L22).