### PR TITLE
Amend SingleElementVectorINTEL decoration use cases according to spec update

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -732,7 +732,10 @@ void LLVMToSPIRVBase::transVectorComputeMetadata(Function *F) {
     assert((RT->isTypeBool() || RT->isTypeFloat() || RT->isTypeInt() ||
             RT->isTypePointer()) &&
            "This decoration is valid only for Scalar or Pointer types");
-    BF->addDecorate(DecorationSingleElementVectorINTEL, StarsOnElement);
+    if (RT->isTypePointer())
+      BF->addDecorate(DecorationSingleElementVectorINTEL, StarsOnElement);
+    else
+      BF->addDecorate(DecorationSingleElementVectorINTEL);
   }
 
   for (Function::arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E;
@@ -756,7 +759,10 @@ void LLVMToSPIRVBase::transVectorComputeMetadata(Function *F) {
       assert((AT->isTypeBool() || AT->isTypeFloat() || AT->isTypeInt() ||
               AT->isTypePointer()) &&
              "This decoration is valid only for Scalar or Pointer types");
-      BA->addDecorate(DecorationSingleElementVectorINTEL, StarsOnElement);
+      if (AT->isTypePointer())
+        BA->addDecorate(DecorationSingleElementVectorINTEL, StarsOnElement);
+      else
+        BA->addDecorate(DecorationSingleElementVectorINTEL);
     }
   }
   if (!isKernel(F) &&
@@ -1540,7 +1546,10 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
         assert((RT->isFloatingPointTy() || RT->isIntegerTy() ||
                 RT->isPointerTy()) &&
                "This decoration is valid only for Scalar or Pointer types");
-        BVar->addDecorate(DecorationSingleElementVectorINTEL, StarsOnElement);
+        if (RT->isPointerTy())
+          BVar->addDecorate(DecorationSingleElementVectorINTEL, StarsOnElement);
+        else
+          BVar->addDecorate(DecorationSingleElementVectorINTEL);
       }
     }
 

--- a/test/transcoding/SPV_INTEL_vector_compute/decoration_single_element_vector.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/decoration_single_element_vector.ll
@@ -12,16 +12,19 @@ target datalayout = "e-p:64:64-i64:64-n8:16:32"
 target triple = "spir64"
 
 
+@global_var = external global i32** #2
 
 ; SPV-DAG: Name [[def:[0-9]+]] "_Z24__cm_intrinsic_impl_sdivu2CMvb1_cS_"
 ; SPV-DAG: Name [[a:[0-9]+]] "a"
 ; SPV-DAG: Name [[b:[0-9]+]] "b"
-; SPV-DAG: Decorate [[def]] SingleElementVectorINTEL
-; SPV-DAG: Decorate [[a]] SingleElementVectorINTEL
-; SPV-DAG: Decorate [[b]] SingleElementVectorINTEL
+; SPV-DAG: Name [[glob:[0-9]+]] "global_var"
+; SPV-DAG: Decorate [[def]] SingleElementVectorINTEL 0
+; SPV-DAG: Decorate [[a]] SingleElementVectorINTEL 0
+; SPV-DAG: Decorate [[b]] SingleElementVectorINTEL 0
+; SPV-DAG: Decorate [[glob]] SingleElementVectorINTEL 2
 
-; LLVM-DAG: "VCSingleElementVector" i8 @_Z24__cm_intrinsic_impl_sdivu2CMvb1_cS_(i8 "VCSingleElementVector" %a, i8 "VCSingleElementVector" %b)
-; LLVM-DAG: i8 @some.unknown.intrinsic(i8 "VCSingleElementVector", i8)
+; LLVM-DAG: "VCSingleElementVector"="0" i8 @_Z24__cm_intrinsic_impl_sdivu2CMvb1_cS_(i8 "VCSingleElementVector"="0" %a, i8 "VCSingleElementVector"="0" %b)
+; LLVM-DAG: i8 @some.unknown.intrinsic(i8 "VCSingleElementVector"="0", i8)
 ; Function Attrs: noinline norecurse nounwind readnone
 define dso_local "VCSingleElementVector" i8 @_Z24__cm_intrinsic_impl_sdivu2CMvb1_cS_(i8 "VCSingleElementVector" %a, i8 "VCSingleElementVector" %b) local_unnamed_addr #1 {
 entry:
@@ -47,4 +50,8 @@ entry:
 ; Function Attrs: nounwind readnone
 declare i8 @some.unknown.intrinsic(i8 "VCSingleElementVector", i8) #1
 
+; LLVM: "VCGlobalVariable"
+; LLVM-SAME: "VCSingleElementVector"="2"
+
 attributes #1 = { noinline norecurse nounwind readnone "VCFunction"}
+attributes #2 = { "VCGlobalVariable" "VCSingleElementVector"="2" }

--- a/test/transcoding/SPV_INTEL_vector_compute/decoration_single_element_vector.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/decoration_single_element_vector.ll
@@ -18,9 +18,9 @@ target triple = "spir64"
 ; SPV-DAG: Name [[a:[0-9]+]] "a"
 ; SPV-DAG: Name [[b:[0-9]+]] "b"
 ; SPV-DAG: Name [[glob:[0-9]+]] "global_var"
-; SPV-DAG: Decorate [[def]] SingleElementVectorINTEL 0
-; SPV-DAG: Decorate [[a]] SingleElementVectorINTEL 0
-; SPV-DAG: Decorate [[b]] SingleElementVectorINTEL 0
+; SPV-DAG: Decorate [[def]] SingleElementVectorINTEL
+; SPV-DAG: Decorate [[a]] SingleElementVectorINTEL
+; SPV-DAG: Decorate [[b]] SingleElementVectorINTEL
 ; SPV-DAG: Decorate [[glob]] SingleElementVectorINTEL 2
 
 ; LLVM-DAG: "VCSingleElementVector"="0" i8 @_Z24__cm_intrinsic_impl_sdivu2CMvb1_cS_(i8 "VCSingleElementVector"="0" %a, i8 "VCSingleElementVector"="0" %b)


### PR DESCRIPTION
Handling of SingleElementVectorINTEL decoration was amended to match new state of a spec: https://github.com/intel/llvm/pull/1612.