### PR TITLE
Add pass to lower Bitcast to nonstandard type instructions

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -42,7 +42,6 @@
 #define SPIRV_H
 
 #include "LLVMSPIRVOpts.h"
-#include "llvm/Pass.h"
 
 #include <iostream>
 #include <string>
@@ -67,6 +66,7 @@ void initializePreprocessMetadataLegacyPass(PassRegistry &);
 void initializeSPIRVLowerBitCastToNonStandardTypeLegacyPass(PassRegistry &);
 
 class ModulePass;
+class FunctionPass;
 } // namespace llvm
 
 #include "llvm/IR/Module.h"

--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -42,6 +42,7 @@
 #define SPIRV_H
 
 #include "LLVMSPIRVOpts.h"
+#include "llvm/Pass.h"
 
 #include <iostream>
 #include <string>
@@ -218,7 +219,7 @@ ModulePass *createSPIRVWriterPass(std::ostream &Str,
 
 /// Create a pass for removing bitcast instructions to non-standard SPIR-V
 /// types
-ModulePass *createSPIRVLowerBitCastToNonStandardTypeLegacy();
+FunctionPass *createSPIRVLowerBitCastToNonStandardTypeLegacy();
 
 } // namespace llvm
 

--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -63,6 +63,7 @@ void initializeSPIRVRegularizeLLVMLegacyPass(PassRegistry &);
 void initializeSPIRVToOCL12LegacyPass(PassRegistry &);
 void initializeSPIRVToOCL20LegacyPass(PassRegistry &);
 void initializePreprocessMetadataLegacyPass(PassRegistry &);
+void initializeSPIRVLowerBitCastToNonStandardTypeLegacyPass(PassRegistry &);
 
 class ModulePass;
 } // namespace llvm
@@ -214,6 +215,10 @@ ModulePass *createSPIRVWriterPass(std::ostream &Str);
 /// ostream.
 ModulePass *createSPIRVWriterPass(std::ostream &Str,
                                   const SPIRV::TranslatorOpts &Opts);
+
+/// Create a pass for removing bitcast instructions to non-standard SPIR-V
+/// types
+ModulePass *createSPIRVLowerBitCastToNonStandardTypeLegacy();
 
 } // namespace llvm
 

--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -9,6 +9,7 @@ add_llvm_library(LLVMSPIRVLib
   OCLTypeToSPIRV.cpp
   OCLUtil.cpp
   VectorComputeUtil.cpp
+  SPIRVLowerBitCastToNonStandardType.cpp
   SPIRVLowerBool.cpp
   SPIRVLowerConstExpr.cpp
   SPIRVLowerMemmove.cpp

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -163,8 +163,7 @@ public:
   }
 };
 
-class SPIRVLowerBitCastToNonStandardTypeLegacy
-    : public FunctionPass {
+class SPIRVLowerBitCastToNonStandardTypeLegacy : public FunctionPass {
 public:
   static char ID;
   SPIRVLowerBitCastToNonStandardTypeLegacy() : FunctionPass(ID) {}

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -63,7 +63,7 @@ public:
   bool runLowerBitCastToNonStandardType(Module &Module) {
     // This pass doesn't cover all possible uses of non-standard types, only
     // known
-    auto M = &Module;
+    auto *M = &Module;
     bool Changed = false;
 
     std::vector<std::pair<Instruction *, VectorType *>> BCastsToNonStdVec;
@@ -154,14 +154,14 @@ public:
         }
       }
     }
-    auto ExtractElement = ExtractElementInst::Create(
+    auto *ExtractElement = ExtractElementInst::Create(
         Load, ConstantInt::get(Type::getInt64Ty(I->getContext()), ElemIdx));
     InstsToInsert.push_back(ExtractElement);
     auto *Trunc = new TruncInst(ExtractElement, DestVecTy->getElementType());
     InstsToInsert.push_back(Trunc);
     InstsToInsert[0]->insertBefore(I);
-    for (unsigned long i = 1; i < InstsToInsert.size(); i++)
-      InstsToInsert[i]->insertAfter(InstsToInsert[i - 1]);
+    for (size_t It = 1; It < InstsToInsert.size(); It++)
+      InstsToInsert[It]->insertAfter(InstsToInsert[It - 1]);
     IIII->replaceAllUsesWith(Trunc);
     if (InstsToInsert.size())
       Changed = true;

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -74,6 +74,8 @@ bool lowerBitCastToNonStdVec(Instruction *Inst,
   VectorType *NewVecTy = getVectorType(NewValue->getType());
   InstsToErase.push_back(OldInstIter);
   // Handle addrspacecast instruction after bitcast if present
+  // TODO: There are can be many addrspacecast instructions using this bitcast,
+  // so that it is necessary to handle all these instructions in the same way
   for (auto *U : OldInstIter->users()) {
     if (auto *ASCastInst = dyn_cast<AddrSpaceCastInst>(U)) {
       unsigned DestAS = ASCastInst->getDestAddressSpace();

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -54,8 +54,7 @@ using namespace llvm;
 namespace SPIRV {
 
 static VectorType *getVectorType(Type *Ty) {
-  if (!Ty)
-    return nullptr;
+  assert(Ty != nullptr && "Expected non-null type");
   if (auto *ElemTy = dyn_cast<PointerType>(Ty))
     Ty = ElemTy->getElementType();
   return dyn_cast<VectorType>(Ty);
@@ -119,7 +118,8 @@ bool lowerBitCastToNonStdVec(Instruction *Inst,
   return true;
 }
 
-class SPIRVLowerBitCastToNonStandardTypePass {
+class SPIRVLowerBitCastToNonStandardTypePass
+    : public llvm::PassInfoMixin<SPIRVLowerBitCastToNonStandardTypePass> {
 public:
   SPIRVLowerBitCastToNonStandardTypePass() {}
 
@@ -164,8 +164,7 @@ public:
 };
 
 class SPIRVLowerBitCastToNonStandardTypeLegacy
-    : public FunctionPass,
-      public SPIRVLowerBitCastToNonStandardTypePass {
+    : public FunctionPass {
 public:
   static char ID;
   SPIRVLowerBitCastToNonStandardTypeLegacy() : FunctionPass(ID) {}

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -75,6 +75,7 @@ bool lowerBitCastToNonStdVec(Instruction *OldInst, Value *NewInst,
   if (RecursionDepth++ > MaxRecursionDepth)
     report_fatal_error(
         "The depth of recursion exceeds the maximum possible depth", false);
+
   bool Changed = false;
   VectorType *NewVecTy = getVectorType(NewInst->getType());
   if (NewVecTy) {

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -1,0 +1,208 @@
+//===============- SPIRVLowerBitCastToNonStandardType.cpp -================//
+//
+//                     The LLVM/SPIRV Translator
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// Copyright (c) 2021 Intel Corporation. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimers.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimers in the documentation
+// and/or other materials provided with the distribution.
+// Neither the names of Intel Corporation, nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// Software without specific prior written permission.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+// THE SOFTWARE.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements lowering of BitCast to nonstandard types. LLVM
+// transformations bitcast some vector types to scalar types, which are not
+// universally supported across all targets. We need ensure that "optimized"
+// LLVM IR doesn't have primitive types other than supported by the
+// SPIR target (i.e. "scalar 8/16/32/64-bit integer and 16/32/64-bit floating
+// point types, 2/3/4/8/16-element vector of scalar types").
+//
+//===----------------------------------------------------------------------===//
+#define DEBUG_TYPE "spv-lower-bitcast-to-nonstandard-type"
+
+#include "SPIRVInternal.h"
+
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/Pass.h"
+
+#include <stack>
+#include <utility>
+
+using namespace llvm;
+
+namespace {
+
+class SPIRVLowerBitCastToNonStandardTypeBase {
+public:
+  SPIRVLowerBitCastToNonStandardTypeBase() {}
+
+  bool runLowerBitCastToNonStandardType(Module &Module) {
+    // This pass doesn't cover all possible uses of non-standard types, only
+    // known
+    auto M = &Module;
+    bool Changed = false;
+
+    std::vector<std::pair<Instruction *, VectorType *>> BCastsToNonStdVec;
+    std::stack<Instruction *> InstsToErase;
+    for (auto &F : M->functions())
+      for (auto &BB : F)
+        for (auto &I : BB)
+          if (BitCastInst *BC = dyn_cast<BitCastInst>(&I)) {
+            auto *DestTy = BC->getDestTy();
+            if (auto *ElemTy = dyn_cast<PointerType>(DestTy))
+              DestTy = ElemTy->getElementType();
+            if (auto *DestVecTy = dyn_cast<VectorType>(DestTy)) {
+              uint64_t NumElemsInDestVec =
+                  DestVecTy->getElementCount().getValue();
+              if (NumElemsInDestVec != 2 && NumElemsInDestVec != 3 &&
+                  NumElemsInDestVec != 4 && NumElemsInDestVec != 8 &&
+                  NumElemsInDestVec != 16)
+                BCastsToNonStdVec.push_back(std::make_pair(&I, DestVecTy));
+            }
+          }
+
+    for (auto &I : BCastsToNonStdVec)
+      Changed |= lowerBitCastToNonStdVec(I, InstsToErase);
+
+    while (!InstsToErase.empty()) {
+      InstsToErase.top()->eraseFromParent();
+      InstsToErase.pop();
+    }
+
+    verifyRegularizationPass(*M, "SPIRVLowerBitCastToNonStandardType");
+    return Changed;
+  }
+
+  bool lowerBitCastToNonStdVec(std::pair<Instruction *, VectorType *> &Inst,
+                               std::stack<Instruction *> &InstsToErase) {
+    bool Changed = false;
+    std::vector<Instruction *> InstsToInsert;
+    Instruction *I = Inst.first;
+    VectorType *DestVecTy = Inst.second;
+    uint64_t NumElemsInDestVec = DestVecTy->getElementCount().getValue();
+    InstsToErase.push(I);
+    AddrSpaceCastInst *Src{nullptr};
+    auto *II = I;
+    while ((II = II->getNextNode())) {
+      if (auto *ASCI = dyn_cast<AddrSpaceCastInst>(II)) {
+        unsigned DestAddrSpace = ASCI->getDestAddressSpace();
+        auto *SrcPointer = cast<CastInst>(I)->getSrcTy();
+        auto *SrcTy = cast<PointerType>(SrcPointer)->getElementType();
+        SrcPointer = SrcTy->getPointerTo(DestAddrSpace);
+        if (ASCI->getOperand(0) == cast<Value>(I)) {
+          Src = new AddrSpaceCastInst(I->getOperand(0), SrcPointer);
+          InstsToInsert.push_back(Src);
+          InstsToErase.push(II);
+          break;
+        }
+      }
+    }
+    if (!II)
+      II = I;
+    auto *SrcTy =
+        cast<PointerType>(cast<Value>(Src)->getType())->getElementType();
+    LoadInst *Load =
+        Src ? new LoadInst(SrcTy, Src, "", false, Align())
+            : new LoadInst(SrcTy, I->getOperand(0), "", false, Align());
+    InstsToInsert.push_back(Load);
+    auto *III = II;
+    while ((III = III->getNextNode())) {
+      if (LoadInst *LI = dyn_cast<LoadInst>(III))
+        if (LI->getOperand(0) == II) {
+          InstsToErase.push(III);
+          break;
+        }
+    }
+    if (!III)
+      III = II;
+    uint64_t NumElemsInSrcVec =
+        cast<VectorType>(SrcTy)->getElementCount().getValue();
+    int ElemIdx = 0;
+    Instruction *IIII{nullptr};
+    while ((II = II->getNextNode())) {
+      if (auto *EEI = dyn_cast<ExtractElementInst>(II)) {
+        if (EEI->getOperand(0) == cast<Value>(III)) {
+          ElemIdx = cast<ConstantInt>(EEI->getIndexOperand())->getSExtValue() /
+                    (NumElemsInDestVec / NumElemsInSrcVec);
+          IIII = II;
+          InstsToErase.push(IIII);
+          break;
+        }
+      }
+    }
+    auto ExtractElement = ExtractElementInst::Create(
+        Load, ConstantInt::get(Type::getInt64Ty(I->getContext()), ElemIdx));
+    InstsToInsert.push_back(ExtractElement);
+    auto *Trunc = new TruncInst(ExtractElement, DestVecTy->getElementType());
+    InstsToInsert.push_back(Trunc);
+    InstsToInsert[0]->insertBefore(I);
+    for (unsigned long i = 1; i < InstsToInsert.size(); i++)
+      InstsToInsert[i]->insertAfter(InstsToInsert[i - 1]);
+    IIII->replaceAllUsesWith(Trunc);
+    if (InstsToInsert.size())
+      Changed = true;
+    return Changed;
+  }
+};
+
+class SPIRVLowerBitCastToNonStandardTypePass
+    : public llvm::PassInfoMixin<SPIRVLowerBitCastToNonStandardTypePass>,
+      public SPIRVLowerBitCastToNonStandardTypeBase {
+public:
+  llvm::PreservedAnalyses run(llvm::Module &M,
+                              llvm::ModuleAnalysisManager &MAM) {
+    return runLowerBitCastToNonStandardType(M) ? llvm::PreservedAnalyses::none()
+                                               : llvm::PreservedAnalyses::all();
+  }
+};
+
+class SPIRVLowerBitCastToNonStandardTypeLegacy
+    : public ModulePass,
+      public SPIRVLowerBitCastToNonStandardTypeBase {
+public:
+  SPIRVLowerBitCastToNonStandardTypeLegacy() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override {
+    return runLowerBitCastToNonStandardType(M);
+  }
+
+  StringRef getPassName() const override { return "Lower nonstandard type"; }
+
+  static char ID;
+};
+
+char SPIRVLowerBitCastToNonStandardTypeLegacy::ID = 0;
+
+} // namespace
+
+INITIALIZE_PASS(SPIRVLowerBitCastToNonStandardTypeLegacy,
+                "spv-lower-bitcast-to-nonstandard-type",
+                "Remove bitcast to nonstandard types", false, false)
+
+llvm::ModulePass *llvm::createSPIRVLowerBitCastToNonStandardTypeLegacy() {
+  return new SPIRVLowerBitCastToNonStandardTypeLegacy();
+}

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -90,16 +90,15 @@ bool lowerBitCastToNonStdVec(Instruction *OldInst, Value *NewInst,
         // doesn't like several nested instructions in one.
         Value *LocalValue = new AddrSpaceCastInst(NewInst, NewVecPtrTy);
         Builder.Insert(LocalValue);
-        Changed |= lowerBitCastToNonStdVec(ASCastInst, LocalValue, OldVecTy,
-                                           InstsToErase, Builder,
-                                           RecursionDepth);
+        Changed |=
+            lowerBitCastToNonStdVec(ASCastInst, LocalValue, OldVecTy,
+                                    InstsToErase, Builder, RecursionDepth);
       }
       // Handle load instruction which is following the bitcast in the pattern
       else if (auto *LI = dyn_cast<LoadInst>(U)) {
         Value *LocalValue = Builder.CreateLoad(NewVecTy, NewInst);
-        Changed |= lowerBitCastToNonStdVec(LI, LocalValue, OldVecTy,
-                                           InstsToErase, Builder,
-                                           RecursionDepth);
+        Changed |= lowerBitCastToNonStdVec(
+            LI, LocalValue, OldVecTy, InstsToErase, Builder, RecursionDepth);
       }
       // Handle extractelement instruction which is following the load
       else if (auto *EEI = dyn_cast<ExtractElementInst>(U)) {
@@ -111,9 +110,8 @@ bool lowerBitCastToNonStdVec(Instruction *OldInst, Value *NewInst,
         Value *LocalValue = Builder.CreateExtractElement(NewInst, ElemIdx);
         LocalValue =
             Builder.CreateTrunc(LocalValue, OldVecTy->getElementType());
-        Changed |= lowerBitCastToNonStdVec(EEI, LocalValue, OldVecTy,
-                                           InstsToErase, Builder,
-                                           RecursionDepth);
+        Changed |= lowerBitCastToNonStdVec(
+            EEI, LocalValue, OldVecTy, InstsToErase, Builder, RecursionDepth);
       }
     }
   }
@@ -161,8 +159,8 @@ public:
     for (auto &I : BCastsToNonStdVec) {
       Value *NewValue = I->getOperand(0);
       VectorType *OldVecTy = getVectorType(I->getType());
-      Changed |= lowerBitCastToNonStdVec(I, NewValue, OldVecTy, InstsToErase,
-                                         Builder);
+      Changed |=
+          lowerBitCastToNonStdVec(I, NewValue, OldVecTy, InstsToErase, Builder);
     }
 
     for (auto *I : InstsToErase)

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -102,7 +102,7 @@ public:
     Value *Src = nullptr;
     // It is assumed that the function can contain addrspacecast after handled
     // bitcast instruction, so addrspacecast should also be handled
-    for (auto *U: I->users()) {
+    for (auto *U : I->users()) {
       if (auto *ASCastInst = dyn_cast<AddrSpaceCastInst>(U)) {
         unsigned DestAddrSpace = ASCastInst->getDestAddressSpace();
         auto *SrcPointer = cast<CastInst>(I)->getSrcTy();
@@ -122,7 +122,7 @@ public:
                      : Builder.CreateLoad(SrcTy, I->getOperand(0));
     // In the already known pattern, the bitcast is followed by load instruction
     auto *LoadInstIter = ASCastInstIter;
-    for (auto *U: ASCastInstIter->users()) {
+    for (auto *U : ASCastInstIter->users()) {
       if (auto *LI = dyn_cast<LoadInst>(U))
         if (LI->getOperand(0) == ASCastInstIter) {
           LoadInstIter = cast<Instruction>(U);
@@ -135,7 +135,7 @@ public:
         cast<VectorType>(SrcTy)->getElementCount().getValue();
     int ElemIdx = 0;
     Instruction *ExtrElInstIter = LoadInstIter;
-    for (auto *U: LoadInstIter->users()) {
+    for (auto *U : LoadInstIter->users()) {
       if (auto *EEI = dyn_cast<ExtractElementInst>(U)) {
         if (EEI->getOperand(0) == cast<Value>(LoadInstIter)) {
           ElemIdx = cast<ConstantInt>(EEI->getIndexOperand())->getSExtValue() /

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -117,9 +117,11 @@ bool lowerBitCastToNonStdVec(Instruction *OldInst, Value *NewInst,
             cast<IntegerType>(OldVecTy->getElementType())->getBitWidth();
         unsigned NewVecElemBitWidth =
             cast<IntegerType>(NewVecTy->getElementType())->getBitWidth();
-        unsigned Ratio = NewVecElemBitWidth / OldVecElemBitWidth;
-        if (auto RequiredBitsIdx = OldElemIdx % Ratio != Ratio - 1) {
-          uint64_t Shift = OldVecElemBitWidth * (Ratio - RequiredBitsIdx);
+        unsigned BitWidthRatio = NewVecElemBitWidth / OldVecElemBitWidth;
+        if (auto RequiredBitsIdx =
+                OldElemIdx % BitWidthRatio != BitWidthRatio - 1) {
+          uint64_t Shift =
+              OldVecElemBitWidth * (BitWidthRatio - RequiredBitsIdx);
           LocalValue = Builder.CreateLShr(LocalValue, Shift);
         }
         LocalValue =

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4266,6 +4266,7 @@ void addPassesForSPIRV(legacy::PassManager &PassMgr,
   PassMgr.add(createSPIRVLowerBoolLegacy());
   PassMgr.add(createSPIRVLowerMemmoveLegacy());
   PassMgr.add(createSPIRVLowerSaddWithOverflowLegacy());
+  PassMgr.add(createSPIRVLowerBitCastToNonStandardTypeLegacy());
 }
 
 bool isValidLLVMModule(Module *M, SPIRVErrorLog &ErrorLog) {

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -11,14 +11,7 @@
 ; CHECK: %conv1 = sitofp i32 %3 to float
 ; CHECK: %conv2 = sitofp i32 %6 to float
 
-; CHECK-NOT: %0 = bitcast <3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*
-; CHECK-NOT: %1 = addrspacecast <6 x i32> addrspace(1)* %0 to <6 x i32> addrspace(4)*
-; CHECK-NOT: %2 = load <6 x i32>, <6 x i32> addrspace(4)* %1, align 32
-; CHECK-NOT: %3 = load <6 x i32>, <6 x i32> addrspace(4)* %1, align 32
-; CHECK-NOT: %4 = extractelement <6 x i32> %2, i32 0
-; CHECK-NOT: %5 = extractelement <6 x i32> %3, i32 4
-; CHECK-NOT: %conv1 = sitofp i32 %4 to float
-; CHECK-NOT: %conv2 = sitofp i32 %5 to float
+; CHECK-NOT: <3 x i64>
 
 ; ModuleID = 'lower-non-standard-types'
 source_filename = "lower-non-standard-types.cpp"

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -1,13 +1,13 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
 
-; CHECK: %0 = addrspacecast <3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <3 x i64> addrspace(4)*
+; CHECK: %0 = addrspacecast <3 x i64> addrspace(1)* @Id to <3 x i64> addrspace(4)*
 ; CHECK: %1 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
 ; CHECK: %2 = extractelement <3 x i64> %1, i64 2
 ; CHECK: %3 = trunc i64 %2 to i32
 ; CHECK: %conv1 = sitofp i32 %3 to float
 
-; CHECK-NOT: %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
+; CHECK-NOT: %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
 ; CHECK-NOT: %conv = extractelement <6 x i32> %0, i32 4
 
 ; ModuleID = 'lower-non-standard-types'
@@ -15,14 +15,12 @@ source_filename = "lower-non-standard-types.cpp"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown-sycldevice"
 
-%"simd" = type { <8 x float> }
-
-@__spirv_BuiltInGlobalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+@Id = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
 
 ; Function Attrs: convergent norecurse
-define dso_local spir_func void @vmult2(%"simd"* %a) local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
+define dso_local spir_func void @vmult2() local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
 entry:
-  %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
+  %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
   %conv = extractelement <6 x i32> %0, i32 4
   %conv1 = sitofp i32 %conv to float
   ret void

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
+; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s --implicit-check-not="<6 x i32>"
 
 ; CHECK: [[ASCastInst:%.*]] = addrspacecast <3 x i64> addrspace(1)* @Id to <3 x i64> addrspace(4)*
 ; CHECK: [[LoadInst1:%.*]] = load <3 x i64>, <3 x i64> addrspace(4)* [[ASCastInst]], align 32
@@ -10,8 +10,6 @@
 ; CHECK: [[TruncInst2:%.*]] = trunc i64 [[ExtrElInst2]] to i32
 ; CHECK: %conv1 = sitofp i32 [[TruncInst1]] to float
 ; CHECK: %conv2 = sitofp i32 [[TruncInst2]] to float
-
-; CHECK-NOT: <6 x i32>
 
 ; ModuleID = 'lower-non-standard-types'
 source_filename = "lower-non-standard-types.cpp"

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -1,17 +1,17 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
 
-; CHECK: %0 = addrspacecast <3 x i64> addrspace(1)* @Id to <3 x i64> addrspace(4)*
-; CHECK: %1 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
-; CHECK: %2 = extractelement <3 x i64> %1, i64 0
-; CHECK: %3 = trunc i64 %2 to i32
-; CHECK: %4 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
-; CHECK: %5 = extractelement <3 x i64> %4, i64 2
-; CHECK: %6 = trunc i64 %5 to i32
-; CHECK: %conv1 = sitofp i32 %3 to float
-; CHECK: %conv2 = sitofp i32 %6 to float
+; CHECK: [[ASCastInst:%.*]] = addrspacecast <3 x i64> addrspace(1)* @Id to <3 x i64> addrspace(4)*
+; CHECK: [[LoadInst1:%.*]] = load <3 x i64>, <3 x i64> addrspace(4)* [[ASCastInst]], align 32
+; CHECK: [[ExtrElInst1:%.*]] = extractelement <3 x i64> [[LoadInst1]], i64 0
+; CHECK: [[TruncInst1:%.*]] = trunc i64 [[ExtrElInst1]] to i32
+; CHECK: [[LoadInst2:%.*]] = load <3 x i64>, <3 x i64> addrspace(4)* [[ASCastInst]], align 32
+; CHECK: [[ExtrElInst2:%.*]] = extractelement <3 x i64> [[LoadInst2]], i64 2
+; CHECK: [[TruncInst2:%.*]] = trunc i64 [[ExtrElInst2]] to i32
+; CHECK: %conv1 = sitofp i32 [[TruncInst1]] to float
+; CHECK: %conv2 = sitofp i32 [[TruncInst2]] to float
 
-; CHECK-NOT: <3 x i64>
+; CHECK-NOT: <6 x i32>
 
 ; ModuleID = 'lower-non-standard-types'
 source_filename = "lower-non-standard-types.cpp"

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -3,11 +3,18 @@
 
 ; CHECK: %0 = addrspacecast <3 x i64> addrspace(1)* @Id to <3 x i64> addrspace(4)*
 ; CHECK: %1 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
-; CHECK: %2 = extractelement <3 x i64> %1, i64 2
-; CHECK: %3 = trunc i64 %2 to i32
-; CHECK: %conv1 = sitofp i32 %3 to float
+; CHECK: %2 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
+; CHECK: %3 = extractelement <3 x i64> %1, i64 0
+; CHECK: %4 = trunc i64 %3 to i32
+; CHECK: %5 = extractelement <3 x i64> %2, i64 2
+; CHECK: %6 = trunc i64 %5 to i32
+; CHECK: %conv1 = sitofp i32 %4 to float
+; CHECK: %conv2 = sitofp i32 %6 to float
 
 ; CHECK-NOT: %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
+; CHECK-NOT: %1 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
+; CHECK-NOT: %2 = extractelement <6 x i32> %0, i32 0
+; CHECK-NOT: %3 = extractelement <6 x i32> %1, i32 4
 ; CHECK-NOT: %conv = extractelement <6 x i32> %0, i32 4
 
 ; ModuleID = 'lower-non-standard-types'
@@ -21,8 +28,11 @@ target triple = "spir64-unknown-unknown-sycldevice"
 define dso_local spir_func void @vmult2() local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
 entry:
   %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
-  %conv = extractelement <6 x i32> %0, i32 4
-  %conv1 = sitofp i32 %conv to float
+  %1 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
+  %2 = extractelement <6 x i32> %0, i32 0
+  %3 = extractelement <6 x i32> %1, i32 4
+  %conv1 = sitofp i32 %2 to float
+  %conv2 = sitofp i32 %3 to float
   ret void
 }
 

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -1,8 +1,14 @@
-; It is assumed that the test will not fail
-
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
+
+; CHECK: %0 = addrspacecast <3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <3 x i64> addrspace(4)*
+; CHECK: %1 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 1
+; CHECK: %2 = extractelement <3 x i64> %1, i64 2
+; CHECK: %3 = trunc i64 %2 to i32
+; CHECK: %conv1 = sitofp i32 %3 to float
+
+; CHECK-NOT: %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
+; CHECK-NOT: %conv = extractelement <6 x i32> %0, i32 4
 
 ; ModuleID = 'lower-non-standard-types'
 source_filename = "lower-non-standard-types.cpp"

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -7,7 +7,8 @@
 ; CHECK: [[TruncInst1:%.*]] = trunc i64 [[ExtrElInst1]] to i32
 ; CHECK: [[LoadInst2:%.*]] = load <3 x i64>, <3 x i64> addrspace(4)* [[ASCastInst]], align 32
 ; CHECK: [[ExtrElInst2:%.*]] = extractelement <3 x i64> [[LoadInst2]], i64 2
-; CHECK: [[TruncInst2:%.*]] = trunc i64 [[ExtrElInst2]] to i32
+; CHECK: [[LShrInst:%.*]] = lshr i64 [[ExtrElInst2]], 32
+; CHECK: [[TruncInst2:%.*]] = trunc i64 [[LShrInst]] to i32
 ; CHECK: %conv1 = sitofp i32 [[TruncInst1]] to float
 ; CHECK: %conv2 = sitofp i32 [[TruncInst2]] to float
 
@@ -23,7 +24,7 @@ define dso_local spir_func void @vmult2() local_unnamed_addr #0 !sycl_explicit_s
 entry:
   %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
   %1 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
-  %2 = extractelement <6 x i32> %0, i32 0
+  %2 = extractelement <6 x i32> %0, i32 1
   %3 = extractelement <6 x i32> %1, i32 4
   %conv1 = sitofp i32 %2 to float
   %conv2 = sitofp i32 %3 to float

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -1,0 +1,44 @@
+; It is assumed that the test will not fail
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+
+; ModuleID = 'lower-non-standard-types'
+source_filename = "lower-non-standard-types.cpp"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown-sycldevice"
+
+%"simd" = type { <8 x float> }
+
+@__spirv_BuiltInGlobalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+; Function Attrs: convergent norecurse
+define dso_local spir_func void @vmult2(%"simd"* %a) local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
+entry:
+  %ref.tmp.i.i = alloca %"simd", align 32
+  %ref.tmp.i = alloca %"simd", align 32
+  %a.ascast = addrspacecast %"simd"* %a to %"simd" addrspace(4)*
+  %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
+  %conv = extractelement <6 x i32> %0, i32 4
+  %conv1 = sitofp i32 %conv to float
+  ret void
+}
+
+attributes #0 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-width"="256" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="lower-external-funcs-with-z.cpp" }
+
+!llvm.module.flags = !{!0, !1}
+!opencl.spir.version = !{!2}
+!spirv.Source = !{!3}
+!opencl.used.extensions = !{!4}
+!opencl.used.optional.core.features = !{!4}
+!opencl.compiler.options = !{!4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{i32 1, i32 2}
+!3 = !{i32 0, i32 100000}
+!4 = !{}
+!5 = !{!"Compiler"}
+!6 = !{i32 1}

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
 
 ; CHECK: %0 = addrspacecast <3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <3 x i64> addrspace(4)*
-; CHECK: %1 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 1
+; CHECK: %1 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
 ; CHECK: %2 = extractelement <3 x i64> %1, i64 2
 ; CHECK: %3 = trunc i64 %2 to i32
 ; CHECK: %conv1 = sitofp i32 %3 to float
@@ -22,9 +22,6 @@ target triple = "spir64-unknown-unknown-sycldevice"
 ; Function Attrs: convergent norecurse
 define dso_local spir_func void @vmult2(%"simd"* %a) local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
 entry:
-  %ref.tmp.i.i = alloca %"simd", align 32
-  %ref.tmp.i = alloca %"simd", align 32
-  %a.ascast = addrspacecast %"simd"* %a to %"simd" addrspace(4)*
   %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
   %conv = extractelement <6 x i32> %0, i32 4
   %conv1 = sitofp i32 %conv to float

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -3,19 +3,22 @@
 
 ; CHECK: %0 = addrspacecast <3 x i64> addrspace(1)* @Id to <3 x i64> addrspace(4)*
 ; CHECK: %1 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
-; CHECK: %2 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
-; CHECK: %3 = extractelement <3 x i64> %1, i64 0
-; CHECK: %4 = trunc i64 %3 to i32
-; CHECK: %5 = extractelement <3 x i64> %2, i64 2
+; CHECK: %2 = extractelement <3 x i64> %1, i64 0
+; CHECK: %3 = trunc i64 %2 to i32
+; CHECK: %4 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
+; CHECK: %5 = extractelement <3 x i64> %4, i64 2
 ; CHECK: %6 = trunc i64 %5 to i32
-; CHECK: %conv1 = sitofp i32 %4 to float
+; CHECK: %conv1 = sitofp i32 %3 to float
 ; CHECK: %conv2 = sitofp i32 %6 to float
 
-; CHECK-NOT: %0 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
-; CHECK-NOT: %1 = load <6 x i32>, <6 x i32> addrspace(4)* addrspacecast (<6 x i32> addrspace(1)* bitcast (<3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*) to <6 x i32> addrspace(4)*), align 32
-; CHECK-NOT: %2 = extractelement <6 x i32> %0, i32 0
-; CHECK-NOT: %3 = extractelement <6 x i32> %1, i32 4
-; CHECK-NOT: %conv = extractelement <6 x i32> %0, i32 4
+; CHECK-NOT: %0 = bitcast <3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*
+; CHECK-NOT: %1 = addrspacecast <6 x i32> addrspace(1)* %0 to <6 x i32> addrspace(4)*
+; CHECK-NOT: %2 = load <6 x i32>, <6 x i32> addrspace(4)* %1, align 32
+; CHECK-NOT: %3 = load <6 x i32>, <6 x i32> addrspace(4)* %1, align 32
+; CHECK-NOT: %4 = extractelement <6 x i32> %2, i32 0
+; CHECK-NOT: %5 = extractelement <6 x i32> %3, i32 4
+; CHECK-NOT: %conv1 = sitofp i32 %4 to float
+; CHECK-NOT: %conv2 = sitofp i32 %5 to float
 
 ; ModuleID = 'lower-non-standard-types'
 source_filename = "lower-non-standard-types.cpp"


### PR DESCRIPTION
It is a pass to lower bitcast instructions to non-standard SPIR-V types.
It covers only known issues. At this moment there is only one pattern
that should be covered - use of vector with unsupported number of
elements. This pattern should be handled this way:

%0 = bitcast <3 x i64> addrspace(1)* @Id to <6 x i32> addrspace(1)*
%1 = addrspacecast <6 x i32> addrspace(1)* %0 to <6 x i32> addrspace(4)*
%2 = load <6 x i32>, <6 x i32> addrspace(4)* %1, align 32
%conv = extractelement <6 x i32> %2, i32 4
%conv1 = sitofp i32 %conv to float

Must be replaced by:
%0 = addrspacecast <3 x i64> addrspace(1)* @Id to  <3 x i64> addrspace(4)*
%1 = load <3 x i64>, <3 x i64> addrspace(4)* %0, align 32
%2 = extractelement <3 x i64> %1, i32 0
%conv = trunc i64 %2 to i32
%conv1 = sitofp i32 %conv to float

It is assumed that the pass will be further developed as new patterns arise.