### PR TITLE
Fix readonly attribute after new LLVM assertion

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3043,7 +3043,6 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF) {
         AttrTy = cast<PointerType>(I->getType())->getElementType();
         break;
       case Attribute::AttrKind::StructRet:
-      case Attribute::AttrKind::ReadOnly:
         AttrTy = I->getType();
         break;
       default:


### PR DESCRIPTION
After LLVM commit 5d1464cbfe90 ("[Attributes] Make type attribute
handling more generic (NFCI)", 2021-07-12), the Attribute constructor
became stricter.  This revealed that the translator was creating
`readonly` attributes with a type attached, tripping the newly added
assertion in `Attribute::get`.