### PR TITLE
Fix leak in LLVMToSPIRV::transExecutionMode()

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3294,8 +3294,8 @@ bool LLVMToSPIRVBase::transExecutionMode() {
           break;
         unsigned SLMSize;
         N.get(SLMSize);
-        BF->addExecutionMode(new SPIRVExecutionMode(
-            BF, static_cast<ExecutionMode>(EMode), SLMSize));
+        BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
+            BF, static_cast<ExecutionMode>(EMode), SLMSize)));
       } break;
 
       case spv::ExecutionModeDenormPreserve:


### PR DESCRIPTION
PR to master:
#1160
In case spv::ExecutionModeSharedLocalMemorySizeINTEL the new
SPIRVExecutionMode was not registered via SPIRVModule::add()
and was leaking