### PR TITLE
Fix support of SPV_INTEL_vector_compute

### DIFF
--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -160,11 +160,11 @@ public:
         VectorType *SrcVecTy = getVectorType(BC->getSrcTy());
         if (SrcVecTy) {
           uint64_t NumElemsInSrcVec = SrcVecTy->getElementCount().getValue();
-          // SPV_INTEL_vector_compute allows 1-element vectors
+          // SPV_INTEL_vector_compute allows to use vectors with any number of
+          // components
           if (!isValidVectorSize(NumElemsInSrcVec) &&
-              !(Opts.isAllowedToUseExtension(
-                    ExtensionID::SPV_INTEL_vector_compute) &&
-                NumElemsInSrcVec == 1))
+              !Opts.isAllowedToUseExtension(
+                  ExtensionID::SPV_INTEL_vector_compute))
             report_fatal_error("Unsupported vector type with the size of: " +
                                    std::to_string(NumElemsInSrcVec),
                                false);
@@ -172,11 +172,11 @@ public:
         VectorType *DestVecTy = getVectorType(BC->getDestTy());
         if (DestVecTy) {
           uint64_t NumElemsInDestVec = DestVecTy->getElementCount().getValue();
-          // SPV_INTEL_vector_compute allows 1-element vectors
+          // SPV_INTEL_vector_compute allows to use vectors with any number of
+          // components
           if (!isValidVectorSize(NumElemsInDestVec) &&
-              !(Opts.isAllowedToUseExtension(
-                    ExtensionID::SPV_INTEL_vector_compute) &&
-                NumElemsInDestVec == 1))
+              !Opts.isAllowedToUseExtension(
+                  ExtensionID::SPV_INTEL_vector_compute))
             BCastsToNonStdVec.push_back(&I);
         }
       }

--- a/test/lower-non-standard-vec-with-ext.ll
+++ b/test/lower-non-standard-vec-with-ext.ll
@@ -15,6 +15,7 @@ entry:
   %1 = extractelement <4 x i8> %0, i32 0
   %2 = bitcast <1 x i32> <i32 131586> to <4 x i8>
   %3 = extractelement <4 x i8> %2, i32 0
+  %4 = bitcast <5 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1> to <20 x i8>
   ret void
 }
 


### PR DESCRIPTION
The previous patch has fixed only case with 1-element vectors, however
after closer look at the spec it became clear that
SPV_INTEL_vector_compute actually allows any number of vector elements
(capability VectorAnyINTEL), so this is the proper fix.