### PR TITLE
Fix SPV-IR for OpBuildNDRange

### DIFF
--- a/docs/SPIRVRepresentationInLLVM.rst
+++ b/docs/SPIRVRepresentationInLLVM.rst
@@ -150,8 +150,17 @@ The unmangled names of SPIR-V builtin GenericCastToPtrExplicit function follow t
 .. code-block:: c
 
   __spirv_GenericCastToPtrExplicit_To{Global|Local|Private}
-  
-SPIR-V 1.1 Builtin CreatePipeFromPipeStorage Function Name 
+
+SPIR-V Builtin BuildNDRange Function Name
+----------------------------------------
+
+The unmangled names of SPIR-V builtin BuildNDRange functions follow the convention:
+
+.. code-block:: c
+
+  __spirv_{BuildNDRange}_{1|2|3}D
+
+SPIR-V 1.1 Builtin CreatePipeFromPipeStorage Function Name
 ----------------------------------------
 
 The unmangled names of SPIR-V builtin CreatePipeFromPipeStorage function follow the convention:

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -1037,6 +1037,23 @@ bool lowerBuiltinVariableToCall(GlobalVariable *GV,
 // Transform all builtin variables into calls
 bool lowerBuiltinVariablesToCalls(Module *M);
 
+/// \brief Post-process OpenCL or SPIRV builtin function returning struct type.
+///
+/// Some builtin functions are translated to SPIR-V instructions with
+/// struct type result, e.g. NDRange creation functions. Such functions
+/// need to be post-processed to return the struct through sret argument.
+bool postProcessBuiltinReturningStruct(Function *F);
+
+/// \brief Post-process OpenCL or SPIRV builtin function having array argument.
+///
+/// These functions are translated to functions with array type argument
+/// first, then post-processed to have pointer arguments.
+bool postProcessBuiltinWithArrayArguments(Function *F, StringRef DemangledName);
+
+bool postProcessBuiltinsReturningStruct(Module *M, bool IsCpp = false);
+
+bool postProcessBuiltinsWithArrayArguments(Module *M, bool IsCpp = false);
+
 } // namespace SPIRV
 
 #endif // SPIRV_SPIRVINTERNAL_H

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -562,41 +562,6 @@ bool SPIRVToLLVM::isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const {
   return isCmpOpCode(OC) && !(OC >= OpLessOrGreater && OC <= OpUnordered);
 }
 
-// TODO: Instead of direct translation to OCL we should always produce SPIR-V
-// friendly IR and apply lowering later if needed
-bool SPIRVToLLVM::isDirectlyTranslatedToOCL(Op OpCode) const {
-  if (isSubgroupAvcINTELInstructionOpCode(OpCode))
-    return false;
-  if (isIntelSubgroupOpCode(OpCode))
-    return false;
-  if (OpCode == OpImageSampleExplicitLod || OpCode == OpSampledImage)
-    return false;
-  if (OpCode == OpImageWrite || OpCode == OpImageRead ||
-      OpCode == OpImageQueryOrder || OpCode == OpImageQueryFormat ||
-      OpCode == OpImageQueryLevels)
-    return false;
-  if (OpCode == OpGenericCastToPtrExplicit)
-    return false;
-  if (isEventOpCode(OpCode))
-    return false;
-  if (OpBitFieldInsert <= OpCode && OpCode <= OpBitReverse)
-    return false;
-  if (OpCode == OpEnqueueMarker || OpCode == OpGetDefaultQueue)
-    return false;
-  if (OCLSPIRVBuiltinMap::rfind(OpCode, nullptr)) {
-    // Not every spirv opcode which is placed in OCLSPIRVBuiltinMap is
-    // translated directly to OCL builtin. Some of them are translated
-    // to LLVM representation without any modifications (SPIRV format of
-    // instruction is represented in LLVM) and then its translated to
-    // clang-consistent format in SPIRVToOCL pass.
-    return !(isAtomicOpCode(OpCode) || isGroupOpCode(OpCode) ||
-             isGroupNonUniformOpcode(OpCode) || isPipeOpCode(OpCode) ||
-             isMediaBlockINTELOpcode(OpCode) || OpCode == OpGroupAsyncCopy ||
-             OpCode == OpGroupWaitEvents);
-  }
-  return false;
-}
-
 void SPIRVToLLVM::setName(llvm::Value *V, SPIRVValue *BV) {
   auto Name = BV->getName();
   if (!Name.empty() && (!V->hasName() || Name != V->getName()))
@@ -1115,102 +1080,6 @@ Value *SPIRVToLLVM::transCmpInst(SPIRVValue *BV, BasicBlock *BB, Function *F) {
     Inst = Builder.CreateFCmp(CmpMap::rmap(OP), Op0, Op1);
   assert(Inst && "not implemented");
   return Inst;
-}
-
-bool SPIRVToLLVM::postProcessOCL() {
-  StringRef DemangledName;
-  SPIRVWord SrcLangVer = 0;
-  BM->getSourceLanguage(&SrcLangVer);
-  bool IsCpp = SrcLangVer == kOCLVer::CL21;
-  for (auto I = M->begin(), E = M->end(); I != E;) {
-    auto F = I++;
-    if (F->hasName() && F->isDeclaration()) {
-      LLVM_DEBUG(dbgs() << "[postProcessOCL sret] " << *F << '\n');
-      if (F->getReturnType()->isStructTy() &&
-          oclIsBuiltin(F->getName(), DemangledName, IsCpp)) {
-        if (!postProcessOCLBuiltinReturnStruct(&(*F)))
-          return false;
-      }
-    }
-  }
-  for (auto I = M->begin(), E = M->end(); I != E;) {
-    auto F = I++;
-    if (F->hasName() && F->isDeclaration()) {
-      LLVM_DEBUG(dbgs() << "[postProcessOCL array arg] " << *F << '\n');
-      if (hasArrayArg(&(*F)) &&
-          oclIsBuiltin(F->getName(), DemangledName, IsCpp))
-        if (!postProcessOCLBuiltinWithArrayArguments(&(*F), DemangledName))
-          return false;
-    }
-  }
-  return true;
-}
-
-bool SPIRVToLLVM::postProcessOCLBuiltinReturnStruct(Function *F) {
-  std::string Name = F->getName().str();
-  F->setName(Name + ".old");
-  for (auto I = F->user_begin(), E = F->user_end(); I != E;) {
-    if (auto CI = dyn_cast<CallInst>(*I++)) {
-      auto ST = dyn_cast<StoreInst>(*(CI->user_begin()));
-      assert(ST);
-      std::vector<Type *> ArgTys;
-      getFunctionTypeParameterTypes(F->getFunctionType(), ArgTys);
-      ArgTys.insert(ArgTys.begin(),
-                    PointerType::get(F->getReturnType(), SPIRAS_Private));
-      auto NewF =
-          getOrCreateFunction(M, Type::getVoidTy(*Context), ArgTys, Name);
-      NewF->setCallingConv(F->getCallingConv());
-      auto Args = getArguments(CI);
-      Args.insert(Args.begin(), ST->getPointerOperand());
-      auto NewCI = CallInst::Create(NewF, Args, CI->getName(), CI);
-      NewCI->setCallingConv(CI->getCallingConv());
-      ST->eraseFromParent();
-      CI->eraseFromParent();
-    }
-  }
-  F->eraseFromParent();
-  return true;
-}
-
-bool SPIRVToLLVM::postProcessOCLBuiltinWithArrayArguments(
-    Function *F, StringRef DemangledName) {
-  LLVM_DEBUG(dbgs() << "[postProcessOCLBuiltinWithArrayArguments] " << *F
-                    << '\n');
-  auto Attrs = F->getAttributes();
-  auto Name = F->getName();
-  mutateFunction(
-      F,
-      [=](CallInst *CI, std::vector<Value *> &Args) {
-        auto FBegin =
-            CI->getParent()->getParent()->begin()->getFirstInsertionPt();
-        for (auto &I : Args) {
-          auto T = I->getType();
-          if (!T->isArrayTy())
-            continue;
-          auto Alloca = new AllocaInst(T, 0, "", &(*FBegin));
-          new StoreInst(I, Alloca, false, CI);
-          auto Zero =
-              ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
-          Value *Index[] = {Zero, Zero};
-          I = GetElementPtrInst::CreateInBounds(T, Alloca, Index, "", CI);
-        }
-        return Name.str();
-      },
-      nullptr, &Attrs);
-  return true;
-}
-
-CallInst *SPIRVToLLVM::postProcessOCLBuildNDRange(SPIRVInstruction *BI,
-                                                  CallInst *CI,
-                                                  const std::string &FuncName) {
-  assert(CI->getNumArgOperands() == 3);
-  auto GWS = CI->getArgOperand(0);
-  auto LWS = CI->getArgOperand(1);
-  auto GWO = CI->getArgOperand(2);
-  CI->setArgOperand(0, GWO);
-  CI->setArgOperand(1, GWS);
-  CI->setArgOperand(2, LWS);
-  return CI;
 }
 
 Type *SPIRVToLLVM::mapType(SPIRVType *BT, Type *T) {
@@ -2571,9 +2440,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto OC = BV->getOpCode();
     if (isSPIRVCmpInstTransToLLVMInst(static_cast<SPIRVInstruction *>(BV))) {
       return mapValue(BV, transCmpInst(BV, BB, F));
-    } else if (isDirectlyTranslatedToOCL(OC)) {
-      return mapValue(
-          BV, transOCLBuiltinFromInst(static_cast<SPIRVInstruction *>(BV), BB));
+    } else if (OCLSPIRVBuiltinMap::rfind(OC, nullptr)) {
+      return mapValue(BV, transSPIRVBuiltinFromInst(
+                              static_cast<SPIRVInstruction *>(BV), BB));
     } else if (isBinaryShiftLogicalBitwiseOpCode(OC) || isLogicalOpCode(OC)) {
       return mapValue(BV, transShiftLogicalBitwiseInst(BV, BB, F));
     } else if (isCvtOpCode(OC) && OC != OpGenericCastToPtrExplicit) {
@@ -2929,8 +2798,6 @@ SPIRVToLLVM::transOCLBuiltinPostproc(SPIRVInstruction *BI, CallInst *CI,
   }
   if (OC == OpGenericPtrMemSemantics)
     return BinaryOperator::CreateShl(CI, getInt32(M, 8), "", BB);
-  if (OC == OpBuildNDRange)
-    return postProcessOCLBuildNDRange(BI, CI, DemangledName);
   if (SPIRVEnableStepExpansion &&
       (DemangledName == "smoothstep" || DemangledName == "step"))
     return expandOCLBuiltinWithScalarArg(CI, DemangledName);
@@ -3161,30 +3028,6 @@ SPIRVToLLVM::SPIRVToLLVM(Module *LLVMModule, SPIRVModule *TheSPIRVModule)
   DbgTran.reset(new SPIRVToLLVMDbgTran(TheSPIRVModule, LLVMModule, this));
 }
 
-std::string SPIRVToLLVM::getOCLBuiltinName(SPIRVInstruction *BI) {
-  auto OC = BI->getOpCode();
-  if (OC == OpBuildNDRange) {
-    auto NDRangeInst = static_cast<SPIRVBuildNDRange *>(BI);
-    auto EleTy = ((NDRangeInst->getOperands())[0])->getType();
-    int Dim = EleTy->isTypeArray() ? EleTy->getArrayLength() : 1;
-    // cygwin does not have std::to_string
-    ostringstream OS;
-    OS << Dim;
-    assert((EleTy->isTypeInt() && Dim == 1) ||
-           (EleTy->isTypeArray() && Dim >= 2 && Dim <= 3));
-    return std::string(kOCLBuiltinName::NDRangePrefix) + OS.str() + "D";
-  }
-
-  return OCLSPIRVBuiltinMap::rmap(OC);
-}
-
-Instruction *SPIRVToLLVM::transOCLBuiltinFromInst(SPIRVInstruction *BI,
-                                                  BasicBlock *BB) {
-  assert(BB && "Invalid BB");
-  auto FuncName = getOCLBuiltinName(BI);
-  return transBuiltinFromInst(FuncName, BI, BB);
-}
-
 std::string getSPIRVFuncSuffix(SPIRVInstruction *BI) {
   string Suffix = "";
   if (BI->getOpCode() == OpCreatePipeFromPipeStorage) {
@@ -3230,6 +3073,17 @@ std::string getSPIRVFuncSuffix(SPIRVInstruction *BI) {
     default:
       llvm_unreachable("Invalid address space");
     }
+  }
+  if (BI->getOpCode() == OpBuildNDRange) {
+    Suffix += kSPIRVPostfix::Divider;
+    auto *NDRangeInst = static_cast<SPIRVBuildNDRange *>(BI);
+    auto *EleTy = ((NDRangeInst->getOperands())[0])->getType();
+    int Dim = EleTy->isTypeArray() ? EleTy->getArrayLength() : 1;
+    assert((EleTy->isTypeInt() && Dim == 1) ||
+           (EleTy->isTypeArray() && Dim >= 2 && Dim <= 3));
+    ostringstream OS;
+    OS << Dim;
+    Suffix += OS.str() + "D";
   }
   return Suffix;
 }
@@ -3319,8 +3173,13 @@ bool SPIRVToLLVM::translate() {
   // as calls.
   if (!lowerBuiltinVariablesToCalls(M))
     return false;
-  if (!postProcessOCL())
-    return false;
+  if (BM->getDesiredBIsRepresentation() == BIsRepresentation::SPIRVFriendlyIR) {
+    SPIRVWord SrcLangVer = 0;
+    BM->getSourceLanguage(&SrcLangVer);
+    bool IsCpp = SrcLangVer == kOCLVer::CL21;
+    if (!postProcessBuiltinsReturningStruct(M, IsCpp))
+      return false;
+  }
   eraseUselessFunctions(M);
 
   DbgTran->addDbgInfoVersion();

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2438,14 +2438,17 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   default: {
     auto OC = BV->getOpCode();
-    if (isSPIRVCmpInstTransToLLVMInst(static_cast<SPIRVInstruction *>(BV))) {
+    if (isSPIRVCmpInstTransToLLVMInst(static_cast<SPIRVInstruction *>(BV)))
       return mapValue(BV, transCmpInst(BV, BB, F));
-    } else if (OCLSPIRVBuiltinMap::rfind(OC, nullptr)) {
+
+    if (OCLSPIRVBuiltinMap::rfind(OC, nullptr))
       return mapValue(BV, transSPIRVBuiltinFromInst(
                               static_cast<SPIRVInstruction *>(BV), BB));
-    } else if (isBinaryShiftLogicalBitwiseOpCode(OC) || isLogicalOpCode(OC)) {
+
+    if (isBinaryShiftLogicalBitwiseOpCode(OC) || isLogicalOpCode(OC))
       return mapValue(BV, transShiftLogicalBitwiseInst(BV, BB, F));
-    } else if (isCvtOpCode(OC) && OC != OpGenericCastToPtrExplicit) {
+
+    if (isCvtOpCode(OC) && OC != OpGenericCastToPtrExplicit) {
       auto BI = static_cast<SPIRVInstruction *>(BV);
       Value *Inst = nullptr;
       if (BI->hasFPRoundingMode() || BI->isSaturatedConversion())

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -78,7 +78,6 @@ public:
   SPIRVToLLVM(Module *LLVMModule, SPIRVModule *TheSPIRVModule);
 
   static const StringSet<> BuiltInConstFunc;
-  std::string getOCLBuiltinName(SPIRVInstruction *BI);
 
   Type *transType(SPIRVType *BT, bool IsClassMember = false);
   std::string transTypeToOCLTypeName(SPIRVType *BT, bool IsSigned = true);
@@ -123,33 +122,7 @@ public:
   Value *transConvertInst(SPIRVValue *BV, Function *F, BasicBlock *BB);
   Instruction *transBuiltinFromInst(const std::string &FuncName,
                                     SPIRVInstruction *BI, BasicBlock *BB);
-  Instruction *transOCLBuiltinFromInst(SPIRVInstruction *BI, BasicBlock *BB);
   Instruction *transSPIRVBuiltinFromInst(SPIRVInstruction *BI, BasicBlock *BB);
-
-  /// Post-process translated LLVM module for OpenCL.
-  bool postProcessOCL();
-
-  /// \brief Post-process OpenCL builtin functions returning struct type.
-  ///
-  /// Some OpenCL builtin functions are translated to SPIR-V instructions with
-  /// struct type result, e.g. NDRange creation functions. Such functions
-  /// need to be post-processed to return the struct through sret argument.
-  bool postProcessOCLBuiltinReturnStruct(Function *F);
-
-  /// \brief Post-process OpenCL builtin functions having array argument.
-  ///
-  /// These functions are translated to functions with array type argument
-  /// first, then post-processed to have pointer arguments.
-  bool postProcessOCLBuiltinWithArrayArguments(Function *F,
-                                               StringRef DemangledName);
-
-  /// \brief Post-process OpBuildNDRange.
-  ///   OpBuildNDRange GlobalWorkSize, LocalWorkSize, GlobalWorkOffset
-  /// =>
-  ///   call ndrange_XD(GlobalWorkOffset, GlobalWorkSize, LocalWorkSize)
-  /// \return transformed call instruction.
-  CallInst *postProcessOCLBuildNDRange(SPIRVInstruction *BI, CallInst *CI,
-                                       const std::string &DemangledName);
 
   /// \brief Expand OCL builtin functions with scalar argument, e.g.
   /// step, smoothstep.

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -586,12 +586,14 @@ void SPIRVToOCLBase::visitCallBuildNDRangeBuiltIn(CallInst *CI, Op OC,
   mutateCallInstOCL(
       M, CI,
       [=](CallInst *Call, std::vector<Value *> &Args) {
-        auto *GWS = Args[0];
-        auto *LWS = Args[1];
-        auto *GWO = Args[2];
-        Args[0] = GWO;
-        Args[1] = GWS;
-        Args[2] = LWS;
+        assert(Args.size() == 3);
+        // OpenCL built-in has another order of parameters.
+        auto *GlobalWorkSize = Args[0];
+        auto *LocalWorkSize = Args[1];
+        auto *GlobalWorkOffset = Args[2];
+        Args[0] = GlobalWorkOffset;
+        Args[1] = GlobalWorkSize;
+        Args[2] = LocalWorkSize;
         // __spirv_BuildNDRange_nD, drop __spirv_
         StringRef S = DemangledName;
         S = S.drop_front(strlen(kSPIRVName::Prefix));
@@ -600,7 +602,7 @@ void SPIRVToOCLBase::visitCallBuildNDRangeBuiltIn(CallInst *CI, Op OC,
         S.split(Split, kSPIRVPostfix::Divider,
                 /*MaxSplit=*/-1, /*KeepEmpty=*/false);
         assert(Split.size() >= 2 && "Invalid SPIRV function name");
-        // Cut _nD and add it to function name
+        // Cut _nD and add it to function name.
         return std::string(kOCLBuiltinName::NDRangePrefix) +
                Split[1].substr(0, 3).str();
       },

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -107,6 +107,11 @@ public:
   /// to_{global|local|private} OCL builtin.
   void visitCallGenericCastToPtrExplicitBuiltIn(CallInst *CI, Op OC);
 
+  /// Transform __spirv_OpBuildINDRange_{1|2|3}D to
+  /// ndrange_{1|2|3}D OCL builtin.
+  void visitCallBuildNDRangeBuiltIn(CallInst *CI, Op OC,
+                                    StringRef DemangledName);
+
   /// Transform __spirv_*Convert_R{ReturnType}{_sat}{_rtp|_rtn|_rtz|_rte} to
   /// convert_{ReturnType}_{sat}{_rtp|_rtn|_rtz|_rte}
   /// example:  <2 x i8> __spirv_SatConvertUToS(<2 x i32>) =>

--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -59,6 +59,9 @@ bool SPIRVToOCL12Base::runSPIRVToOCL(Module &Module) {
 
   visit(*M);
 
+  postProcessBuiltinsReturningStruct(M);
+  postProcessBuiltinsWithArrayArguments(M);
+
   eraseUselessFunctions(&Module);
 
   LLVM_DEBUG(dbgs() << "After SPIRVToOCL12:\n" << *M);

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -58,6 +58,9 @@ bool SPIRVToOCL20Base::runSPIRVToOCL(Module &Module) {
 
   visit(*M);
 
+  postProcessBuiltinsReturningStruct(M);
+  postProcessBuiltinsWithArrayArguments(M);
+
   eraseUselessFunctions(&Module);
 
   LLVM_DEBUG(dbgs() << "After SPIRVToOCL20:\n" << *M);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1905,8 +1905,7 @@ bool postProcessBuiltinWithArrayArguments(Function *F,
   mutateFunction(
       F,
       [=](CallInst *CI, std::vector<Value *> &Args) {
-        auto FBegin =
-            CI->getFunction()->begin()->getFirstInsertionPt();
+        auto FBegin = CI->getFunction()->begin()->getFirstInsertionPt();
         for (auto &I : Args) {
           auto *T = I->getType();
           if (!T->isArrayTy())

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1863,6 +1863,97 @@ bool lowerBuiltinVariablesToCalls(Module *M) {
   return true;
 }
 
+bool postProcessBuiltinReturningStruct(Function *F) {
+  Module *M = F->getParent();
+  LLVMContext *Context = &M->getContext();
+  std::string Name = F->getName().str();
+  F->setName(Name + ".old");
+  for (auto *U : F->users()) {
+    if (auto *CI = dyn_cast<CallInst>(U)) {
+      auto ST = dyn_cast<StoreInst>(*(CI->user_begin()));
+      assert(ST);
+      std::vector<Type *> ArgTys;
+      getFunctionTypeParameterTypes(F->getFunctionType(), ArgTys);
+      ArgTys.insert(ArgTys.begin(),
+                    PointerType::get(F->getReturnType(), SPIRAS_Private));
+      auto *NewF =
+          getOrCreateFunction(M, Type::getVoidTy(*Context), ArgTys, Name);
+      NewF->addParamAttr(0, Attribute::get(*Context,
+                                           Attribute::AttrKind::StructRet,
+                                           F->getReturnType()));
+      NewF->setCallingConv(F->getCallingConv());
+      auto Args = getArguments(CI);
+      Args.insert(Args.begin(), ST->getPointerOperand());
+      auto *NewCI = CallInst::Create(NewF, Args, CI->getName(), CI);
+      NewCI->setCallingConv(CI->getCallingConv());
+      ST->eraseFromParent();
+      CI->eraseFromParent();
+    }
+  }
+  F->eraseFromParent();
+  return true;
+}
+
+bool postProcessBuiltinWithArrayArguments(Function *F,
+                                          StringRef DemangledName) {
+  LLVM_DEBUG(dbgs() << "[postProcessOCLBuiltinWithArrayArguments] " << *F
+                    << '\n');
+  auto Attrs = F->getAttributes();
+  auto Name = F->getName();
+  mutateFunction(
+      F,
+      [=](CallInst *CI, std::vector<Value *> &Args) {
+        auto FBegin =
+            CI->getParent()->getParent()->begin()->getFirstInsertionPt();
+        for (auto &I : Args) {
+          auto *T = I->getType();
+          if (!T->isArrayTy())
+            continue;
+          auto *Alloca = new AllocaInst(T, 0, "", &(*FBegin));
+          new StoreInst(I, Alloca, false, CI);
+          auto *Zero =
+              ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
+          Value *Index[] = {Zero, Zero};
+          I = GetElementPtrInst::CreateInBounds(T, Alloca, Index, "", CI);
+        }
+        return Name.str();
+      },
+      nullptr, &Attrs);
+  return true;
+}
+
+bool postProcessBuiltinsReturningStruct(Module *M, bool IsCpp) {
+  StringRef DemangledName;
+  // postProcessBuiltinReturningStruct may remove some functions from the
+  // module, so use make_early_inc_range
+  for (auto &F : make_early_inc_range(M->functions())) {
+    if (F.hasName() && F.isDeclaration()) {
+      LLVM_DEBUG(dbgs() << "[postProcess sret] " << F << '\n');
+      if (F.getReturnType()->isStructTy() &&
+          oclIsBuiltin(F.getName(), DemangledName, IsCpp)) {
+        if (!postProcessBuiltinReturningStruct(&F))
+          return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool postProcessBuiltinsWithArrayArguments(Module *M, bool IsCpp) {
+  StringRef DemangledName;
+  // postProcessBuiltinWithArrayArguments may remove some functions from the
+  // module, so use make_early_inc_range
+  for (auto &F : make_early_inc_range(M->functions())) {
+    if (F.hasName() && F.isDeclaration()) {
+      LLVM_DEBUG(dbgs() << "[postProcess array arg] " << F << '\n');
+      if (hasArrayArg(&F) && oclIsBuiltin(F.getName(), DemangledName, IsCpp))
+        if (!postProcessBuiltinWithArrayArguments(&F, DemangledName))
+          return false;
+    }
+  }
+  return true;
+}
+
 } // namespace SPIRV
 
 namespace {

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1870,7 +1870,7 @@ bool postProcessBuiltinReturningStruct(Function *F) {
   F->setName(Name + ".old");
   for (auto *U : F->users()) {
     if (auto *CI = dyn_cast<CallInst>(U)) {
-      auto ST = dyn_cast<StoreInst>(*(CI->user_begin()));
+      auto *ST = dyn_cast<StoreInst>(*(CI->user_begin()));
       assert(ST);
       std::vector<Type *> ArgTys;
       getFunctionTypeParameterTypes(F->getFunctionType(), ArgTys);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4329,6 +4329,5 @@ bool llvm::regularizeLlvmForSpirv(Module *M, std::string &ErrMsg,
   legacy::PassManager PassMgr;
   addPassesForSPIRV(PassMgr, Opts);
   PassMgr.run(*M);
-
   return true;
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4329,5 +4329,6 @@ bool llvm::regularizeLlvmForSpirv(Module *M, std::string &ErrMsg,
   legacy::PassManager PassMgr;
   addPassesForSPIRV(PassMgr, Opts);
   PassMgr.run(*M);
+
   return true;
 }

--- a/test/transcoding/BuildNDRange.ll
+++ b/test/transcoding/BuildNDRange.ll
@@ -6,13 +6,20 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM-SPV
+
+; RUN: llvm-spirv %t.rev.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
 ; CHECK-SPIRV-DAG: BuildNDRange {{[0-9]+}} {{[0-9]+}} [[GWS:[0-9]+]] [[LWS:[0-9]+]] [[GWO:[0-9]+]]
 ; CHECK-SPIRV-DAG: Constant {{[0-9]+}} [[GWS]] 123
 ; CHECK-SPIRV-DAG: Constant {{[0-9]+}} [[LWS]] 456
 ; CHECK-SPIRV-DAG: Constant {{[0-9]+}} [[GWO]] 0
 
-; CHECK-LLVM: call spir_func void @_Z10ndrange_1Djjj(%struct.ndrange_t* %ndrange, i32 0, i32 123, i32 456)
+; CHECK-LLVM: call spir_func void @_Z10ndrange_1Djjj(%struct.ndrange_t* sret(%struct.ndrange_t) %ndrange, i32 0, i32 123, i32 456)
+; CHECK-LLVM-SPV: call spir_func void @_Z23__spirv_BuildNDRange_1Diii(%struct.ndrange_t* sret(%struct.ndrange_t) %ndrange, i32 123, i32 456, i32 0)
 
 ; ModuleID = 'BuildNDRange.bc'
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/transcoding/BuildNDRange_2.ll
+++ b/test/transcoding/BuildNDRange_2.ll
@@ -26,6 +26,13 @@
 ; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM-SPV
+
+; RUN: llvm-spirv %t.rev.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
 ; CHECK-SPIRV-DAG:     Constant {{[0-9]+}} [[LEN2_ID:[0-9]+]] 2
 ; CHECK-SPIRV-DAG:     Constant {{[0-9]+}} [[LEN3_ID:[0-9]+]] 3
 ; CHECK-SPIRV-DAG:     TypeArray [[ARRAY_T2:[0-9]+]] {{[0-9]+}} [[LEN2_ID]]
@@ -46,11 +53,20 @@
 ; CHECK-SPIRV-LABEL:   1 FunctionEnd
 
 ; CHECK-LLVM-LABEL: @test_ndrange_2D3D
-; CHECK-LLVM:       call spir_func void @_Z10ndrange_2D
-; CHECK-LLVM:       call spir_func void @_Z10ndrange_3D
+; CHECK-LLVM:       call spir_func void @_Z10ndrange_2DPKmS0_S0_(%struct.ndrange_t* sret(%struct.ndrange_t)
+; CHECK-LLVM:       call spir_func void @_Z10ndrange_3DPKmS0_S0_(%struct.ndrange_t* sret(%struct.ndrange_t)
 ; CHECK-LLVM-LABEL: @test_ndrange_const_2D3D
-; CHECK-LLVM:       call spir_func void @_Z10ndrange_2D
-; CHECK-LLVM:       call spir_func void @_Z10ndrange_3D
+; CHECK-LLVM:       call spir_func void @_Z10ndrange_2DPKmS0_S0_(%struct.ndrange_t* sret(%struct.ndrange_t)
+; CHECK-LLVM:       call spir_func void @_Z10ndrange_3DPKmS0_S0_(%struct.ndrange_t* sret(%struct.ndrange_t)
+
+; CHECK-LLVM-SPV-LABEL: @test_ndrange_2D3D
+; CHECK-LLVM-SPV:   call spir_func void @_Z23__spirv_BuildNDRange_2DPlS0_S0_(%struct.ndrange_t* sret(%struct.ndrange_t) %{{[A-Z,a-z,0-9]+}}, [2 x i64] %{{[0-9]+}}, [2 x i64] zeroinitializer, [2 x i64] zeroinitializer)
+; CHECK-LLVM-SPV:   call spir_func void @_Z23__spirv_BuildNDRange_3DPlS0_S0_(%struct.ndrange_t* sret(%struct.ndrange_t) %{{[A-Z,a-z,0-9]+}}, [3 x i64] %{{[0-9]+}}, [3 x i64] zeroinitializer, [3 x i64] zeroinitializer)
+; CHECK-LLVM-SPV-LABEL: @test_ndrange_const_2D3D
+; CHECK-LLVM-SPV:   call spir_func void @_Z23__spirv_BuildNDRange_2DPlS0_S0_(%struct.ndrange_t* sret(%struct.ndrange_t) %{{[a-z,a-z,0-9]+}}, [2 x i64] %{{[0-9]+}}, [2 x i64] zeroinitializer, [2 x i64] zeroinitializer)
+
+; CHECK-LLVM-SPV:   call spir_func void @_Z23__spirv_BuildNDRange_3DPlS0_S0_(%struct.ndrange_t* sret(%struct.ndrange_t) %{{[a-z,a-z,0-9]+}}, [3 x i64] %{{[0-9]+}}, [3 x i64] zeroinitializer, [3 x i64] zeroinitializer)
+
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknonw-unknown"


### PR DESCRIPTION
It is translated to a function with unmangled name
__spirv_BuildNDRange_{1|2|3}D with struct return parameter and array
arguments, since translator only translates it properly to SPIR-V with
this signature. _ND postfix is requred because array arguments are mangled
in the same way, so if there was no postfix, translator would produce
functions with same name for different dimensions.