### PR TITLE
Update dbg-prolog-end test after LLVM change

### DIFF
--- a/test/DebugInfo/X86/dbg-prolog-end.ll
+++ b/test/DebugInfo/X86/dbg-prolog-end.ll
@@ -30,7 +30,7 @@ entry:
 declare void @llvm.dbg.declare(metadata, metadata, metadata) nounwind readnone
 
 ;CHECK-LABEL: main:
-;CHECK: .loc 1 0 0 prologue_end
+;CHECK: .loc 1 8 2 prologue_end
 
 define i32 @main() nounwind ssp !dbg !6 {
 entry:


### PR DESCRIPTION
Update test for LLVM commit 9f93f2bfbd3f ("Do not emit prologue_end
for line 0 locs if there is a non-zero loc present", 2021-10-07).