### PR TITLE
Fix duplication of global annotation strings in reverse translation

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3400,9 +3400,9 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
     SmallString<256> AnnotStr;
     generateIntelFPGAAnnotation(BV, AnnotStr);
     if (!AnnotStr.empty()) {
-      Constant* GS = nullptr;
+      Constant *GS = nullptr;
       std::string StringAnnotStr = AnnotStr.c_str();
-      static unordered_map<std::string, Constant*> Annotations;
+      static unordered_map<std::string, Constant *> Annotations;
       if (Annotations.find(StringAnnotStr) != Annotations.end())
         GS = Annotations[StringAnnotStr];
       else {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3402,12 +3402,11 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
     if (!AnnotStr.empty()) {
       Constant *GS = nullptr;
       std::string StringAnnotStr = AnnotStr.c_str();
-      static unordered_map<std::string, Constant *> Annotations;
-      if (Annotations.find(StringAnnotStr) != Annotations.end())
-        GS = Annotations[StringAnnotStr];
-      else {
+      if (AnnotationsMap.find(StringAnnotStr) != AnnotationsMap.end()) {
+        GS = AnnotationsMap[StringAnnotStr];
+      } else {
         GS = Builder.CreateGlobalStringPtr(AnnotStr);
-        Annotations.insert(std::make_pair(StringAnnotStr, GS));
+        AnnotationsMap.insert(std::make_pair(StringAnnotStr, GS));
       }
 
       Value *BaseInst =

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3400,7 +3400,15 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
     SmallString<256> AnnotStr;
     generateIntelFPGAAnnotation(BV, AnnotStr);
     if (!AnnotStr.empty()) {
-      auto *GS = Builder.CreateGlobalStringPtr(AnnotStr);
+      Constant* GS = nullptr;
+      std::string StringAnnotStr = AnnotStr.c_str();
+      static unordered_map<std::string, Constant*> Annotations;
+      if (Annotations.find(StringAnnotStr) != Annotations.end())
+        GS = Annotations[StringAnnotStr];
+      else {
+        GS = Builder.CreateGlobalStringPtr(AnnotStr);
+        Annotations.insert(std::make_pair(StringAnnotStr, GS));
+      }
 
       Value *BaseInst =
           AL ? Builder.CreateBitCast(V, Int8PtrTyPrivate, V->getName()) : Inst;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3404,7 +3404,7 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
       std::string StringAnnotStr = AnnotStr.c_str();
       auto AnnotItr = AnnotationsMap.find(StringAnnotStr);
       if (AnnotItr != AnnotationsMap.end()) {
-        GS = AnnotItr->second();
+        GS = AnnotItr->second;
       } else {
         GS = Builder.CreateGlobalStringPtr(AnnotStr);
         AnnotationsMap.emplace(std::move(StringAnnotStr), GS);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3402,11 +3402,12 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
     if (!AnnotStr.empty()) {
       Constant *GS = nullptr;
       std::string StringAnnotStr = AnnotStr.c_str();
-      if (AnnotationsMap.find(StringAnnotStr) != AnnotationsMap.end()) {
-        GS = AnnotationsMap[StringAnnotStr];
+      auto AnnotItr = AnnotationsMap.find(StringAnnotStr);
+      if (AnnotItr != AnnotationsMap.end()) {
+        GS = AnnotItr->second();
       } else {
         GS = Builder.CreateGlobalStringPtr(AnnotStr);
-        AnnotationsMap.insert(std::make_pair(StringAnnotStr, GS));
+        AnnotationsMap.emplace(std::move(StringAnnotStr), GS);
       }
 
       Value *BaseInst =

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -158,6 +158,9 @@ private:
   SPIRVBlockToLLVMStructMap BlockMap;
   SPIRVToLLVMPlaceholderMap PlaceholderMap;
   std::unique_ptr<SPIRVToLLVMDbgTran> DbgTran;
+  // GlobalAnnotations collects array of annotation entries
+  // for global variables and functions.
+  // They are used in translation of llvm.global.annotations instruction.
   std::vector<Constant *> GlobalAnnotations;
   // There is also GlobalAnnotations vector which is used to store arrays of
   // arguments for llvm.global.annotations instructions. But SPIR-V may also

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -162,14 +162,11 @@ private:
   // for global variables and functions.
   // They are used in translation of llvm.global.annotations instruction.
   std::vector<Constant *> GlobalAnnotations;
-  // There is also GlobalAnnotations vector which is used to store arrays of
-  // arguments for llvm.global.annotations instructions. But SPIR-V may also
-  // contain annotations for llvm.ptr.annotation.
-  // During reverse translation we need to check if a similar annotation with
-  // the same string has already been translated to avoid duplication of these
-  // global strings in LLVM-IR, which can be caused by multiple translation of
-  // UserSemantic decorations with the same literal. This map is used to store
-  // global strings by their annotations.
+  // AnnotationsMap helps to translate annotation strings for local variables.
+  // Map values are pointers on global strings in LLVM-IR.
+  // It is used to avoid duplication of these annotation strings in LLVM-IR,
+  // which can be caused by multiple translation of
+  // UserSemantic decorations with the same literal.
   std::unordered_map<std::string, Constant *> AnnotationsMap;
 
   // Loops metadata is translated in the end of a function translation.

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -158,15 +158,14 @@ private:
   SPIRVBlockToLLVMStructMap BlockMap;
   SPIRVToLLVMPlaceholderMap PlaceholderMap;
   std::unique_ptr<SPIRVToLLVMDbgTran> DbgTran;
-  // GlobalAnnotations collects array of annotation entries
-  // for global variables and functions.
-  // They are used in translation of llvm.global.annotations instruction.
+  // GlobalAnnotations collects array of annotation entries for global variables
+  // and functions. They are used in translation of llvm.global.annotations
+  // instruction.
   std::vector<Constant *> GlobalAnnotations;
   // AnnotationsMap helps to translate annotation strings for local variables.
-  // Map values are pointers on global strings in LLVM-IR.
-  // It is used to avoid duplication of these annotation strings in LLVM-IR,
-  // which can be caused by multiple translation of
-  // UserSemantic decorations with the same literal.
+  // Map values are pointers on global strings in LLVM-IR. It is used to avoid
+  // duplication of these annotation strings in LLVM-IR, which can be caused by
+  // multiple translation of UserSemantic decorations with the same literal.
   std::unordered_map<std::string, Constant *> AnnotationsMap;
 
   // Loops metadata is translated in the end of a function translation.

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -159,6 +159,7 @@ private:
   SPIRVToLLVMPlaceholderMap PlaceholderMap;
   std::unique_ptr<SPIRVToLLVMDbgTran> DbgTran;
   std::vector<Constant *> GlobalAnnotations;
+  std::unordered_map<std::string, Constant *> AnnotationsMap;
 
   // Loops metadata is translated in the end of a function translation.
   // This storage contains pairs of translated loop header basic block and loop

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -159,10 +159,14 @@ private:
   SPIRVToLLVMPlaceholderMap PlaceholderMap;
   std::unique_ptr<SPIRVToLLVMDbgTran> DbgTran;
   std::vector<Constant *> GlobalAnnotations;
-  // This map is used to store global annotation strings by their annotations
-  // to avoid duplication of these global strings in LLVM-IR after reverse
-  // translation that can be caused by multiple translation of UserSemantic
-  // decorations with the same annotation.
+  // There is also GlobalAnnotations vector which is used to store arrays of
+  // arguments for llvm.global.annotations instructions. But SPIR-V may also
+  // contain annotations for llvm.ptr.annotation.
+  // During reverse translation we need to check if a similar annotation with
+  // the same string has already been translated to avoid duplication of these
+  // global strings in LLVM-IR, which can be caused by multiple translation of
+  // UserSemantic decorations with the same literal. This map is used to store
+  // global strings by their annotations.
   std::unordered_map<std::string, Constant *> AnnotationsMap;
 
   // Loops metadata is translated in the end of a function translation.

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -159,6 +159,10 @@ private:
   SPIRVToLLVMPlaceholderMap PlaceholderMap;
   std::unique_ptr<SPIRVToLLVMDbgTran> DbgTran;
   std::vector<Constant *> GlobalAnnotations;
+  // This map is used to store global annotation strings by their annotations
+  // to avoid duplication of these global strings in LLVM-IR after reverse
+  // translation that can be caused by multiple translation of UserSemantic
+  // decorations with the same annotation.
   std::unordered_map<std::string, Constant *> AnnotationsMap;
 
   // Loops metadata is translated in the end of a function translation.

--- a/test/transcoding/IntelFPGAMemoryAccesses.ll
+++ b/test/transcoding/IntelFPGAMemoryAccesses.ll
@@ -81,10 +81,6 @@ target triple = "spir64-unknown-unknown"
 @.str.5 = private unnamed_addr constant [27 x i8] c"{params:0}{cache-size:127}\00", section "llvm.metadata"
 ; CHECK-LLVM: [[PARAM_15_CACHE_127:@[a-z0-9_.]+]] = {{.*}}{params:15}{cache-size:127}
 @.str.6 = private unnamed_addr constant [28 x i8] c"{params:15}{cache-size:127}\00", section "llvm.metadata"
-; TODO: Investigate why the same global annotation string shows up twice in backwards translation.
-; CHECK-LLVM: [[PARAM_3_CACHE_0_DOUBLE:@[a-z0-9_.]+]] = {{.*}}{params:3}{cache-size:0}
-; CHECK-LLVM: [[PARAM_3_CACHE_0_DOUBLE2:@[a-z0-9_.]+]] = {{.*}}{params:3}{cache-size:0}
-; CHECK-LLVM: [[PARAM_12_CACHE_0_DOUBLE:@[a-z0-9_.]+]] = {{.*}}{params:12}
 
 ; Function Attrs: norecurse nounwind
 define spir_kernel void @_ZTSZ4mainE11fake_kernel() #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
@@ -206,14 +202,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 8, i8* %15) #5
 ; CHECK-LLVM: %[[FLOAT_FUNC_PARAM_LOAD:[[:alnum:].]+]] = load float addrspace(4)*, float addrspace(4)** %[[FLOAT_FUNC_PARAM]]
 ; CHECK-LLVM: %[[BITCAST_FLOAT_TO_DOUBLE:[[:alnum:].]+]] = bitcast float addrspace(4)* %[[FLOAT_FUNC_PARAM_LOAD]] to double addrspace(4)*
-; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call double addrspace(4)* @llvm.ptr.annotation.p4f64(double addrspace(4)* %[[BITCAST_FLOAT_TO_DOUBLE]], i8* getelementptr inbounds ({{.*}} [[PARAM_3_CACHE_0_DOUBLE]]
+; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call double addrspace(4)* @llvm.ptr.annotation.p4f64(double addrspace(4)* %[[BITCAST_FLOAT_TO_DOUBLE]], i8* getelementptr inbounds ({{.*}} [[PARAM_3_CACHE_0]]
 ; CHECK-LLVM: store double addrspace(4)* %[[INTRINSIC_CALL]], double addrspace(4)** %[[DOUBLE_VAR]]
   %16 = load float addrspace(4)*, float addrspace(4)** %A.addr, align 8, !tbaa !5
   %17 = bitcast float addrspace(4)* %16 to double addrspace(4)*
   %18 = call double addrspace(4)* @llvm.ptr.annotation.p4f64(double addrspace(4)* %17, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str.1, i32 0, i32 0), i32 0, i8* null) #6
   store double addrspace(4)* %18, double addrspace(4)** %t, align 8, !tbaa !5
 ; CHECK-LLVM: %[[FLOAT_FUNC_PARAM_LOAD:[[:alnum:].]+]] = load float addrspace(4)*, float addrspace(4)** %[[FLOAT_FUNC_PARAM]]
-; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call float addrspace(4)* @llvm.ptr.annotation.p4f32(float addrspace(4)* %[[FLOAT_FUNC_PARAM_LOAD]], i8* getelementptr inbounds ({{.*}} [[PARAM_3_CACHE_0_DOUBLE2]]
+; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call float addrspace(4)* @llvm.ptr.annotation.p4f32(float addrspace(4)* %[[FLOAT_FUNC_PARAM_LOAD]], i8* getelementptr inbounds ({{.*}} [[PARAM_3_CACHE_0]]
 ; CHECK-LLVM: store float 5.000000e+00, float addrspace(4)* %[[INTRINSIC_CALL]]
   %19 = load float addrspace(4)*, float addrspace(4)** %A.addr, align 8, !tbaa !5
   %20 = call float addrspace(4)* @llvm.ptr.annotation.p4f32(float addrspace(4)* %19, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str.1, i32 0, i32 0), i32 0, i8* null) #6
@@ -221,7 +217,7 @@ entry:
   %21 = bitcast i32* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %21) #5
 ; CHECK-LLVM: %[[INT1_FUNC_PARAM_LOAD:[[:alnum:].]+]] = load i32 addrspace(4)*, i32 addrspace(4)** %[[INT_FUNC_PARAM]]
-; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call i32 addrspace(4)* @llvm.ptr.annotation.p4i32(i32 addrspace(4)* %[[INT1_FUNC_PARAM_LOAD]], i8* getelementptr inbounds ({{.*}} [[PARAM_12_CACHE_0_DOUBLE]]
+; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call i32 addrspace(4)* @llvm.ptr.annotation.p4i32(i32 addrspace(4)* %[[INT1_FUNC_PARAM_LOAD]], i8* getelementptr inbounds ({{.*}} [[PARAM_12_CACHE_0]]
 ; CHECK-LLVM: %[[INTRINSIC_RESULT_LOAD:[[:alnum:].]+]] = load i32, i32 addrspace(4)* %[[INTRINSIC_CALL]]
 ; CHECK-LLVM: store i32 %[[INTRINSIC_RESULT_LOAD]], i32* %[[INT_VAR_1]]
   %22 = load i32 addrspace(4)*, i32 addrspace(4)** %B.addr, align 8, !tbaa !5

--- a/test/transcoding/IntelFPGAMemoryAttributes.ll
+++ b/test/transcoding/IntelFPGAMemoryAttributes.ll
@@ -274,41 +274,30 @@ target triple = "spir"
 
 ; CHECK-LLVM: [[STR_NMB_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:16}
 ; CHECK-LLVM: [[STR_NMB_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:2}
-; CHECK-LLVM: [[STR_NMB_TE1:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:4}
-; CHECK-LLVM: [[STR_NMB_TE2:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:4}
+; CHECK-LLVM: [[STR_NMB_TE:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:4}
 ; CHECK-LLVM: [[STR_REG_VAR:@[0-9_.]+]] = {{.*}}{register:1}
-; CHECK-LLVM: [[STR_REG_SCT:@[0-9_.]+]] = {{.*}}{register:1}
 ; CHECK-LLVM: [[STR_MEM_VAR:@[0-9_.]+]] = {{.*}}{memory:MLAB}
 ; CHECK-LLVM: [[STR_MEM_SCT:@[0-9_.]+]] = {{.*}}{memory:BLOCK_RAM}
 ; CHECK-LLVM: [[STR_BWD_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:8}
 ; CHECK-LLVM: [[STR_BWD_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:4}
-; CHECK-LLVM: [[STR_BWD_TE1:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:16}
-; CHECK-LLVM: [[STR_BWD_TE2:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:16}
+; CHECK-LLVM: [[STR_BWD_TE:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{bankwidth:16}
 ; CHECK-LLVM: [[STR_PRC_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{private_copies:4}
 ; CHECK-LLVM: [[STR_PRC_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{private_copies:2}
-; CHECK-LLVM: [[STR_PRC_TE1:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{private_copies:8}
-; CHECK-LLVM: [[STR_PRC_TE2:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{private_copies:8}
+; CHECK-LLVM: [[STR_PRC_TE:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{private_copies:8}
 ; CHECK-LLVM: [[STR_SNP_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{pump:1}
-; CHECK-LLVM: [[STR_SNP_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{pump:1}
 ; CHECK-LLVM: [[STR_DBP_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{pump:2}
-; CHECK-LLVM: [[STR_DBP_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{pump:2}
 ; CHECK-LLVM: [[STR_MRG_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{merge:foo:depth}
 ; CHECK-LLVM: [[STR_MRG_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{merge:bar:width}
 ; CHECK-LLVM: [[STR_MXR_VAR:@[0-9_.]+]] = {{.*}}{max_replicates:4}
 ; CHECK-LLVM: [[STR_MXR_SCT:@[0-9_.]+]] = {{.*}}{max_replicates:2}
-; CHECK-LLVM: [[STR_MXR_TE1:@[0-9_.]+]] = {{.*}}{max_replicates:8}
-; CHECK-LLVM: [[STR_MXR_TE2:@[0-9_.]+]] = {{.*}}{max_replicates:8}
+; CHECK-LLVM: [[STR_MXR_TE:@[0-9_.]+]] = {{.*}}{max_replicates:8}
 ; CHECK-LLVM: [[STR_SDP_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{simple_dual_port:1}
-; CHECK-LLVM: [[STR_SDP_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{simple_dual_port:1}
 ; CHECK-LLVM: [[STR_BBT_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:8}{bank_bits:2,1,0}
 ; CHECK-LLVM: [[STR_BBT_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:2}{bank_bits:2}
 ; CHECK-LLVM: [[STR_BBT_TE1:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:4}{bank_bits:4,5}
 ; CHECK-LLVM: [[STR_BBT_TE2:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{numbanks:2}{bank_bits:5}
 ; CHECK-LLVM: [[STR_FP2_VAR:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{force_pow2_depth:0}
 ; CHECK-LLVM: [[STR_FP2_SCT:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{force_pow2_depth:1}
-; CHECK-LLVM: [[STR_FP2_TE1:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{force_pow2_depth:1}
-; CHECK-LLVM: [[STR_FP2_TE2:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}{force_pow2_depth:1}
-; CHECK-LLVM: [[STR_REG_ARR:@[0-9_.]+]] = {{.*}}{register:1}
 @.str = private unnamed_addr constant [42 x i8] c"{memory:DEFAULT}{sizeinfo:4}{numbanks:16}\00", section "llvm.metadata"
 @.str.1 = private unnamed_addr constant [25 x i8] c"intel-fpga-local-var.cpp\00", section "llvm.metadata"
 @.str.2 = private unnamed_addr constant [41 x i8] c"{memory:DEFAULT}{sizeinfo:4}{numbanks:2}\00", section "llvm.metadata"
@@ -418,12 +407,12 @@ entry:
   %0 = bitcast i32* %templ_numbanks_var to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #5
   %templ_numbanks_var1 = bitcast i32* %templ_numbanks_var to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_NMB_TE1]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_NMB_TE]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %templ_numbanks_var1, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @.str.3, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 12, i8* null)
   %1 = bitcast %struct.templ_numbanks_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.templ_numbanks_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_NMB_TE2]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_NMB_TE]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([41 x i8], [41 x i8]* @.str.3, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 16, i8* null)
   %field = getelementptr inbounds %struct.templ_numbanks_st, %struct.templ_numbanks_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !12
@@ -447,7 +436,7 @@ entry:
   %1 = bitcast %struct.register_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.register_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_REG_SCT]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_REG_VAR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 25, i8* null)
   %field = getelementptr inbounds %struct.register_st, %struct.register_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !14
@@ -516,12 +505,12 @@ entry:
   %0 = bitcast i32* %templ_bankwidth_var to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #5
   %templ_bankwidth_var1 = bitcast i32* %templ_bankwidth_var to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_BWD_TE1]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_BWD_TE]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %templ_bankwidth_var1, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @.str.9, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 49, i8* null)
   %1 = bitcast %struct.templ_bankwidth_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.templ_bankwidth_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_BWD_TE2]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_BWD_TE]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([43 x i8], [43 x i8]* @.str.9, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 53, i8* null)
   %field = getelementptr inbounds %struct.templ_bankwidth_st, %struct.templ_bankwidth_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !19
@@ -564,12 +553,12 @@ entry:
   %0 = bitcast i32* %templ_priv_copies_var to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #5
   %templ_priv_copies_var1 = bitcast i32* %templ_priv_copies_var to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_PRC_TE1]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_PRC_TE]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %templ_priv_copies_var1, i8* getelementptr inbounds ([47 x i8], [47 x i8]* @.str.12, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 68, i8* null)
   %1 = bitcast %struct.templ_priv_copies_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.templ_priv_copies_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_PRC_TE2]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_PRC_TE]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([47 x i8], [47 x i8]* @.str.12, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 72, i8* null)
   %field = getelementptr inbounds %struct.templ_priv_copies_st, %struct.templ_priv_copies_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !23
@@ -593,7 +582,7 @@ entry:
   %1 = bitcast %struct.singlepump_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.singlepump_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_SNP_SCT]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_SNP_VAR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([37 x i8], [37 x i8]* @.str.13, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 81, i8* null)
   %field = getelementptr inbounds %struct.singlepump_st, %struct.singlepump_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !25
@@ -617,7 +606,7 @@ entry:
   %1 = bitcast %struct.doublepump_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.doublepump_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_DBP_SCT]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_DBP_VAR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([37 x i8], [37 x i8]* @.str.14, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 90, i8* null)
   %field = getelementptr inbounds %struct.doublepump_st, %struct.doublepump_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !27
@@ -684,12 +673,12 @@ entry:
   %0 = bitcast i32* %templ_max_repl_var to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #5
   %templ_max_repl_var1 = bitcast i32* %templ_max_repl_var to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_MXR_TE1]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_MXR_TE]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %templ_max_repl_var1, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.19, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 114, i8* null)
   %1 = bitcast %struct.templ_max_repl_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.templ_max_repl_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_MXR_TE2]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_MXR_TE]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.19, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 118, i8* null)
   %field = getelementptr inbounds %struct.templ_max_repl_st, %struct.templ_max_repl_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !33
@@ -713,7 +702,7 @@ entry:
   %1 = bitcast %struct.simple_dual_port_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.simple_dual_port_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_SDP_SCT]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_SDP_VAR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([49 x i8], [49 x i8]* @.str.20, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 127, i8* null)
   %field = getelementptr inbounds %struct.simple_dual_port_st, %struct.simple_dual_port_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !35
@@ -804,12 +793,12 @@ entry:
   %0 = bitcast i32* %templ_fp2d_var to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #5
   %templ_fp2d_var1 = bitcast i32* %templ_fp2d_var to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_FP2_TE1]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_FP2_SCT]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %templ_fp2d_var1, i8* getelementptr inbounds ([49 x i8], [49 x i8]* @.str.26, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 161, i8* null)
   %1 = bitcast %struct.templ_fp2d_st* %s to i8*
   call void @llvm.lifetime.start.p0i8(i64 4, i8* %1) #5
   %s2 = bitcast %struct.templ_fp2d_st* %s to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_FP2_TE2]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_FP2_SCT]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %s2, i8* getelementptr inbounds ([49 x i8], [49 x i8]* @.str.26, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 165, i8* null)
   %field = getelementptr inbounds %struct.templ_fp2d_st, %struct.templ_fp2d_st* %s, i32 0, i32 0
   store i32 0, i32* %field, align 4, !tbaa !43
@@ -827,7 +816,7 @@ entry:
   %register_var.ascast = addrspacecast [32 x i32]* %register_var to [32 x i32] addrspace(4)*
   %register_var.ascast1 = bitcast [32 x i32] addrspace(4)* %register_var.ascast to i8 addrspace(4)*
   %register_var.ascast2 = addrspacecast i8 addrspace(4)* %register_var.ascast1 to i8*
-  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_.]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_REG_ARR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  ; CHECK-LLVM: call void @llvm.var.annotation(i8* %{{[a-zA-Z0-9_.]+}}, i8* getelementptr inbounds ([{{[0-9]+}} x i8], [{{[0-9]+}} x i8]* [[STR_REG_VAR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
   call void @llvm.var.annotation(i8* %register_var.ascast2, i8* getelementptr inbounds ([13 x i8], [13 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.1, i32 0, i32 0), i32 2, i8* null)
   ret void
 }


### PR DESCRIPTION
This is a patch to avoid duplication of global annotation strings in reverse
translation caused by the fact that translator translates each
UserSemantic decoration, even if a similar decoration with the same string
has also been translated.