### PR TITLE
Fix SPIR-V IR for opcodes operating on images

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -507,6 +507,9 @@ template <typename T> std::string toString(const T *Object) {
 // Scalar data assumed to be represented as vector of one element.
 std::string getIntelSubgroupBlockDataPostfix(unsigned ElementBitSize,
                                              unsigned VectorNumElements);
+
+void insertImageNameAccessQualifier(SPIRVAccessQualifierKind Acc,
+                                    std::string &Name);
 } // namespace OCLUtil
 
 using namespace OCLUtil;

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -978,14 +978,29 @@ PointerType *getInt8PtrTy(PointerType *T);
 Value *castToInt8Ptr(Value *V, Instruction *Pos);
 
 template <> inline void SPIRVMap<std::string, Op, SPIRVOpaqueType>::init() {
-  add(kSPIRVTypeName::DeviceEvent, OpTypeDeviceEvent);
-  add(kSPIRVTypeName::Event, OpTypeEvent);
-  add(kSPIRVTypeName::Image, OpTypeImage);
-  add(kSPIRVTypeName::Pipe, OpTypePipe);
-  add(kSPIRVTypeName::Queue, OpTypeQueue);
-  add(kSPIRVTypeName::ReserveId, OpTypeReserveId);
-  add(kSPIRVTypeName::Sampler, OpTypeSampler);
-  add(kSPIRVTypeName::SampledImg, OpTypeSampledImage);
+#define _SPIRV_OP(x) add(#x, OpType##x);
+  _SPIRV_OP(DeviceEvent)
+  _SPIRV_OP(Event)
+  _SPIRV_OP(Image)
+  _SPIRV_OP(Pipe)
+  _SPIRV_OP(Queue)
+  _SPIRV_OP(ReserveId)
+  _SPIRV_OP(Sampler)
+  _SPIRV_OP(SampledImage)
+  // SPV_INTEL_device_side_avc_motion_estimation types
+  _SPIRV_OP(AvcMcePayloadINTEL)
+  _SPIRV_OP(AvcImePayloadINTEL)
+  _SPIRV_OP(AvcRefPayloadINTEL)
+  _SPIRV_OP(AvcSicPayloadINTEL)
+  _SPIRV_OP(AvcMceResultINTEL)
+  _SPIRV_OP(AvcImeResultINTEL)
+  _SPIRV_OP(AvcImeResultSingleReferenceStreamoutINTEL)
+  _SPIRV_OP(AvcImeResultDualReferenceStreamoutINTEL)
+  _SPIRV_OP(AvcImeSingleReferenceStreaminINTEL)
+  _SPIRV_OP(AvcImeDualReferenceStreaminINTEL)
+  _SPIRV_OP(AvcRefResultINTEL)
+  _SPIRV_OP(AvcSicResultINTEL)
+#undef _SPIRV_OP
 }
 
 // Check if the module contains llvm.loop.* metadata
@@ -997,6 +1012,13 @@ bool isSPIRVOCLExtInst(const CallInst *CI, OCLExtOpKind *ExtOp);
 
 // check LLVM Intrinsics type(s) for validity
 bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM);
+
+/// Decode SPIR-V type name in the format spirv.{TypeName}._{Postfixes}
+/// where Postfixes are strings separated by underscores.
+/// \return TypeName.
+/// \param Strs contains the integers decoded from postfixes.
+std::string decodeSPIRVTypeName(StringRef Name,
+                                SmallVectorImpl<std::string> &Strs);
 } // namespace SPIRV
 
 #endif // SPIRV_SPIRVINTERNAL_H

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -788,7 +788,8 @@ bool SPIRVToLLVM::isDirectlyTranslatedToOCL(Op OpCode) const {
   if (OpCode == OpImageSampleExplicitLod || OpCode == OpSampledImage)
     return false;
   if (OpCode == OpImageWrite || OpCode == OpImageRead ||
-      OpCode == OpImageQueryOrder || OpCode == OpImageQueryFormat)
+      OpCode == OpImageQueryOrder || OpCode == OpImageQueryFormat ||
+      OpCode == OpImageQueryLevels)
     return false;
   if (OpCode == OpGenericCastToPtrExplicit)
     return false;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -479,10 +479,13 @@ Type *SPIRVToLLVM::transFPType(SPIRVType *T) {
 }
 
 std::string SPIRVToLLVM::transOCLImageTypeName(SPIRV::SPIRVTypeImage *ST) {
-  std::string Name = std::string(kSPR2TypeName::OCLPrefix) +
-                     rmap<std::string>(ST->getDescriptor());
-  SPIRVToLLVM::insertImageNameAccessQualifier(ST, Name);
-  return Name;
+  return getSPIRVTypeName(
+      kSPIRVTypeName::Image,
+      getSPIRVImageTypePostfixes(
+          getSPIRVImageSampledTypeName(ST->getSampledType()),
+          ST->getDescriptor(),
+          ST->hasAccessQualifier() ? ST->getAccessQualifier()
+                                   : AccessQualifierReadOnly));
 }
 
 std::string
@@ -494,6 +497,18 @@ SPIRVToLLVM::transOCLSampledImageTypeName(SPIRV::SPIRVTypeSampledImage *ST) {
           ST->getImageType()->getDescriptor(),
           ST->getImageType()->hasAccessQualifier()
               ? ST->getImageType()->getAccessQualifier()
+              : AccessQualifierReadOnly));
+}
+
+std::string
+SPIRVToLLVM::transVMEImageTypeName(SPIRV::SPIRVTypeVmeImageINTEL *VT) {
+  return getSPIRVTypeName(
+      kSPIRVTypeName::VmeImageINTEL,
+      getSPIRVImageTypePostfixes(
+          getSPIRVImageSampledTypeName(VT->getImageType()->getSampledType()),
+          VT->getImageType()->getDescriptor(),
+          VT->getImageType()->hasAccessQualifier()
+              ? VT->getImageType()->getAccessQualifier()
               : AccessQualifierReadOnly));
 }
 
@@ -621,10 +636,10 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool IsClassMember) {
         T, getOrCreateOpaquePtrType(M, transOCLPipeStorageTypeName(PST),
                                     getOCLOpaqueTypeAddrSpace(T->getOpCode())));
   }
-  // OpenCL Compiler does not use this instruction
-  case OpTypeVmeImageINTEL:
-    return nullptr;
-
+  case OpTypeVmeImageINTEL: {
+    auto *VT = static_cast<SPIRVTypeVmeImageINTEL *>(T);
+    return mapType(T, getOrCreateOpaquePtrType(M, transVMEImageTypeName(VT)));
+  }
   case OpTypeBufferSurfaceINTEL: {
     auto PST = static_cast<SPIRVTypeBufferSurfaceINTEL *>(T);
     return mapType(T,
@@ -634,14 +649,21 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool IsClassMember) {
 
   default: {
     auto OC = T->getOpCode();
-    if (isOpaqueGenericTypeOpCode(OC) || isSubgroupAvcINTELTypeOpCode(OC)) {
-      auto Name = isSubgroupAvcINTELTypeOpCode(OC)
-                      ? OCLSubgroupINTELTypeOpCodeMap::rmap(OC)
-                      : OCLOpaqueTypeOpCodeMap::rmap(OC);
-      return mapType(
-          T, getOrCreateOpaquePtrType(M, Name, getOCLOpaqueTypeAddrSpace(OC)));
+    SPIRAddressSpace AS = getOCLOpaqueTypeAddrSpace(OC);
+    std::string Name;
+    if (isOpaqueGenericTypeOpCode(OC)) {
+      // TODO: Generic opaque type opcodes shouldn't be translated directly to
+      // OCL representation
+      //       SPIRVOpaqueTypeOpCodeMap should be used. The same as for AVC
+      //       INTEL opcodes.
+      Name = OCLOpaqueTypeOpCodeMap::rmap(OC);
+    } else if (isSubgroupAvcINTELTypeOpCode(OC)) {
+      Name =
+          kSPIRVTypeName::PrefixAndDelim + SPIRVOpaqueTypeOpCodeMap::rmap(OC);
+    } else {
+      llvm_unreachable("Not implemented");
     }
-    llvm_unreachable("Not implemented");
+    return mapType(T, getOrCreateOpaquePtrType(M, Name, AS));
   }
   }
   return 0;
@@ -759,12 +781,14 @@ bool SPIRVToLLVM::isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const {
 // TODO: Instead of direct translation to OCL we should always produce SPIR-V
 // friendly IR and apply lowering later if needed
 bool SPIRVToLLVM::isDirectlyTranslatedToOCL(Op OpCode) const {
-  if (isSubgroupAvcINTELInstructionOpCode(OpCode) ||
-      isIntelSubgroupOpCode(OpCode))
-    return true;
+  if (isSubgroupAvcINTELInstructionOpCode(OpCode))
+    return false;
+  if (isIntelSubgroupOpCode(OpCode))
+    return false;
   if (OpCode == OpImageSampleExplicitLod || OpCode == OpSampledImage)
     return false;
-  if (OpCode == OpImageWrite)
+  if (OpCode == OpImageWrite || OpCode == OpImageRead ||
+      OpCode == OpImageQueryOrder || OpCode == OpImageQueryFormat)
     return false;
   if (OpCode == OpGenericCastToPtrExplicit)
     return false;
@@ -1137,18 +1161,6 @@ void SPIRVToLLVM::transLLVMLoopMetadata(const Function *F) {
 
     FuncLoopMetadataMap.erase(LMDItr);
   }
-}
-
-void SPIRVToLLVM::insertImageNameAccessQualifier(SPIRV::SPIRVTypeImage *ST,
-                                                 std::string &Name) {
-  SPIRVAccessQualifierKind Acc = ST->hasAccessQualifier()
-                                     ? ST->getAccessQualifier()
-                                     : AccessQualifierReadOnly;
-  std::string QName = rmap<std::string>(Acc);
-  // transform: read_only -> ro, write_only -> wo, read_write -> rw
-  QName = QName.substr(0, 1) + QName.substr(QName.find("_") + 1, 1) + "_";
-  assert(!Name.empty() && "image name should not be empty");
-  Name.insert(Name.size() - 1, QName);
 }
 
 Value *SPIRVToLLVM::transValue(SPIRVValue *BV, Function *F, BasicBlock *BB,
@@ -2078,7 +2090,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
                                          BV->getName()));
   }
 
-  case OpVmeImageINTEL:
   case OpLine:
   case OpSelectionMerge: // OpenCL Compiler does not use this instruction
     return nullptr;
@@ -3121,7 +3132,6 @@ void SPIRVToLLVM::transOCLBuiltinFromInstPreproc(
   if (!BI->hasType())
     return;
   auto BT = BI->getType();
-  auto OC = BI->getOpCode();
   if (isCmpOpCode(BI->getOpCode())) {
     if (BT->isTypeBool())
       RetTy = IntegerType::getInt32Ty(*Context);
@@ -3133,56 +3143,6 @@ void SPIRVToLLVM::transOCLBuiltinFromInstPreproc(
           BT->getVectorComponentCount());
     else
       llvm_unreachable("invalid compare instruction");
-  } else if (OC == OpImageRead && Args.size() > 2) {
-    // Drop "Image operands" argument
-    Args.erase(Args.begin() + 2);
-  } else if (isSubgroupAvcINTELEvaluateOpcode(OC)) {
-    // There are three types of AVC Intel Evaluate opcodes:
-    // 1. With multi reference images - does not use OpVmeImageINTEL opcode for
-    // reference images
-    // 2. With dual reference images - uses two OpVmeImageINTEL opcodes for
-    // reference image
-    // 3. With single reference image - uses one OpVmeImageINTEL opcode for
-    // reference image
-    int NumImages =
-        std::count_if(Args.begin(), Args.end(), [](SPIRVValue *Arg) {
-          return static_cast<SPIRVInstruction *>(Arg)->getOpCode() ==
-                 OpVmeImageINTEL;
-        });
-    if (NumImages) {
-      SPIRVInstruction *SrcImage = static_cast<SPIRVInstruction *>(Args[0]);
-      assert(SrcImage &&
-             "Src image operand not found in avc evaluate instruction");
-      if (NumImages == 1) {
-        // Multi reference opcode - remove src image OpVmeImageINTEL opcode
-        // and replace it with corresponding OpImage and OpSampler arguments
-        size_t SamplerPos = Args.size() - 1;
-        Args.erase(Args.begin(), Args.begin() + 1);
-        Args.insert(Args.begin(), SrcImage->getOperands()[0]);
-        Args.insert(Args.begin() + SamplerPos, SrcImage->getOperands()[1]);
-      } else {
-        SPIRVInstruction *FwdRefImage =
-            static_cast<SPIRVInstruction *>(Args[1]);
-        SPIRVInstruction *BwdRefImage =
-            static_cast<SPIRVInstruction *>(Args[2]);
-        assert(FwdRefImage && "invalid avc evaluate instruction");
-        // Single reference opcode - remove src and ref image OpVmeImageINTEL
-        // opcodes and replace them with src and ref OpImage opcodes and
-        // OpSampler
-        Args.erase(Args.begin(), Args.begin() + NumImages);
-        // insert source OpImage and OpSampler
-        auto SrcOps = SrcImage->getOperands();
-        Args.insert(Args.begin(), SrcOps.begin(), SrcOps.end());
-        // insert reference OpImage
-        Args.insert(Args.begin() + 1, FwdRefImage->getOperands()[0]);
-        if (NumImages == 3) {
-          // Dual reference opcode - insert second reference OpImage argument
-          assert(BwdRefImage && "invalid avc evaluate instruction");
-          Args.insert(Args.begin() + 2, BwdRefImage->getOperands()[0]);
-        }
-      }
-    } else
-      llvm_unreachable("invalid avc instruction");
   }
 }
 
@@ -3197,12 +3157,6 @@ SPIRVToLLVM::transOCLBuiltinPostproc(SPIRVInstruction *BI, CallInst *CI,
   }
   if (OC == OpGenericPtrMemSemantics)
     return BinaryOperator::CreateShl(CI, getInt32(M, 8), "", BB);
-  if (OC == OpImageQueryFormat)
-    return BinaryOperator::CreateSub(
-        CI, getInt32(M, OCLImageChannelDataTypeOffset), "", BB);
-  if (OC == OpImageQueryOrder)
-    return BinaryOperator::CreateSub(
-        CI, getInt32(M, OCLImageChannelOrderOffset), "", BB);
   if (OC == OpBuildNDRange)
     return postProcessOCLBuildNDRange(BI, CI, DemangledName);
   if (SPIRVEnableStepExpansion &&
@@ -3451,60 +3405,8 @@ std::string SPIRVToLLVM::getOCLBuiltinName(SPIRVInstruction *BI) {
            (EleTy->isTypeArray() && Dim >= 2 && Dim <= 3));
     return std::string(kOCLBuiltinName::NDRangePrefix) + OS.str() + "D";
   }
-  if (isIntelSubgroupOpCode(OC)) {
-    std::stringstream Name;
-    SPIRVType *DataTy = nullptr;
-    switch (OC) {
-    case OpSubgroupBlockReadINTEL:
-    case OpSubgroupImageBlockReadINTEL:
-      Name << "intel_sub_group_block_read";
-      DataTy = BI->getType();
-      break;
-    case OpSubgroupBlockWriteINTEL:
-      Name << "intel_sub_group_block_write";
-      DataTy = BI->getOperands()[1]->getType();
-      break;
-    case OpSubgroupImageBlockWriteINTEL:
-      Name << "intel_sub_group_block_write";
-      DataTy = BI->getOperands()[2]->getType();
-      break;
-    default:
-      return OCLSPIRVBuiltinMap::rmap(OC);
-    }
-    assert(DataTy && "Intel subgroup block builtins should have data type");
-    unsigned VectorNumElements = 1;
-    if (DataTy->isTypeVector())
-      VectorNumElements = DataTy->getVectorComponentCount();
-    unsigned ElementBitSize = DataTy->getBitWidth();
-    Name << getIntelSubgroupBlockDataPostfix(ElementBitSize, VectorNumElements);
-    return Name.str();
-  }
-  if (isSubgroupAvcINTELInstructionOpCode(OC))
-    return OCLSPIRVSubgroupAVCIntelBuiltinMap::rmap(OC);
 
-  auto Name = OCLSPIRVBuiltinMap::rmap(OC);
-
-  SPIRVType *T = nullptr;
-  switch (OC) {
-  case OpImageRead:
-    T = BI->getType();
-    break;
-  default:
-    // do nothing
-    break;
-  }
-  if (T && T->isTypeVector())
-    T = T->getVectorComponentType();
-  if (T) {
-    if (T->isTypeFloat(16))
-      Name += 'h';
-    else if (T->isTypeFloat(32))
-      Name += 'f';
-    else
-      Name += 'i';
-  }
-
-  return Name;
+  return OCLSPIRVBuiltinMap::rmap(OC);
 }
 
 Instruction *SPIRVToLLVM::transOCLBuiltinFromInst(SPIRVInstruction *BI,
@@ -3568,7 +3470,9 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   assert(BB && "Invalid BB");
   const auto OC = BI->getOpCode();
   bool AddRetTypePostfix = false;
-  if (OC == OpImageQuerySizeLod || OC == OpImageQuerySize)
+  if (OC == OpImageQuerySizeLod || OC == OpImageQuerySize ||
+      OC == OpImageRead || OC == OpSubgroupImageBlockReadINTEL ||
+      OC == OpSubgroupBlockReadINTEL)
     AddRetTypePostfix = true;
 
   bool IsRetSigned = false;

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -240,6 +240,7 @@ private:
                                        const std::string &DemangledName);
   std::string transOCLImageTypeName(SPIRV::SPIRVTypeImage *ST);
   std::string transOCLSampledImageTypeName(SPIRV::SPIRVTypeSampledImage *ST);
+  std::string transVMEImageTypeName(SPIRV::SPIRVTypeVmeImageINTEL *VT);
   std::string transOCLPipeTypeName(
       SPIRV::SPIRVTypePipe *ST, bool UseSPIRVFriendlyFormat = false,
       SPIRVAccessQualifierKind PipeAccess = AccessQualifierReadOnly);
@@ -260,8 +261,6 @@ private:
   getMetadataFromNameAndParameter(std::string Name, SPIRVWord Parameter);
   inline MDNode *getMetadataFromNameAndParameter(std::string Name,
                                                  int64_t Parameter);
-  void insertImageNameAccessQualifier(SPIRV::SPIRVTypeImage *ST,
-                                      std::string &Name);
   template <class Source, class Func> bool foreachFuncCtlMask(Source, Func);
   llvm::GlobalValue::LinkageTypes transLinkageType(const SPIRVValue *V);
   Instruction *transOCLAllAny(SPIRVInstruction *BI, BasicBlock *BB);

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -115,6 +115,18 @@ void SPIRVToOCLBase::visitCallInst(CallInst &CI) {
     visitCallSPIRVImageMediaBlockBuiltin(&CI, OC);
     return;
   }
+  if (isIntelSubgroupOpCode(OC)) {
+    visitCallSPIRVSubgroupINTELBuiltIn(&CI, OC);
+    return;
+  }
+  if (isSubgroupAvcINTELEvaluateOpcode(OC)) {
+    visitCallSPIRVAvcINTELEvaluateBuiltIn(&CI, OC);
+    return;
+  }
+  if (isSubgroupAvcINTELInstructionOpCode(OC)) {
+    visitCallSPIRVAvcINTELInstructionBuiltin(&CI, OC);
+    return;
+  }
   if (OC == OpGenericCastToPtrExplicit) {
     visitCallGenericCastToPtrExplicitBuiltIn(&CI, OC);
     return;
@@ -137,6 +149,14 @@ void SPIRVToOCLBase::visitCallInst(CallInst &CI) {
   }
   if (OC == OpImageWrite) {
     visitCallSPIRVImageWriteBuiltIn(&CI, OC);
+    return;
+  }
+  if (OC == OpImageRead) {
+    visitCallSPIRVImageReadBuiltIn(&CI, OC);
+    return;
+  }
+  if (OC == OpImageQueryOrder || OC == OpImageQueryFormat) {
+    visitCallSPIRVImageQueryBuiltIn(&CI, OC);
     return;
   }
   if (OCLSPIRVBuiltinMap::rfind(OC))
@@ -723,12 +743,172 @@ void SPIRVToOCLBase::visitCallSPIRVImageWriteBuiltIn(CallInst *CI, Op OC) {
       &Attrs);
 }
 
+void SPIRVToOCLBase::visitCallSPIRVImageReadBuiltIn(CallInst *CI, Op OC) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
+  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  mutateCallInstOCL(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> &Args) {
+        // Drop "Image operands" argument
+        if (Args.size() > 2)
+          Args.erase(Args.begin() + 2);
+
+        llvm::Type *T = CI->getType();
+        return std::string(kOCLBuiltinName::ReadImage) + getTypeSuffix(T);
+      },
+      &Attrs);
+}
+
+void SPIRVToOCLBase::visitCallSPIRVImageQueryBuiltIn(CallInst *CI, Op OC) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
+  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  CI = mutateCallInstOCL(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> &Args) {
+        return OCLSPIRVBuiltinMap::rmap(OC);
+      },
+      &Attrs);
+  unsigned int Offset = 0;
+  if (OC == OpImageQueryFormat)
+    Offset = OCLImageChannelDataTypeOffset;
+  else if (OC == OpImageQueryOrder)
+    Offset = OCLImageChannelOrderOffset;
+  else
+    llvm_unreachable("Unsupported opcode");
+
+  auto *Sub =
+      BinaryOperator::CreateSub(CI, getInt32(M, Offset), "", CI->getNextNode());
+  for (auto &Use : CI->uses()) {
+    if (Use.getUser() == Sub)
+      continue;
+    Use.set(Sub);
+  }
+}
+
+void SPIRVToOCLBase::visitCallSPIRVSubgroupINTELBuiltIn(CallInst *CI, Op OC) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
+  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  mutateCallInstOCL(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> &Args) {
+        std::stringstream Name;
+        Type *DataTy = nullptr;
+        switch (OC) {
+        case OpSubgroupBlockReadINTEL:
+        case OpSubgroupImageBlockReadINTEL:
+          Name << "intel_sub_group_block_read";
+          DataTy = CI->getType();
+          break;
+        case OpSubgroupBlockWriteINTEL:
+          Name << "intel_sub_group_block_write";
+          DataTy = CI->getOperand(1)->getType();
+          break;
+        case OpSubgroupImageBlockWriteINTEL:
+          Name << "intel_sub_group_block_write";
+          DataTy = CI->getOperand(2)->getType();
+          break;
+        default:
+          return OCLSPIRVBuiltinMap::rmap(OC);
+        }
+        assert(DataTy && "Intel subgroup block builtins should have data type");
+        unsigned VectorNumElements = 1;
+        if (FixedVectorType *VT = dyn_cast<FixedVectorType>(DataTy))
+          VectorNumElements = VT->getNumElements();
+        unsigned ElementBitSize = DataTy->getScalarSizeInBits();
+        Name << getIntelSubgroupBlockDataPostfix(ElementBitSize,
+                                                 VectorNumElements);
+        return Name.str();
+      },
+      &Attrs);
+}
+
+void SPIRVToOCLBase::visitCallSPIRVAvcINTELEvaluateBuiltIn(CallInst *CI,
+                                                           Op OC) {
+  assert(CI->getCalledFunction() && "Unexpected indirect call");
+  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  mutateCallInstOCL(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> &Args) {
+        // There are three types of AVC Intel Evaluate opcodes:
+        // 1. With multi reference images - does not use OpVmeImageINTEL opcode
+        // for reference images
+        // 2. With dual reference images - uses two OpVmeImageINTEL opcodes for
+        // reference image
+        // 3. With single reference image - uses one OpVmeImageINTEL opcode for
+        // reference image
+        int NumImages = std::count_if(Args.begin(), Args.end(), [](Value *Arg) {
+          if (auto *PT = dyn_cast<PointerType>(Arg->getType())) {
+            if (auto *ST = dyn_cast<StructType>(PT->getElementType())) {
+              if (ST->getName().startswith("spirv.VmeImageINTEL"))
+                return true;
+            }
+          }
+          return false;
+        });
+        auto EraseVmeImageCall = [](CallInst *CI) {
+          if (CI->hasOneUse()) {
+            CI->replaceAllUsesWith(UndefValue::get(CI->getType()));
+            CI->dropAllReferences();
+            CI->eraseFromParent();
+          }
+        };
+        if (NumImages) {
+          CallInst *SrcImage = cast<CallInst>(Args[0]);
+          if (NumImages == 1) {
+            // Multi reference opcode - remove src image OpVmeImageINTEL opcode
+            // and replace it with corresponding OpImage and OpSampler arguments
+            size_t SamplerPos = Args.size() - 1;
+            Args.erase(Args.begin(), Args.begin() + 1);
+            Args.insert(Args.begin(), SrcImage->getOperand(0));
+            Args.insert(Args.begin() + SamplerPos, SrcImage->getOperand(1));
+            EraseVmeImageCall(SrcImage);
+          } else {
+            CallInst *FwdRefImage = cast<CallInst>(Args[1]);
+            CallInst *BwdRefImage =
+                NumImages == 3 ? cast<CallInst>(Args[2]) : nullptr;
+            // Single reference opcode - remove src and ref image
+            // OpVmeImageINTEL opcodes and replace them with src and ref OpImage
+            // opcodes and OpSampler
+            Args.erase(Args.begin(), Args.begin() + NumImages);
+            // insert source OpImage and OpSampler
+            auto SrcOps = SrcImage->args();
+            Args.insert(Args.begin(), SrcOps.begin(), SrcOps.end());
+            // insert reference OpImage
+            Args.insert(Args.begin() + 1, FwdRefImage->getOperand(0));
+            EraseVmeImageCall(SrcImage);
+            EraseVmeImageCall(FwdRefImage);
+            if (BwdRefImage) {
+              // Dual reference opcode - insert second reference OpImage
+              // argument
+              Args.insert(Args.begin() + 2, BwdRefImage->getOperand(0));
+              EraseVmeImageCall(BwdRefImage);
+            }
+          }
+        } else
+          llvm_unreachable("invalid avc instruction");
+
+        return OCLSPIRVSubgroupAVCIntelBuiltinMap::rmap(OC);
+      },
+      &Attrs);
+}
+
 void SPIRVToOCLBase::visitCallSPIRVBuiltin(CallInst *CI, Op OC) {
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   mutateCallInstOCL(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {
         return OCLSPIRVBuiltinMap::rmap(OC);
+      },
+      &Attrs);
+}
+
+void SPIRVToOCLBase::visitCallSPIRVAvcINTELInstructionBuiltin(CallInst *CI,
+                                                              Op OC) {
+  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  mutateCallInstOCL(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> &Args) {
+        return OCLSPIRVSubgroupAVCIntelBuiltinMap::rmap(OC);
       },
       &Attrs);
 }
@@ -830,6 +1010,50 @@ std::string SPIRVToOCLBase::getGroupBuiltinPrefix(CallInst *CI) {
     llvm_unreachable("Invalid execution scope");
   }
   return Prefix;
+}
+
+std::string
+SPIRVToOCLBase::getOCLImageOpaqueType(SmallVector<std::string, 8> &Postfixes) {
+  SmallVector<int, 7> Ops;
+  for (unsigned I = 1; I < 8; ++I)
+    Ops.push_back(atoi(Postfixes[I].c_str()));
+  SPIRVTypeImageDescriptor Desc(static_cast<SPIRVImageDimKind>(Ops[0]), Ops[1],
+                                Ops[2], Ops[3], Ops[4], Ops[5]);
+
+  std::string OCLStructName =
+      std::string(kSPR2TypeName::OCLPrefix) + rmap<std::string>(Desc);
+
+  SPIRVAccessQualifierKind Acc = static_cast<SPIRVAccessQualifierKind>(Ops[6]);
+  insertImageNameAccessQualifier(Acc, OCLStructName);
+  return OCLStructName;
+}
+
+void SPIRVToOCLBase::translateOpaqueTypes() {
+  for (auto *S : M->getIdentifiedStructTypes()) {
+    StringRef STName = S->getStructName();
+    bool IsSPIRVOpaque =
+        S->isOpaque() && STName.startswith(kSPIRVTypeName::PrefixAndDelim);
+
+    if (!IsSPIRVOpaque)
+      continue;
+
+    SmallVector<std::string, 8> Postfixes;
+    std::string DecodedST = decodeSPIRVTypeName(STName, Postfixes);
+
+    if (!SPIRVOpaqueTypeOpCodeMap::find(DecodedST))
+      continue;
+
+    Op OP = SPIRVOpaqueTypeOpCodeMap::map(DecodedST);
+    std::string OCLOpaqueName;
+    if (OP == OpTypeImage)
+      OCLOpaqueName = getOCLImageOpaqueType(Postfixes);
+    else if (isSubgroupAvcINTELTypeOpCode(OP))
+      OCLOpaqueName = OCLSubgroupINTELTypeOpCodeMap::rmap(OP);
+    else
+      continue;
+
+    S->setName(OCLOpaqueName);
+  }
 }
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -128,6 +128,29 @@ public:
   /// Transform __spirv_ImageWrite to write_image
   void visitCallSPIRVImageWriteBuiltIn(CallInst *CI, Op OC);
 
+  /// Transform __spirv_ImageRead to read_image
+  void visitCallSPIRVImageReadBuiltIn(CallInst *CI, Op OC);
+
+  /// Transform __spirv_ImageQueryOrder to get_image_channel_order
+  //            __spirv_ImageQueryFormat to get_image_channel_data_type
+  void visitCallSPIRVImageQueryBuiltIn(CallInst *CI, Op OC);
+
+  /// Transform subgroup Intel opcodes
+  /// example: __spirv_SubgroupBlockWriteINTEL
+  ///    =>    intel_sub_group_block_write_ul
+  void visitCallSPIRVSubgroupINTELBuiltIn(CallInst *CI, Op OC);
+
+  /// Transform AVC INTEL Evaluate opcodes
+  /// example: __spirv_SubgroupAvcImeEvaluateWithSingleReference
+  ///    => intel_sub_group_avc_ime_evaluate_with_single_reference
+  void visitCallSPIRVAvcINTELEvaluateBuiltIn(CallInst *CI, Op OC);
+
+  /// Transform AVC INTEL general opcodes
+  /// example: __spirv_SubgroupAvcMceGetDefaultInterBaseMultiReferencePenalty
+  ///   =>
+  ///   intel_sub_group_avc_mce_get_default_inter_base_multi_reference_penalty
+  void visitCallSPIRVAvcINTELInstructionBuiltin(CallInst *CI, Op OC);
+
   /// Transform __spirv_* builtins to OCL 2.0 builtins.
   /// No change with arguments.
   void visitCallSPIRVBuiltin(CallInst *CI, Op OC);
@@ -199,6 +222,11 @@ public:
   std::string getBallotBuiltinName(CallInst *CI, Op OC);
   /// Transform group opcode to corresponding OpenCL function name
   std::string groupOCToOCLBuiltinName(CallInst *CI, Op OC);
+  /// Transform SPV-IR image opaque type into OpenCL representation,
+  /// example: spirv.Image._void_1_0_0_0_0_0_1 => opencl.image2d_wo_t
+  std::string getOCLImageOpaqueType(SmallVector<std::string, 8> &Postfixes);
+
+  void translateOpaqueTypes();
 
   Module *M;
   LLVMContext *Ctx;

--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -52,6 +52,9 @@ bool SPIRVToOCL12Legacy::runOnModule(Module &Module) {
 bool SPIRVToOCL12Base::runSPIRVToOCL(Module &Module) {
   M = &Module;
   Ctx = &M->getContext();
+
+  translateOpaqueTypes();
+
   visit(*M);
 
   eraseUselessFunctions(&Module);

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -51,6 +51,9 @@ bool SPIRVToOCL20Legacy::runOnModule(Module &Module) {
 bool SPIRVToOCL20Base::runSPIRVToOCL(Module &Module) {
   M = &Module;
   Ctx = &M->getContext();
+
+  translateOpaqueTypes();
+
   visit(*M);
 
   eraseUselessFunctions(&Module);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1553,6 +1553,26 @@ bool isSPIRVOCLExtInst(const CallInst *CI, OCLExtOpKind *ExtOp) {
   return true;
 }
 
+std::string decodeSPIRVTypeName(StringRef Name,
+                                SmallVectorImpl<std::string> &Strs) {
+  SmallVector<StringRef, 4> SubStrs;
+  const char Delim[] = {kSPIRVTypeName::Delimiter, 0};
+  Name.split(SubStrs, Delim, -1, true);
+  assert(SubStrs.size() >= 2 && "Invalid SPIRV type name");
+  assert(SubStrs[0] == kSPIRVTypeName::Prefix && "Invalid prefix");
+  assert((SubStrs.size() == 2 || !SubStrs[2].empty()) && "Invalid postfix");
+
+  if (SubStrs.size() > 2) {
+    const char PostDelim[] = {kSPIRVTypeName::PostfixDelim, 0};
+    SmallVector<StringRef, 4> Postfixes;
+    SubStrs[2].split(Postfixes, PostDelim, -1, true);
+    assert(Postfixes.size() > 1 && Postfixes[0].empty() && "Invalid postfix");
+    for (unsigned I = 1, E = Postfixes.size(); I != E; ++I)
+      Strs.push_back(std::string(Postfixes[I]).c_str());
+  }
+  return SubStrs[1].str();
+}
+
 // Returns true if type(s) and number of elements (if vector) is valid
 bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
   switch (II->getIntrinsicID()) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -223,30 +223,6 @@ bool LLVMToSPIRVBase::isBuiltinTransToExtInst(
   return true;
 }
 
-/// Decode SPIR-V type name in the format spirv.{TypeName}._{Postfixes}
-/// where Postfixes are strings separated by underscores.
-/// \return TypeName.
-/// \param Ops contains the integers decoded from postfixes.
-static std::string decodeSPIRVTypeName(StringRef Name,
-                                       SmallVectorImpl<std::string> &Strs) {
-  SmallVector<StringRef, 4> SubStrs;
-  const char Delim[] = {kSPIRVTypeName::Delimiter, 0};
-  Name.split(SubStrs, Delim, -1, true);
-  assert(SubStrs.size() >= 2 && "Invalid SPIRV type name");
-  assert(SubStrs[0] == kSPIRVTypeName::Prefix && "Invalid prefix");
-  assert((SubStrs.size() == 2 || !SubStrs[2].empty()) && "Invalid postfix");
-
-  if (SubStrs.size() > 2) {
-    const char PostDelim[] = {kSPIRVTypeName::PostfixDelim, 0};
-    SmallVector<StringRef, 4> Postfixes;
-    SubStrs[2].split(Postfixes, PostDelim, -1, true);
-    assert(Postfixes.size() > 1 && Postfixes[0].empty() && "Invalid postfix");
-    for (unsigned I = 1, E = Postfixes.size(); I != E; ++I)
-      Strs.push_back(std::string(Postfixes[I]).c_str());
-  }
-  return SubStrs[1].str();
-}
-
 static bool recursiveType(const StructType *ST, const Type *Ty) {
   SmallPtrSet<const StructType *, 4> Seen;
 

--- a/test/GroupAndSubgroupInstructions.spvasm
+++ b/test/GroupAndSubgroupInstructions.spvasm
@@ -45,6 +45,9 @@
 ; RUN: llvm-dis %t.bc -o %t.ll
 ; RUN: FileCheck < %t.ll %s --check-prefixes=CHECK-COMMON,CHECK-SPV-IR
 
+; RUN: llvm-spirv %t.bc --spirv-ext=+all -o %t.rev.spv
+; RUN: spirv-val %t.rev.spv
+
 
 ; CHECK-CL-DAG: declare spir_func i32 @_Z14work_group_alli(i32) #[[#Attrs:]]
 ; CHECK-CL-DAG: declare spir_func i32 @_Z14work_group_anyi(i32) #[[#Attrs]]
@@ -84,14 +87,14 @@
 ; CHECK-SPV-IR: declare spir_func i32 @_Z17__spirv_GroupSMaxiii(i32, i32, i32) #[[#Attrs]]
 ; CHECK-SPV-IR: declare spir_func i32 @_Z17__spirv_GroupUMaxiij(i32, i32, i32) #[[#Attrs]]
 ; CHECK-SPV-IR: declare spir_func float @_Z17__spirv_GroupFMaxiif(i32, i32, float) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func i32 @_Z23intel_sub_group_shuffleij(i32, i32) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func i32 @_Z28intel_sub_group_shuffle_downiij(i32, i32, i32) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func i32 @_Z26intel_sub_group_shuffle_upiij(i32, i32, i32) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func i32 @_Z27intel_sub_group_shuffle_xorij(i32, i32) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func i32 @_Z26intel_sub_group_block_readPU3AS1Kj(i32 addrspace(1)*) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func void @_Z27intel_sub_group_block_writePU3AS1jj(i32 addrspace(1)*, i32) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func i32 @_Z26intel_sub_group_block_read14ocl_image2d_rwDv2_i(%opencl.image2d_rw_t addrspace(1)*, <2 x i32>) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func void @_Z27intel_sub_group_block_write14ocl_image2d_rwDv2_ij(%opencl.image2d_rw_t addrspace(1)*, <2 x i32>, i32) #[[#Attrs]]
+; CHECK-SPV-IR: declare spir_func i32 @_Z28__spirv_SubgroupShuffleINTELij(i32, i32) #[[#Attrs]]
+; CHECK-SPV-IR: declare spir_func i32 @_Z32__spirv_SubgroupShuffleDownINTELiij(i32, i32, i32) #[[#Attrs]]
+; CHECK-SPV-IR: declare spir_func i32 @_Z30__spirv_SubgroupShuffleUpINTELiij(i32, i32, i32) #[[#Attrs]]
+; CHECK-SPV-IR: declare spir_func i32 @_Z31__spirv_SubgroupShuffleXorINTELij(i32, i32) #[[#Attrs]]
+; CHECK-SPV-IR: declare spir_func i32 @_Z36__spirv_SubgroupBlockReadINTEL_RuintPU3AS1Kj(i32 addrspace(1)*) #[[#Attrs]]
+; CHECK-SPV-IR: declare spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1jj(i32 addrspace(1)*, i32) #[[#Attrs]]
+; CHECK-SPV-IR: declare spir_func i32 @_Z41__spirv_SubgroupImageBlockReadINTEL_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_2Dv2_i(%spirv.Image._void_1_0_0_0_0_0_2 addrspace(1)*, <2 x i32>) #[[#Attrs]]
+; CHECK-SPV-IR: declare spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_2Dv2_ij(%spirv.Image._void_1_0_0_0_0_0_2 addrspace(1)*, <2 x i32>, i32) #[[#Attrs]]
 
 ; CHECK-COMMON: attributes #[[#Attrs]] =
 ; CHECK-COMMON-SAME: convergent

--- a/test/image.ll
+++ b/test/image.ll
@@ -5,6 +5,8 @@
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
+; RUN: llvm-spirv %t.rev.bc -o %t.rev.spv
+; RUN: spirv-val %t.rev.spv
 
 ; CHECK-SPIRV-DAG: 10 TypeImage {{[0-9]*}} 6 1 0 0 0 0 0 0
 ; CHECK-SPIRV-DAG: 10 TypeImage {{[0-9]*}} 6 1 0 0 0 0 0 1
@@ -30,7 +32,7 @@ entry:
   %call4 = tail call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(%opencl.image2d_t addrspace(1)* %image1, i32 20, <2 x i32> %vecinit3) #3
   tail call spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f(%opencl.image2d_t addrspace(1)* %image2, <2 x i32> %vecinit3, <4 x float> %call4) #4
 ; CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(%opencl.image2d_wo_t addrspace(1)* %image2, <2 x i32> %vecinit3, <4 x float> %call4) #0
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWrite14ocl_image2d_woDv2_iDv4_f(%opencl.image2d_wo_t addrspace(1)* %image2, <2 x i32> %vecinit3, <4 x float> %call4) #0
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_f(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)* %image2, <2 x i32> %vecinit3, <4 x float> %call4) #0
   ret void
 }
 
@@ -42,7 +44,7 @@ declare spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(%o
 
 declare spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f(%opencl.image2d_t addrspace(1)*, <2 x i32>, <4 x float>) #2
 ; CHECK-LLVM: declare spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(%opencl.image2d_wo_t addrspace(1)*, <2 x i32>, <4 x float>)
-; CHECK-SPV-IR: declare spir_func void @_Z18__spirv_ImageWrite14ocl_image2d_woDv2_iDv4_f(%opencl.image2d_wo_t addrspace(1)*, <2 x i32>, <4 x float>)
+; CHECK-SPV-IR: declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_f(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*, <2 x i32>, <4 x float>)
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/read_image.cl
+++ b/test/read_image.cl
@@ -2,8 +2,11 @@
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv -s %t.bc -o %t1.bc
-// RUN: llvm-dis %t1.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-LLVM
+// RUN: llvm-spirv %t.rev.bc -o %t.rev.spv
+// RUN: spirv-val %t.rev.spv
+// RUN: llvm-spirv %t.rev.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 // CHECK-SPIRV: TypeInt [[IntTy:[0-9]+]]
 // CHECK-SPIRV: TypeVector [[IVecTy:[0-9]+]] [[IntTy]]
@@ -12,8 +15,8 @@
 // CHECK-SPIRV: ImageRead [[IVecTy]]
 // CHECK-SPIRV: ImageRead [[FVecTy]]
 
-// CHECK-LLVM: call spir_func <4 x i32> @_Z24__spirv_ImageRead_Ruint414ocl_image3d_roDv4_i
-// CHECK-LLVM: call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat414ocl_image3d_roDv4_i
+// CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z24__spirv_ImageRead_Ruint4PU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_i(%spirv.Image._void_2_0_0_0_0_0_0 addrspace(1)*
+// CHECK-SPV-LLVM: call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_i(%spirv.Image._void_2_0_0_0_0_0_0 addrspace(1)*
 
 __kernel void kernelA(__read_only image3d_t input) {
   uint4 c = read_imageui(input, (int4)(0, 0, 0, 0));

--- a/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_generic.cl
+++ b/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_generic.cl
@@ -4,7 +4,11 @@
 // There is no validation for SPV_INTEL_device_side_avc_motion_estimation implemented in
 // SPIRV-Tools. TODO: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM-COMMON,CHECK-LLVM
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM-COMMON,CHECK-LLVM-SPIRV
+// RUN: llvm-spirv %t.rev.bc --spirv-ext=+SPV_INTEL_device_side_avc_motion_estimation -o %t.spv
+// RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 #pragma OPENCL EXTENSION cl_intel_device_side_avc_motion_estimation : enable
 void foo(intel_sub_group_avc_ime_payload_t ime_payload,
@@ -115,6 +119,18 @@ void foo(intel_sub_group_avc_ime_payload_t ime_payload,
 // CHECK-LLVM: %[[ImeSRefInTy:opencl.intel_sub_group_avc_ime_single_reference_streamin_t]] = type opaque
 // CHECK-LLVM: %[[ImeDRefInTy:opencl.intel_sub_group_avc_ime_dual_reference_streamin_t]] = type opaque
 
+// CHECK-LLVM-SPIRV: %[[ImePayloadTy:spirv.AvcImePayloadINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeSRefOutTy:spirv.AvcImeResultSingleReferenceStreamoutINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeDRefOutTy:spirv.AvcImeResultDualReferenceStreamoutINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeResultTy:spirv.AvcImeResultINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[MceResultTy:spirv.AvcMceResultINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[RefPayloadTy:spirv.AvcRefPayloadINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[SicPayloadTy:spirv.AvcSicPayloadINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[SicResultTy:spirv.AvcSicResultINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[McePayloadTy:spirv.AvcMcePayloadINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeSRefInTy:spirv.AvcImeSingleReferenceStreaminINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeDRefInTy:spirv.AvcImeDualReferenceStreaminINTEL]] = type opaque
+
 
 // CHECK-SPIRV:  FunctionParameter [[ImePayloadTy]] [[ImePayload:[0-9]+]]
 // CHECK-SPIRV:  FunctionParameter [[ImeSRefOutTy]] [[ImeSRefOut:[0-9]+]]
@@ -126,58 +142,72 @@ void foo(intel_sub_group_avc_ime_payload_t ime_payload,
 // CHECK-SPIRV:  FunctionParameter [[SicResultTy]]  [[SicResult:[0-9]+]]
 // CHECK-SPIRV:  FunctionParameter [[McePayloadTy]] [[McePayload:[0-9]+]]
 
-// CHECK-LLVM: spir_func void @foo(%[[ImePayloadTy]]* %[[ImePayload:.*]], %[[ImeSRefOutTy]]* %[[ImeSRefOut:.*]], %[[ImeDRefOutTy]]* %[[ImeDRefOut:.*]], %[[ImeResultTy]]* %[[ImeResult:.*]], %[[MceResultTy]]* %[[MceResult:.*]], %[[RefPayloadTy]]* %[[RefPayload:.*]], %[[SicPayloadTy]]* %[[SicPayload:.*]], %[[SicResultTy]]* %[[SicResult:.*]], %[[McePayloadTy]]* %[[McePayload:.*]])
+// CHECK-LLVM-COMMON: spir_func void @foo(%[[ImePayloadTy]]* %[[ImePayload:.*]], %[[ImeSRefOutTy]]* %[[ImeSRefOut:.*]], %[[ImeDRefOutTy]]* %[[ImeDRefOut:.*]], %[[ImeResultTy]]* %[[ImeResult:.*]], %[[MceResultTy]]* %[[MceResult:.*]], %[[RefPayloadTy]]* %[[RefPayload:.*]], %[[SicPayloadTy]]* %[[SicPayload:.*]], %[[SicResultTy]]* %[[SicResult:.*]], %[[McePayloadTy]]* %[[McePayload:.*]])
 
 // CHECK-SPIRV:  SubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTEL
 // CHECK-LLVM: call spir_func i8 @_Z70intel_sub_group_avc_mce_get_default_inter_base_multi_reference_penaltyhh(i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i8 @_Z67__spirv_SubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTELcc(i8 0, i8 0)
 
 // CHECK-SPIRV:  SubgroupAvcMceGetDefaultInterShapePenaltyINTEL
 // CHECK-LLVM: call spir_func i64 @_Z55intel_sub_group_avc_mce_get_default_inter_shape_penaltyhh(i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i64 @_Z54__spirv_SubgroupAvcMceGetDefaultInterShapePenaltyINTELcc(i8 0, i8 0)
 
 // CHECK-SPIRV:  SubgroupAvcMceGetDefaultIntraLumaShapePenaltyINTEL
 // CHECK-LLVM: call spir_func i32 @_Z60intel_sub_group_avc_mce_get_default_intra_luma_shape_penaltyhh(i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i32 @_Z58__spirv_SubgroupAvcMceGetDefaultIntraLumaShapePenaltyINTELcc(i8 0, i8 0)
 
 // CHECK-SPIRV:  SubgroupAvcMceGetDefaultInterMotionVectorCostTableINTEL
 // CHECK-LLVM: call spir_func <2 x i32> @_Z66intel_sub_group_avc_mce_get_default_inter_motion_vector_cost_tablehh(i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func <2 x i32> @_Z63__spirv_SubgroupAvcMceGetDefaultInterMotionVectorCostTableINTELcc(i8 0, i8 0)
 
 // CHECK-SPIRV:  SubgroupAvcMceGetDefaultInterDirectionPenaltyINTEL
 // CHECK-LLVM: call spir_func i8 @_Z59intel_sub_group_avc_mce_get_default_inter_direction_penaltyhh(i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i8 @_Z58__spirv_SubgroupAvcMceGetDefaultInterDirectionPenaltyINTELcc(i8 0, i8 0)
 
 // CHECK-SPIRV:  SubgroupAvcMceGetDefaultIntraLumaModePenaltyINTEL
 // CHECK-LLVM: call spir_func i8 @_Z59intel_sub_group_avc_mce_get_default_intra_luma_mode_penaltyhh(i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i8 @_Z57__spirv_SubgroupAvcMceGetDefaultIntraLumaModePenaltyINTELcc(i8 0, i8 0)
 
 
 // CHECK-SPIRV:  SubgroupAvcImeInitializeINTEL [[ImePayloadTy]]
 // CHECK-LLVM: call spir_func %[[ImePayloadTy]]* @_Z34intel_sub_group_avc_ime_initializeDv2_thh(<2 x i16> zeroinitializer, i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func %spirv.AvcImePayloadINTEL* @_Z37__spirv_SubgroupAvcImeInitializeINTELDv2_scc(<2 x i16> zeroinitializer, i8 0, i8 0)
 
 // CHECK-SPIRV:  SubgroupAvcImeSetSingleReferenceINTEL [[ImePayloadTy]] {{.*}} [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImePayloadTy]]* @_Z44intel_sub_group_avc_ime_set_single_referenceDv2_sh37ocl_intel_sub_group_avc_ime_payload_t(<2 x i16> zeroinitializer, i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %spirv.AvcImePayloadINTEL* @_Z45__spirv_SubgroupAvcImeSetSingleReferenceINTELDv2_scP26__spirv_AvcImePayloadINTEL(<2 x i16> zeroinitializer, i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV:  SubgroupAvcImeSetDualReferenceINTEL [[ImePayloadTy]] {{.*}} [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImePayloadTy]]* @_Z42intel_sub_group_avc_ime_set_dual_referenceDv2_sS_h37ocl_intel_sub_group_avc_ime_payload_t(<2 x i16> zeroinitializer, <2 x i16> zeroinitializer, i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
-
+// CHECK-LLVM-SPIRV: call spir_func %spirv.AvcImePayloadINTEL* @_Z43__spirv_SubgroupAvcImeSetDualReferenceINTELDv2_sS_cP26__spirv_AvcImePayloadINTEL(<2 x i16> zeroinitializer, <2 x i16> zeroinitializer, i8 0, %spirv.AvcImePayloadINTEL* %[[ImePayload]])
 
 // CHECK-SPIRV:  SubgroupAvcImeRefWindowSizeINTEL
 // CHECK-LLVM: call spir_func <2 x i16> @_Z39intel_sub_group_avc_ime_ref_window_sizehc(i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func <2 x i16> @_Z40__spirv_SubgroupAvcImeRefWindowSizeINTELcc(i8 0, i8 0)
+
 // CHECK-SPIRV:  SubgroupAvcImeRefWindowSizeINTEL
 // CHECK-LLVM: call spir_func <2 x i16> @_Z39intel_sub_group_avc_ime_ref_window_sizehc(i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func <2 x i16> @_Z40__spirv_SubgroupAvcImeRefWindowSizeINTELcc(i8 0, i8 0)
 
 // CHECK-SPIRV:  SubgroupAvcImeAdjustRefOffsetINTEL
 // CHECK-LLVM: call spir_func <2 x i16> @_Z41intel_sub_group_avc_ime_adjust_ref_offsetDv2_sDv2_tS0_S0_(<2 x i16> zeroinitializer, <2 x i16> zeroinitializer, <2 x i16> zeroinitializer, <2 x i16> zeroinitializer)
-
+// CHECK-LLVM-SPIRV: call spir_func <2 x i16> @_Z42__spirv_SubgroupAvcImeAdjustRefOffsetINTELDv2_sS_S_S_(<2 x i16> zeroinitializer, <2 x i16> zeroinitializer, <2 x i16> zeroinitializer, <2 x i16> zeroinitializer)
 
 // CHECK-SPIRV:  SubgroupAvcImeSetMaxMotionVectorCountINTEL [[ImePayloadTy]] {{.*}} [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImePayloadTy]]* @_Z51intel_sub_group_avc_ime_set_max_motion_vector_counth37ocl_intel_sub_group_avc_ime_payload_t(i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
-
+// CHECK-LLVM-SPIRV: call spir_func %[[ImePayloadTy]]* @_Z50__spirv_SubgroupAvcImeSetMaxMotionVectorCountINTELcP26__spirv_AvcImePayloadINTEL(i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV:  SubgroupAvcImeGetSingleReferenceStreaminINTEL [[ImeSRefInTy]] {{.*}} [[ImeSRefOut]]
 // CHECK-LLVM: call spir_func %[[ImeSRefInTy]]* @_Z53intel_sub_group_avc_ime_get_single_reference_streamin63ocl_intel_sub_group_avc_ime_result_single_reference_streamout_t(%[[ImeSRefOutTy]]* %[[ImeSRefOut]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeSRefInTy]]* @_Z53__spirv_SubgroupAvcImeGetSingleReferenceStreaminINTELP49__spirv_AvcImeResultSingleReferenceStreamoutINTEL(%[[ImeSRefOutTy]]* %[[ImeSRefOut]])
 
 // CHECK-SPIRV:  SubgroupAvcImeGetDualReferenceStreaminINTEL [[ImeDRefInTy]] {{.*}} [[ImeDRefOut]]
 // CHECK-LLVM: call spir_func %[[ImeDRefInTy]]* @_Z51intel_sub_group_avc_ime_get_dual_reference_streamin61ocl_intel_sub_group_avc_ime_result_dual_reference_streamout_t(%[[ImeDRefOutTy]]* %[[ImeDRefOut]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeDRefInTy]]* @_Z51__spirv_SubgroupAvcImeGetDualReferenceStreaminINTELP47__spirv_AvcImeResultDualReferenceStreamoutINTEL(%[[ImeDRefOutTy]]* %[[ImeDRefOut]])
 
 // CHECK-SPIRV:  SubgroupAvcImeGetBorderReachedINTEL {{.*}} [[ImeResult]]
 // CHECK-LLVM: call spir_func i8 @_Z42intel_sub_group_avc_ime_get_border_reachedh36ocl_intel_sub_group_avc_ime_result_t(i8 0, %[[ImeResultTy]]* %[[ImeResult]])
+// CHECK-LLVM-SPIRV: call spir_func i8 @_Z43__spirv_SubgroupAvcImeGetBorderReachedINTELcP25__spirv_AvcImeResultINTEL(i8 0, %[[ImeResultTy]]* %[[ImeResult]])
 
 // CHECK-SPIRV: SubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTEL {{.*}} [[ImeSRefOut]]
 // CHECK-SPIRV: SubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTEL {{.*}} [[ImeDRefOut]]
@@ -191,56 +221,78 @@ void foo(intel_sub_group_avc_ime_payload_t ime_payload,
 // CHECK-LLVM: call spir_func i32 @_Z64intel_sub_group_avc_ime_get_streamout_major_shape_motion_vectors61ocl_intel_sub_group_avc_ime_result_dual_reference_streamout_thh(%[[ImeDRefOutTy]]* %[[ImeDRefOut]], i8 0, i8 0)
 // CHECK-LLVM: call spir_func i8 @_Z63intel_sub_group_avc_ime_get_streamout_major_shape_reference_ids63ocl_intel_sub_group_avc_ime_result_single_reference_streamout_th(%[[ImeSRefOutTy]]* %[[ImeSRefOut]], i8 0)
 // CHECK-LLVM: call spir_func i8 @_Z63intel_sub_group_avc_ime_get_streamout_major_shape_reference_ids61ocl_intel_sub_group_avc_ime_result_dual_reference_streamout_thh(%[[ImeDRefOutTy]]* %[[ImeDRefOut]], i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i16 @_Z75__spirv_SubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTELP49__spirv_AvcImeResultSingleReferenceStreamoutINTELc(%[[ImeSRefOutTy]]* %[[ImeSRefOut]], i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i16 @_Z73__spirv_SubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTELP47__spirv_AvcImeResultDualReferenceStreamoutINTELcc(%[[ImeDRefOutTy]]* %[[ImeDRefOut]], i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i32 @_Z77__spirv_SubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTELP49__spirv_AvcImeResultSingleReferenceStreamoutINTELc(%[[ImeSRefOutTy]]* %[[ImeSRefOut]], i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i32 @_Z75__spirv_SubgroupAvcImeGetStreamoutDualReferenceMajorShapeMotionVectorsINTELP47__spirv_AvcImeResultDualReferenceStreamoutINTELcc(%[[ImeDRefOutTy]]* %[[ImeDRefOut]], i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i8 @_Z76__spirv_SubgroupAvcImeGetStreamoutSingleReferenceMajorShapeReferenceIdsINTELP49__spirv_AvcImeResultSingleReferenceStreamoutINTELc(%[[ImeSRefOutTy]]* %[[ImeSRefOut]], i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i8 @_Z74__spirv_SubgroupAvcImeGetStreamoutDualReferenceMajorShapeReferenceIdsINTELP47__spirv_AvcImeResultDualReferenceStreamoutINTELcc(%[[ImeDRefOutTy]]* %[[ImeDRefOut]], i8 0, i8 0)
 
 
 // CHECK-SPIRV: SubgroupAvcImeSetDualReferenceINTEL [[ImePayloadTy]] {{.*}} [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImePayloadTy]]* @_Z42intel_sub_group_avc_ime_set_dual_referenceDv2_sS_h37ocl_intel_sub_group_avc_ime_payload_t(<2 x i16> zeroinitializer, <2 x i16> zeroinitializer, i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImePayloadTy]]* @_Z43__spirv_SubgroupAvcImeSetDualReferenceINTELDv2_sS_cP26__spirv_AvcImePayloadINTEL(<2 x i16> zeroinitializer, <2 x i16> zeroinitializer, i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV: SubgroupAvcImeSetWeightedSadINTEL [[ImePayloadTy]] {{.*}} [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImePayloadTy]]* @_Z40intel_sub_group_avc_ime_set_weighted_sadj37ocl_intel_sub_group_avc_ime_payload_t(i32 0, %[[ImePayloadTy]]* %[[ImePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImePayloadTy]]* @_Z41__spirv_SubgroupAvcImeSetWeightedSadINTELiP26__spirv_AvcImePayloadINTEL(i32 0, %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV: SubgroupAvcImeSetEarlySearchTerminationThresholdINTEL [[ImePayloadTy]] {{.*}} [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImePayloadTy]]* @_Z62intel_sub_group_avc_ime_set_early_search_termination_thresholdh37ocl_intel_sub_group_avc_ime_payload_t(i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImePayloadTy]]* @_Z61__spirv_SubgroupAvcImeSetEarlySearchTerminationThresholdINTELcP26__spirv_AvcImePayloadINTEL(i8 0, %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV:  SubgroupAvcFmeInitializeINTEL [[RefPayloadTy]]
 // CHECK-LLVM: call spir_func %[[RefPayloadTy]]* @_Z34intel_sub_group_avc_fme_initializeDv2_tmhhhhh(<2 x i16> zeroinitializer, i64 0, i8 0, i8 0, i8 0, i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func %[[RefPayloadTy]]* @_Z37__spirv_SubgroupAvcFmeInitializeINTELDv2_slccccc(<2 x i16> zeroinitializer, i64 0, i8 0, i8 0, i8 0, i8 0, i8 0)
 
 // CHECK-SPIRV:  SubgroupAvcBmeInitializeINTEL [[RefPayloadTy]]
 // CHECK-LLVM: call spir_func %[[RefPayloadTy]]* @_Z34intel_sub_group_avc_bme_initializeDv2_tmhhhhhh(<2 x i16> zeroinitializer, i64 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func %[[RefPayloadTy]]* @_Z37__spirv_SubgroupAvcBmeInitializeINTELDv2_slcccccc(<2 x i16> zeroinitializer, i64 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0)
 
 
 // CHECK-SPIRV:  SubgroupAvcRefSetBidirectionalMixDisableINTEL [[RefPayloadTy]] {{.*}} [[RefPayload]]
 // CHECK-LLVM: call spir_func %[[RefPayloadTy]]* @_Z53intel_sub_group_avc_ref_set_bidirectional_mix_disable37ocl_intel_sub_group_avc_ref_payload_t(%[[RefPayloadTy]]* %[[RefPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[RefPayloadTy]]* @_Z53__spirv_SubgroupAvcRefSetBidirectionalMixDisableINTELP26__spirv_AvcRefPayloadINTEL(%[[RefPayloadTy]]* %[[RefPayload]])
 
 
 // CHECK-SPIRV:  SubgroupAvcSicInitializeINTEL [[SicPayloadTy]]
 // CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z34intel_sub_group_avc_sic_initializeDv2_t(<2 x i16> zeroinitializer)
-
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z37__spirv_SubgroupAvcSicInitializeINTELDv2_s(<2 x i16> zeroinitializer)
 
 // CHECK-SPIRV:  SubgroupAvcSicConfigureIpeLumaINTEL [[SicPayloadTy]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z37intel_sub_group_avc_sic_configure_ipehhhhhhh37ocl_intel_sub_group_avc_sic_payload_t(i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z43__spirv_SubgroupAvcSicConfigureIpeLumaINTELcccccccP26__spirv_AvcSicPayloadINTEL(i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
 // CHECK-SPIRV:  SubgroupAvcSicConfigureIpeLumaChromaINTEL [[SicPayloadTy]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z37intel_sub_group_avc_sic_configure_ipehhhhhhttth37ocl_intel_sub_group_avc_sic_payload_t(i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i16 0, i16 0, i16 0, i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z49__spirv_SubgroupAvcSicConfigureIpeLumaChromaINTELccccccssscP26__spirv_AvcSicPayloadINTEL(i8 0, i8 0, i8 0, i8 0, i8 0, i8 0, i16 0, i16 0, i16 0, i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
 
 // CHECK-SPIRV: SubgroupAvcSicConfigureSkcINTEL [[SicPayloadTy]] {{.*}} [[SicPayload]]
-// call spir_func %opencl.intel_sub_group_avc_sic_payload_t* @_Z37intel_sub_group_avc_sic_configure_skcjjmhh37ocl_intel_sub_group_avc_sic_payload_t(i32 0, i32 0, i64 0, i8 0, i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
- 
+// CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z37intel_sub_group_avc_sic_configure_skcjjmhh37ocl_intel_sub_group_avc_sic_payload_t(i32 0, i32 0, i64 0, i8 0, i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z39__spirv_SubgroupAvcSicConfigureSkcINTELiilccP26__spirv_AvcSicPayloadINTEL(i32 0, i32 0, i64 0, i8 0, i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
+
 // CHECK-SPIRV: SubgroupAvcSicSetSkcForwardTransformEnableINTEL [[SicPayloadTy]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z56intel_sub_group_avc_sic_set_skc_forward_transform_enablem37ocl_intel_sub_group_avc_sic_payload_t(i64 0, %[[SicPayloadTy]]* %[[SicPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z55__spirv_SubgroupAvcSicSetSkcForwardTransformEnableINTELlP26__spirv_AvcSicPayloadINTEL(i64 0, %[[SicPayloadTy]]* %[[SicPayload]])
 // CHECK-SPIRV: SubgroupAvcSicSetBlockBasedRawSkipSadINTEL [[SicPayloadTy]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z52intel_sub_group_avc_sic_set_block_based_raw_skip_sadh37ocl_intel_sub_group_avc_sic_payload_t(i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z50__spirv_SubgroupAvcSicSetBlockBasedRawSkipSadINTELcP26__spirv_AvcSicPayloadINTEL(i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
 // CHECK-SPIRV: SubgroupAvcSicSetIntraLumaShapePenaltyINTEL [[SicPayloadTy]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z52intel_sub_group_avc_sic_set_intra_luma_shape_penaltyj37ocl_intel_sub_group_avc_sic_payload_t(i32 0, %[[SicPayloadTy]]* %[[SicPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z51__spirv_SubgroupAvcSicSetIntraLumaShapePenaltyINTELiP26__spirv_AvcSicPayloadINTEL(i32 0, %[[SicPayloadTy]]* %[[SicPayload]])
 // CHECK-SPIRV: SubgroupAvcSicSetIntraLumaModeCostFunctionINTEL [[SicPayloadTy]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z57intel_sub_group_avc_sic_set_intra_luma_mode_cost_functionhjj37ocl_intel_sub_group_avc_sic_payload_t(i8 0, i32 0, i32 0, %[[SicPayloadTy]]* %[[SicPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z55__spirv_SubgroupAvcSicSetIntraLumaModeCostFunctionINTELciiP26__spirv_AvcSicPayloadINTEL(i8 0, i32 0, i32 0, %[[SicPayloadTy]]* %[[SicPayload]])
 // CHECK-SPIRV: SubgroupAvcSicSetIntraChromaModeCostFunctionINTEL [[SicPayloadTy]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicPayloadTy]]* @_Z59intel_sub_group_avc_sic_set_intra_chroma_mode_cost_functionh37ocl_intel_sub_group_avc_sic_payload_t(i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicPayloadTy]]* @_Z57__spirv_SubgroupAvcSicSetIntraChromaModeCostFunctionINTELcP26__spirv_AvcSicPayloadINTEL(i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
 
 // CHECK-SPIRV:  SubgroupAvcSicGetBestIpeLumaDistortionINTEL {{.*}} [[SicResult]]
 // CHECK-LLVM: call spir_func i16 @_Z52intel_sub_group_avc_sic_get_best_ipe_luma_distortion36ocl_intel_sub_group_avc_sic_result_t(%[[SicResultTy]]* %[[SicResult]])
+// CHECK-LLVM-SPIRV: call spir_func i16 @_Z51__spirv_SubgroupAvcSicGetBestIpeLumaDistortionINTELP25__spirv_AvcSicResultINTEL(%[[SicResultTy]]* %[[SicResult]])
 
 // CHECK-SPIRV:  SubgroupAvcSicGetMotionVectorMaskINTEL
 // CHECK-LLVM: call spir_func i32 @_Z46intel_sub_group_avc_sic_get_motion_vector_maskjh(i32 0, i8 0)
+// CHECK-LLVM-SPIRV: call spir_func i32 @_Z46__spirv_SubgroupAvcSicGetMotionVectorMaskINTELic(i32 0, i8 0)
 
 // CHECK-SPIRV: SubgroupAvcMceSetSourceInterlacedFieldPolarityINTEL [[McePayloadTy]] {{.*}} [[McePayload]]
 // CHECK-SPIRV: SubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTEL [[McePayloadTy]] {{.*}} [[McePayload]]
@@ -256,5 +308,15 @@ void foo(intel_sub_group_avc_ime_payload_t ime_payload,
 // CHECK-LLVM: call spir_func %[[McePayloadTy]]* @_Z47intel_sub_group_avc_mce_set_inter_shape_penaltym37ocl_intel_sub_group_avc_mce_payload_t(i64 0, %[[McePayloadTy]]* %[[McePayload]])
 // CHECK-LLVM: call spir_func %[[McePayloadTy]]* @_Z51intel_sub_group_avc_mce_set_inter_direction_penaltyh37ocl_intel_sub_group_avc_mce_payload_t(i8 0, %[[McePayloadTy]]* %[[McePayload]])
 // CHECK-LLVM: call spir_func %[[McePayloadTy]]* @_Z55intel_sub_group_avc_mce_set_motion_vector_cost_functionmDv2_jh37ocl_intel_sub_group_avc_mce_payload_t(i64 0, <2 x i32> zeroinitializer, i8 0, %[[McePayloadTy]]* %[[McePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[McePayloadTy]]* @_Z59__spirv_SubgroupAvcMceSetSourceInterlacedFieldPolarityINTELcP26__spirv_AvcMcePayloadINTEL(i8 0, %[[McePayloadTy]]* %[[McePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[McePayloadTy]]* @_Z68__spirv_SubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTELcP26__spirv_AvcMcePayloadINTEL(i8 0, %[[McePayloadTy]]* %[[McePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[McePayloadTy]]* @_Z68__spirv_SubgroupAvcMceSetDualReferenceInterlacedFieldPolaritiesINTELccP26__spirv_AvcMcePayloadINTEL(i8 0, i8 0, %[[McePayloadTy]]* %[[McePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[McePayloadTy]]* @_Z60__spirv_SubgroupAvcMceSetInterBaseMultiReferencePenaltyINTELcP26__spirv_AvcMcePayloadINTEL(i8 0, %[[McePayloadTy]]* %[[McePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[McePayloadTy]]* @_Z47__spirv_SubgroupAvcMceSetInterShapePenaltyINTELlP26__spirv_AvcMcePayloadINTEL(i64 0, %[[McePayloadTy]]* %[[McePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[McePayloadTy]]* @_Z51__spirv_SubgroupAvcMceSetInterDirectionPenaltyINTELcP26__spirv_AvcMcePayloadINTEL(i8 0, %[[McePayloadTy]]* %[[McePayload]])
+// CHECK-LLVM-SPIRV: call spir_func %[[McePayloadTy]]* @_Z54__spirv_SubgroupAvcMceSetMotionVectorCostFunctionINTELlDv2_icP26__spirv_AvcMcePayloadINTEL(i64 0, <2 x i32> zeroinitializer, i8 0, %[[McePayloadTy]]* %[[McePayload]])
+
 
 // CHECK-SPIRV: SubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL {{.*}} [[MceResult]]
+// CHECK-LLVM: call spir_func i8 @_Z71intel_sub_group_avc_mce_get_inter_reference_interlaced_field_polaritiesjj36ocl_intel_sub_group_avc_mce_result_t(i32 0, i32 0, %[[MceResultTy]]* %[[MceResult]])
+// CHECK-LLVM-SPIRV: call spir_func i8 @_Z69__spirv_SubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTELiiP25__spirv_AvcMceResultINTEL(i32 0, i32 0, %[[MceResultTy]]* %[[MceResult]])

--- a/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_types.spt
+++ b/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_types.spt
@@ -94,7 +94,9 @@
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
-; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-LLVM-SPIRV
 
 ; CHECK-LLVM: %opencl.intel_sub_group_avc_mce_payload_t = type opaque
 ; CHECK-LLVM: %opencl.intel_sub_group_avc_ime_payload_t = type opaque
@@ -108,4 +110,18 @@
 ; CHECK-LLVM: %opencl.intel_sub_group_avc_ime_result_dual_reference_streamout_t = type opaque
 ; CHECK-LLVM: %opencl.intel_sub_group_avc_ime_single_reference_streamin_t = type opaque
 ; CHECK-LLVM: %opencl.intel_sub_group_avc_ime_dual_reference_streamin_t = type opaque
-; CHECK-LLVM: define spir_func void @foo()
+
+; CHECK-LLVM-SPIRV: %spirv.AvcMcePayloadINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcImePayloadINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcRefPayloadINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcSicPayloadINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcMceResultINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcImeResultINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcRefResultINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcSicResultINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcImeResultSingleReferenceStreamoutINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcImeResultDualReferenceStreamoutINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcImeSingleReferenceStreaminINTEL = type opaque
+; CHECK-LLVM-SPIRV: %spirv.AvcImeDualReferenceStreaminINTEL = type opaque
+
+; CHECK-COMMON: define spir_func void @foo()

--- a/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_vme_image.cl
+++ b/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_vme_image.cl
@@ -4,7 +4,11 @@
 // There is no validation for SPV_INTEL_device_side_avc_motion_estimation implemented in
 // SPIRV-Tools. TODO: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM-COMMON,CHECK-LLVM
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM-COMMON,CHECK-LLVM-SPIRV
+// RUN: llvm-spirv %t.rev.bc --spirv-ext=+SPV_INTEL_device_side_avc_motion_estimation -o %t.rev.spv
+// RUN: llvm-spirv %t.rev.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 #pragma OPENCL EXTENSION cl_intel_device_side_avc_motion_estimation : enable
 
@@ -83,6 +87,20 @@ void foo(__read_only image2d_t src, __read_only image2d_t ref,
 // CHECK-LLVM: %[[RefResultTy:opencl.intel_sub_group_avc_ref_result_t]] = type opaque
 // CHECK-LLVM: %[[SicResultTy:opencl.intel_sub_group_avc_sic_result_t]] = type opaque
 
+// CHECK-LLVM-SPIRV: %[[ImageTy:spirv.Image._void_1_0_0_0_0_0_0]] = type opaque
+// CHECK-LLVM-SPIRV: %[[SamplerTy:opencl.sampler_t]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImePayloadTy:spirv.AvcImePayloadINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeSRefInTy:spirv.AvcImeSingleReferenceStreaminINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeDRefInTy:spirv.AvcImeDualReferenceStreaminINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[RefPayloadTy:spirv.AvcRefPayloadINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[SicPayloadTy:spirv.AvcSicPayloadINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[VmeImageTy:spirv.VmeImageINTEL._void_1_0_0_0_0_0_0]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeResultTy:spirv.AvcImeResultINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeSRefOutTy:spirv.AvcImeResultSingleReferenceStreamoutINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[ImeDRefOutTy:spirv.AvcImeResultDualReferenceStreamoutINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[RefResultTy:spirv.AvcRefResultINTEL]] = type opaque
+// CHECK-LLVM-SPIRV: %[[SicResultTy:spirv.AvcSicResultINTEL]] = type opaque
+
 // CHECK-SPIRV: FunctionParameter [[ImageTy]] [[SrcImg:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter [[ImageTy]] [[RefImg:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter [[SamplerTy]] [[Sampler:[0-9]+]]
@@ -91,108 +109,144 @@ void foo(__read_only image2d_t src, __read_only image2d_t ref,
 // CHECK-SPIRV: FunctionParameter [[ImeDRefInTy]] [[ImeDRefIn:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter [[RefPayloadTy]] [[RefPayload:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter [[SicPayloadTy]] [[SicPayload:[0-9]+]]
-// CHECK-LLVM: @foo(%[[ImageTy]] addrspace(1)* %[[SrcImg:.*]], %[[ImageTy]] addrspace(1)* %[[RefImg:.*]], %[[SamplerTy]] addrspace(2)* %[[Sampler:.*]], %[[ImePayloadTy]]* %[[ImePayload:.*]], %[[ImeSRefInTy]]* %[[ImeSRefIn:.*]], %[[ImeDRefInTy]]* %[[ImeDRefIn:.*]], %[[RefPayloadTy]]* %[[RefPayload:.*]], %[[SicPayloadTy]]* %[[SicPayload:.*]])
+// CHECK-LLVM-COMMON: @foo(%[[ImageTy]] addrspace(1)* %[[SrcImg:.*]], %[[ImageTy]] addrspace(1)* %[[RefImg:.*]], %[[SamplerTy]] addrspace(2)* %[[Sampler:.*]], %[[ImePayloadTy]]* %[[ImePayload:.*]], %[[ImeSRefInTy]]* %[[ImeSRefIn:.*]], %[[ImeDRefInTy]]* %[[ImeDRefIn:.*]], %[[RefPayloadTy]]* %[[RefPayload:.*]], %[[SicPayloadTy]]* %[[SicPayload:.*]])
 
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg0:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg1:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcImeEvaluateWithSingleReferenceINTEL [[ImeResultTy]] {{.*}} [[VmeImg0]] [[VmeImg1]] [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImeResultTy]]* @_Z54intel_sub_group_avc_ime_evaluate_with_single_reference14ocl_image2d_roS_11ocl_sampler37ocl_intel_sub_group_avc_ime_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[ImePayloadTy]]* %[[ImePayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg0:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %src, %[[SamplerTy]] addrspace(2)* %sampler)
+// CHECK-LLVM-SPIRV: %[[VmeImg1:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %ref, %[[SamplerTy]] addrspace(2)* %sampler)
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeResultTy]]* @_Z54__spirv_SubgroupAvcImeEvaluateWithSingleReferenceINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcImePayloadINTEL(%[[VmeImageTy]] addrspace(1)* %TempSampledImage, %[[VmeImageTy]] addrspace(1)* %[[VmeImg1]], %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg2:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg3:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg4:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcImeEvaluateWithDualReferenceINTEL [[ImeResultTy]] {{.*}} [[VmeImg2]] [[VmeImg3]] [[VmeImg4]] [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImeResultTy]]* @_Z52intel_sub_group_avc_ime_evaluate_with_dual_reference14ocl_image2d_roS_S_11ocl_sampler37ocl_intel_sub_group_avc_ime_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[ImePayloadTy]]* %[[ImePayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg2:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg3:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg4:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeResultTy]]* @_Z52__spirv_SubgroupAvcImeEvaluateWithDualReferenceINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcImePayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg2]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg3]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg4]], %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg5:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg6:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTEL [[ImeSRefOutTy]] {{.*}} [[VmeImg5]] [[VmeImg6]] [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImeSRefOutTy]]* @_Z64intel_sub_group_avc_ime_evaluate_with_single_reference_streamout14ocl_image2d_roS_11ocl_sampler37ocl_intel_sub_group_avc_ime_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[ImePayloadTy]]* %[[ImePayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg5:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg6:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeSRefOutTy]]* @_Z63__spirv_SubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcImePayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg5]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg6]], %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg7:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg8:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg9:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcImeEvaluateWithDualReferenceStreamoutINTEL [[ImeDRefOutTy]] {{.*}} [[VmeImg7]] [[VmeImg8]] [[VmeImg9]] [[ImePayload]]
 // CHECK-LLVM: call spir_func %[[ImeDRefOutTy]]* @_Z62intel_sub_group_avc_ime_evaluate_with_dual_reference_streamout14ocl_image2d_roS_S_11ocl_sampler37ocl_intel_sub_group_avc_ime_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[ImePayloadTy]]* %[[ImePayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg7:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg8:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg9:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeDRefOutTy]]* @_Z61__spirv_SubgroupAvcImeEvaluateWithDualReferenceStreamoutINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcImePayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg7]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg8]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg9]], %[[ImePayloadTy]]* %[[ImePayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg10:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg11:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcImeEvaluateWithSingleReferenceStreaminINTEL [[ImeResultTy]] {{.*}} [[VmeImg10]] [[VmeImg11]] [[ImePayload]] [[ImeSRefIn]]
 // CHECK-LLVM: call spir_func %[[ImeResultTy]]* @_Z63intel_sub_group_avc_ime_evaluate_with_single_reference_streamin14ocl_image2d_roS_11ocl_sampler37ocl_intel_sub_group_avc_ime_payload_t55ocl_intel_sub_group_avc_ime_single_reference_streamin_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[ImePayloadTy]]* %[[ImePayload]], %[[ImeSRefInTy]]* %[[ImeSRefIn]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg10:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg11:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeResultTy]]* @_Z62__spirv_SubgroupAvcImeEvaluateWithSingleReferenceStreaminINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcImePayloadINTELP42__spirv_AvcImeSingleReferenceStreaminINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg10]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg11]], %[[ImePayloadTy]]* %[[ImePayload]], %[[ImeSRefInTy]]* %[[ImeSRefIn]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg12:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg13:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg14:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcImeEvaluateWithDualReferenceStreaminINTEL [[ImeResultTy]] {{.*}} [[VmeImg12]] [[VmeImg13]] [[VmeImg14]] [[ImePayload]] [[ImeDRefIn]]
 // CHECK-LLVM: call spir_func %[[ImeResultTy]]* @_Z61intel_sub_group_avc_ime_evaluate_with_dual_reference_streamin14ocl_image2d_roS_S_11ocl_sampler37ocl_intel_sub_group_avc_ime_payload_t53ocl_intel_sub_group_avc_ime_dual_reference_streamin_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[ImePayloadTy]]* %[[ImePayload]], %[[ImeDRefInTy]]* %[[ImeDRefIn]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg12:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg13:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg14:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeResultTy]]* @_Z60__spirv_SubgroupAvcImeEvaluateWithDualReferenceStreaminINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcImePayloadINTELP40__spirv_AvcImeDualReferenceStreaminINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg12]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg13]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg14]], %[[ImePayloadTy]]* %[[ImePayload]], %[[ImeDRefInTy]]* %[[ImeDRefIn]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg1:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg2:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTEL [[ImeSRefOutTy]] {{.*}} [[VmeImg1]] [[VmeImg2]] [[ImePayload]] [[ImeSRefIn]]
 // CHECK-LLVM: call spir_func %[[ImeSRefOutTy]]* @_Z66intel_sub_group_avc_ime_evaluate_with_single_reference_streaminout14ocl_image2d_roS_11ocl_sampler37ocl_intel_sub_group_avc_ime_payload_t55ocl_intel_sub_group_avc_ime_single_reference_streamin_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[ImePayloadTy]]* %[[ImePayload]], %[[ImeSRefInTy]]* %[[ImeSRefIn]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg15:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg16:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeSRefOutTy]]* @_Z65__spirv_SubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcImePayloadINTELP42__spirv_AvcImeSingleReferenceStreaminINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg15]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg16]], %[[ImePayloadTy]]* %[[ImePayload]], %[[ImeSRefInTy]]* %[[ImeSRefIn]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg1:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg2:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg3:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTEL [[ImeDRefOutTy]] {{.*}} [[VmeImg1]] [[VmeImg2]] [[VmeImg3]] [[ImePayload]] [[ImeDRefIn]]
 // CHECK-LLVM: call spir_func %[[ImeDRefOutTy]]* @_Z64intel_sub_group_avc_ime_evaluate_with_dual_reference_streaminout14ocl_image2d_roS_S_11ocl_sampler37ocl_intel_sub_group_avc_ime_payload_t53ocl_intel_sub_group_avc_ime_dual_reference_streamin_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[ImePayloadTy]]* %[[ImePayload]], %[[ImeDRefInTy]]* %[[ImeDRefIn]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg17:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg18:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg19:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[ImeDRefOutTy]]* @_Z63__spirv_SubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcImePayloadINTELP40__spirv_AvcImeDualReferenceStreaminINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg17]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg18]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg19]], %[[ImePayloadTy]]* %[[ImePayload]], %[[ImeDRefInTy]]* %[[ImeDRefIn]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg15:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg16:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcRefEvaluateWithSingleReferenceINTEL [[RefResultTy]] {{.*}} [[VmeImg15]] [[VmeImg16]] [[RefPayload]]
 // CHECK-LLVM: call spir_func %[[RefResultTy]]* @_Z54intel_sub_group_avc_ref_evaluate_with_single_reference14ocl_image2d_roS_11ocl_sampler37ocl_intel_sub_group_avc_ref_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[RefPayloadTy]]* %[[RefPayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg20:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg21:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[RefResultTy]]* @_Z54__spirv_SubgroupAvcRefEvaluateWithSingleReferenceINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcRefPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg20]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg21]], %[[RefPayloadTy]]* %[[RefPayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg17:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg18:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg19:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcRefEvaluateWithDualReferenceINTEL [[RefResultTy]] {{.*}} [[VmeImg17]] [[VmeImg18]] [[VmeImg19]] [[RefPayload]]
 // CHECK-LLVM: call spir_func %[[RefResultTy]]* @_Z52intel_sub_group_avc_ref_evaluate_with_dual_reference14ocl_image2d_roS_S_11ocl_sampler37ocl_intel_sub_group_avc_ref_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[RefPayloadTy]]* %[[RefPayload]])
+// CHECK-LLVM-SPIRV: %[[VmeImg22:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg23:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg24:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[RefResultTy]]* @_Z52__spirv_SubgroupAvcRefEvaluateWithDualReferenceINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcRefPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg22]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg23]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg24]], %[[RefPayloadTy]]* %[[RefPayload]])
 
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg20:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcRefEvaluateWithMultiReferenceINTEL [[RefResultTy]] {{.*}} [[VmeImg20]] {{.*}} [[RefPayload]]
 // CHECK-LLVM: call spir_func %[[RefResultTy]]* @_Z53intel_sub_group_avc_ref_evaluate_with_multi_reference14ocl_image2d_roj11ocl_sampler37ocl_intel_sub_group_avc_ref_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], i32 0, %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[RefPayloadTy]]* %[[RefPayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg25:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[RefResultTy]]* @_Z53__spirv_SubgroupAvcRefEvaluateWithMultiReferenceINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0iP26__spirv_AvcRefPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg25]], i32 0, %[[RefPayloadTy]]* %[[RefPayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg21:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL [[RefResultTy]] {{.*}} [[VmeImg21]] {{.*}} [[RefPayload]]
 // CHECK-LLVM: call spir_func %[[RefResultTy]]* @_Z53intel_sub_group_avc_ref_evaluate_with_multi_reference14ocl_image2d_rojh11ocl_sampler37ocl_intel_sub_group_avc_ref_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], i32 0, i8 0, %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[RefPayloadTy]]* %[[RefPayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg26:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[RefResultTy]]* @_Z63__spirv_SubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0icP26__spirv_AvcRefPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg26]], i32 0, i8 0, %[[RefPayloadTy]]* %[[RefPayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg23:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg24:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcSicEvaluateWithSingleReferenceINTEL [[SicResultTy]] {{.*}} [[VmeImg23]] [[VmeImg24]] [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicResultTy]]* @_Z54intel_sub_group_avc_sic_evaluate_with_single_reference14ocl_image2d_roS_11ocl_sampler37ocl_intel_sub_group_avc_sic_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[SicPayloadTy]]* %[[SicPayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg27:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg28:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicResultTy]]* @_Z54__spirv_SubgroupAvcSicEvaluateWithSingleReferenceINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcSicPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg27]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg28]], %[[SicPayloadTy]]* %[[SicPayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg25:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg26:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg27:[0-9]+]] [[RefImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcSicEvaluateWithDualReferenceINTEL [[SicResultTy]] {{.*}} [[VmeImg25]] [[VmeImg26]] [[VmeImg27]] [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicResultTy]]* @_Z52intel_sub_group_avc_sic_evaluate_with_dual_reference14ocl_image2d_roS_S_11ocl_sampler37ocl_intel_sub_group_avc_sic_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[SicPayloadTy]]* %[[SicPayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg29:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg30:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: %[[VmeImg31:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[RefImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicResultTy]]* @_Z52__spirv_SubgroupAvcSicEvaluateWithDualReferenceINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0PU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcSicPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg29]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg30]], %[[VmeImageTy]] addrspace(1)* %[[VmeImg31]], %[[SicPayloadTy]]* %[[SicPayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg28:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcSicEvaluateWithMultiReferenceINTEL [[SicResultTy]] {{.*}} [[VmeImg28]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicResultTy]]* @_Z53intel_sub_group_avc_sic_evaluate_with_multi_reference14ocl_image2d_roj11ocl_sampler37ocl_intel_sub_group_avc_sic_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], i32 0, %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[SicPayloadTy]]* %[[SicPayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg32:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicResultTy]]* @_Z53__spirv_SubgroupAvcSicEvaluateWithMultiReferenceINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0iP26__spirv_AvcSicPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg32]], i32 0, %[[SicPayloadTy]]* %[[SicPayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg29:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL [[SicResultTy]] {{.*}} [[VmeImg29]] {{.*}} [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicResultTy]]* @_Z53intel_sub_group_avc_sic_evaluate_with_multi_reference14ocl_image2d_rojh11ocl_sampler37ocl_intel_sub_group_avc_sic_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], i32 0, i8 0, %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[SicPayloadTy]]* %[[SicPayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg33:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicResultTy]]* @_Z63__spirv_SubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0icP26__spirv_AvcSicPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg33]], i32 0, i8 0, %[[SicPayloadTy]]* %[[SicPayload]])
 
 // CHECK-SPIRV: VmeImageINTEL [[VmeImageTy]] [[VmeImg30:[0-9]+]] [[SrcImg]] [[Sampler]]
 // CHECK-SPIRV: SubgroupAvcSicEvaluateIpeINTEL [[SicResultTy]] {{.*}} [[VmeImg30]] [[SicPayload]]
 // CHECK-LLVM: call spir_func %[[SicResultTy]]* @_Z36intel_sub_group_avc_sic_evaluate_ipe14ocl_image2d_ro11ocl_sampler37ocl_intel_sub_group_avc_sic_payload_t(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]], %[[SicPayloadTy]]* %[[SicPayload]])
-
+// CHECK-LLVM-SPIRV: %[[VmeImg34:.*]] = call spir_func %[[VmeImageTy]] addrspace(1)* @_Z21__spirv_VmeImageINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%[[ImageTy]] addrspace(1)* %[[SrcImg]], %[[SamplerTy]] addrspace(2)* %[[Sampler]])
+// CHECK-LLVM-SPIRV: call spir_func %[[SicResultTy]]* @_Z38__spirv_SubgroupAvcSicEvaluateIpeINTELPU3AS141__spirv_VmeImageINTEL__void_1_0_0_0_0_0_0P26__spirv_AvcSicPayloadINTEL(%[[VmeImageTy]] addrspace(1)* %[[VmeImg34]], %[[SicPayloadTy]]* %[[SicPayload]])

--- a/test/transcoding/SampledImage.cl
+++ b/test/transcoding/SampledImage.cl
@@ -35,21 +35,21 @@ void sample_kernel(image2d_t input, float2 coords, global float4 *results, sampl
 // CHECK-SPIRV: SampledImage [[SampledImageTy]] [[SampledImage1:[0-9]+]] [[InputImage]] [[ConstSampler1]]
 // CHECK-SPIRV: ImageSampleExplicitLod {{.*}} [[SampledImage1]]
 // CHECK-LLVM:  call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %0, <2 x float> %coords)
-// CHECK-SPV-IR: call spir_func %spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* @_Z20__spirv_SampledImage14ocl_image2d_ro11ocl_sampler(%opencl.image2d_ro_t addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %0)
+// CHECK-SPV-IR: call spir_func %spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* @_Z20__spirv_SampledImagePU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %0)
 // CHECK-SPV-IR: call spir_func <4 x float> @_Z38__spirv_ImageSampleExplicitLod_Rfloat4PU3AS140__spirv_SampledImage__void_1_0_0_0_0_0_0Dv2_fif(%spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* %TempSampledImage, <2 x float> %coords, i32 2, float 0.000000e+00)
 
 // CHECK-SPIRV: SampledImage [[SampledImageTy]] [[SampledImage2:[0-9]+]] [[InputImage]] [[argSampl]]
 // CHECK-SPIRV: ImageSampleExplicitLod {{.*}} [[SampledImage2]]
 // CHECK-LLVM:   call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %argSampl, <2 x float> %coords)
-// CHECK-SPV-IR: call spir_func %spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* @_Z20__spirv_SampledImage14ocl_image2d_ro11ocl_sampler(%opencl.image2d_ro_t addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %argSampl)
+// CHECK-SPV-IR: call spir_func %spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* @_Z20__spirv_SampledImagePU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %argSampl)
 // CHECK-SPV-IR: call spir_func <4 x float> @_Z38__spirv_ImageSampleExplicitLod_Rfloat4PU3AS140__spirv_SampledImage__void_1_0_0_0_0_0_0Dv2_fif(%spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* %TempSampledImage4, <2 x float> %coords, i32 2, float 0.000000e+00)
 
 // CHECK-SPIRV: SampledImage [[SampledImageTy]] [[SampledImage3:[0-9]+]] [[InputImage]] [[ConstSampler2]]
 // CHECK-SPIRV: ImageSampleExplicitLod {{.*}} [[SampledImage3]]
 // CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %{{[0-9]+}}, <2 x float> %coords)
-// CHECK-SPV-IR: call spir_func %spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* @_Z20__spirv_SampledImage14ocl_image2d_ro11ocl_sampler(%opencl.image2d_ro_t addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %1)
+// CHECK-SPV-IR: call spir_func %spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* @_Z20__spirv_SampledImagePU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)* %input, %opencl.sampler_t addrspace(2)* %1)
 // CHECK-SPV-IR: call spir_func <4 x float> @_Z38__spirv_ImageSampleExplicitLod_Rfloat4PU3AS140__spirv_SampledImage__void_1_0_0_0_0_0_0Dv2_fif(%spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* %TempSampledImage6, <2 x float> %coords, i32 2, float 0.000000e+00)
 
 // CHECK-LLVM: declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>)
-// CHECK-SPV-IR: declare spir_func %spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* @_Z20__spirv_SampledImage14ocl_image2d_ro11ocl_sampler(%opencl.image2d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*)
+// CHECK-SPV-IR: declare spir_func %spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)* @_Z20__spirv_SampledImagePU3AS133__spirv_Image__void_1_0_0_0_0_0_011ocl_sampler(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*, %opencl.sampler_t addrspace(2)*)
 // CHECK-SPV-IR: declare spir_func <4 x float> @_Z38__spirv_ImageSampleExplicitLod_Rfloat4PU3AS140__spirv_SampledImage__void_1_0_0_0_0_0_0Dv2_fif(%spirv.SampledImage._void_1_0_0_0_0_0_0 addrspace(1)*, <2 x float>, i32, float)

--- a/test/transcoding/check_ro_qualifier.ll
+++ b/test/transcoding/check_ro_qualifier.ll
@@ -5,6 +5,8 @@
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-LLVM
+; RUN: llvm-spirv %t.rev.bc -o %t.back.spv
+; RUN: llvm-spirv %t.back.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; CHECK-LLVM: opencl.image2d_array_ro_t = type opaque
 ; CHECK-LLVM: define spir_kernel void @sample_kernel(%opencl.image2d_array_ro_t addrspace(1)
@@ -17,10 +19,15 @@
 ; CHECK-LLVM: declare spir_func <2 x i32> @_Z13get_image_dim20ocl_image2d_array_ro(%opencl.image2d_array_ro_t addrspace(1)
 ; CHECK-LLVM: declare spir_func i64 @_Z20get_image_array_size20ocl_image2d_array_ro(%opencl.image2d_array_ro_t addrspace(1)
 
-; CHECK-SPV-LLVM: call spir_func <3 x i32> @_Z32__spirv_ImageQuerySizeLod_Ruint320ocl_image2d_array_roi(%opencl.image2d_array_ro_t addrspace(1)
-; CHECK-SPV-LLVM: call spir_func <3 x i64> @_Z33__spirv_ImageQuerySizeLod_Rulong320ocl_image2d_array_roi(%opencl.image2d_array_ro_t addrspace(1)
-; CHECK-SPV-LLVM: declare spir_func <3 x i32> @_Z32__spirv_ImageQuerySizeLod_Ruint320ocl_image2d_array_roi(%opencl.image2d_array_ro_t addrspace(1)
-; CHECK-SPV-LLVM: declare spir_func <3 x i64> @_Z33__spirv_ImageQuerySizeLod_Rulong320ocl_image2d_array_roi(%opencl.image2d_array_ro_t addrspace(1)
+; CHECK-SPV-LLVM: call spir_func <3 x i32> @_Z32__spirv_ImageQuerySizeLod_Ruint3PU3AS133__spirv_Image__void_1_0_1_0_0_0_0i(%spirv.Image._void_1_0_1_0_0_0_0 addrspace(1)
+; CHECK-SPV-LLVM: call spir_func <3 x i64> @_Z33__spirv_ImageQuerySizeLod_Rulong3PU3AS133__spirv_Image__void_1_0_1_0_0_0_0i(%spirv.Image._void_1_0_1_0_0_0_0 addrspace(1)
+; CHECK-SPV-LLVM: declare spir_func <3 x i32> @_Z32__spirv_ImageQuerySizeLod_Ruint3PU3AS133__spirv_Image__void_1_0_1_0_0_0_0i(%spirv.Image._void_1_0_1_0_0_0_0 addrspace(1)
+; CHECK-SPV-LLVM: declare spir_func <3 x i64> @_Z33__spirv_ImageQuerySizeLod_Rulong3PU3AS133__spirv_Image__void_1_0_1_0_0_0_0i(%spirv.Image._void_1_0_1_0_0_0_0 addrspace(1)
+
+; CHECK-SPIRV: TypeImage [[IMAGE_TYPE:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter [[IMAGE_TYPE]] [[IMAGE_ARG:[0-9]+]]
+; CHECK-SPIRV: ImageQuerySizeLod {{[0-9]+}} {{[0-9]+}} [[IMAGE_ARG]]
+; CHECK-SPIRV: ImageQuerySizeLod {{[0-9]+}} {{[0-9]+}} [[IMAGE_ARG]]
 
 ; CHECK-LLVM-DAG: [[AQ]] = !{!"read_only"}
 ; CHECK-LLVM-DAG: [[TYPE]] = !{!"image2d_array_t"}

--- a/test/transcoding/cl_intel_sub_groups.ll
+++ b/test/transcoding/cl_intel_sub_groups.ll
@@ -38,6 +38,9 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_subgroups
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPIRV
+; RUN: llvm-spirv %t.rev.bc -o - -spirv-text --spirv-ext=+SPV_INTEL_subgroups | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; CHECK-SPIRV: Capability SubgroupShuffleINTEL
 ; CHECK-SPIRV: Capability SubgroupBufferBlockIOINTEL
@@ -106,7 +109,28 @@ define spir_kernel void @test(<2 x float> %x, i32 %c, %opencl.image2d_ro_t addrs
 ; CHECK-LLVM-NEXT:    [[CALL11:%.*]] = call spir_func <2 x i64> @_Z30intel_sub_group_block_read_ul2PU3AS1Km(i64 addrspace(1)* [[LP:%.*]])
 ; CHECK-LLVM-NEXT:    call spir_func void @_Z31intel_sub_group_block_write_ul2PU3AS1mDv2_m(i64 addrspace(1)* [[LP]], <2 x i64> [[CALL11]])
 ; CHECK-LLVM-NEXT:    ret void
-;
+
+; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z28__spirv_SubgroupShuffleINTELDv2_fj
+; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z32__spirv_SubgroupShuffleDownINTELDv2_fS_j
+; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z30__spirv_SubgroupShuffleUpINTELDv2_fS_j
+; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z31__spirv_SubgroupShuffleXorINTELDv2_fj
+; CHECK-LLVM-SPIRV: call spir_func <2 x i32> @_Z42__spirv_SubgroupImageBlockReadINTEL_Ruint2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
+; CHECK-LLVM-SPIRV: call spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv2_j(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*
+; CHECK-LLVM-SPIRV: call spir_func <2 x i32> @_Z37__spirv_SubgroupBlockReadINTEL_Ruint2PU3AS1Kj
+; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1jDv2_j
+; CHECK-LLVM-SPIRV: call spir_func <2 x i16> @_Z44__spirv_SubgroupImageBlockReadINTEL_Rushort2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
+; CHECK-LLVM-SPIRV: call spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv2_t(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*
+; CHECK-LLVM-SPIRV: call spir_func <2 x i16> @_Z39__spirv_SubgroupBlockReadINTEL_Rushort2PU3AS1Kt
+; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1tDv2_t
+; CHECK-LLVM-SPIRV: call spir_func <2 x i8> @_Z43__spirv_SubgroupImageBlockReadINTEL_Ruchar2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
+; CHECK-LLVM-SPIRV: call spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv2_h(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*
+; CHECK-LLVM-SPIRV: call spir_func <2 x i8> @_Z38__spirv_SubgroupBlockReadINTEL_Ruchar2PU3AS1Kh
+; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1hDv2_h
+; CHECK-LLVM-SPIRV: call spir_func <2 x i64> @_Z43__spirv_SubgroupImageBlockReadINTEL_Rulong2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
+; CHECK-LLVM-SPIRV: call spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv2_m(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*
+; CHECK-LLVM-SPIRV: call spir_func <2 x i64> @_Z38__spirv_SubgroupBlockReadINTEL_Rulong2PU3AS1Km
+; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1mDv2_m
+
 entry:
   %call = tail call spir_func <2 x float> @_Z23intel_sub_group_shuffleDv2_fj(<2 x float> %x, i32 %c) #2
   %call1 = tail call spir_func <2 x float> @_Z28intel_sub_group_shuffle_downDv2_fS_j(<2 x float> %x, <2 x float> %x, i32 %c) #2

--- a/test/transcoding/get_image_num_mip_levels.ll
+++ b/test/transcoding/get_image_num_mip_levels.ll
@@ -1,0 +1,161 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
+; RUN: llvm-spirv -spirv-text %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+; Generated from the following OpenCL C code:
+; #pragma OPENCL EXTENSION cl_khr_mipmap_image : enable
+; void test(image1d_t img1, 
+;           image2d_t img2,
+;           image3d_t img3,
+;           image1d_array_t img4,
+;           image2d_array_t img5,
+;           image2d_depth_t img6,
+;           image2d_array_depth_t img7)
+; {
+;     get_image_num_mip_levels(img1);
+;     get_image_num_mip_levels(img2);
+;     get_image_num_mip_levels(img3);
+;     get_image_num_mip_levels(img4);
+;     get_image_num_mip_levels(img5);
+;     get_image_num_mip_levels(img6);
+;     get_image_num_mip_levels(img7);
+; }
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.image1d_ro_t = type opaque
+%opencl.image2d_ro_t = type opaque
+%opencl.image3d_ro_t = type opaque
+%opencl.image1d_array_ro_t = type opaque
+%opencl.image2d_array_ro_t = type opaque
+%opencl.image2d_depth_ro_t = type opaque
+%opencl.image2d_array_depth_ro_t = type opaque
+
+; CHECK-SPIRV: TypeInt [[INT:[0-9]+]] 32
+; CHECK-SPIRV: TypeImage [[IMAGE1D_T:[0-9]+]] 2 0 0 0 0 0 0 0
+; CHECK-SPIRV: TypeImage [[IMAGE2D_T:[0-9]+]] 2 1 0 0 0 0 0 0
+; CHECK-SPIRV: TypeImage [[IMAGE3D_T:[0-9]+]] 2 2 0 0 0 0 0 0
+; CHECK-SPIRV: TypeImage [[IMAGE1D_ARRAY_T:[0-9]+]] 2 0 0 1 0 0 0 0
+; CHECK-SPIRV: TypeImage [[IMAGE2D_ARRAY_T:[0-9]+]] 2 1 0 1 0 0 0 0
+; CHECK-SPIRV: TypeImage [[IMAGE2D_DEPTH_T:[0-9]+]] 2 1 1 0 0 0 0 0
+; CHECK-SPIRV: TypeImage [[IMAGE2D_ARRAY_DEPTH_T:[0-9]+]] 2 1 1 1 0 0 0 0
+
+; CHECK-LLVM: %opencl.image1d_ro_t = type opaque
+; CHECK-LLVM: %opencl.image2d_ro_t = type opaque
+; CHECK-LLVM: %opencl.image3d_ro_t = type opaque
+; CHECK-LLVM: %opencl.image1d_array_ro_t = type opaque
+; CHECK-LLVM: %opencl.image2d_array_ro_t = type opaque
+; CHECK-LLVM: %opencl.image2d_depth_ro_t = type opaque
+; CHECK-LLVM: %opencl.image2d_array_depth_ro_t = type opaque
+
+; CHECK-SPV-IR: %spirv.Image._void_0_0_0_0_0_0_0 = type opaque
+; CHECK-SPV-IR: %spirv.Image._void_1_0_0_0_0_0_0 = type opaque
+; CHECK-SPV-IR: %spirv.Image._void_2_0_0_0_0_0_0 = type opaque
+; CHECK-SPV-IR: %spirv.Image._void_0_0_1_0_0_0_0 = type opaque
+; CHECK-SPV-IR: %spirv.Image._void_1_0_1_0_0_0_0 = type opaque
+; CHECK-SPV-IR: %spirv.Image._void_1_1_0_0_0_0_0 = type opaque
+; CHECK-SPV-IR: %spirv.Image._void_1_1_1_0_0_0_0 = type opaque
+
+; Function Attrs: convergent noinline norecurse nounwind optnone
+define dso_local spir_func void @testimage1d(%opencl.image1d_ro_t addrspace(1)* %img1, %opencl.image2d_ro_t addrspace(1)* %img2, %opencl.image3d_ro_t addrspace(1)* %img3, %opencl.image1d_array_ro_t addrspace(1)* %img4, %opencl.image2d_array_ro_t addrspace(1)* %img5, %opencl.image2d_depth_ro_t addrspace(1)* %img6, %opencl.image2d_array_depth_ro_t addrspace(1)* %img7) #0 {
+entry:
+  %img1.addr = alloca %opencl.image1d_ro_t addrspace(1)*, align 4
+  %img2.addr = alloca %opencl.image2d_ro_t addrspace(1)*, align 4
+  %img3.addr = alloca %opencl.image3d_ro_t addrspace(1)*, align 4
+  %img4.addr = alloca %opencl.image1d_array_ro_t addrspace(1)*, align 4
+  %img5.addr = alloca %opencl.image2d_array_ro_t addrspace(1)*, align 4
+  %img6.addr = alloca %opencl.image2d_depth_ro_t addrspace(1)*, align 4
+  %img7.addr = alloca %opencl.image2d_array_depth_ro_t addrspace(1)*, align 4
+  store %opencl.image1d_ro_t addrspace(1)* %img1, %opencl.image1d_ro_t addrspace(1)** %img1.addr, align 4
+  store %opencl.image2d_ro_t addrspace(1)* %img2, %opencl.image2d_ro_t addrspace(1)** %img2.addr, align 4
+  store %opencl.image3d_ro_t addrspace(1)* %img3, %opencl.image3d_ro_t addrspace(1)** %img3.addr, align 4
+  store %opencl.image1d_array_ro_t addrspace(1)* %img4, %opencl.image1d_array_ro_t addrspace(1)** %img4.addr, align 4
+  store %opencl.image2d_array_ro_t addrspace(1)* %img5, %opencl.image2d_array_ro_t addrspace(1)** %img5.addr, align 4
+  store %opencl.image2d_depth_ro_t addrspace(1)* %img6, %opencl.image2d_depth_ro_t addrspace(1)** %img6.addr, align 4
+  store %opencl.image2d_array_depth_ro_t addrspace(1)* %img7, %opencl.image2d_array_depth_ro_t addrspace(1)** %img7.addr, align 4
+  %0 = load %opencl.image1d_ro_t addrspace(1)*, %opencl.image1d_ro_t addrspace(1)** %img1.addr, align 4
+  %call = call spir_func i32 @_Z24get_image_num_mip_levels14ocl_image1d_ro(%opencl.image1d_ro_t addrspace(1)* %0) #2
+  %1 = load %opencl.image2d_ro_t addrspace(1)*, %opencl.image2d_ro_t addrspace(1)** %img2.addr, align 4
+  %call1 = call spir_func i32 @_Z24get_image_num_mip_levels14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)* %1) #2
+  %2 = load %opencl.image3d_ro_t addrspace(1)*, %opencl.image3d_ro_t addrspace(1)** %img3.addr, align 4
+  %call2 = call spir_func i32 @_Z24get_image_num_mip_levels14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)* %2) #2
+  %3 = load %opencl.image1d_array_ro_t addrspace(1)*, %opencl.image1d_array_ro_t addrspace(1)** %img4.addr, align 4
+  %call3 = call spir_func i32 @_Z24get_image_num_mip_levels20ocl_image1d_array_ro(%opencl.image1d_array_ro_t addrspace(1)* %3) #2
+  %4 = load %opencl.image2d_array_ro_t addrspace(1)*, %opencl.image2d_array_ro_t addrspace(1)** %img5.addr, align 4
+  %call4 = call spir_func i32 @_Z24get_image_num_mip_levels20ocl_image2d_array_ro(%opencl.image2d_array_ro_t addrspace(1)* %4) #2
+  %5 = load %opencl.image2d_depth_ro_t addrspace(1)*, %opencl.image2d_depth_ro_t addrspace(1)** %img6.addr, align 4
+  %call5 = call spir_func i32 @_Z24get_image_num_mip_levels20ocl_image2d_depth_ro(%opencl.image2d_depth_ro_t addrspace(1)* %5) #2
+  %6 = load %opencl.image2d_array_depth_ro_t addrspace(1)*, %opencl.image2d_array_depth_ro_t addrspace(1)** %img7.addr, align 4
+  %call6 = call spir_func i32 @_Z24get_image_num_mip_levels26ocl_image2d_array_depth_ro(%opencl.image2d_array_depth_ro_t addrspace(1)* %6) #2
+  ret void
+}
+
+; CHECK-SPIRV: Load [[IMAGE1D_T]] [[IMAGE1D:[0-9]+]] 
+; CHECK-SPIRV: ImageQueryLevels [[INT]] {{[0-9]+}} [[IMAGE1D]]
+; CHECK-SPIRV: Load [[IMAGE2D_T]] [[IMAGE2D:[0-9]+]] 
+; CHECK-SPIRV: ImageQueryLevels [[INT]] {{[0-9]+}} [[IMAGE2D]]
+; CHECK-SPIRV: Load [[IMAGE3D_T]] [[IMAGE3D:[0-9]+]] 
+; CHECK-SPIRV: ImageQueryLevels [[INT]] {{[0-9]+}} [[IMAGE3D]]
+; CHECK-SPIRV: Load [[IMAGE1D_ARRAY_T]] [[IMAGE1D_ARRAY:[0-9]+]] 
+; CHECK-SPIRV: ImageQueryLevels [[INT]] {{[0-9]+}} [[IMAGE1D_ARRAY]]
+; CHECK-SPIRV: Load [[IMAGE2D_ARRAY_T]] [[IMAGE2D_ARRAY:[0-9]+]] 
+; CHECK-SPIRV: ImageQueryLevels [[INT]] {{[0-9]+}} [[IMAGE2D_ARRAY]]
+; CHECK-SPIRV: Load [[IMAGE2D_DEPTH_T]] [[IMAGE2D_DEPTH:[0-9]+]] 
+; CHECK-SPIRV: ImageQueryLevels [[INT]] {{[0-9]+}} [[IMAGE2D_DEPTH]]
+; CHECK-SPIRV: Load [[IMAGE2D_ARRAY_DEPTH_T]] [[IMAGE2D_ARRAY_DEPTH:[0-9]+]] 
+; CHECK-SPIRV: ImageQueryLevels [[INT]] {{[0-9]+}} [[IMAGE2D_ARRAY_DEPTH]]
+
+; CHECK-LLVM: call spir_func i32 @_Z24get_image_num_mip_levels14ocl_image1d_ro(%opencl.image1d_ro_t addrspace(1)*
+; CHECK-LLVM: call spir_func i32 @_Z24get_image_num_mip_levels14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)*
+; CHECK-LLVM: call spir_func i32 @_Z24get_image_num_mip_levels14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)*
+; CHECK-LLVM: call spir_func i32 @_Z24get_image_num_mip_levels20ocl_image1d_array_ro(%opencl.image1d_array_ro_t addrspace(1)*
+; CHECK-LLVM: call spir_func i32 @_Z24get_image_num_mip_levels20ocl_image2d_array_ro(%opencl.image2d_array_ro_t addrspace(1)*
+; CHECK-LLVM: call spir_func i32 @_Z24get_image_num_mip_levels20ocl_image2d_depth_ro(%opencl.image2d_depth_ro_t addrspace(1)*
+; CHECK-LLVM: call spir_func i32 @_Z24get_image_num_mip_levels26ocl_image2d_array_depth_ro(%opencl.image2d_array_depth_ro_t addrspace(1)*
+
+; CHECK-SPV-IR: call spir_func i32 @_Z24__spirv_ImageQueryLevelsPU3AS133__spirv_Image__void_0_0_0_0_0_0_0(%spirv.Image._void_0_0_0_0_0_0_0 addrspace(1)*
+; CHECK-SPV-IR: call spir_func i32 @_Z24__spirv_ImageQueryLevelsPU3AS133__spirv_Image__void_1_0_0_0_0_0_0(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
+; CHECK-SPV-IR: call spir_func i32 @_Z24__spirv_ImageQueryLevelsPU3AS133__spirv_Image__void_2_0_0_0_0_0_0(%spirv.Image._void_2_0_0_0_0_0_0 addrspace(1)*
+; CHECK-SPV-IR: call spir_func i32 @_Z24__spirv_ImageQueryLevelsPU3AS133__spirv_Image__void_0_0_1_0_0_0_0(%spirv.Image._void_0_0_1_0_0_0_0 addrspace(1)*
+; CHECK-SPV-IR: call spir_func i32 @_Z24__spirv_ImageQueryLevelsPU3AS133__spirv_Image__void_1_0_1_0_0_0_0(%spirv.Image._void_1_0_1_0_0_0_0 addrspace(1)*
+; CHECK-SPV-IR: call spir_func i32 @_Z24__spirv_ImageQueryLevelsPU3AS133__spirv_Image__void_1_1_0_0_0_0_0(%spirv.Image._void_1_1_0_0_0_0_0 addrspace(1)*
+; CHECK-SPV-IR: call spir_func i32 @_Z24__spirv_ImageQueryLevelsPU3AS133__spirv_Image__void_1_1_1_0_0_0_0(%spirv.Image._void_1_1_1_0_0_0_0 addrspace(1)*
+
+; Function Attrs: convergent
+declare spir_func i32 @_Z24get_image_num_mip_levels14ocl_image1d_ro(%opencl.image1d_ro_t addrspace(1)*) #1
+
+; Function Attrs: convergent
+declare spir_func i32 @_Z24get_image_num_mip_levels14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)*) #1
+
+; Function Attrs: convergent
+declare spir_func i32 @_Z24get_image_num_mip_levels14ocl_image3d_ro(%opencl.image3d_ro_t addrspace(1)*) #1
+
+; Function Attrs: convergent
+declare spir_func i32 @_Z24get_image_num_mip_levels20ocl_image1d_array_ro(%opencl.image1d_array_ro_t addrspace(1)*) #1
+
+; Function Attrs: convergent
+declare spir_func i32 @_Z24get_image_num_mip_levels20ocl_image2d_array_ro(%opencl.image2d_array_ro_t addrspace(1)*) #1
+
+; Function Attrs: convergent
+declare spir_func i32 @_Z24get_image_num_mip_levels20ocl_image2d_depth_ro(%opencl.image2d_depth_ro_t addrspace(1)*) #1
+
+; Function Attrs: convergent
+declare spir_func i32 @_Z24get_image_num_mip_levels26ocl_image2d_array_depth_ro(%opencl.image2d_array_depth_ro_t addrspace(1)*) #1
+
+attributes #0 = { convergent noinline norecurse nounwind optnone "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #1 = { convergent "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #2 = { convergent }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}

--- a/test/transcoding/image_channel.ll
+++ b/test/transcoding/image_channel.ll
@@ -3,9 +3,13 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
-; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
-
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPIRV
+; RUN: llvm-spirv %t.rev.bc -o %t.rev.spv
+; RUN: spirv-val %t.rev.spv
+; RUN: llvm-spirv %t.rev.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
@@ -20,18 +24,29 @@ define spir_kernel void @f(%opencl.image2d_ro_t addrspace(1)* %img, i32 addrspac
 ; CHECK-LLVM: [[DTSUB:%.+]] = sub i32 [[DTCALL]], 4304
 ; CHECK-LLVM: [[DTADD:%.+]] = add i32 [[DTSUB]], 4304
 ; CHECK-LLVM: store i32 [[DTADD]]
+
+; CHECK-LLVM-SPIRV: [[DTCALL:%.+]] = call spir_func i32 @_Z24__spirv_ImageQueryFormatPU3AS133__spirv_Image__void_1_0_0_0_0_0_0(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)* %img)
+; CHECK-LLVM-SPIRV: add i32 [[DTCALL]], 4304
+
 ; CHECK-SPIRV: 4 ImageQueryFormat {{[0-9]+}} [[DataTypeID:[0-9]+]]
 ; CHECK-SPIRV: 5 IAdd {{[0-9]+}} [[DTAddID:[0-9]+]] [[DataTypeID]] [[DataTypeOffsetId]]
 ; CHECK-SPIRV: 5 Store {{[0-9]+}} [[DTAddID]]
+
   %1 = tail call spir_func i32 @_Z27get_image_channel_data_type14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)* %img) #2
   store i32 %1, i32 addrspace(1)* %type, align 4
+
 ; CHECK-LLVM-DAG: [[OCALL:%.+]] ={{.*}} call spir_func i32 @_Z23get_image_channel_order14ocl_image2d_ro
 ; CHECK-LLVM: [[OSUB:%.+]] = sub i32 [[OCALL]], 4272
 ; CHECK-LLVM: [[OADD:%.+]] = add i32 [[OSUB]], 4272
 ; CHECK-LLVM: store i32 [[OADD]]
+
+; CHECK-LLVM-SPIRV: [[OCALL:%.+]] = call spir_func i32 @_Z23__spirv_ImageQueryOrderPU3AS133__spirv_Image__void_1_0_0_0_0_0_0(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)* %img)
+; CHECK-LLVM-SPIRV: add i32 [[OCALL]], 4272
+
 ; CHECK-SPIRV: 4 ImageQueryOrder {{[0-9]+}} [[OrderID:[0-9]+]]
 ; CHECK-SPIRV: 5 IAdd {{[0-9]+}} [[OrderAddID:[0-9]+]] [[OrderID]] [[OrderOffsetId]]
 ; CHECK-SPIRV: 5 Store {{[0-9]+}} [[OrderAddID]]
+
   %2 = tail call spir_func i32 @_Z23get_image_channel_order14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)* %img) #2
   store i32 %2, i32 addrspace(1)* %order, align 4
   ret void


### PR DESCRIPTION
This change fixes SPIR-V IR generation for the following opcodes:
1) OpImageRead
2) OpImageWrite
3) OpImageQueryOrder
3) OpImageQueryFormat
4) Opcodes from SPV_INTEL_subgroups extension
https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/INTEL/SPV_INTEL_subgroups.asciidoc
5) Opcodes from SPV_INTEL_device_side_avc_motion_estimation extension
https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc

The following translation chain testing has been implemented for all these opcodes:
LLVM->SPIRV->SPV-IR->SPIRV