### PR TITLE
Clean up translation of islessgreater() and OpLessOrGreater

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -293,7 +293,7 @@ template <> void SPIRVMap<std::string, Op, SPIRVInstruction>::init() {
   _SPIRV_OP(isgreaterequal, FOrdGreaterThanEqual)
   _SPIRV_OP(isless, FOrdLessThan)
   _SPIRV_OP(islessequal, FOrdLessThanEqual)
-  _SPIRV_OP(islessgreater, LessOrGreater)
+  _SPIRV_OP(islessgreater, FOrdNotEqual)
   _SPIRV_OP(isordered, Ordered)
   _SPIRV_OP(isunordered, Unordered)
   _SPIRV_OP(isfinite, IsFinite)

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -598,11 +598,6 @@ SPIRVToLLVM::transValue(const std::vector<SPIRVValue *> &BV, Function *F,
   return V;
 }
 
-bool SPIRVToLLVM::isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const {
-  auto OC = BI->getOpCode();
-  return isCmpOpCode(OC) && OC != OpLessOrGreater;
-}
-
 void SPIRVToLLVM::setName(llvm::Value *V, SPIRVValue *BV) {
   auto Name = BV->getName();
   if (!Name.empty() && (!V->hasName() || Name != V->getName()))
@@ -1113,6 +1108,9 @@ Value *SPIRVToLLVM::transCmpInst(SPIRVValue *BV, BasicBlock *BB, Function *F) {
   if (BB) {
     Builder.SetInsertPoint(BB);
   }
+
+  if (OP == OpLessOrGreater)
+    OP = OpFOrdNotEqual;
 
   if (BT->isTypeVectorOrScalarInt() || BT->isTypeVectorOrScalarBool() ||
       BT->isTypePointer())
@@ -2490,7 +2488,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   default: {
     auto OC = BV->getOpCode();
-    if (isSPIRVCmpInstTransToLLVMInst(static_cast<SPIRVInstruction *>(BV)))
+    if (isCmpOpCode(OC))
       return mapValue(BV, transCmpInst(BV, BB, F));
 
     if (OCLSPIRVBuiltinMap::rfind(OC, nullptr))

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -194,7 +194,6 @@ private:
     return BuiltInConstFunc.count(Name);
   }
 
-  bool isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const;
   bool isDirectlyTranslatedToOCL(Op OpCode) const;
   MDString *transOCLKernelArgTypeName(SPIRVFunctionParameter *);
   Value *mapFunction(SPIRVFunction *BF, Function *F);

--- a/test/transcoding/relationals_float.ll
+++ b/test/transcoding/relationals_float.ll
@@ -11,7 +11,7 @@
 ; CHECK-LLVM: call spir_func i32 @_Z5isinff(
 ; CHECK-LLVM: call spir_func i32 @_Z8isnormalf(
 ; CHECK-LLVM: call spir_func i32 @_Z7signbitf(
-; CHECK-LLVM: call spir_func i32 @_Z13islessgreaterff(
+; CHECK-LLVM: fcmp one float
 ; CHECK-LLVM: fcmp ord float
 ; CHECK-LLVM: fcmp uno float
 
@@ -19,7 +19,7 @@
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z5isnanDv2_f(
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z5isinfDv2_f(
 ; CHECK-LLVM: call spir_func <2 x i32> @_Z8isnormalDv2_f(
-; CHECK-LLVM: call spir_func <2 x i32> @_Z13islessgreaterDv2_fS_(
+; CHECK-LLVM: fcmp one <2 x float>
 ; CHECK-LLVM: fcmp ord <2 x float>
 ; CHECK-LLVM: fcmp uno <2 x float>
 
@@ -31,7 +31,7 @@
 ; CHECK-SPIRV: 4 IsInf [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolTypeID]]
 ; CHECK-SPIRV: 4 SignBitSet [[BoolTypeID]]
-; CHECK-SPIRV: 5 LessOrGreater [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdNotEqual [[BoolTypeID]]
 ; CHECK-SPIRV: 5 Ordered [[BoolTypeID]]
 ; CHECK-SPIRV: 5 Unordered [[BoolTypeID]]
 
@@ -39,7 +39,7 @@
 ; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsInf [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolVectorTypeID]]
-; CHECK-SPIRV: 5 LessOrGreater [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdNotEqual [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 Ordered [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 Unordered [[BoolVectorTypeID]]
 

--- a/test/transcoding/relationals_half.ll
+++ b/test/transcoding/relationals_half.ll
@@ -11,7 +11,7 @@
 ; CHECK-LLVM: call spir_func i32 @_Z5isinfDh(
 ; CHECK-LLVM: call spir_func i32 @_Z8isnormalDh(
 ; CHECK-LLVM: call spir_func i32 @_Z7signbitDh(
-; CHECK-LLVM: call spir_func i32 @_Z13islessgreaterDhDh(
+; CHECK-LLVM: fcmp one half
 ; CHECK-LLVM: fcmp ord half
 ; CHECK-LLVM: fcmp uno half
 
@@ -19,7 +19,7 @@
 ; CHECK-LLVM: call spir_func <2 x i16> @_Z5isnanDv2_Dh(
 ; CHECK-LLVM: call spir_func <2 x i16> @_Z5isinfDv2_Dh(
 ; CHECK-LLVM: call spir_func <2 x i16> @_Z8isnormalDv2_Dh(
-; CHECK-LLVM: call spir_func <2 x i16> @_Z13islessgreaterDv2_DhS_(
+; CHECK-LLVM: fcmp one <2 x half>
 ; CHECK-LLVM: fcmp ord <2 x half>
 ; CHECK-LLVM: fcmp uno <2 x half>
 
@@ -31,7 +31,7 @@
 ; CHECK-SPIRV: 4 IsInf [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolTypeID]]
 ; CHECK-SPIRV: 4 SignBitSet [[BoolTypeID]]
-; CHECK-SPIRV: 5 LessOrGreater [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdNotEqual [[BoolTypeID]]
 ; CHECK-SPIRV: 5 Ordered [[BoolTypeID]]
 ; CHECK-SPIRV: 5 Unordered [[BoolTypeID]]
 
@@ -39,7 +39,7 @@
 ; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsInf [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolVectorTypeID]]
-; CHECK-SPIRV: 5 LessOrGreater [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdNotEqual [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 Ordered [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 Unordered [[BoolVectorTypeID]]
 


### PR DESCRIPTION
Translate `islessgreater()` to _OpFOrdNotEqual_ instead of _OpLessOrGreater_, which is deprecated as of SPIR-V 1.5 revision 2, and has identical semantics.

Translate _OpLessOrGreater_ to `fcmp one` instead of `islessgreater()`, which has identical semantics.