### PR TITLE
Update minimum cmake version to 3.13.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.13.4)
 
 set (BASE_LLVM_VERSION 13.0.0)
 set(LLVM_SPIRV_VERSION ${BASE_LLVM_VERSION}.0)


### PR DESCRIPTION
7251f3cb ("Make spirv.hpp be an external dependency (#813)",
2021-07-27) introduces use of the FetchContent module, which is only
available from CMake 3.11.

We might just as well align with LLVM's cmake requirement, so bump the
requirement to CMake 3.13.4.