### PR TITLE
Update after LLVM getNumArgOperands removal

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -810,7 +810,7 @@ void OCLToSPIRVBase::visitCallAtomicCpp11(CallInst *CI, StringRef MangledName,
     } else {
       auto MaxOps =
           getOCLCpp11AtomicMaxNumOps(Stem.drop_back(strlen("_explicit")));
-      if (CI->getNumArgOperands() < MaxOps)
+      if (CI->arg_size() < MaxOps)
         PostOps.push_back(OCLMS_device);
     }
   } else if (Stem == "work_item_fence") {
@@ -1424,7 +1424,7 @@ void OCLToSPIRVBase::visitCallScalToVec(CallInst *CI, StringRef MangledName,
   // Check if all arguments have the same type - it's simple case.
   auto Uniform = true;
   auto IsArg0Vector = isa<VectorType>(CI->getOperand(0)->getType());
-  for (unsigned I = 1, E = CI->getNumArgOperands(); Uniform && (I != E); ++I) {
+  for (unsigned I = 1, E = CI->arg_size(); Uniform && (I != E); ++I) {
     Uniform = isa<VectorType>(CI->getOperand(I)->getType()) == IsArg0Vector;
   }
   if (Uniform) {
@@ -1654,7 +1654,7 @@ void OCLToSPIRVBase::visitSubgroupBlockWriteINTEL(CallInst *CI) {
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupBlockWriteINTEL);
   assert(!CI->arg_empty() &&
          "Intel subgroup block write should have arguments");
-  unsigned DataArg = CI->getNumArgOperands() - 1;
+  unsigned DataArg = CI->arg_size() - 1;
   Type *DataTy = CI->getArgOperand(DataArg)->getType();
   processSubgroupBlockReadWriteINTEL(CI, Info, DataTy, M);
 }
@@ -1723,7 +1723,7 @@ void OCLToSPIRVBase::visitSubgroupAVCBuiltinCall(CallInst *CI,
     FName += (STy->getName().contains("single")) ? "_single_reference"
                                                  : "_dual_reference";
   } else if (FName.find(Prefix + "sic_configure_ipe") == 0) {
-    FName += (CI->getNumArgOperands() == 8) ? "_luma" : "_luma_chroma";
+    FName += (CI->arg_size() == 8) ? "_luma" : "_luma_chroma";
   }
 
   OCLSPIRVSubgroupAVCIntelBuiltinMap::find(FName, &OC);
@@ -1758,7 +1758,7 @@ void OCLToSPIRVBase::visitSubgroupAVCWrapperBuiltinCall(
   // The operand required conversion is always the last one.
   const char *OpKind = getSubgroupAVCIntelOpKind(DemangledName);
   const char *TyKind = getSubgroupAVCIntelTyKind(
-      CI->getArgOperand(CI->getNumArgOperands() - 1)->getType());
+      CI->getArgOperand(CI->arg_size() - 1)->getType());
   std::string MCETName =
       std::string(kOCLSubgroupsAVCIntel::TypePrefix) + "mce_" + TyKind + "_t";
   auto *MCETy =
@@ -1822,7 +1822,7 @@ void OCLToSPIRVBase::visitSubgroupAVCBuiltinCallWithSampler(
   // Update names for built-ins mapped on two or more SPIRV instructions
   if (FName.find(Prefix + "ref_evaluate_with_multi_reference") == 0 ||
       FName.find(Prefix + "sic_evaluate_with_multi_reference") == 0) {
-    FName += (CI->getNumArgOperands() == 5) ? "_interlaced" : "";
+    FName += (CI->arg_size() == 5) ? "_interlaced" : "";
   }
 
   Op OC = OpNop;

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -119,7 +119,7 @@ void OCLTypeToSPIRVBase::addWork(Function *F) {
 
 /// Find index of \param V as argument of function call \param CI.
 static unsigned getArgIndex(CallInst *CI, Value *V) {
-  for (unsigned AI = 0, AE = CI->getNumArgOperands(); AI != AE; ++AI) {
+  for (unsigned AI = 0, AE = CI->arg_size(); AI != AE; ++AI) {
     if (CI->getArgOperand(AI) == V)
       return AI;
   }

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -689,7 +689,7 @@ bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
 }
 
 BarrierLiterals getBarrierLiterals(CallInst *CI) {
-  auto N = CI->getNumArgOperands();
+  auto N = CI->arg_size();
   assert(N == 1 || N == 2);
 
   StringRef DemangledName;

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -344,7 +344,7 @@ Function *getOrCreateFunction(Module *M, Type *RetTy, ArrayRef<Type *> ArgTypes,
 std::vector<Value *> getArguments(CallInst *CI, unsigned Start, unsigned End) {
   std::vector<Value *> Args;
   if (End == 0)
-    End = CI->getNumArgOperands();
+    End = CI->arg_size();
   for (; Start != End; ++Start) {
     Args.push_back(CI->getArgOperand(Start));
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4145,7 +4145,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     Type *ResTy = CI->getType();
 
     auto OpItr = CI->value_op_begin();
-    auto OpEnd = OpItr + CI->getNumArgOperands();
+    auto OpEnd = OpItr + CI->arg_size();
 
     // If the return type of an instruction is wider than 64-bit, then this
     // instruction will return via 'sret' argument added into the arguments
@@ -4229,7 +4229,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     Type *ResTy = CI->getType();
 
     auto OpItr = CI->value_op_begin();
-    auto OpEnd = OpItr + CI->getNumArgOperands();
+    auto OpEnd = OpItr + CI->arg_size();
 
     // If the return type of an instruction is wider than 64-bit, then this
     // instruction will return via 'sret' argument added into the arguments
@@ -4297,7 +4297,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     Type *ResTy = CI->getType();
 
     auto OpItr = CI->value_op_begin();
-    auto OpEnd = OpItr + CI->getNumArgOperands();
+    auto OpEnd = OpItr + CI->arg_size();
 
     // If the return type of an instruction is wider than 64-bit, then this
     // instruction will return via 'sret' argument added into the arguments
@@ -4337,11 +4337,11 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       auto BBT = transType(BoolTy);
       SPIRVInstruction *Res;
       if (isCmpOpCode(OC)) {
-        assert(CI && CI->getNumArgOperands() == 2 && "Invalid call inst");
+        assert(CI && CI->arg_size() == 2 && "Invalid call inst");
         Res = BM->addCmpInst(OC, BBT, transValue(CI->getArgOperand(0), BB),
                              transValue(CI->getArgOperand(1), BB), BB);
       } else {
-        assert(CI && CI->getNumArgOperands() == 1 && "Invalid call inst");
+        assert(CI && CI->arg_size() == 1 && "Invalid call inst");
         Res =
             BM->addUnaryInst(OC, BBT, transValue(CI->getArgOperand(0), BB), BB);
       }
@@ -4354,11 +4354,11 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
           IsVector ? Constant::getAllOnesValue(ResultTy) : getInt32(M, 1), BB);
       return BM->addSelectInst(Res, One, Zero, BB);
     } else if (isBinaryOpCode(OC)) {
-      assert(CI && CI->getNumArgOperands() == 2 && "Invalid call inst");
+      assert(CI && CI->arg_size() == 2 && "Invalid call inst");
       return BM->addBinaryInst(OC, transType(CI->getType()),
                                transValue(CI->getArgOperand(0), BB),
                                transValue(CI->getArgOperand(1), BB), BB);
-    } else if (CI->getNumArgOperands() == 1 && !CI->getType()->isVoidTy() &&
+    } else if (CI->arg_size() == 1 && !CI->getType()->isVoidTy() &&
                !hasExecScope(OC) && !isAtomicOpCode(OC)) {
       return BM->addUnaryInst(OC, transType(CI->getType()),
                               transValue(CI->getArgOperand(0), BB), BB);


### PR DESCRIPTION
Update for LLVM commit 3e1c787b3160 ("[IR] Remove arg_operands and
getNumArgOperands (NFC)", 2021-10-09).