### PR TITLE
Fix leak in LLVMToSPIRV::transExecutionMode()

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1879,8 +1879,8 @@ bool LLVMToSPIRV::transExecutionMode() {
       case spv::ExecutionModeSharedLocalMemorySizeINTEL: {
         unsigned SLMSize;
         N.get(SLMSize);
-        BF->addExecutionMode(new SPIRVExecutionMode(
-            BF, static_cast<ExecutionMode>(EMode), SLMSize));
+        BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
+            BF, static_cast<ExecutionMode>(EMode), SLMSize)));
       } break;
 
       case spv::ExecutionModeDenormPreserve:


### PR DESCRIPTION
PR to master:
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1160
In case spv::ExecutionModeSharedLocalMemorySizeINTEL the new
SPIRVExecutionMode was not registered via SPIRVModule::add()
and was leaking