### PR TITLE
[SPV-IR] Fix SPIRV builtin variable/call translation

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -108,9 +108,6 @@ public:
   /// Transform OCL builtin function to SPIR-V builtin function.
   void transBuiltin(CallInst *CI, OCLBuiltinTransInfo &Info);
 
-  /// Transform OCL work item builtin functions to SPIR-V builtin variables.
-  void transWorkItemBuiltinsToVariables();
-
   /// Transform atomic_work_item_fence/mem_fence to __spirv_MemoryBarrier.
   /// func(flag, order, scope) =>
   ///   __spirv_MemoryBarrier(map(scope), map(flag)|map(order))
@@ -367,7 +364,7 @@ bool OCLToSPIRVBase::runOCLToSPIRV(Module &Module) {
 
   LLVM_DEBUG(dbgs() << "Enter OCLToSPIRV:\n");
 
-  transWorkItemBuiltinsToVariables();
+  transWorkItemBuiltinsToVariables(M);
 
   visit(*M);
 
@@ -1271,60 +1268,6 @@ void OCLToSPIRVBase::visitCallBuiltinSimple(CallInst *CI, StringRef MangledName,
   Info.MangledName = MangledName.str();
   Info.UniqName = DemangledName.str();
   transBuiltin(CI, Info);
-}
-
-/// Translates OCL work-item builtin functions to SPIRV builtin variables.
-/// Function like get_global_id(i) -> x = load GlobalInvocationId; extract x, i
-/// Function like get_work_dim() -> load WorkDim
-void OCLToSPIRVBase::transWorkItemBuiltinsToVariables() {
-  LLVM_DEBUG(dbgs() << "Enter transWorkItemBuiltinsToVariables\n");
-  std::vector<Function *> WorkList;
-  for (auto &I : *M) {
-    StringRef DemangledName;
-    if (!oclIsBuiltin(I.getName(), DemangledName))
-      continue;
-    LLVM_DEBUG(dbgs() << "Function demangled name: " << DemangledName << '\n');
-    std::string BuiltinVarName;
-    SPIRVBuiltinVariableKind BVKind;
-    if (!SPIRSPIRVBuiltinVariableMap::find(DemangledName.str(), &BVKind))
-      continue;
-    BuiltinVarName =
-        std::string(kSPIRVName::Prefix) + SPIRVBuiltInNameMap::map(BVKind);
-    LLVM_DEBUG(dbgs() << "builtin variable name: " << BuiltinVarName << '\n');
-    bool IsVec = I.getFunctionType()->getNumParams() > 0;
-    Type *GVType =
-        IsVec ? FixedVectorType::get(I.getReturnType(), 3) : I.getReturnType();
-    auto BV = new GlobalVariable(*M, GVType, true, GlobalValue::ExternalLinkage,
-                                 nullptr, BuiltinVarName, 0,
-                                 GlobalVariable::NotThreadLocal, SPIRAS_Input);
-    std::vector<Instruction *> InstList;
-    for (auto UI = I.user_begin(), UE = I.user_end(); UI != UE; ++UI) {
-      auto CI = dyn_cast<CallInst>(*UI);
-      assert(CI && "invalid instruction");
-      const DebugLoc &DLoc = CI->getDebugLoc();
-      Instruction *NewValue = new LoadInst(GVType, BV, "", CI);
-      if (DLoc)
-        NewValue->setDebugLoc(DLoc);
-      LLVM_DEBUG(dbgs() << "Transform: " << *CI << " => " << *NewValue << '\n');
-      if (IsVec) {
-        NewValue =
-            ExtractElementInst::Create(NewValue, CI->getArgOperand(0), "", CI);
-        if (DLoc)
-          NewValue->setDebugLoc(DLoc);
-        LLVM_DEBUG(dbgs() << *NewValue << '\n');
-      }
-      NewValue->takeName(CI);
-      CI->replaceAllUsesWith(NewValue);
-      InstList.push_back(CI);
-    }
-    for (auto &Inst : InstList) {
-      Inst->eraseFromParent();
-    }
-    WorkList.push_back(&I);
-  }
-  for (auto &I : WorkList) {
-    I->eraseFromParent();
-  }
 }
 
 void OCLToSPIRVBase::visitCallReadWriteImage(CallInst *CI,

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -641,10 +641,14 @@ StringRef undecorateSPIRVFunction(StringRef S);
 /// and get the original name.
 bool isDecoratedSPIRVFunc(const Function *F, StringRef &UndecName);
 
+StringRef dePrefixSPIRVName(StringRef R, SmallVectorImpl<StringRef> &Postfix);
+
 /// Get a canonical function name for a SPIR-V op code.
 std::string getSPIRVFuncName(Op OC, StringRef PostFix = "");
 
 std::string getSPIRVFuncName(Op OC, const Type *PRetTy, bool IsSigned = false);
+
+std::string getSPIRVFuncName(SPIRVBuiltinVariableKind BVKind);
 
 /// Get a canonical function name for a SPIR-V extended instruction
 std::string getSPIRVExtFuncName(SPIRVExtInstSetKind Set, unsigned ExtOp,
@@ -1031,8 +1035,6 @@ bool lowerBuiltinVariableToCall(GlobalVariable *GV,
                                 SPIRVBuiltinVariableKind Kind);
 // Transform all builtin variables into calls
 bool lowerBuiltinVariablesToCalls(Module *M);
-
-void transWorkItemBuiltinsToVariables(Module *M);
 
 } // namespace SPIRV
 

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -1019,6 +1019,21 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM);
 /// \param Strs contains the integers decoded from postfixes.
 std::string decodeSPIRVTypeName(StringRef Name,
                                 SmallVectorImpl<std::string> &Strs);
+
+// Copy attributes from function to call site.
+void setAttrByCalledFunc(CallInst *Call);
+bool isSPIRVBuiltinVariable(GlobalVariable *GV, SPIRVBuiltinVariableKind *Kind);
+// Transform builtin variable from GlobalVariable to builtin call.
+// e.g.
+// - GlobalInvolcationId[x] -> _Z33__spirv_BuiltInGlobalInvocationIdi(x)
+// - WorkDim -> _Z22__spirv_BuiltInWorkDimv()
+bool lowerBuiltinVariableToCall(GlobalVariable *GV,
+                                SPIRVBuiltinVariableKind Kind);
+// Transform all builtin variables into calls
+bool lowerBuiltinVariablesToCalls(Module *M);
+
+void transWorkItemBuiltinsToVariables(Module *M);
+
 } // namespace SPIRV
 
 #endif // SPIRV_SPIRVINTERNAL_H

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -245,32 +245,6 @@ void SPIRVToLLVM::setCallingConv(CallInst *Call) {
   Call->setCallingConv(F->getCallingConv());
 }
 
-void SPIRVToLLVM::setAttrByCalledFunc(CallInst *Call) {
-  Function *F = Call->getCalledFunction();
-  assert(F);
-  if (F->isIntrinsic()) {
-    return;
-  }
-  Call->setCallingConv(F->getCallingConv());
-  Call->setAttributes(F->getAttributes());
-}
-
-bool SPIRVToLLVM::transOCLBuiltinsFromVariables() {
-  std::vector<GlobalVariable *> WorkList;
-  for (auto I = M->global_begin(), E = M->global_end(); I != E; ++I) {
-    SPIRVBuiltinVariableKind Kind;
-    if (!isSPIRVBuiltinVariable(&(*I), &Kind))
-      continue;
-    if (!transOCLBuiltinFromVariable(&(*I), Kind))
-      return false;
-    WorkList.push_back(&(*I));
-  }
-  for (auto &I : WorkList) {
-    I->eraseFromParent();
-  }
-  return true;
-}
-
 // For integer types shorter than 32 bit, unsigned/signedness can be inferred
 // from zext/sext attribute.
 MDString *SPIRVToLLVM::transOCLKernelArgTypeName(SPIRVFunctionParameter *Arg) {
@@ -284,184 +258,6 @@ Value *SPIRVToLLVM::mapFunction(SPIRVFunction *BF, Function *F) {
            dbgs() << *F << '\n';)
   FuncMap[BF] = F;
   return F;
-}
-
-// Variable like GlobalInvolcationId[x] -> get_global_id(x).
-// Variable like WorkDim -> get_work_dim().
-// Replace the following pattern:
-// %a = addrspacecast i32 addrspace(1)* @__spirv_BuiltInSubgroupMaxSize to
-// i32 addrspace(4)*
-// %b = load i32, i32 addrspace(4)* %a, align 4
-// %c = load i32, i32 addrspace(4)* %a, align 4
-// With:
-// %b = call spir_func i32 @_Z22get_max_sub_group_sizev()
-// %c = call spir_func i32 @_Z22get_max_sub_group_sizev()
-
-// And replace the following pattern:
-// %a = addrspacecast <3 x i64> addrspace(1)* @__spirv_BuiltInWorkgroupId to
-// <3 x i64> addrspace(4)*
-// %b = load <3 x i64>, <3 x i64> addrspace(4)* %a, align 32
-// %c = extractelement <3 x i64> %b, i32 idx
-// %d = extractelement <3 x i64> %b, i32 idx
-// With:
-// %0 = call spir_func i64 @_Z13get_global_idj(i32 0) #1
-// %1 = insertelement <3 x i64> undef, i64 %0, i32 0
-// %2 = call spir_func i64 @_Z13get_global_idj(i32 1) #1
-// %3 = insertelement <3 x i64> %1, i64 %2, i32 1
-// %4 = call spir_func i64 @_Z13get_global_idj(i32 2) #1
-// %5 = insertelement <3 x i64> %3, i64 %4, i32 2
-// %c = extractelement <3 x i64> %5, i32 idx
-// %d = extractelement <3 x i64> %5, i32 idx
-//
-// Replace the following pattern:
-// %0 = addrspacecast <3 x i64> addrspace(1)* @__spirv_BuiltInWorkgroupSize to
-// <3 x i64> addrspace(4)*
-// %1 = getelementptr <3 x i64>, <3 x i64> addrspace(4)* %0, i64 0, i64 0
-// %2 = load i64, i64 addrspace(4)* %1, align 32
-// With:
-// %0 = call spir_func i64 @_Z13get_global_idj(i32 0) #1
-// %1 = insertelement <3 x i64> undef, i64 %0, i32 0
-// %2 = call spir_func i64 @_Z13get_global_idj(i32 1) #1
-// %3 = insertelement <3 x i64> %1, i64 %2, i32 1
-// %4 = call spir_func i64 @_Z13get_global_idj(i32 2) #1
-// %5 = insertelement <3 x i64> %3, i64 %4, i32 2
-// %6 = extractelement <3 x i64> %5, i32 0
-bool SPIRVToLLVM::transOCLBuiltinFromVariable(GlobalVariable *GV,
-                                              SPIRVBuiltinVariableKind Kind) {
-  std::string FuncName;
-  // TODO: we should always produce SPIR-V friendly IR and apply lowering later
-  // if needed
-  if (BM->getDesiredBIsRepresentation() != BIsRepresentation::SPIRVFriendlyIR) {
-    FuncName = SPIRSPIRVBuiltinVariableMap::rmap(Kind);
-  } else {
-    FuncName = std::string(GV->getName());
-  }
-  Type *GVTy = GV->getType()->getPointerElementType();
-  Type *ReturnTy = GVTy;
-  // Some SPIR-V builtin variables are translated to a function with an index
-  // argument.
-  bool HasIndexArg =
-      ReturnTy->isVectorTy() &&
-      !(BuiltInSubgroupEqMask <= Kind && Kind <= BuiltInSubgroupLtMask);
-  if (HasIndexArg)
-    ReturnTy = cast<VectorType>(ReturnTy)->getElementType();
-  std::vector<Type *> ArgTy;
-  if (HasIndexArg)
-    ArgTy.push_back(Type::getInt32Ty(*Context));
-  std::string MangledName;
-  mangleOpenClBuiltin(FuncName, ArgTy, MangledName);
-  Function *Func = M->getFunction(MangledName);
-  if (!Func) {
-    FunctionType *FT = FunctionType::get(ReturnTy, ArgTy, false);
-    Func = Function::Create(FT, GlobalValue::ExternalLinkage, MangledName, M);
-    Func->setCallingConv(CallingConv::SPIR_FUNC);
-    Func->addFnAttr(Attribute::NoUnwind);
-    Func->addFnAttr(Attribute::ReadNone);
-    Func->addFnAttr(Attribute::WillReturn);
-  }
-
-  // Collect instructions in these containers to remove them later.
-  std::vector<Instruction *> Loads;
-  std::vector<Instruction *> Casts;
-  std::vector<Instruction *> GEPs;
-
-  auto Replace = [&](std::vector<Value *> Arg, Instruction *I) {
-    auto Call = CallInst::Create(Func, Arg, "", I);
-    Call->takeName(I);
-    setAttrByCalledFunc(Call);
-    SPIRVDBG(dbgs() << "[transOCLBuiltinFromVariable] " << *I << " -> " << *Call
-                    << '\n';)
-    I->replaceAllUsesWith(Call);
-  };
-
-  // If HasIndexArg is true, we create 3 built-in calls and insertelement to
-  // get 3-element vector filled with ids and replace uses of Load instruction
-  // with this vector.
-  // If HasIndexArg is false, the result of the Load instruction is the value
-  // which should be replaced with the Func.
-  // Returns true if Load was replaced, false otherwise.
-  auto ReplaceIfLoad = [&](User *I) {
-    auto *LD = dyn_cast<LoadInst>(I);
-    if (!LD)
-      return false;
-    std::vector<Value *> Vectors;
-    Loads.push_back(LD);
-    if (HasIndexArg) {
-      auto *VecTy = cast<FixedVectorType>(GVTy);
-      Value *EmptyVec = UndefValue::get(VecTy);
-      Vectors.push_back(EmptyVec);
-      const DebugLoc &DLoc = LD->getDebugLoc();
-      for (unsigned I = 0; I < VecTy->getNumElements(); ++I) {
-        auto *Idx = ConstantInt::get(Type::getInt32Ty(*Context), I);
-        auto *Call = CallInst::Create(Func, {Idx}, "", LD);
-        if (DLoc)
-          Call->setDebugLoc(DLoc);
-        setAttrByCalledFunc(Call);
-        auto *Insert = InsertElementInst::Create(Vectors.back(), Call, Idx);
-        if (DLoc)
-          Insert->setDebugLoc(DLoc);
-        Insert->insertAfter(Call);
-        Vectors.push_back(Insert);
-      }
-
-      Value *Ptr = LD->getPointerOperand();
-
-      if (isa<FixedVectorType>(Ptr->getType()->getPointerElementType())) {
-        LD->replaceAllUsesWith(Vectors.back());
-      } else {
-        auto *GEP = dyn_cast<GetElementPtrInst>(Ptr);
-        assert(GEP && "Unexpected pattern!");
-        assert(GEP->getNumIndices() == 2 && "Unexpected pattern!");
-        Value *Idx = GEP->getOperand(2);
-        Value *Vec = Vectors.back();
-        auto *NewExtract = ExtractElementInst::Create(Vec, Idx);
-        NewExtract->insertAfter(cast<Instruction>(Vec));
-        LD->replaceAllUsesWith(NewExtract);
-      }
-
-    } else {
-      Replace({}, LD);
-    }
-
-    return true;
-  };
-
-  // Go over the GV users, find Load and ExtractElement instructions and
-  // replace them with the corresponding function call.
-  for (auto *UI : GV->users()) {
-    // There might or might not be an addrspacecast instruction.
-    if (auto *ASCast = dyn_cast<AddrSpaceCastInst>(UI)) {
-      Casts.push_back(ASCast);
-      for (auto *CastUser : ASCast->users()) {
-        if (ReplaceIfLoad(CastUser))
-          continue;
-        if (auto *GEP = dyn_cast<GetElementPtrInst>(CastUser)) {
-          GEPs.push_back(GEP);
-          for (auto *GEPUser : GEP->users()) {
-            if (!ReplaceIfLoad(GEPUser))
-              llvm_unreachable("Unexpected pattern!");
-          }
-        } else {
-          llvm_unreachable("Unexpected pattern!");
-        }
-      }
-    } else if (!ReplaceIfLoad(UI)) {
-      llvm_unreachable("Unexpected pattern!");
-    }
-  }
-
-  auto Erase = [](std::vector<Instruction *> &ToErase) {
-    for (Instruction *I : ToErase) {
-      assert(I->hasNUses(0));
-      I->eraseFromParent();
-    }
-  };
-  // Order of erasing is important.
-  Erase(Loads);
-  Erase(GEPs);
-  Erase(Casts);
-
-  return true;
 }
 
 Type *SPIRVToLLVM::transFPType(SPIRVType *T) {
@@ -1452,16 +1248,6 @@ Value *SPIRVToLLVM::mapValue(SPIRVValue *BV, Value *V) {
   return V;
 }
 
-bool SPIRVToLLVM::isSPIRVBuiltinVariable(GlobalVariable *GV,
-                                         SPIRVBuiltinVariableKind *Kind) {
-  auto Loc = BuiltinGVMap.find(GV);
-  if (Loc == BuiltinGVMap.end())
-    return false;
-  if (Kind)
-    *Kind = Loc->second;
-  return true;
-}
-
 CallInst *
 SPIRVToLLVM::expandOCLBuiltinWithScalarArg(CallInst *CI,
                                            const std::string &FuncName) {
@@ -1847,9 +1633,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         LVar->addAttribute(kVCMetadata::VCVolatile);
     }
 
-    SPIRVBuiltinVariableKind BVKind;
-    if (BVar->isBuiltin(&BVKind))
-      BuiltinGVMap[LVar] = BVKind;
     return Res;
   }
 
@@ -3542,7 +3325,14 @@ bool SPIRVToLLVM::translate() {
   if (!transSourceExtension())
     return false;
   transGeneratorMD();
-  if (!transOCLBuiltinsFromVariables())
+  // TODO: add an option to control the builtin format in SPV-IR.
+  // The primary format should be function calls:
+  //   e.g. call spir_func i32 @_Z29__spirv_BuiltInGlobalLinearIdv()
+  // The secondary format should be global variables:
+  //   e.g. load i32, i32* @__spirv_BuiltInGlobalLinearId, align 4
+  // If the desired format is global variables, we don't have to lower them
+  // as calls.
+  if (!lowerBuiltinVariablesToCalls(M))
     return false;
   if (!postProcessOCL())
     return false;

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -177,7 +177,6 @@ public:
 
 private:
   Module *M;
-  BuiltinVarMap BuiltinGVMap;
   LLVMContext *Context;
   SPIRVModule *BM;
   SPIRVToLLVMTypeMap TypeMap;
@@ -206,9 +205,6 @@ private:
   // with kPlaceholderPrefix.
   Value *mapValue(SPIRVValue *BV, Value *V);
 
-  bool isSPIRVBuiltinVariable(GlobalVariable *GV,
-                              SPIRVBuiltinVariableKind *Kind = nullptr);
-
   // OpenCL function always has NoUnwind attribute.
   // Change this if it is no longer true.
   bool isFuncNoUnwind() const { return true; }
@@ -219,16 +215,12 @@ private:
 
   bool isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const;
   bool isDirectlyTranslatedToOCL(Op OpCode) const;
-  bool transOCLBuiltinsFromVariables();
-  bool transOCLBuiltinFromVariable(GlobalVariable *GV,
-                                   SPIRVBuiltinVariableKind Kind);
   MDString *transOCLKernelArgTypeName(SPIRVFunctionParameter *);
   Value *mapFunction(SPIRVFunction *BF, Function *F);
   Value *getTranslatedValue(SPIRVValue *BV);
   IntrinsicInst *getLifetimeStartIntrinsic(Instruction *I);
   SPIRVErrorLog &getErrorLog();
   void setCallingConv(CallInst *Call);
-  void setAttrByCalledFunc(CallInst *Call);
   Type *transFPType(SPIRVType *T);
   Value *transShiftLogicalBitwiseInst(SPIRVValue *BV, BasicBlock *BB,
                                       Function *F);

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -155,6 +155,13 @@ public:
   /// No change with arguments.
   void visitCallSPIRVBuiltin(CallInst *CI, Op OC);
 
+  /// Transform __spirv_* builtins (originates from builtin variables) to OCL
+  /// builtins.
+  /// No change with arguments.
+  /// e.g.
+  /// _Z33__spirv_BuiltInGlobalInvocationIdi(x) -> get_global_id(x)
+  void visitCallSPIRVBuiltin(CallInst *CI, SPIRVBuiltinVariableKind Kind);
+
   /// Transform __spirv_ocl* instructions (OpenCL Extended Instruction Set)
   /// to OpenCL builtins.
   void visitCallSPIRVOCLExt(CallInst *CI, OCLExtOpKind Kind);

--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -53,6 +53,8 @@ bool SPIRVToOCL12Base::runSPIRVToOCL(Module &Module) {
   M = &Module;
   Ctx = &M->getContext();
 
+  // Lower builtin variables to builtin calls first.
+  lowerBuiltinVariablesToCalls(M);
   translateOpaqueTypes();
 
   visit(*M);

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -52,6 +52,8 @@ bool SPIRVToOCL20Base::runSPIRVToOCL(Module &Module) {
   M = &Module;
   Ctx = &M->getContext();
 
+  // Lower builtin variables to builtin calls first.
+  lowerBuiltinVariablesToCalls(M);
   translateOpaqueTypes();
 
   visit(*M);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1639,6 +1639,274 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
   }
   return true;
 }
+
+void setAttrByCalledFunc(CallInst *Call) {
+  Function *F = Call->getCalledFunction();
+  assert(F);
+  if (F->isIntrinsic()) {
+    return;
+  }
+  Call->setCallingConv(F->getCallingConv());
+  Call->setAttributes(F->getAttributes());
+}
+
+bool isSPIRVBuiltinVariable(GlobalVariable *GV,
+                            SPIRVBuiltinVariableKind *Kind) {
+  if (!GV->hasName() || !getSPIRVBuiltin(GV->getName().str(), *Kind))
+    return false;
+  return true;
+}
+
+// Variable like GlobalInvolcationId[x] -> get_global_id(x).
+// Variable like WorkDim -> get_work_dim().
+// Replace the following pattern:
+// %a = addrspacecast i32 addrspace(1)* @__spirv_BuiltInSubgroupMaxSize to
+// i32 addrspace(4)*
+// %b = load i32, i32 addrspace(4)* %a, align 4
+// %c = load i32, i32 addrspace(4)* %a, align 4
+// With:
+// %b = call spir_func i32 @_Z22get_max_sub_group_sizev()
+// %c = call spir_func i32 @_Z22get_max_sub_group_sizev()
+
+// And replace the following pattern:
+// %a = addrspacecast <3 x i64> addrspace(1)* @__spirv_BuiltInWorkgroupId to
+// <3 x i64> addrspace(4)*
+// %b = load <3 x i64>, <3 x i64> addrspace(4)* %a, align 32
+// %c = extractelement <3 x i64> %b, i32 idx
+// %d = extractelement <3 x i64> %b, i32 idx
+// With:
+// %0 = call spir_func i64 @_Z13get_global_idj(i32 0) #1
+// %1 = insertelement <3 x i64> undef, i64 %0, i32 0
+// %2 = call spir_func i64 @_Z13get_global_idj(i32 1) #1
+// %3 = insertelement <3 x i64> %1, i64 %2, i32 1
+// %4 = call spir_func i64 @_Z13get_global_idj(i32 2) #1
+// %5 = insertelement <3 x i64> %3, i64 %4, i32 2
+// %c = extractelement <3 x i64> %5, i32 idx
+// %d = extractelement <3 x i64> %5, i32 idx
+//
+// Replace the following pattern:
+// %0 = addrspacecast <3 x i64> addrspace(1)* @__spirv_BuiltInWorkgroupSize to
+// <3 x i64> addrspace(4)*
+// %1 = getelementptr <3 x i64>, <3 x i64> addrspace(4)* %0, i64 0, i64 0
+// %2 = load i64, i64 addrspace(4)* %1, align 32
+// With:
+// %0 = call spir_func i64 @_Z13get_global_idj(i32 0) #1
+// %1 = insertelement <3 x i64> undef, i64 %0, i32 0
+// %2 = call spir_func i64 @_Z13get_global_idj(i32 1) #1
+// %3 = insertelement <3 x i64> %1, i64 %2, i32 1
+// %4 = call spir_func i64 @_Z13get_global_idj(i32 2) #1
+// %5 = insertelement <3 x i64> %3, i64 %4, i32 2
+// %6 = extractelement <3 x i64> %5, i32 0
+bool lowerBuiltinVariableToCall(GlobalVariable *GV,
+                                SPIRVBuiltinVariableKind Kind) {
+  Module *M = GV->getParent();
+  LLVMContext &C = M->getContext();
+  std::string FuncName = GV->getName().str();
+  Type *GVTy = GV->getType()->getPointerElementType();
+  Type *ReturnTy = GVTy;
+  // Some SPIR-V builtin variables are translated to a function with an index
+  // argument.
+  bool HasIndexArg =
+      ReturnTy->isVectorTy() &&
+      !(BuiltInSubgroupEqMask <= Kind && Kind <= BuiltInSubgroupLtMask);
+  if (HasIndexArg)
+    ReturnTy = cast<VectorType>(ReturnTy)->getElementType();
+  std::vector<Type *> ArgTy;
+  if (HasIndexArg)
+    ArgTy.push_back(Type::getInt32Ty(C));
+  std::string MangledName;
+  mangleOpenClBuiltin(FuncName, ArgTy, MangledName);
+  Function *Func = M->getFunction(MangledName);
+  if (!Func) {
+    FunctionType *FT = FunctionType::get(ReturnTy, ArgTy, false);
+    Func = Function::Create(FT, GlobalValue::ExternalLinkage, MangledName, M);
+    Func->setCallingConv(CallingConv::SPIR_FUNC);
+    Func->addFnAttr(Attribute::NoUnwind);
+    Func->addFnAttr(Attribute::ReadNone);
+    Func->addFnAttr(Attribute::WillReturn);
+  }
+
+  // Collect instructions in these containers to remove them later.
+  std::vector<Instruction *> Loads;
+  std::vector<Instruction *> Casts;
+  std::vector<Instruction *> GEPs;
+
+  auto Replace = [&](std::vector<Value *> Arg, Instruction *I) {
+    auto Call = CallInst::Create(Func, Arg, "", I);
+    Call->takeName(I);
+    setAttrByCalledFunc(Call);
+    SPIRVDBG(dbgs() << "[lowerBuiltinVariableToCall] " << *I << " -> " << *Call
+                    << '\n';)
+    I->replaceAllUsesWith(Call);
+  };
+
+  // If HasIndexArg is true, we create 3 built-in calls and insertelement to
+  // get 3-element vector filled with ids and replace uses of Load instruction
+  // with this vector.
+  // If HasIndexArg is false, the result of the Load instruction is the value
+  // which should be replaced with the Func.
+  // Returns true if Load was replaced, false otherwise.
+  auto ReplaceIfLoad = [&](User *I) {
+    auto *LD = dyn_cast<LoadInst>(I);
+    if (!LD)
+      return false;
+    std::vector<Value *> Vectors;
+    Loads.push_back(LD);
+    if (HasIndexArg) {
+      auto *VecTy = cast<FixedVectorType>(GVTy);
+      Value *EmptyVec = UndefValue::get(VecTy);
+      Vectors.push_back(EmptyVec);
+      const DebugLoc &DLoc = LD->getDebugLoc();
+      for (unsigned I = 0; I < VecTy->getNumElements(); ++I) {
+        auto *Idx = ConstantInt::get(Type::getInt32Ty(C), I);
+        auto *Call = CallInst::Create(Func, {Idx}, "", LD);
+        if (DLoc)
+          Call->setDebugLoc(DLoc);
+        setAttrByCalledFunc(Call);
+        auto *Insert = InsertElementInst::Create(Vectors.back(), Call, Idx);
+        if (DLoc)
+          Insert->setDebugLoc(DLoc);
+        Insert->insertAfter(Call);
+        Vectors.push_back(Insert);
+      }
+
+      Value *Ptr = LD->getPointerOperand();
+
+      if (isa<FixedVectorType>(Ptr->getType()->getPointerElementType())) {
+        LD->replaceAllUsesWith(Vectors.back());
+      } else {
+        auto *GEP = dyn_cast<GetElementPtrInst>(Ptr);
+        assert(GEP && "Unexpected pattern!");
+        assert(GEP->getNumIndices() == 2 && "Unexpected pattern!");
+        Value *Idx = GEP->getOperand(2);
+        Value *Vec = Vectors.back();
+        auto *NewExtract = ExtractElementInst::Create(Vec, Idx);
+        NewExtract->insertAfter(cast<Instruction>(Vec));
+        LD->replaceAllUsesWith(NewExtract);
+      }
+
+    } else {
+      Replace({}, LD);
+    }
+
+    return true;
+  };
+
+  // Go over the GV users, find Load and ExtractElement instructions and
+  // replace them with the corresponding function call.
+  for (auto *UI : GV->users()) {
+    // There might or might not be an addrspacecast instruction.
+    if (auto *ASCast = dyn_cast<AddrSpaceCastInst>(UI)) {
+      Casts.push_back(ASCast);
+      for (auto *CastUser : ASCast->users()) {
+        if (ReplaceIfLoad(CastUser))
+          continue;
+        if (auto *GEP = dyn_cast<GetElementPtrInst>(CastUser)) {
+          GEPs.push_back(GEP);
+          for (auto *GEPUser : GEP->users()) {
+            if (!ReplaceIfLoad(GEPUser))
+              llvm_unreachable("Unexpected pattern!");
+          }
+        } else {
+          llvm_unreachable("Unexpected pattern!");
+        }
+      }
+    } else if (!ReplaceIfLoad(UI)) {
+      llvm_unreachable("Unexpected pattern!");
+    }
+  }
+
+  auto Erase = [](std::vector<Instruction *> &ToErase) {
+    for (Instruction *I : ToErase) {
+      assert(I->hasNUses(0));
+      I->eraseFromParent();
+    }
+  };
+  // Order of erasing is important.
+  Erase(Loads);
+  Erase(GEPs);
+  Erase(Casts);
+
+  return true;
+}
+
+bool lowerBuiltinVariablesToCalls(Module *M) {
+  std::vector<GlobalVariable *> WorkList;
+  for (auto I = M->global_begin(), E = M->global_end(); I != E; ++I) {
+    SPIRVBuiltinVariableKind Kind;
+    if (!isSPIRVBuiltinVariable(&(*I), &Kind))
+      continue;
+    if (!lowerBuiltinVariableToCall(&(*I), Kind))
+      return false;
+    WorkList.push_back(&(*I));
+  }
+  for (auto &I : WorkList) {
+    I->eraseFromParent();
+  }
+
+  return true;
+}
+
+/// Translates OCL/SPR-IR work-item builtin functions to SPIRV builtin variables.
+/// Function like get_global_id(i) -> x = load GlobalInvocationId; extract x, i
+/// Function like get_work_dim() -> load WorkDim
+void transWorkItemBuiltinsToVariables(Module *M) {
+  LLVM_DEBUG(dbgs() << "Enter transWorkItemBuiltinsToVariables\n");
+  std::vector<Function *> WorkList;
+  for (auto &I : *M) {
+    StringRef DemangledName;
+    if (!oclIsBuiltin(I.getName(), DemangledName))
+      continue;
+    LLVM_DEBUG(dbgs() << "Function demangled name: " << DemangledName << '\n');
+    std::string BuiltinVarName;
+    SPIRVBuiltinVariableKind BVKind;
+    // OCL builtin -> variable
+    if (!SPIRSPIRVBuiltinVariableMap::find(DemangledName.str(), &BVKind)) {
+      // SPV-IR builtin call -> variable
+      SmallVector<StringRef, 2> Postfix;
+      StringRef Name = dePrefixSPIRVName(DemangledName, Postfix);
+      if (!SPIRVBuiltInNameMap::rfind(Name.str(), &BVKind))
+        continue;
+    }
+    BuiltinVarName =
+      std::string(kSPIRVName::Prefix) + SPIRVBuiltInNameMap::map(BVKind);
+    LLVM_DEBUG(dbgs() << "builtin variable name: " << BuiltinVarName << '\n');
+    bool IsVec = I.getFunctionType()->getNumParams() > 0;
+    Type *GVType =
+        IsVec ? FixedVectorType::get(I.getReturnType(), 3) : I.getReturnType();
+    auto BV = new GlobalVariable(*M, GVType, true, GlobalValue::ExternalLinkage,
+                                 nullptr, BuiltinVarName, 0,
+                                 GlobalVariable::NotThreadLocal, SPIRAS_Input);
+    std::vector<Instruction *> InstList;
+    for (auto UI = I.user_begin(), UE = I.user_end(); UI != UE; ++UI) {
+      auto CI = dyn_cast<CallInst>(*UI);
+      assert(CI && "invalid instruction");
+      const DebugLoc &DLoc = CI->getDebugLoc();
+      Instruction *NewValue = new LoadInst(GVType, BV, "", CI);
+      if (DLoc)
+        NewValue->setDebugLoc(DLoc);
+      LLVM_DEBUG(dbgs() << "Transform: " << *CI << " => " << *NewValue << '\n');
+      if (IsVec) {
+        NewValue =
+            ExtractElementInst::Create(NewValue, CI->getArgOperand(0), "", CI);
+        if (DLoc)
+          NewValue->setDebugLoc(DLoc);
+        LLVM_DEBUG(dbgs() << *NewValue << '\n');
+      }
+      NewValue->takeName(CI);
+      CI->replaceAllUsesWith(NewValue);
+      InstList.push_back(CI);
+    }
+    for (auto &Inst : InstList) {
+      Inst->eraseFromParent();
+    }
+    WorkList.push_back(&I);
+  }
+  for (auto &I : WorkList) {
+    I->eraseFromParent();
+  }
+}
+
 } // namespace SPIRV
 
 namespace {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3443,6 +3443,9 @@ bool LLVMToSPIRVBase::translate() {
   if (isEmptyLLVMModule(M))
     BM->addCapability(CapabilityLinkage);
 
+  // Transform SPV-IR builtin calls to builtin variables.
+  transWorkItemBuiltinsToVariables(M);
+
   if (!transSourceLanguage())
     return false;
   if (!transExtension())

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -94,6 +94,7 @@ public:
   bool transSourceLanguage();
   bool transExtension();
   bool transBuiltinSet();
+  bool transWorkItemBuiltinCallsToVariables();
   bool isKnownIntrinsic(Intrinsic::ID Id);
   SPIRVValue *transIntrinsicInst(IntrinsicInst *Intrinsic, SPIRVBasicBlock *BB);
   SPIRVValue *transCallInst(CallInst *Call, SPIRVBasicBlock *BB);

--- a/test/transcoding/builtin_calls.ll
+++ b/test/transcoding/builtin_calls.ll
@@ -1,0 +1,36 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.out.bc
+; RUN: llvm-dis %t.out.bc -o - | FileCheck %s --check-prefix=CHECK-OCL-IR
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.out.bc
+; RUN: llvm-dis %t.out.bc -o - | FileCheck %s --check-prefix=CHECK-SPV-IR
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Check that builtin-call based SPV-IR is recognized by the translator.
+; CHECK-SPIRV: Decorate [[Id:[0-9]+]] BuiltIn 28
+; CHECK-SPIRV: Decorate [[Id:[0-9]+]] BuiltIn 34
+; CHECK-SPIRV: Variable {{[0-9]+}} [[Id:[0-9]+]]
+; CHECK-SPIRV: Variable {{[0-9]+}} [[Id:[0-9]+]]
+
+; Function Attrs: nounwind readnone
+define spir_kernel void @f() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
+entry:
+  %0 = call spir_func i32 @_Z29__spirv_BuiltInGlobalLinearIdv()
+  ; CHECK-OCL-IR: call spir_func i32 @_Z20get_global_linear_idv()
+  ; CHECK-SPV-IR: call spir_func i32 @_Z29__spirv_BuiltInGlobalLinearIdv()
+  %1 = call spir_func i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 1)
+  ; CHECK-OCL-IR: call spir_func i64 @_Z13get_global_idj(i32 1)
+  ; CHECK-SPV-IR: call spir_func i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 1)
+  ret void
+}
+
+declare spir_func i32 @_Z29__spirv_BuiltInGlobalLinearIdv()
+declare spir_func i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32)
+
+attributes #0 = { alwaysinline nounwind readonly "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!0 = !{}

--- a/test/transcoding/builtin_vars.ll
+++ b/test/transcoding/builtin_vars.ll
@@ -1,10 +1,17 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.out.bc
-; RUN: llvm-dis %t.out.bc -o - | FileCheck %s --check-prefix=CHECK-OCL
+; RUN: llvm-dis %t.out.bc -o - | FileCheck %s --check-prefix=CHECK-OCL-IR
 ; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.out.bc
-; RUN: llvm-dis %t.out.bc -o - | FileCheck %s --check-prefix=CHECK-SPV
+; RUN: llvm-dis %t.out.bc -o - | FileCheck %s --check-prefix=CHECK-SPV-IR
+
+; Check that produced builtin-call-based SPV-IR is recognized by the translator
+; RUN: llvm-spirv -spirv-text %t.out.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+; CHECK-SPIRV: Decorate [[Id:[0-9]+]] BuiltIn 34
+; CHECK-SPIRV: Variable {{[0-9]+}} [[Id:[0-9]+]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
@@ -15,8 +22,8 @@ target triple = "spir-unknown-unknown"
 define spir_kernel void @f() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
 entry:
   %0 = load i32, i32 addrspace(4)* addrspacecast (i32 addrspace(1)* @__spirv_BuiltInGlobalLinearId to i32 addrspace(4)*), align 4
-  ; CHECK-OCL: %0 = call spir_func i32 @_Z20get_global_linear_idv() #1
-  ; CHECK-SPV: %0 = call spir_func i32 @_Z29__spirv_BuiltInGlobalLinearIdv() #1
+  ; CHECK-OCL-IR: %0 = call spir_func i32 @_Z20get_global_linear_idv() #1
+  ; CHECK-SPV-IR: %0 = call spir_func i32 @_Z29__spirv_BuiltInGlobalLinearIdv() #1
   ret void
 }
 

--- a/test/transcoding/builtin_vars_arithmetics.ll
+++ b/test/transcoding/builtin_vars_arithmetics.ll
@@ -7,6 +7,9 @@
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefixes=CHECK-LLVM,CHECK-LLVM-SPV
 
+; Check that produced builtin-call-based SPV-IR is recognized by the translator
+; RUN: llvm-spirv %t.rev.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
 ; The IR was generated from the following source:
 ; #include <CL/sycl.hpp>
 ;

--- a/test/transcoding/builtin_vars_opt.ll
+++ b/test/transcoding/builtin_vars_opt.ll
@@ -7,6 +7,9 @@
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefixes=CHECK-LLVM,CHECK-LLVM-SPV
 
+; Check that produced builtin-call-based SPV-IR is recognized by the translator
+; RUN: llvm-spirv %t.rev.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
 ; The IR was generated from the following source:
 ; #include <CL/sycl.hpp>
 ;


### PR DESCRIPTION
This PR fixes the translation of SPIRV builtin variables/calls. The translator
now is able to recognize builtin-call-based SPV-IR input.
  e.g. call  spir_func i64 @_Z33__spirv_BuiltinGlobalInvocationIdi(i32 1)

- LLVM --> SPIRV translation:

  1. We first translate OCL work item builtins to SPV-IR builtin calls in
     OCLToSPIRV. For example:
      @_Z13get_global_idj(i) -> @_Z33__spirv_BuiltinGlobalInvocationIdi(i)

  2. SPV-IR builtin calls are transformed to variables in LLVMToSPIRV. This
     step is shared by all source inputs (SPV-IR, OCL-IR). For example:
      @_Z33__spirv_BuiltinGlobalInvocationIdi(i) ->
        x = load GlobalInvocationId; extract x, i

- SPIRV --> LLVM translation:

  1. We lower SPIRV builtin variables into calls in SPIRVToLLVM so that SPV-IR
     has builtin function calls (instead of variables) by default.

  2. Builtin calls in SPV-IR can be then translated into OpenCL builtin calls,
     in SPIRVToOCL.
     e.g. @_Z33__spirv_BuiltinGlobalInvocationIdi(i) -> @_Z13get_global_idj(i)

  3. SPIRVToOCL is also capable of lower SPIRV builtin variables into calls as
     preprocessing, so that this pass can be used by users independently to
     translate SPV-IR into OCL-IR.

Signed-off-by: Yilong Guo <yilong.guo@intel.com>