### PR TITLE
Use StorageClassConstant for constant global variables

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1466,7 +1466,11 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     bool IsVectorCompute =
         BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute) &&
         GV->hasAttribute(kVCMetadata::VCGlobalVariable);
-    if (IsVectorCompute)
+    if (AddressSpace == SPIRAS_Global &&
+        AddressSpace == GV->isConstant()) {
+      AddressSpace = SPIRAS_Constant;
+      StorageClass = SPIRSPIRVAddrSpaceMap::map(AddressSpace);
+    } else if (IsVectorCompute)
       StorageClass =
           VectorComputeUtil::getVCGlobalVarStorageClass(AddressSpace);
     else {


### PR DESCRIPTION
The following OpenCL code :

```
   struct DummyStruct {
      uint a;
   };
   const uint my_var = 42;

   kernel void
   test(global struct DummyStruct *a_ptr)
   {
      a_ptr->a = my_var;
   }
```

Currently generates this :

```
                            OpDecorate %my_var Constant
                 %uint_42 = OpConstant %uint 42
%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
                  %my_var = OpVariable %_ptr_CrossWorkgroup_uint CrossWorkgroup %uint_42
```

But those global constant variables could be turned into
UniformConstant.

Signed-off-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>