### PR TITLE
Add convergent attribute during reverse translation of OpControlBarrier

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3034,7 +3034,8 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
     if (isFuncNoUnwind())
       Func->addFnAttr(Attribute::NoUnwind);
     auto OC = BI->getOpCode();
-    if (isGroupOpCode(OC) || isIntelSubgroupOpCode(OC))
+    if (isGroupOpCode(OC) || isIntelSubgroupOpCode(OC) ||
+        OC == OpControlBarrier)
       Func->addFnAttr(Attribute::Convergent);
   }
   auto Call =

--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -89,7 +89,6 @@ void SPIRVToOCL12Base::visitCallSPIRVMemoryBarrier(CallInst *CI) {
 
 void SPIRVToOCL12Base::visitCallSPIRVControlBarrier(CallInst *CI) {
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  Attrs = Attrs.addFnAttribute(CI->getContext(), Attribute::Convergent);
   mutateCallInstOCL(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -97,7 +97,6 @@ void SPIRVToOCL20Base::visitCallSPIRVMemoryBarrier(CallInst *CI) {
 
 void SPIRVToOCL20Base::visitCallSPIRVControlBarrier(CallInst *CI) {
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  Attrs = Attrs.addFnAttribute(CI->getContext(), Attribute::Convergent);
   mutateCallInstOCL(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {

--- a/test/GroupAndSubgroupInstructions.spvasm
+++ b/test/GroupAndSubgroupInstructions.spvasm
@@ -78,7 +78,7 @@
 ; CHECK-SPV-IR: declare spir_func i1 @_Z16__spirv_GroupAllib(i32, i1) #[[#Attrs:]]
 ; CHECK-SPV-IR: declare spir_func i1 @_Z16__spirv_GroupAnyib(i32, i1) #[[#Attrs]]
 ; CHECK-SPV-IR: declare spir_func i32 @_Z22__spirv_GroupBroadcastiii(i32, i32, i32) #[[#Attrs]]
-; CHECK-SPV-IR: declare spir_func void @_Z22__spirv_ControlBarrieriii(i32, i32, i32) #0
+; CHECK-SPV-IR: declare spir_func void @_Z22__spirv_ControlBarrieriii(i32, i32, i32) #[[#Attrs]]
 ; CHECK-SPV-IR: declare spir_func i32 @_Z17__spirv_GroupIAddiii(i32, i32, i32) #[[#Attrs]]
 ; CHECK-SPV-IR: declare spir_func float @_Z17__spirv_GroupFAddiif(i32, i32, float) #[[#Attrs]]
 ; CHECK-SPV-IR: declare spir_func i32 @_Z17__spirv_GroupSMiniii(i32, i32, i32) #[[#Attrs]]

--- a/test/spirv-ocl-builtins-version.spt
+++ b/test/spirv-ocl-builtins-version.spt
@@ -64,5 +64,5 @@
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 784) [[attr]]
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2320) [[attr]]
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2832) [[attr]]
-; FIXME: shall we apply convergent attribute to SPIR-V friendly IR representaiton as well?
-; CHECK-LLVM-SPV-IR: attributes [[attr]] = { nounwind }
+; FIXME: shall we apply convergent attribute to SPIR-V friendly IR representaiton as well? (There is workaround to keep convergent attr for OpControlBarrier)
+; CHECK-LLVM-SPV-IR: attributes [[attr]] = { convergent nounwind }

--- a/test/spirv-ocl-builtins-version.spt
+++ b/test/spirv-ocl-builtins-version.spt
@@ -64,5 +64,5 @@
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 784) [[attr]]
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2320) [[attr]]
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2832) [[attr]]
-; FIXME: shall we apply convergent attribute to SPIR-V friendly IR representaiton as well? (There is workaround to keep convergent attr for OpControlBarrier)
+; FIXME: shall we apply convergent attribute to SPIR-V friendly IR representaiton as well?
 ; CHECK-LLVM-SPV-IR: attributes [[attr]] = { convergent nounwind }


### PR DESCRIPTION
There is a patch to keep convergent attr during translation of
OpControlBarrier to prevent optimization passes from making barrier calls
control-dependent.