### PR TITLE
add an entry point wrapper function around functions.

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -86,7 +86,8 @@ public:
   // Complete constructor. It does not construct basic blocks.
   SPIRVFunction(SPIRVModule *M, SPIRVTypeFunction *FunctionType, SPIRVId TheId)
       : SPIRVValue(M, 5, OpFunction, FunctionType->getReturnType(), TheId),
-        FuncType(FunctionType), FCtrlMask(FunctionControlMaskNone) {
+        FuncType(FunctionType), FCtrlMask(FunctionControlMaskNone),
+        EntryPointWrapperFunc(nullptr) {
     addAllArguments(TheId + 1);
     validate();
   }
@@ -128,6 +129,14 @@ public:
     ExecModes = std::move(Forward->ExecModes);
   }
 
+  void setEntryPointWrapper(SPIRVFunction *Wrap) {
+    EntryPointWrapperFunc = Wrap;
+  }
+
+  SPIRVFunction *getEntryPointWrapper(void) {
+    return EntryPointWrapperFunc;
+  }
+
   // Assume BB contains valid Id.
   SPIRVBasicBlock *addBasicBlock(SPIRVBasicBlock *BB) {
     Module->add(BB);
@@ -167,6 +176,8 @@ private:
   std::vector<const SPIRVValue *> Variables;
   typedef std::vector<SPIRVBasicBlock *> SPIRVLBasicBlockVector;
   SPIRVLBasicBlockVector BBVec;
+
+  SPIRVFunction *EntryPointWrapperFunc;
 };
 
 typedef SPIRVEntryOpCodeOnly<OpFunctionEnd> SPIRVFunctionEnd;


### PR DESCRIPTION
SPIR-V spec states:
"It is invalid for any function to be targeted by both an OpEntryPoint instruction
 and an OpFunctionCall instruction."

However the SPIR-V generated from LLVM violates this and spirv-val fails

This is a first attempt to fix that problem, by creating the entrypoint
as a wrapper around the function.

I'm just creating an MR to get some input on this plan.