### PR TITLE
Set generator ID in generated SPIR-V

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -63,6 +63,9 @@ class IntrinsicInst;
 
 namespace SPIRV {
 
+// The LLVM/SPIR-V translator identifier (see vendor section of spir-v.xml)
+const static unsigned short kTranslatorId = 6;
+
 /// The LLVM/SPIR-V translator version used to fill the lower 16 bits of the
 /// generator's magic number in the generated SPIR-V module.
 /// This number should be bumped up whenever the generated SPIR-V changes.

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3438,6 +3438,7 @@ bool isEmptyLLVMModule(Module *M) {
 }
 
 bool LLVMToSPIRVBase::translate() {
+  BM->setGeneratorId(kTranslatorId);
   BM->setGeneratorVer(KTranslatorVer);
 
   if (isEmptyLLVMModule(M))


### PR DESCRIPTION
This is useful they you want to identify a particular version of a generator to apply workarounds.