### PR TITLE
Improve LLVM annotations translation to SPIR-V

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3078,6 +3078,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     }
 
     std::string AnnotationString;
+    // Process main annotation with the attached optional integer parameters
     if (GetElementPtrInst *GEP =
             dyn_cast<GetElementPtrInst>(II->getArgOperand(1))) {
       if (Constant *C = dyn_cast<Constant>(GEP->getOperand(0))) {
@@ -3456,11 +3457,10 @@ bool LLVMToSPIRVBase::transGlobalVariables() {
                      Return = true;
                      break;
                    default:
-                     Return = false;
-                     break;
+                     return false;
                    }
                  } else
-                   Return = false;
+                   return false;
                }
                return Return;
              }())

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2200,7 +2200,7 @@ SPIRVValue *LLVMToSPIRVBase::oclTransSpvcCastSampler(CallInst *CI,
 
 using DecorationsInfoVec = std::vector<std::pair<Decoration, std::string>>;
 
-struct IntelFPGADecorations {
+struct AnnotationDecorations {
   DecorationsInfoVec MemoryAttributesVec;
   DecorationsInfoVec MemoryAccessesVec;
 };
@@ -2242,9 +2242,47 @@ struct IntelLSUControlsInfo {
   llvm::Optional<unsigned> PrefetchInfo;
 };
 
-IntelFPGADecorations
-tryParseIntelFPGAAnnotationString(StringRef AnnotatedCode) {
-  IntelFPGADecorations Decorates;
+void processOptionalAnnotationInfo(Constant *Const,
+                                   std::string &AnnotationString) {
+  // Handle optional parameter. It can be for example
+  // { %struct.S, i8*, void ()* } { %struct.S undef, i8* null,
+  //                                void ()* @_Z4blahv }
+  // Now we will just handle integer constants (wrapped in a constant
+  // struct, that is being bitcasted to i8*), converting them to string.
+  // TODO: remove this workaround when/if an extension spec that allows or adds
+  // variadic-arguments UserSemantic decoration
+  if (!Const->getNumOperands())
+    return;
+  if (auto *CStruct = dyn_cast_or_null<ConstantStruct>(Const->getOperand(0))) {
+    uint32_t NumOperands = CStruct->getNumOperands();
+    if (!NumOperands)
+      return;
+    if (auto *CInt = dyn_cast<ConstantInt>(CStruct->getOperand(0))) {
+      AnnotationString += ": ";
+      AnnotationString += std::to_string(CInt->getSExtValue());
+    }
+    for (uint32_t I = 1; I != CStruct->getNumOperands(); ++I) {
+      if (auto *CInt = dyn_cast<ConstantInt>(CStruct->getOperand(I))) {
+        AnnotationString += ", ";
+        AnnotationString += std::to_string(CInt->getSExtValue());
+      }
+    }
+  }
+}
+
+AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
+                                               StringRef AnnotatedCode) {
+  AnnotationDecorations Decorates;
+  const bool AllowFPGAMemAccesses =
+      BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fpga_memory_accesses);
+  const bool AllowFPGAMemAttr = BM->isAllowedToUseExtension(
+      ExtensionID::SPV_INTEL_fpga_memory_attributes);
+  if (!(AllowFPGAMemAccesses || AllowFPGAMemAttr)) {
+    Decorates.MemoryAttributesVec.emplace_back(DecorationUserSemantic,
+                                               AnnotatedCode.str());
+    return Decorates;
+  }
+
   IntelLSUControlsInfo LSUControls;
 
   // Intel FPGA decorations are separated into
@@ -2258,25 +2296,27 @@ tryParseIntelFPGAAnnotationString(StringRef AnnotatedCode) {
     // Drop the braces surrounding the actual decoration
     const StringRef AnnotatedDecoration = AnnotatedCode.substr(
         DecorationsIt->position() + 1, DecorationsIt->length() - 2);
+
     std::pair<StringRef, StringRef> Split = AnnotatedDecoration.split(':');
     StringRef Name = Split.first, ValueStr = Split.second;
-
-    if (Name == "params") {
-      unsigned ParamsBitMask = 0;
-      bool Failure = ValueStr.getAsInteger(10, ParamsBitMask);
-      assert(!Failure && "Non-integer LSU controls value");
-      (void)Failure;
-      LSUControls.setWithBitMask(ParamsBitMask);
-    } else if (Name == "cache-size") {
-      if (!LSUControls.CacheSizeInfo.hasValue())
-        continue;
-      unsigned CacheSizeValue = 0;
-      bool Failure = ValueStr.getAsInteger(10, CacheSizeValue);
-      assert(!Failure && "Non-integer cache size value");
-      (void)Failure;
-      LSUControls.CacheSizeInfo = CacheSizeValue;
-    } // TODO: Support LSU prefetch size, which currently defaults to 0
-    else /* Memory attributes */ {
+    if (AllowFPGAMemAccesses) {
+      if (Name == "params") {
+        unsigned ParamsBitMask = 0;
+        bool Failure = ValueStr.getAsInteger(10, ParamsBitMask);
+        assert(!Failure && "Non-integer LSU controls value");
+        (void)Failure;
+        LSUControls.setWithBitMask(ParamsBitMask);
+      } else if (Name == "cache-size") {
+        if (!LSUControls.CacheSizeInfo.hasValue())
+          continue;
+        unsigned CacheSizeValue = 0;
+        bool Failure = ValueStr.getAsInteger(10, CacheSizeValue);
+        assert(!Failure && "Non-integer cache size value");
+        (void)Failure;
+        LSUControls.CacheSizeInfo = CacheSizeValue;
+      } // TODO: Support LSU prefetch size, which currently defaults to 0
+    }
+    if (AllowFPGAMemAttr) {
       StringRef Annotation;
       Decoration Dec;
       if (Name == "pump") {
@@ -2322,13 +2362,8 @@ std::vector<SPIRVWord> getBankBitsFromString(StringRef S) {
   return Bits;
 }
 
-void addIntelFPGADecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
+void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
   SPIRVModule *M = E->getModule();
-  if (!M->isAllowedToUseExtension(
-          ExtensionID::SPV_INTEL_fpga_memory_attributes) &&
-      !M->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fpga_memory_accesses))
-    return;
-
   for (const auto &I : Decorations) {
     // Such decoration already exists on a type, skip it
     if (E->hasDecorate(I.first, /*Index=*/0, /*Result=*/nullptr)) {
@@ -2339,48 +2374,76 @@ void addIntelFPGADecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
     case DecorationUserSemantic:
       E->addDecorate(new SPIRVDecorateUserSemanticAttr(E, I.second));
       break;
-    case DecorationMemoryINTEL:
-      E->addDecorate(new SPIRVDecorateMemoryINTELAttr(E, I.second));
-      break;
-    case DecorationMergeINTEL: {
-      StringRef Name = StringRef(I.second).split(':').first;
-      StringRef Direction = StringRef(I.second).split(':').second;
-      E->addDecorate(
-          new SPIRVDecorateMergeINTELAttr(E, Name.str(), Direction.str()));
+    case DecorationMemoryINTEL: {
+      if (M->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_fpga_memory_attributes))
+        E->addDecorate(new SPIRVDecorateMemoryINTELAttr(E, I.second));
     } break;
-    case DecorationBankBitsINTEL:
-      E->addDecorate(new SPIRVDecorateBankBitsINTELAttr(
-          E, getBankBitsFromString(I.second)));
-      break;
+    case DecorationMergeINTEL: {
+      if (M->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
+        StringRef Name = StringRef(I.second).split(':').first;
+        StringRef Direction = StringRef(I.second).split(':').second;
+        E->addDecorate(
+            new SPIRVDecorateMergeINTELAttr(E, Name.str(), Direction.str()));
+      }
+    } break;
+    case DecorationBankBitsINTEL: {
+      if (M->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_fpga_memory_attributes))
+        E->addDecorate(new SPIRVDecorateBankBitsINTELAttr(
+            E, getBankBitsFromString(I.second)));
+    } break;
     case DecorationRegisterINTEL:
     case DecorationSinglepumpINTEL:
     case DecorationDoublepumpINTEL:
-    case DecorationSimpleDualPortINTEL:
+    case DecorationSimpleDualPortINTEL: {
+      if (M->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
+        assert(I.second.empty());
+        E->addDecorate(I.first);
+      }
+    } break;
     case DecorationBurstCoalesceINTEL:
-    case DecorationDontStaticallyCoalesceINTEL:
-      assert(I.second.empty());
-      E->addDecorate(I.first);
-      break;
-    // The rest of IntelFPGA decorations:
-    // DecorationNumbanksINTEL
-    // DecorationBankwidthINTEL
-    // DecorationMaxPrivateCopiesINTEL
-    // DecorationMaxReplicatesINTEL
-    // DecorationForcePow2DepthINTEL
-    // DecorationCacheSizeINTEL
-    // DecorationPrefetchINTEL
+    case DecorationDontStaticallyCoalesceINTEL: {
+      if (M->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_fpga_memory_accesses)) {
+        assert(I.second.empty());
+        E->addDecorate(I.first);
+      }
+    } break;
+    case DecorationNumbanksINTEL:
+    case DecorationBankwidthINTEL:
+    case DecorationMaxPrivateCopiesINTEL:
+    case DecorationMaxReplicatesINTEL:
+    case DecorationForcePow2DepthINTEL: {
+      if (M->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
+        SPIRVWord Result = 0;
+        StringRef(I.second).getAsInteger(10, Result);
+        E->addDecorate(I.first, Result);
+      }
+    } break;
+    case DecorationCacheSizeINTEL:
+    case DecorationPrefetchINTEL: {
+      if (M->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_fpga_memory_accesses)) {
+        SPIRVWord Result = 0;
+        StringRef(I.second).getAsInteger(10, Result);
+        E->addDecorate(I.first, Result);
+      }
+    } break;
     default:
-      SPIRVWord Result = 0;
-      StringRef(I.second).getAsInteger(10, Result);
-      E->addDecorate(I.first, Result);
+      // Other decorations are either not supported by the translator or
+      // handled in other places.
       break;
     }
   }
 }
 
-void addIntelFPGADecorationsForStructMember(SPIRVEntry *E,
-                                            SPIRVWord MemberNumber,
-                                            DecorationsInfoVec &Decorations) {
+void addAnnotationDecorationsForStructMember(SPIRVEntry *E,
+                                             SPIRVWord MemberNumber,
+                                             DecorationsInfoVec &Decorations) {
   for (const auto &I : Decorations) {
     // Such decoration already exists on a type, skip it
     if (E->hasMemberDecorate(I.first, /*Index=*/0, MemberNumber,
@@ -2971,35 +3034,41 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       SV = transValue(II->getOperand(0), BB);
     }
 
-    GetElementPtrInst *GEP = cast<GetElementPtrInst>(II->getArgOperand(1));
-    Constant *C = cast<Constant>(GEP->getOperand(0));
-    StringRef AnnotationString;
-    getConstantStringInfo(C, AnnotationString);
+    std::string AnnotationString;
+    if (GetElementPtrInst *GEP =
+            dyn_cast<GetElementPtrInst>(II->getArgOperand(1))) {
+      if (Constant *C = dyn_cast<Constant>(GEP->getOperand(0))) {
+        StringRef StrRef;
+        getConstantStringInfo(C, StrRef);
+        AnnotationString += StrRef.str();
+      }
+    }
+    if (BitCastInst *Cast = dyn_cast<BitCastInst>(II->getArgOperand(4)))
+      if (Constant *C = dyn_cast_or_null<Constant>(Cast->getOperand(0)))
+        processOptionalAnnotationInfo(C, AnnotationString);
 
-    DecorationsInfoVec Decorations;
-    if (BB->getModule()->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_fpga_memory_attributes))
-      // If it is allowed, let's try to parse annotation string to find
-      // IntelFPGA-specific decorations
-      Decorations = tryParseIntelFPGAAnnotationString(AnnotationString)
-                        .MemoryAttributesVec;
+    DecorationsInfoVec Decorations =
+        tryParseAnnotationString(BM, AnnotationString).MemoryAttributesVec;
 
     // If we didn't find any IntelFPGA-specific decorations, let's add the whole
     // annotation string as UserSemantic Decoration
     if (Decorations.empty()) {
       SV->addDecorate(
-          new SPIRVDecorateUserSemanticAttr(SV, AnnotationString.str()));
+          new SPIRVDecorateUserSemanticAttr(SV, AnnotationString.c_str()));
     } else {
-      addIntelFPGADecorations(SV, Decorations);
+      addAnnotationDecorations(SV, Decorations);
     }
     return SV;
   }
+  // The layout of llvm.ptr.annotation is:
+  // declare iN*   @llvm.ptr.annotation.p<address space>iN(
+  // iN* <val>, i8* <str>, i8* <str>, i32  <int>, i8* <ptr>)
+  // where N is a power of two number,
+  // first i8* <str> stands for the annotation itself,
+  // second i8* <str> is for the location (file name),
+  // i8* <ptr> is a pointer on a GV, which can carry optinal variadic
+  // clang::annotation attribute expression arguments.
   case Intrinsic::ptr_annotation: {
-    GetElementPtrInst *GEP = dyn_cast<GetElementPtrInst>(II->getArgOperand(1));
-    Constant *C = dyn_cast<Constant>(GEP->getOperand(0));
-    StringRef AnnotationString;
-    getConstantStringInfo(C, AnnotationString);
-
     // Strip all bitcast and addrspace casts from the pointer argument:
     //   llvm annotation intrinsic only takes i8*, so the original pointer
     //   probably had to loose its addrspace and its original type.
@@ -3008,19 +3077,20 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       AnnotSubj = cast<CastInst>(AnnotSubj)->getOperand(0);
     }
 
-    IntelFPGADecorations Decorations;
-    if (BB->getModule()->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_fpga_memory_attributes) ||
-        BB->getModule()->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_fpga_memory_accesses))
-      // If it is allowed, let's try to parse annotation string to find
-      // IntelFPGA-specific decorations
-      // TODO: The check is not entirely correct, since it allows usage
-      // of extension A even if extension B is the only one enabled.
-      // With the existing stack, these are always enabled/disabled
-      // simultaneously, however we should find a way to separate the
-      // actions for each individual extension.
-      Decorations = tryParseIntelFPGAAnnotationString(AnnotationString);
+    std::string AnnotationString;
+    if (GetElementPtrInst *GEP =
+            dyn_cast<GetElementPtrInst>(II->getArgOperand(1))) {
+      if (Constant *C = dyn_cast<Constant>(GEP->getOperand(0))) {
+        StringRef StrRef;
+        getConstantStringInfo(C, StrRef);
+        AnnotationString += StrRef.str();
+      }
+    }
+    if (BitCastInst *Cast = dyn_cast<BitCastInst>(II->getArgOperand(4)))
+      if (Constant *C = dyn_cast_or_null<Constant>(Cast->getOperand(0)))
+        processOptionalAnnotationInfo(C, AnnotationString);
+    AnnotationDecorations Decorations =
+        tryParseAnnotationString(BM, AnnotationString);
 
     // If the pointer is a GEP on a struct, then we have to emit a member
     // decoration for the GEP-accessed struct, or a memory access decoration
@@ -3040,18 +3110,18 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
         // to struct member memory atributes or struct member memory access
         // controls? This would allow emitting just the necessary decoration.
         Ty->addMemberDecorate(new SPIRVMemberDecorateUserSemanticAttr(
-            Ty, MemberNumber, AnnotationString.str()));
-        ResPtr->addDecorate(
-            new SPIRVDecorateUserSemanticAttr(ResPtr, AnnotationString.str()));
+            Ty, MemberNumber, AnnotationString.c_str()));
+        ResPtr->addDecorate(new SPIRVDecorateUserSemanticAttr(
+            ResPtr, AnnotationString.c_str()));
       } else {
-        addIntelFPGADecorationsForStructMember(Ty, MemberNumber,
-                                               Decorations.MemoryAttributesVec);
+        addAnnotationDecorationsForStructMember(
+            Ty, MemberNumber, Decorations.MemoryAttributesVec);
         // Apply the LSU parameter decoration to the pointer result of a GEP
         // to the given struct member (InBoundsPtrAccessChain in SPIR-V).
         // Decorating the member itself with a MemberDecoration is not feasible,
         // because multiple accesses to the struct-held memory can require
         // different LSU parameters.
-        addIntelFPGADecorations(ResPtr, Decorations.MemoryAccessesVec);
+        addAnnotationDecorations(ResPtr, Decorations.MemoryAccessesVec);
       }
       II->replaceAllUsesWith(II->getOperand(0));
     } else {
@@ -3066,13 +3136,13 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
         auto *DecSubj = transValue(II->getArgOperand(0), BB);
         if (Decorations.MemoryAccessesVec.empty())
           DecSubj->addDecorate(new SPIRVDecorateUserSemanticAttr(
-              DecSubj, AnnotationString.str()));
+              DecSubj, AnnotationString.c_str()));
         else
           // Apply the LSU parameter decoration to the pointer result of an
           // instruction. Note it's the address to the accessed memory that's
           // loaded from the original pointer variable, and not the value
           // accessed by the latter.
-          addIntelFPGADecorations(DecSubj, Decorations.MemoryAccessesVec);
+          addAnnotationDecorations(DecSubj, Decorations.MemoryAccessesVec);
         II->replaceAllUsesWith(II->getOperand(0));
       }
     }
@@ -3325,6 +3395,10 @@ void LLVMToSPIRVBase::transGlobalAnnotation(GlobalVariable *V) {
 
   // @llvm.global.annotations is an array that contains structs with 4 fields.
   // Get the array of structs with metadata
+  // TODO: actually, now it contains 5 fields, the fifth by default is nullptr
+  // or undef, but it can be defined to include variadic arguments of
+  // clang::annotation attribute. Need to refactor this function to turn on this
+  // translation
   ConstantArray *CA = cast<ConstantArray>(V->getOperand(0));
   for (Value *Op : CA->operands()) {
     ConstantStruct *CS = cast<ConstantStruct>(Op);
@@ -3338,20 +3412,16 @@ void LLVMToSPIRVBase::transGlobalAnnotation(GlobalVariable *V) {
 
     StringRef AnnotationString;
     getConstantStringInfo(GV, AnnotationString);
+    DecorationsInfoVec Decorations =
+        tryParseAnnotationString(BM, AnnotationString).MemoryAttributesVec;
 
-    DecorationsInfoVec Decorations;
-    if (BM->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_fpga_memory_attributes))
-      Decorations = tryParseIntelFPGAAnnotationString(AnnotationString)
-                        .MemoryAttributesVec;
-
-    // If we didn't find any IntelFPGA-specific decorations, let's
-    // add the whole annotation string as UserSemantic Decoration
+    // If we didn't find any annotation decorations, let's add the whole
+    // annotation string as UserSemantic Decoration
     if (Decorations.empty()) {
       SV->addDecorate(
           new SPIRVDecorateUserSemanticAttr(SV, AnnotationString.str()));
     } else {
-      addIntelFPGADecorations(SV, Decorations);
+      addAnnotationDecorations(SV, Decorations);
     }
   }
 }
@@ -3370,6 +3440,31 @@ bool LLVMToSPIRVBase::transGlobalVariables() {
   for (auto I = M->global_begin(), E = M->global_end(); I != E; ++I) {
     if ((*I).getName() == "llvm.global.annotations")
       transGlobalAnnotation(&(*I));
+    else if ([&]() -> bool {
+               // Check if the GV is used only in var/ptr instructions. If yes -
+               // skip processing of this since it's only an annotation GV.
+               bool Return = false;
+               for (auto *U : I->users()) {
+                 auto *V = U->stripPointerCasts();
+                 if (GetElementPtrInst *GEP =
+                         dyn_cast_or_null<GetElementPtrInst>(V))
+                   V = GEP;
+                 if (IntrinsicInst *II = dyn_cast_or_null<IntrinsicInst>(V)) {
+                   switch (II->getIntrinsicID()) {
+                   case Intrinsic::var_annotation:
+                   case Intrinsic::ptr_annotation:
+                     Return = true;
+                     break;
+                   default:
+                     Return = false;
+                     break;
+                   }
+                 } else
+                   Return = false;
+               }
+               return Return;
+             }())
+      continue;
     else if ((I->getName() == "llvm.global_ctors" ||
               I->getName() == "llvm.global_dtors") &&
              !BM->isAllowedToUseExtension(

--- a/test/transcoding/annotate_attribute.ll
+++ b/test/transcoding/annotate_attribute.ll
@@ -8,22 +8,26 @@
 ; CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "42"
 ; CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "bar"
 ; CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "{FOO}"
+; CHECK-SPIRV: Decorate {{[0-9]+}} UserSemantic "my_custom_annotations: 30, 60"
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 1 UserSemantic "128"
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 2 UserSemantic "qux"
 ; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 0 UserSemantic "{baz}"
+; CHECK-SPIRV: MemberDecorate {{[0-9]+}} 3 UserSemantic "my_custom_annotations: 20, 60, 80"
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
 
 %class.anon = type { i8 }
-%struct.bar = type { i32, i8, float }
+%struct.bar = type { i32, i8, float, i8 }
 
-; CHECK-LLVM:  [[STR:@[0-9_.]+]] = {{.*}}42
-; CHECK-LLVM: [[STR2:@[0-9_.]+]] = {{.*}}{FOO}
-; CHECK-LLVM: [[STR3:@[0-9_.]+]] = {{.*}}bar
-; CHECK-LLVM: [[STR4:@[0-9_.]+]] = {{.*}}{baz}
-; CHECK-LLVM: [[STR5:@[0-9_.]+]] = {{.*}}128
-; CHECK-LLVM: [[STR6:@[0-9_.]+]] = {{.*}}qux
+; CHECK-LLVM-DAG:  [[STR:@[0-9_.]+]] = {{.*}}42
+; CHECK-LLVM-DAG: [[STR2:@[0-9_.]+]] = {{.*}}{FOO}
+; CHECK-LLVM-DAG: [[STR3:@[0-9_.]+]] = {{.*}}bar
+; CHECK-LLVM-DAG: [[STR4:@[0-9_.]+]] = {{.*}}{baz}
+; CHECK-LLVM-DAG: [[STR5:@[0-9_.]+]] = {{.*}}128
+; CHECK-LLVM-DAG: [[STR6:@[0-9_.]+]] = {{.*}}qux
+; CHECK-LLVM-DAG: [[STR7:@[0-9_.]+]] = {{.*}}my_custom_annotations: 30, 60
+; CHECK-LLVM-DAG: [[STR8:@[0-9_.]+]] = {{.*}}my_custom_annotations: 20, 60, 80
 @.str = private unnamed_addr constant [3 x i8] c"42\00", section "llvm.metadata"
 @.str.1 = private unnamed_addr constant [23 x i8] c"annotate_attribute.cpp\00", section "llvm.metadata"
 @.str.2 = private unnamed_addr constant [6 x i8] c"{FOO}\00", section "llvm.metadata"
@@ -31,6 +35,10 @@ target triple = "spir64-unknown-linux"
 @.str.4 = private unnamed_addr constant [6 x i8] c"{baz}\00", section "llvm.metadata"
 @.str.5 = private unnamed_addr constant [4 x i8] c"128\00", section "llvm.metadata"
 @.str.6 = private unnamed_addr constant [4 x i8] c"qux\00", section "llvm.metadata"
+@.str.7 = private unnamed_addr constant [22 x i8] c"my_custom_annotations\00", section "llvm.metadata"
+@.args.0 = private unnamed_addr constant { i32, i32 } { i32 30, i32 60 }, section "llvm.metadata"
+@.args.1 = private unnamed_addr constant { i32, i32, i32 } { i32 20, i32 60, i32 80 }, section "llvm.metadata"
+
 
 ; Function Attrs: nounwind
 define spir_kernel void @_ZTSZ4mainE15kernel_function() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
@@ -67,20 +75,25 @@ entry:
   %var_one = alloca i32, align 4
   %var_two = alloca i32, align 4
   %var_three = alloca i8, align 1
+  %var_four = alloca i8, align 1
   %0 = bitcast i32* %var_one to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #4
   %var_one1 = bitcast i32* %var_one to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %[[VAR1:[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([3 x i8], [3 x i8]* [[STR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{.*}}, i8* getelementptr inbounds ([3 x i8], [3 x i8]* [[STR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %var_one1, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str.1, i32 0, i32 0), i32 2, i8* undef)
   %1 = bitcast i32* %var_two to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #4
   %var_two2 = bitcast i32* %var_two to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %[[VAR2:[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([6 x i8], [6 x i8]* [[STR2]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{.*}}, i8* getelementptr inbounds ([6 x i8], [6 x i8]* [[STR2]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %var_two2, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @.str.2, i32 0, i32 0), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str.1, i32 0, i32 0), i32 3, i8* undef)
   call void @llvm.lifetime.start.p0i8(i64 1, i8* %var_three) #4
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %[[VAR3:[a-zA-Z0-9_]+]], i8* getelementptr inbounds ([4 x i8], [4 x i8]* [[STR3]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{.*}}, i8* getelementptr inbounds ([4 x i8], [4 x i8]* [[STR3]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %var_three, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str.3, i32 0, i32 0), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str.1, i32 0, i32 0), i32 4, i8* undef)
   call void @llvm.lifetime.end.p0i8(i64 1, i8* %var_three) #4
+  call void @llvm.lifetime.start.p0i8(i64 1, i8* %var_four) #4
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{.*}}, i8* getelementptr inbounds ([30 x i8], [30 x i8]* [[STR7]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  call void @llvm.var.annotation(i8* %var_four, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @.str.7, i32 0, i32 0), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str.1, i32 0, i32 0), i32 4, i8* bitcast ({ i32, i32 }* @.args.0 to i8*))
+  call void @llvm.lifetime.end.p0i8(i64 1, i8* %var_four) #4
   %2 = bitcast i32* %var_two to i8*
   call void @llvm.lifetime.end.p0i8(i64 4, i8* %2) #4
   %3 = bitcast i32* %var_one to i8*
@@ -115,8 +128,13 @@ entry:
   %4 = call i8* @llvm.ptr.annotation.p0i8(i8* %3, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str.6, i32 0, i32 0), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str.1, i32 0, i32 0), i32 9, i8* undef)
   %5 = bitcast i8* %4 to float*
   store float 0.000000e+00, float* %5, align 4, !tbaa !14
-  %6 = bitcast %struct.bar* %s1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 12, i8* %6) #4
+  ; CHECK-LLVM: %[[FIELD4:.*]] = getelementptr inbounds %struct.bar, %struct.bar* %{{[a-zA-Z0-9]+}}, i32 0, i32 3
+  ; CHECK-LLVM: call i8* @llvm.ptr.annotation.p0i8{{.*}}%[[FIELD4]]{{.*}}[[STR8]]
+  %f4 = getelementptr inbounds %struct.bar, %struct.bar* %s1, i32 0, i32 3
+  %6 = call i8* @llvm.ptr.annotation.p0i8(i8* %f4, i8* getelementptr inbounds ([22 x i8], [22 x i8]* @.str.7, i32 0, i32 0), i8* getelementptr inbounds ([23 x i8], [23 x i8]* @.str.1, i32 0, i32 0), i32 9, i8* bitcast ({ i32, i32, i32 }* @.args.1 to i8*))
+  store i8 0, i8* %6, align 4, !tbaa !13
+  %7 = bitcast %struct.bar* %s1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 12, i8* %7) #4
   ret void
 }
 


### PR DESCRIPTION
https://reviews.llvm.org/D88645 introduces additional parameter
to var/ptr/global annotation instruction, which can be set by
clang::annotation attribute that has variadic constant expression
argument. Right now we can't translate it properly and an extension
is being discussed, but yet we need a W/A for this. As a W/A the
current patch makes this argument (in case if it is const int) be
translatable as a string put in UserSemantic decorations, so the
IL flow is looking like this:
Annotation in source-code:
[[clang::annotate("custom", 30, 60)]] int *Var;

LLVM IR before:
 @.str = private unnamed_addr constant [7 x i8] c"custom\00"
 @.args = private unnamed_addr constant { i32, i32 } { i32 30, i32 60 }
 // ...
 call void @llvm.var.annotation(i8* ...,
       i8* getelementptr inbounds ([7 x i8], [7 x i8]* @.str, i32 0, i32 0),
       i8* ... , i32 ..., i8* bitcast ({ i32, i32 }* @.args to i8*))
 // ...

SPIR-V:
  Decorate %GEP% UserSemantic "custom: 30, 60"

LLVM IR after:
  @3 = private unnamed_addr constant [15 x i8] c"custom: 30, 60\00"
  // ...
  call void @llvm.var.annotation(i8* ..., i8* getelementptr inbounds (
      [15 x i8], [15 x i8]* @3, i32 0, i32 0), i8* ..., i32 ..., i8* undef)
  // ...

As you see the annotation remains to be a string after the translation. It's
done so because we wouldn't be able to distinguish
[[clang::annotate("custom", 30, 60)]] from [[clang::annotate("custom, 30, 60")]]
as they both would result in the same UserSemantic decoration.

Also this patch brings a bit of refactoring of add Intel FPGA decoration functions,
since their infrustructure can (and should) be reused here, solving an issue of
incorrect allowed FPGA memory SPIR-V extensions processing.

TODO:
1. Replace this W/A with an extension, when it's ready;
2. Global annotation instruction isn't handled properly yet, its handling requires even
   more refactoring, which I plan to do, when the extension is ready;
3. Filename annotation is not being always and properly translated. To fix this additional
   round of refactoring is required, yet again it will be done with the new extension implementation.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>