### PR TITLE
Update for LLVM -enable-dwarf-directory change

### DIFF
--- a/test/DebugInfo/X86/dbg-file-name.ll
+++ b/test/DebugInfo/X86/dbg-file-name.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 
-; RUN: llc -enable-dwarf-directory -mtriple x86_64-apple-darwin10.0.0  < %t.ll | FileCheck %s
+; RUN: llc -mtriple x86_64-apple-darwin10.0.0  < %t.ll | FileCheck %s
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"


### PR DESCRIPTION
Update after upstream commit `fada2782cf6f ("[llc] Default
MCUseDwarfDirectory to true", 2021-07-12)`.