### PR TITLE
Store result of fixed point integer SPIR-V instructions wider than 64 bits

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4164,9 +4164,8 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
         BM->addFixedPointIntelInst(OC, transType(ResTy), Input, Literals, BB);
     if (!CI->hasStructRetAttr())
       return APIntInst;
-    std::vector<SPIRVWord> Mem;
-    return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), APIntInst,
-                            Mem, BB);
+    return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), APIntInst, {},
+                            BB);
   }
   case OpArbitraryFloatCastINTEL:
   case OpArbitraryFloatCastFromIntINTEL:
@@ -4252,9 +4251,8 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
                                                     nullptr, Literals, BB);
     if (!CI->hasStructRetAttr())
       return APIntInst;
-    std::vector<SPIRVWord> Mem;
-    return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), APIntInst,
-                            Mem, BB);
+    return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), APIntInst, {},
+                            BB);
   }
   case OpArbitraryFloatAddINTEL:
   case OpArbitraryFloatSubINTEL:
@@ -4329,9 +4327,8 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
                                                     InB, Literals, BB);
     if (!CI->hasStructRetAttr())
       return APIntInst;
-    std::vector<SPIRVWord> Mem;
-    return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), APIntInst,
-                            Mem, BB);
+    return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), APIntInst, {},
+                            BB);
   }
   default: {
     if (isCvtOpCode(OC) && OC != OpGenericCastToPtrExplicit) {

--- a/test/transcoding/capability-arbitrary-precision-fixed-point-numbers.ll
+++ b/test/transcoding/capability-arbitrary-precision-fixed-point-numbers.ll
@@ -164,8 +164,8 @@
 ; CHECK-SPIRV-NEXT: 9 FixedExpINTEL [[Ty_34]] [[#]] [[Exp_InId]] 0 20 20 0 0
 
 ; CHECK-SPIRV: 6 Load [[Ty_34]] [[SinCos_InId:[0-9]+]]
-; CHECK-SPIRV-NEXT: 9 FixedSinCosINTEL [[Ty_66]] [[SinCos_RetId:[0-9]+]] [[SinCos_InId]] 1 3 2 0 0
-; CHECK-SPIRV: 3 Store [[#]] [[SinCos_RetId]]
+; CHECK-SPIRV-NEXT: 9 FixedSinCosINTEL [[Ty_66]] [[SinCos_ResultId:[0-9]+]] [[SinCos_InId]] 1 3 2 0 0
+; CHECK-SPIRV: 3 Store [[#]] [[SinCos_ResultId]]
 
 ; CHECK-LLVM: call i5 @intel_arbitrary_fixed_sqrt.i5.i13(i13 %[[#]], i1 false, i32 2, i32 2, i32 0, i32 0)
 ; CHECK-LLVM: call i13 @intel_arbitrary_fixed_sqrt.i13.i5(i5 %[[#]], i1 false, i32 2, i32 2, i32 0, i32 0)

--- a/test/transcoding/capability-arbitrary-precision-floating-point.ll
+++ b/test/transcoding/capability-arbitrary-precision-floating-point.ll
@@ -1578,8 +1578,8 @@ define linkonce_odr dso_local spir_func void @_Z15ap_float_sincosILi8ELi18ELi10E
   %7 = load i34, i34 addrspace(4)* %2, align 8
   call spir_func void @_Z33__spirv_ArbitraryFloatSinCosINTELILi34ELi66EEU7_ExtIntIXmlLi2ET0_EEiU7_ExtIntIXT_EEiiiiii(i66 addrspace(4)* sret(i66) align 8 %4, i34 %7, i32 18, i32 20, i32 0, i32 2, i32 1) #5
 ; CHECK-SPIRV: 6 Load [[Ty_34]] [[SinCos_AId:[0-9]+]]
-; CHECK-SPIRV-NEXT: 9 ArbitraryFloatSinCosINTEL [[Ty_66]] [[SinCos_RetId:[0-9]+]] [[SinCos_AId]] 18 20 0 2 1
-; CHECK-SPIRV: 3 Store [[#]] [[SinCos_RetId]]
+; CHECK-SPIRV-NEXT: 9 ArbitraryFloatSinCosINTEL [[Ty_66]] [[SinCos_ResultId:[0-9]+]] [[SinCos_AId]] 18 20 0 2 1
+; CHECK-SPIRV: 3 Store [[#]] [[SinCos_ResultId]]
 ; CHECK-LLVM: call i66 @intel_arbitrary_float_sincos.i66.i34(i34 %[[#]], i32 18, i32 20, i32 0, i32 2, i32 1)
   %8 = load i66, i66 addrspace(4)* %4, align 8
   store i66 %8, i66 addrspace(4)* %4, align 8
@@ -1607,8 +1607,8 @@ define linkonce_odr dso_local spir_func void @_Z14ap_float_atan2ILi7ELi16ELi7ELi
   call spir_func void @_Z32__spirv_ArbitraryFloatATan2INTELILi24ELi25ELi66EEU7_ExtIntIXT1_EEiU7_ExtIntIXT_EEiiU7_ExtIntIXT0_EEiiiiii(i66 addrspace(4)* sret(i66) align 8 %4, i24 signext %8, i32 16, i25 signext %9, i32 17, i32 18, i32 0, i32 2, i32 1) #5
 ; CHECK-SPIRV: 6 Load [[Ty_24]] [[ATan2_AId:[0-9]+]]
 ; CHECK-SPIRV-NEXT: 6 Load [[Ty_25]] [[ATan2_BId:[0-9]+]]
-; CHECK-SPIRV-NEXT: 11 ArbitraryFloatATan2INTEL [[Ty_66]] [[SinCos_RetId:[0-9]+]] [[ATan2_AId]] 16 [[ATan2_BId]] 17 18 0 2 1
-; CHECK-SPIRV: 3 Store [[#]] [[SinCos_RetId]]
+; CHECK-SPIRV-NEXT: 11 ArbitraryFloatATan2INTEL [[Ty_66]] [[ATan2_ResultId:[0-9]+]] [[ATan2_AId]] 16 [[ATan2_BId]] 17 18 0 2 1
+; CHECK-SPIRV: 3 Store [[#]] [[ATan2_ResultId]]
 ; CHECK-LLVM: call i66 @intel_arbitrary_float_atan2.i66.i24.i25(i24 %[[#]], i32 16, i25 %[[#]], i32 17, i32 18, i32 0, i32 2, i32 1)
   %10 = load i66, i66 addrspace(4)* %4, align 8
   store i66 %10, i66 addrspace(4)* %4, align 8


### PR DESCRIPTION
This if fix for https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1213
This patch adds `Store` instructions in cases when return value is wider than 64 bits