### PR TITLE
Translate OpOrdered and OpUnordered to fcmp instructions

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -600,7 +600,7 @@ SPIRVToLLVM::transValue(const std::vector<SPIRVValue *> &BV, Function *F,
 
 bool SPIRVToLLVM::isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const {
   auto OC = BI->getOpCode();
-  return isCmpOpCode(OC) && !(OC >= OpLessOrGreater && OC <= OpUnordered);
+  return isCmpOpCode(OC) && OC != OpLessOrGreater;
 }
 
 void SPIRVToLLVM::setName(llvm::Value *V, SPIRVValue *BV) {

--- a/test/transcoding/fcmp.ll
+++ b/test/transcoding/fcmp.ll
@@ -229,9 +229,9 @@
 ; CHECK-LLVM: %r40 = fcmp oge float %a, %b
 ; CHECK-LLVM: %r41 = fcmp oge float %a, %b
 ; CHECK-LLVM: %r42 = fcmp oge float %a, %b
-; CHECK-LLVM: %r43 = call spir_func i32 @_Z9isorderedff(float %a, float %b)
-; CHECK-LLVM: %r44 = call spir_func i32 @_Z9isorderedff(float %a, float %b)
-; CHECK-LLVM: %r45 = call spir_func i32 @_Z9isorderedff(float %a, float %b)
+; CHECK-LLVM: %r43 = fcmp ord float %a, %b
+; CHECK-LLVM: %r44 = fcmp ord float %a, %b
+; CHECK-LLVM: %r45 = fcmp ord float %a, %b
 ; CHECK-LLVM: %r46 = fcmp ueq float %a, %b
 ; CHECK-LLVM: %r47 = fcmp ueq float %a, %b
 ; CHECK-LLVM: %r48 = fcmp ueq float %a, %b
@@ -274,9 +274,9 @@
 ; CHECK-LLVM: %r85 = fcmp uge float %a, %b
 ; CHECK-LLVM: %r86 = fcmp uge float %a, %b
 ; CHECK-LLVM: %r87 = fcmp uge float %a, %b
-; CHECK-LLVM: %r88 = call spir_func i32 @_Z11isunorderedff(float %a, float %b)
-; CHECK-LLVM: %r89 = call spir_func i32 @_Z11isunorderedff(float %a, float %b)
-; CHECK-LLVM: %r90 = call spir_func i32 @_Z11isunorderedff(float %a, float %b)
+; CHECK-LLVM: %r88 = fcmp uno float %a, %b
+; CHECK-LLVM: %r89 = fcmp uno float %a, %b
+; CHECK-LLVM: %r90 = fcmp uno float %a, %b
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"

--- a/test/transcoding/relationals_float.ll
+++ b/test/transcoding/relationals_float.ll
@@ -12,16 +12,16 @@
 ; CHECK-LLVM: call spir_func i32 @_Z8isnormalf(
 ; CHECK-LLVM: call spir_func i32 @_Z7signbitf(
 ; CHECK-LLVM: call spir_func i32 @_Z13islessgreaterff(
-; CHECK-LLVM: call spir_func i32 @_Z9isorderedff(
-; CHECK-LLVM: call spir_func i32 @_Z11isunorderedff(
+; CHECK-LLVM: fcmp ord float
+; CHECK-LLVM: fcmp uno float
 
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z8isfiniteDv2_f(
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z5isnanDv2_f(
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z5isinfDv2_f(
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z8isnormalDv2_f(
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z13islessgreaterDv2_fS_(
-; CHECK-LLVM: call spir_func <2 x i32> @_Z9isorderedDv2_fS_(
-; CHECK-LLVM: call spir_func <2 x i32> @_Z11isunorderedDv2_fS_(
+; CHECK-LLVM: fcmp ord <2 x float>
+; CHECK-LLVM: fcmp uno <2 x float>
 
 ; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
 ; CHECK-SPIRV: 4 TypeVector [[BoolVectorTypeID:[0-9]+]] [[BoolTypeID]] 2

--- a/test/transcoding/relationals_half.ll
+++ b/test/transcoding/relationals_half.ll
@@ -12,16 +12,16 @@
 ; CHECK-LLVM: call spir_func i32 @_Z8isnormalDh(
 ; CHECK-LLVM: call spir_func i32 @_Z7signbitDh(
 ; CHECK-LLVM: call spir_func i32 @_Z13islessgreaterDhDh(
-; CHECK-LLVM: call spir_func i32 @_Z9isorderedDhDh(
-; CHECK-LLVM: call spir_func i32 @_Z11isunorderedDhDh(
+; CHECK-LLVM: fcmp ord half
+; CHECK-LLVM: fcmp uno half
 
 ; CHECK-LLVM: call spir_func <2 x i16> @_Z8isfiniteDv2_Dh(
 ; CHECK-LLVM: call spir_func <2 x i16> @_Z5isnanDv2_Dh(
 ; CHECK-LLVM: call spir_func <2 x i16> @_Z5isinfDv2_Dh(
 ; CHECK-LLVM: call spir_func <2 x i16> @_Z8isnormalDv2_Dh(
 ; CHECK-LLVM: call spir_func <2 x i16> @_Z13islessgreaterDv2_DhS_(
-; CHECK-LLVM: call spir_func <2 x i16> @_Z9isorderedDv2_DhS_(
-; CHECK-LLVM: call spir_func <2 x i16> @_Z11isunorderedDv2_DhS_(
+; CHECK-LLVM: fcmp ord <2 x half>
+; CHECK-LLVM: fcmp uno <2 x half>
 
 ; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
 ; CHECK-SPIRV: 4 TypeVector [[BoolVectorTypeID:[0-9]+]] [[BoolTypeID]] 2


### PR DESCRIPTION
Instead of translating this instructions to OCL builtin calls, use core llvm
fcmp instructions for better code preservation during translation.