### PR TITLE
[SPV-IR] Ignore SPIR-V linkage name for BuiltIn variable

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -642,6 +642,8 @@ StringRef undecorateSPIRVFunction(StringRef S);
 /// and get the original name.
 bool isDecoratedSPIRVFunc(const Function *F, StringRef &UndecName);
 
+std::string prefixSPIRVName(const std::string &S);
+
 StringRef dePrefixSPIRVName(StringRef R, SmallVectorImpl<StringRef> &Postfix);
 
 /// Get a canonical function name for a SPIR-V op code.

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -930,14 +930,6 @@ Value *SPIRVToLLVM::transValue(SPIRVValue *BV, Function *F, BasicBlock *BB,
     return nullptr;
   }
   setName(V, BV);
-  // Force SPIRV BuiltIn variable's name to be __spirv_BuiltInXXXX.
-  // No matter what BV's linkage name is.
-  if (BV->getOpCode() == spv::OpVariable) {
-    SPIRVBuiltinVariableKind BVKind;
-    auto *BVar = static_cast<SPIRVVariable *>(BV);
-    if (BVar->isBuiltin(&BVKind))
-      V->setName(prefixSPIRVName(SPIRVBuiltInNameMap::map(BVKind)));
-  }
   if (!transDecoration(BV, V)) {
     assert(0 && "trans decoration fail");
     return nullptr;
@@ -1468,6 +1460,11 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       Initializer = UndefValue::get(Ty);
     } else
       AddrSpace = SPIRSPIRVAddrSpaceMap::rmap(BS);
+    // Force SPIRV BuiltIn variable's name to be __spirv_BuiltInXXXX.
+    // No matter what BV's linkage name is.
+    SPIRVBuiltinVariableKind BVKind;
+    if (BVar->isBuiltin(&BVKind))
+      BV->setName(prefixSPIRVName(SPIRVBuiltInNameMap::map(BVKind)));
     auto LVar = new GlobalVariable(*M, Ty, IsConst, LinkageTy,
                                    /*Initializer=*/nullptr, BV->getName(), 0,
                                    GlobalVariable::NotThreadLocal, AddrSpace);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -930,6 +930,14 @@ Value *SPIRVToLLVM::transValue(SPIRVValue *BV, Function *F, BasicBlock *BB,
     return nullptr;
   }
   setName(V, BV);
+  // Force SPIRV BuiltIn variable's name to be __spirv_BuiltInXXXX.
+  // No matter what BV's linkage name is.
+  if (BV->getOpCode() == spv::OpVariable) {
+    SPIRVBuiltinVariableKind BVKind;
+    auto *BVar = static_cast<SPIRVVariable *>(BV);
+    if (BVar->isBuiltin(&BVKind))
+      V->setName(prefixSPIRVName(SPIRVBuiltInNameMap::map(BVKind)));
+  }
   if (!transDecoration(BV, V)) {
     assert(0 && "trans decoration fail");
     return nullptr;

--- a/test/ignore-builtin-linkage-name.spt
+++ b/test/ignore-builtin-linkage-name.spt
@@ -1,0 +1,59 @@
+119734787 65536 458752 26 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+2 Capability Int64
+3 MemoryModel 2 2
+8 EntryPoint 6 1 "decorate_aliased"
+3 Source 3 102000
+9 Name 2 "__spirv_GlobalInvocationId"
+3 Name 3 "res"
+3 Name 4 "lhs"
+3 Name 5 "rhs"
+4 Name 6 "entry"
+
+3 Decorate 7 Aliased
+2 DecorationGroup 7
+4 Decorate 2 BuiltIn 28
+3 Decorate 2 Constant
+11 Decorate 2 LinkageAttributes "__spirv_GlobalInvocationId" Import
+5 GroupDecorate 7 3 4 5
+4 TypeInt 8 64 0
+4 TypeInt 12 32 0
+5 Constant 8 15 32 0
+4 TypeVector 9 8 3
+4 TypePointer 10 1 9
+2 TypeVoid 11
+4 TypePointer 13 5 12
+6 TypeFunction 14 11 13 13 13
+4 Variable 10 2 1
+
+
+
+5 Function 11 1 0 14
+3 FunctionParameter 13 3
+3 FunctionParameter 13 4
+3 FunctionParameter 13 5
+
+2 Label 6
+6 Load 9 16 2 2 0
+5 CompositeExtract 8 17 16 0
+5 ShiftLeftLogical 8 18 17 15
+5 ShiftRightArithmetic 8 19 18 15
+5 InBoundsPtrAccessChain 13 20 4 19
+6 Load 12 21 20 2 4
+5 InBoundsPtrAccessChain 13 22 5 19
+6 Load 12 23 22 2 4
+5 IAdd 12 24 21 23
+5 InBoundsPtrAccessChain 13 25 3 19
+5 Store 25 24 2 4
+1 Return
+
+1 FunctionEnd
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s -check-prefix=CHECK-LLVM
+
+; CHECK-LLVM-NOT: __spirv_GlobalInvocationId
+; CHECK-LLVM: __spirv_BuiltInGlobalInvocationId

--- a/test/ignore-builtin-linkage-name.spt
+++ b/test/ignore-builtin-linkage-name.spt
@@ -1,52 +1,48 @@
-119734787 65536 458752 26 0
+119734787 65536 393230 25 0
 2 Capability Addresses
 2 Capability Linkage
 2 Capability Kernel
 2 Capability Int64
+2 Capability GenericPointer
+5 ExtInstImport 1 "OpenCL.std"
 3 MemoryModel 2 2
-8 EntryPoint 6 1 "decorate_aliased"
-3 Source 3 102000
-9 Name 2 "__spirv_GlobalInvocationId"
-3 Name 3 "res"
-3 Name 4 "lhs"
-3 Name 5 "rhs"
-4 Name 6 "entry"
+4 EntryPoint 6 8 "foo"
+3 Source 0 0
+8 Name 5 "__spirv_WorkgroupSize"
+4 Name 9 "entry"
+4 Name 13 "GroupID"
+3 Name 24 "mul"
 
-3 Decorate 7 Aliased
-2 DecorationGroup 7
-4 Decorate 2 BuiltIn 28
-3 Decorate 2 Constant
-11 Decorate 2 LinkageAttributes "__spirv_GlobalInvocationId" Import
-5 GroupDecorate 7 3 4 5
-4 TypeInt 8 64 0
-4 TypeInt 12 32 0
-5 Constant 8 15 32 0
-4 TypeVector 9 8 3
-4 TypePointer 10 1 9
-2 TypeVoid 11
-4 TypePointer 13 5 12
-6 TypeFunction 14 11 13 13 13
-4 Variable 10 2 1
+4 Decorate 5 BuiltIn 25
+3 Decorate 5 Constant
+10 Decorate 5 LinkageAttributes "__spirv_WorkgroupSize" Import
+4 Decorate 13 Alignment 8
+4 Decorate 5 Alignment 32
+4 TypeInt 2 64 0
+5 Constant 2 10 3 0
+5 Constant 2 16 0 0
+5 Constant 2 20 2 0
+4 TypeVector 3 2 3
+4 TypePointer 4 5 3
+2 TypeVoid 6
+3 TypeFunction 7 6
+4 TypeArray 11 2 10
+4 TypePointer 12 7 11
+4 TypePointer 14 8 3
+4 TypePointer 17 8 2
+4 Variable 4 5 5
 
+5 Function 6 8 0 7
 
-
-5 Function 11 1 0 14
-3 FunctionParameter 13 3
-3 FunctionParameter 13 4
-3 FunctionParameter 13 5
-
-2 Label 6
-6 Load 9 16 2 2 0
-5 CompositeExtract 8 17 16 0
-5 ShiftLeftLogical 8 18 17 15
-5 ShiftRightArithmetic 8 19 18 15
-5 InBoundsPtrAccessChain 13 20 4 19
-6 Load 12 21 20 2 4
-5 InBoundsPtrAccessChain 13 22 5 19
-6 Load 12 23 22 2 4
-5 IAdd 12 24 21 23
-5 InBoundsPtrAccessChain 13 25 3 19
-5 Store 25 24 2 4
+2 Label 9
+4 Variable 12 13 7
+4 PtrCastToGeneric 14 15 5
+6 PtrAccessChain 17 18 15 16 16
+4 PtrCastToGeneric 14 19 5
+6 PtrAccessChain 17 21 19 16 20
+6 Load 2 22 18 2 32
+6 Load 2 23 21 2 8
+5 IMul 2 24 22 23
 1 Return
 
 1 FunctionEnd
@@ -55,5 +51,5 @@
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s -check-prefix=CHECK-LLVM
 
-; CHECK-LLVM-NOT: __spirv_GlobalInvocationId
-; CHECK-LLVM: __spirv_BuiltInGlobalInvocationId
+; CHECK-LLVM-NOT: __spirv_WorkgroupSize
+; CHECK-LLVM: __spirv_BuiltInWorkgroupSize


### PR DESCRIPTION
The BuiltIn variable/call name in SPV-IR should stick to
"__spirv_BuiltIn*", no matter what the SPIR-V linkage name is.

This is an issue exposed by PR #1133.