### PR TITLE
Update for LLVM hasFnAttr renaming

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -319,7 +319,7 @@ void PreprocessMetadataBase::preprocessVectorComputeMetadata(Module *M,
     // RoundMode and FloatMode are always same for all types in VC
     // While Denorm could be different for double, float and half
     auto Attrs = F.getAttributes();
-    if (Attrs.hasFnAttribute(kVCMetadata::VCFloatControl)) {
+    if (Attrs.hasFnAttr(kVCMetadata::VCFloatControl)) {
       SPIRVWord Mode = 0;
       Attrs
           .getAttribute(AttributeList::FunctionIndex,
@@ -342,7 +342,7 @@ void PreprocessMetadataBase::preprocessVectorComputeMetadata(Module *M,
                 .done();
           });
     }
-    if (Attrs.hasFnAttribute(kVCMetadata::VCSLMSize)) {
+    if (Attrs.hasFnAttr(kVCMetadata::VCSLMSize)) {
       SPIRVWord SLMSize = 0;
       Attrs.getAttribute(AttributeList::FunctionIndex, kVCMetadata::VCSLMSize)
           .getValueAsString()
@@ -353,7 +353,7 @@ void PreprocessMetadataBase::preprocessVectorComputeMetadata(Module *M,
           .add(SLMSize)
           .done();
     }
-    if (Attrs.hasFnAttribute(kVCMetadata::VCFCEntry)) {
+    if (Attrs.hasFnAttr(kVCMetadata::VCFCEntry)) {
       EM.addOp()
           .add(&F)
           .add(spv::internal::ExecutionModeFastCompositeKernelINTEL)

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -655,13 +655,13 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
     BF->addDecorate(DecorationFuncParamAttr, FunctionParameterAttributeZext);
   if (Attrs.hasAttribute(AttributeList::ReturnIndex, Attribute::SExt))
     BF->addDecorate(DecorationFuncParamAttr, FunctionParameterAttributeSext);
-  if (Attrs.hasFnAttribute("referenced-indirectly")) {
+  if (Attrs.hasFnAttr("referenced-indirectly")) {
     assert(!isKernel(F) &&
            "kernel function was marked as referenced-indirectly");
     BF->addDecorate(DecorationReferencedIndirectlyINTEL);
   }
 
-  if (Attrs.hasFnAttribute(kVCMetadata::VCCallable) &&
+  if (Attrs.hasFnAttr(kVCMetadata::VCCallable) &&
       BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fast_composite)) {
     BF->addDecorate(internal::DecorationCallableFunctionINTEL);
   }
@@ -684,14 +684,14 @@ void LLVMToSPIRVBase::transVectorComputeMetadata(Function *F) {
   assert(BF && "The SPIRVFunction pointer shouldn't be nullptr");
   auto Attrs = F->getAttributes();
 
-  if (Attrs.hasFnAttribute(kVCMetadata::VCStackCall))
+  if (Attrs.hasFnAttr(kVCMetadata::VCStackCall))
     BF->addDecorate(DecorationStackCallINTEL);
-  if (Attrs.hasFnAttribute(kVCMetadata::VCFunction))
+  if (Attrs.hasFnAttr(kVCMetadata::VCFunction))
     BF->addDecorate(DecorationVectorComputeFunctionINTEL);
   else
     return;
 
-  if (Attrs.hasFnAttribute(kVCMetadata::VCSIMTCall)) {
+  if (Attrs.hasFnAttr(kVCMetadata::VCSIMTCall)) {
     SPIRVWord SIMTMode = 0;
     Attrs.getAttribute(AttributeList::FunctionIndex, kVCMetadata::VCSIMTCall)
         .getValueAsString()
@@ -731,7 +731,7 @@ void LLVMToSPIRVBase::transVectorComputeMetadata(Function *F) {
   }
   if (!isKernel(F) &&
       BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_float_controls2) &&
-      Attrs.hasFnAttribute(kVCMetadata::VCFloatControl)) {
+      Attrs.hasFnAttr(kVCMetadata::VCFloatControl)) {
 
     SPIRVWord Mode = 0;
     Attrs


### PR DESCRIPTION
Fix build after LLVM commit `92ce6db9ee76 ("[NFC] Rename
AttributeList::hasFnAttribute() -> hasFnAttr()", 2021-08-13)`.

Fixes #1154 .