### PR TITLE
Fix reverse translation for ap/hls instructions if result type > 64 bit

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2527,8 +2527,7 @@ static std::string getFuncAPIntSuffix(const Type *RetTy, const Type *In1Ty,
   return Suffix.str();
 }
 
-CallInst *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI,
-                                           BasicBlock *BB) {
+Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
   // LLVM fixed point functions return value:
   // iN (arbitrary precision integer of N bits length)
   // Arguments:
@@ -2545,25 +2544,50 @@ CallInst *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI,
   IntegerType *Int32Ty = IntegerType::get(*Context, 32);
   IntegerType *Int1Ty = IntegerType::get(*Context, 1);
 
-  SmallVector<Type *, 7> ArgTys = {InTy,    Int1Ty,  Int32Ty,
-                                   Int32Ty, Int32Ty, Int32Ty};
-  FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
-
   Op OpCode = Inst->getOpCode();
   std::string FuncName =
       SPIRVFixedPointIntelMap::rmap(OpCode) + getFuncAPIntSuffix(RetTy, InTy);
+  auto Words = Inst->getOpWords();
 
+  if (RetTy->getIntegerBitWidth() <= 64) {
+    SmallVector<Type *, 7> ArgTys = {InTy,    Int1Ty,  Int32Ty,
+                                     Int32Ty, Int32Ty, Int32Ty};
+
+    FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
+    FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
+
+    auto *Fn = cast<Function>(FCallee.getCallee());
+    Fn->setCallingConv(CallingConv::SPIR_FUNC);
+    if (isFuncNoUnwind())
+      Fn->addFnAttr(Attribute::NoUnwind);
+
+    // Words contain:
+    // In<id> Literal S Literal I Literal rI Literal Q Literal O
+    std::vector<Value *> Args = {
+        transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
+        ConstantInt::get(Int1Ty, Words[1]) /* S - indicator of signedness */,
+        ConstantInt::get(Int32Ty,
+                         Words[2]) /* I - fixed-point location of the input */,
+        ConstantInt::get(Int32Ty,
+                         Words[3]) /* rI - fixed-point location of the result*/,
+        ConstantInt::get(Int32Ty, Words[4]) /* Quantization mode */,
+        ConstantInt::get(Int32Ty, Words[5]) /* Overflow mode */};
+
+    return CallInst::Create(FCallee, Args, "", BB);
+  }
+
+  llvm::PointerType *RetPtrTy = llvm::PointerType::get(RetTy, SPIRAS_Generic);
+  SmallVector<Type *, 8> ArgTys = {RetPtrTy, InTy,    Int1Ty, Int32Ty,
+                                   Int32Ty,  Int32Ty, Int32Ty};
+
+  FunctionType *FT =
+      FunctionType::get(Type::getVoidTy(*Context), ArgTys, false);
   FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
 
-  auto *Fn = cast<Function>(FCallee.getCallee());
-  Fn->setCallingConv(CallingConv::SPIR_FUNC);
-  if (isFuncNoUnwind())
-    Fn->addFnAttr(Attribute::NoUnwind);
-
-  // Words contain:
-  // In<id> Literal S Literal I Literal rI Literal Q Literal O
-  auto Words = Inst->getOpWords();
+  Value *Alloca = new AllocaInst(RetTy, SPIRAS_Private, "", BB);
+  Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
   std::vector<Value *> Args = {
+      RetValPtr,
       transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
       ConstantInt::get(Int1Ty, Words[1]) /* S - indicator of signedness */,
       ConstantInt::get(Int32Ty,
@@ -2573,11 +2597,22 @@ CallInst *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI,
       ConstantInt::get(Int32Ty, Words[4]) /* Quantization mode */,
       ConstantInt::get(Int32Ty, Words[5]) /* Overflow mode */};
 
-  return CallInst::Create(FCallee, Args, "", BB);
+  auto *Func = cast<Function>(FCallee.getCallee());
+  Func->setCallingConv(CallingConv::SPIR_FUNC);
+  if (isFuncNoUnwind())
+    Func->addFnAttr(Attribute::NoUnwind);
+  Func->addParamAttr(
+      0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
+  CallInst *APIntInst = CallInst::Create(FCallee, Args, "", BB);
+  APIntInst->addParamAttr(
+      0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
+
+  Value *LI = new LoadInst(RetTy, RetValPtr, "", false, BB);
+  return LI;
 }
 
-CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
-                                         bool IsBinaryInst) {
+Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
+                                      bool IsBinaryInst) {
   // Format of instructions Add, Sub, Mul, Div, Hypot, ATan2, Pow, PowR:
   //   LLVM arbitrary floating point functions return value:
   //       iN (arbitrary precision integer of N bits length)
@@ -2650,10 +2685,30 @@ CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   const std::vector<SPIRVWord> Words = Inst->getOpWords();
   auto WordsItr = Words.begin() + 1; /* Skip word for A input id */
 
-  SmallVector<Type *, 8> ArgTys = {ATy, Int32Ty};
-  std::vector<Value *> Args = {
-      transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
-      ConstantInt::get(Int32Ty, *WordsItr++) /* MA/Mout - width of mantissa */};
+  SmallVector<Type *> ArgTys;
+  std::vector<Value *> Args;
+
+  if (RetTy->getIntegerBitWidth() <= 64) {
+    SmallVector<Type *, 8> ArgTysLocal = {ATy, Int32Ty};
+    std::vector<Value *> ArgsLocal = {
+        transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
+        ConstantInt::get(Int32Ty,
+                         *WordsItr++) /* MA/Mout - width of mantissa */};
+    ArgTys = std::move(ArgTysLocal);
+    Args = std::move(ArgsLocal);
+  } else {
+    llvm::PointerType *RetPtrTy = llvm::PointerType::get(RetTy, SPIRAS_Generic);
+    SmallVector<Type *, 9> ArgTysLocal = {RetPtrTy, ATy, Int32Ty};
+    Value *Alloca = new AllocaInst(RetTy, SPIRAS_Private, "", BB);
+    Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
+    std::vector<Value *> ArgsLocal = {
+        RetValPtr,
+        transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
+        ConstantInt::get(Int32Ty,
+                         *WordsItr++) /* MA/Mout - width of mantissa */};
+    ArgTys = std::move(ArgTysLocal);
+    Args = std::move(ArgsLocal);
+  }
 
   Op OC = Inst->getOpCode();
   if (OC == OpArbitraryFloatCastFromIntINTEL ||
@@ -2677,9 +2732,22 @@ CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
                    return ConstantInt::get(Int32Ty, Word);
                  });
 
-  FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
   std::string FuncName =
       SPIRVArbFloatIntelMap::rmap(OC) + getFuncAPIntSuffix(RetTy, ATy, BTy);
+  if (RetTy->getIntegerBitWidth() <= 64) {
+    FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
+    FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
+
+    auto *Func = cast<Function>(FCallee.getCallee());
+    Func->setCallingConv(CallingConv::SPIR_FUNC);
+    if (isFuncNoUnwind())
+      Func->addFnAttr(Attribute::NoUnwind);
+
+    return CallInst::Create(Func, Args, "", BB);
+  }
+
+  FunctionType *FT =
+      FunctionType::get(Type::getVoidTy(*Context), ArgTys, false);
   FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
 
   auto *Func = cast<Function>(FCallee.getCallee());
@@ -2687,7 +2755,14 @@ CallInst *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   if (isFuncNoUnwind())
     Func->addFnAttr(Attribute::NoUnwind);
 
-  return CallInst::Create(Func, Args, "", BB);
+  Func->addParamAttr(
+      0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
+  CallInst *APFloatInst = CallInst::Create(FCallee, Args, "", BB);
+  APFloatInst->addParamAttr(
+      0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
+
+  Value *LI = new LoadInst(RetTy, Args[0], "", false, BB);
+  return LI;
 }
 
 template <class SourceTy, class FuncTy>

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2551,26 +2551,26 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
   std::string FuncName =
       SPIRVFixedPointIntelMap::rmap(OpCode) + getFuncAPIntSuffix(RetTy, InTy);
   auto Words = Inst->getOpWords();
-  SmallVector<Type *> ArgTys;
+  SmallVector<Type *, 8> ArgTys;
   std::vector<Value *> Args;
   Args.reserve(8);
   if (RetTy->getIntegerBitWidth() > 64) {
     llvm::PointerType *RetPtrTy = llvm::PointerType::get(RetTy, SPIRAS_Generic);
     Value *Alloca = new AllocaInst(RetTy, SPIRAS_Private, "", BB);
     Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
-    ArgTys.push_back(RetPtrTy);
-    Args.push_back(RetValPtr);
+    ArgTys.emplace_back(RetPtrTy);
+    Args.emplace_back(RetValPtr);
   }
 
-  ArgTys.push_back(InTy);
-  ArgTys.push_back(Int1Ty);
-  for (int i = 0; i < 4; i++)
-    ArgTys.push_back(Int32Ty);
+  ArgTys.emplace_back(InTy);
+  ArgTys.emplace_back(Int1Ty);
+  for (int I = 0; I < 4; I++)
+    ArgTys.emplace_back(Int32Ty);
 
-  Args.push_back(transValue(Inst->getOperand(0), BB->getParent(), BB));
-  Args.push_back(ConstantInt::get(Int1Ty, Words[1]));
-  for (int i = 2; i <= 5; i++)
-    Args.push_back(ConstantInt::get(Int32Ty, Words[i]));
+  Args.emplace_back(transValue(Inst->getOperand(0), BB->getParent(), BB));
+  Args.emplace_back(ConstantInt::get(Int1Ty, Words[1]));
+  for (int I = 2; I <= 5; I++)
+    Args.emplace_back(ConstantInt::get(Int32Ty, Words[I]));
 
   if (RetTy->getIntegerBitWidth() <= 64) {
     FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2547,10 +2547,6 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
   IntegerType *Int32Ty = IntegerType::get(*Context, 32);
   IntegerType *Int1Ty = IntegerType::get(*Context, 1);
 
-  Op OpCode = Inst->getOpCode();
-  std::string FuncName =
-      SPIRVFixedPointIntelMap::rmap(OpCode) + getFuncAPIntSuffix(RetTy, InTy);
-  auto Words = Inst->getOpWords();
   SmallVector<Type *, 8> ArgTys;
   std::vector<Value *> Args;
   Args.reserve(8);
@@ -2562,42 +2558,40 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
     Args.emplace_back(RetValPtr);
   }
 
-  ArgTys.emplace_back(InTy);
-  ArgTys.emplace_back(Int1Ty);
-  for (int I = 0; I < 4; I++)
-    ArgTys.emplace_back(Int32Ty);
+  ArgTys.insert(ArgTys.end(),
+                {InTy, Int1Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty});
 
+  auto Words = Inst->getOpWords();
   Args.emplace_back(transValue(Inst->getOperand(0), BB->getParent(), BB));
   Args.emplace_back(ConstantInt::get(Int1Ty, Words[1]));
   for (int I = 2; I <= 5; I++)
     Args.emplace_back(ConstantInt::get(Int32Ty, Words[I]));
 
-  if (RetTy->getIntegerBitWidth() <= 64) {
-    FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
-    FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
-    auto *Fn = cast<Function>(FCallee.getCallee());
-    Fn->setCallingConv(CallingConv::SPIR_FUNC);
-    if (isFuncNoUnwind())
-      Fn->addFnAttr(Attribute::NoUnwind);
-    return CallInst::Create(FCallee, Args, "", BB);
-  }
+  Type *FuncRetTy =
+      (RetTy->getIntegerBitWidth() <= 64) ? RetTy : Type::getVoidTy(*Context);
+  FunctionType *FT = FunctionType::get(FuncRetTy, ArgTys, false);
 
-  FunctionType *FT =
-      FunctionType::get(Type::getVoidTy(*Context), ArgTys, false);
+  Op OpCode = Inst->getOpCode();
+  std::string FuncName =
+      SPIRVFixedPointIntelMap::rmap(OpCode) + getFuncAPIntSuffix(RetTy, InTy);
+
   FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
 
   auto *Func = cast<Function>(FCallee.getCallee());
   Func->setCallingConv(CallingConv::SPIR_FUNC);
   if (isFuncNoUnwind())
     Func->addFnAttr(Attribute::NoUnwind);
+
+  if (RetTy->getIntegerBitWidth() <= 64)
+    return CallInst::Create(FCallee, Args, "", BB);
+
   Func->addParamAttr(
       0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
   CallInst *APIntInst = CallInst::Create(FCallee, Args, "", BB);
   APIntInst->addParamAttr(
       0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
 
-  Value *LI = new LoadInst(RetTy, Args[0], "", false, BB);
-  return LI;
+  return static_cast<Value *>(new LoadInst(RetTy, Args[0], "", false, BB));
 }
 
 Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
@@ -2674,30 +2668,22 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   const std::vector<SPIRVWord> Words = Inst->getOpWords();
   auto WordsItr = Words.begin() + 1; /* Skip word for A input id */
 
-  SmallVector<Type *> ArgTys;
+  SmallVector<Type *, 8> ArgTys;
   std::vector<Value *> Args;
 
-  if (RetTy->getIntegerBitWidth() <= 64) {
-    SmallVector<Type *, 8> ArgTysLocal = {ATy, Int32Ty};
-    std::vector<Value *> ArgsLocal = {
-        transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
-        ConstantInt::get(Int32Ty,
-                         *WordsItr++) /* MA/Mout - width of mantissa */};
-    ArgTys = std::move(ArgTysLocal);
-    Args = std::move(ArgsLocal);
-  } else {
+  if (RetTy->getIntegerBitWidth() > 64) {
     llvm::PointerType *RetPtrTy = llvm::PointerType::get(RetTy, SPIRAS_Generic);
-    SmallVector<Type *, 9> ArgTysLocal = {RetPtrTy, ATy, Int32Ty};
+    ArgTys.push_back(RetPtrTy);
     Value *Alloca = new AllocaInst(RetTy, SPIRAS_Private, "", BB);
     Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
-    std::vector<Value *> ArgsLocal = {
-        RetValPtr,
-        transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
-        ConstantInt::get(Int32Ty,
-                         *WordsItr++) /* MA/Mout - width of mantissa */};
-    ArgTys = std::move(ArgTysLocal);
-    Args = std::move(ArgsLocal);
+    Args.push_back(RetValPtr);
   }
+
+  ArgTys.insert(ArgTys.end(), {ATy, Int32Ty});
+  // A - input
+  Args.emplace_back(transValue(Inst->getOperand(0), BB->getParent(), BB));
+  // MA/Mout - width of mantissa
+  Args.emplace_back(ConstantInt::get(Int32Ty, *WordsItr++));
 
   Op OC = Inst->getOpCode();
   if (OC == OpArbitraryFloatCastFromIntINTEL ||
@@ -2723,20 +2709,10 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
 
   std::string FuncName =
       SPIRVArbFloatIntelMap::rmap(OC) + getFuncAPIntSuffix(RetTy, ATy, BTy);
-  if (RetTy->getIntegerBitWidth() <= 64) {
-    FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
-    FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
 
-    auto *Func = cast<Function>(FCallee.getCallee());
-    Func->setCallingConv(CallingConv::SPIR_FUNC);
-    if (isFuncNoUnwind())
-      Func->addFnAttr(Attribute::NoUnwind);
-
-    return CallInst::Create(Func, Args, "", BB);
-  }
-
-  FunctionType *FT =
-      FunctionType::get(Type::getVoidTy(*Context), ArgTys, false);
+  Type *FuncRetTy =
+      (RetTy->getIntegerBitWidth() <= 64) ? RetTy : Type::getVoidTy(*Context);
+  FunctionType *FT = FunctionType::get(FuncRetTy, ArgTys, false);
   FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
 
   auto *Func = cast<Function>(FCallee.getCallee());
@@ -2744,14 +2720,16 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   if (isFuncNoUnwind())
     Func->addFnAttr(Attribute::NoUnwind);
 
+  if (RetTy->getIntegerBitWidth() <= 64)
+    return CallInst::Create(Func, Args, "", BB);
+
   Func->addParamAttr(
       0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
   CallInst *APFloatInst = CallInst::Create(FCallee, Args, "", BB);
   APFloatInst->addParamAttr(
       0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
 
-  Value *LI = new LoadInst(RetTy, Args[0], "", false, BB);
-  return LI;
+  return static_cast<Value *>(new LoadInst(RetTy, Args[0], "", false, BB));
 }
 
 template <class SourceTy, class FuncTy>

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2532,6 +2532,9 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
   // iN (arbitrary precision integer of N bits length)
   // Arguments:
   // A(iN), S(i1), I(i32), rI(i32), Quantization(i32), Overflow(i32)
+  // If return value wider than 64 bit:
+  // iN addrspace(4)* sret(iN), A(iN), S(i1), I(i32), rI(i32),
+  // Quantization(i32), Overflow(i32)
 
   // SPIR-V fixed point instruction contains:
   // <id>ResTy Res<id> In<id> Literal S Literal I Literal rI Literal Q Literal O
@@ -2548,54 +2551,40 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
   std::string FuncName =
       SPIRVFixedPointIntelMap::rmap(OpCode) + getFuncAPIntSuffix(RetTy, InTy);
   auto Words = Inst->getOpWords();
+  SmallVector<Type *> ArgTys;
+  std::vector<Value *> Args;
+  Args.reserve(8);
+  if (RetTy->getIntegerBitWidth() > 64) {
+    llvm::PointerType *RetPtrTy = llvm::PointerType::get(RetTy, SPIRAS_Generic);
+    Value *Alloca = new AllocaInst(RetTy, SPIRAS_Private, "", BB);
+    Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
+    ArgTys.push_back(RetPtrTy);
+    Args.push_back(RetValPtr);
+  }
+
+  ArgTys.push_back(InTy);
+  ArgTys.push_back(Int1Ty);
+  for (int i = 0; i < 4; i++)
+    ArgTys.push_back(Int32Ty);
+
+  Args.push_back(transValue(Inst->getOperand(0), BB->getParent(), BB));
+  Args.push_back(ConstantInt::get(Int1Ty, Words[1]));
+  for (int i = 2; i <= 5; i++)
+    Args.push_back(ConstantInt::get(Int32Ty, Words[i]));
 
   if (RetTy->getIntegerBitWidth() <= 64) {
-    SmallVector<Type *, 7> ArgTys = {InTy,    Int1Ty,  Int32Ty,
-                                     Int32Ty, Int32Ty, Int32Ty};
-
     FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
     FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
-
     auto *Fn = cast<Function>(FCallee.getCallee());
     Fn->setCallingConv(CallingConv::SPIR_FUNC);
     if (isFuncNoUnwind())
       Fn->addFnAttr(Attribute::NoUnwind);
-
-    // Words contain:
-    // In<id> Literal S Literal I Literal rI Literal Q Literal O
-    std::vector<Value *> Args = {
-        transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
-        ConstantInt::get(Int1Ty, Words[1]) /* S - indicator of signedness */,
-        ConstantInt::get(Int32Ty,
-                         Words[2]) /* I - fixed-point location of the input */,
-        ConstantInt::get(Int32Ty,
-                         Words[3]) /* rI - fixed-point location of the result*/,
-        ConstantInt::get(Int32Ty, Words[4]) /* Quantization mode */,
-        ConstantInt::get(Int32Ty, Words[5]) /* Overflow mode */};
-
     return CallInst::Create(FCallee, Args, "", BB);
   }
-
-  llvm::PointerType *RetPtrTy = llvm::PointerType::get(RetTy, SPIRAS_Generic);
-  SmallVector<Type *, 8> ArgTys = {RetPtrTy, InTy,    Int1Ty, Int32Ty,
-                                   Int32Ty,  Int32Ty, Int32Ty};
 
   FunctionType *FT =
       FunctionType::get(Type::getVoidTy(*Context), ArgTys, false);
   FunctionCallee FCallee = M->getOrInsertFunction(FuncName, FT);
-
-  Value *Alloca = new AllocaInst(RetTy, SPIRAS_Private, "", BB);
-  Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
-  std::vector<Value *> Args = {
-      RetValPtr,
-      transValue(Inst->getOperand(0), BB->getParent(), BB) /* A - input */,
-      ConstantInt::get(Int1Ty, Words[1]) /* S - indicator of signedness */,
-      ConstantInt::get(Int32Ty,
-                       Words[2]) /* I - fixed-point location of the input */,
-      ConstantInt::get(Int32Ty,
-                       Words[3]) /* rI - fixed-point location of the result*/,
-      ConstantInt::get(Int32Ty, Words[4]) /* Quantization mode */,
-      ConstantInt::get(Int32Ty, Words[5]) /* Overflow mode */};
 
   auto *Func = cast<Function>(FCallee.getCallee());
   Func->setCallingConv(CallingConv::SPIR_FUNC);
@@ -2607,7 +2596,7 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
   APIntInst->addParamAttr(
       0, Attribute::get(*Context, Attribute::AttrKind::StructRet, RetTy));
 
-  Value *LI = new LoadInst(RetTy, RetValPtr, "", false, BB);
+  Value *LI = new LoadInst(RetTy, Args[0], "", false, BB);
   return LI;
 }
 

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -108,9 +108,9 @@ public:
   Value *transAsmINTEL(SPIRVAsmINTEL *BA);
   CallInst *transAsmCallINTEL(SPIRVAsmCallINTEL *BI, Function *F,
                               BasicBlock *BB);
-  CallInst *transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB);
-  CallInst *transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
-                              bool IsBinaryInst = false);
+  Value *transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB);
+  Value *transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
+                           bool IsBinaryInst = false);
   bool transNonTemporalMetadata(Instruction *I);
   template <typename SPIRVInstType>
   void transAliasingMemAccess(SPIRVInstType *BI, Instruction *I);

--- a/test/transcoding/capability-arbitrary-precision-fixed-point-numbers.ll
+++ b/test/transcoding/capability-arbitrary-precision-fixed-point-numbers.ll
@@ -187,8 +187,8 @@
 ; CHECK-LLVM: call i10 @intel_arbitrary_fixed_sincospi.i10.i13(i13 %[[#]], i1 false, i32 2, i32 2, i32 0, i32 0)
 ; CHECK-LLVM: call i44 @intel_arbitrary_fixed_log.i44.i64(i64 %[[#]], i1 true, i32 24, i32 22, i32 0, i32 0)
 ; CHECK-LLVM: call i34 @intel_arbitrary_fixed_exp.i34.i44(i44 %[[#]], i1 false, i32 20, i32 20, i32 0, i32 0)
-; CHECK-LLVM: call i66 @intel_arbitrary_fixed_sincos.i66.i34(i34 %[[#]], i1 true, i32 3, i32 2, i32 0, i32 0)
-; CHECK-LLVM: call i68 @intel_arbitrary_fixed_exp.i68.i68(i68 %[[#]], i1 false, i32 20, i32 20, i32 0, i32 0)
+; CHECK-LLVM: call void @intel_arbitrary_fixed_sincos.i66.i34(i66 addrspace(4)* sret(i66) %[[#]], i34 %[[#]], i1 true, i32 3, i32 2, i32 0, i32 0)
+; CHECK-LLVM: call void @intel_arbitrary_fixed_exp.i68.i68(i68 addrspace(4)* sret(i68) %[[#]], i68 %[[#]], i1 false, i32 20, i32 20, i32 0, i32 0)
 
 ; ModuleID = 'ap_fixed.cpp'
 source_filename = "ap_fixed.cpp"

--- a/test/transcoding/capability-arbitrary-precision-floating-point.ll
+++ b/test/transcoding/capability-arbitrary-precision-floating-point.ll
@@ -1583,7 +1583,7 @@ define linkonce_odr dso_local spir_func void @_Z15ap_float_sincosILi8ELi18ELi10E
 ; CHECK-SPIRV: 6 Load [[Ty_34]] [[SinCos_AId:[0-9]+]]
 ; CHECK-SPIRV-NEXT: 9 ArbitraryFloatSinCosINTEL [[Ty_66]] [[SinCos_ResultId:[0-9]+]] [[SinCos_AId]] 18 20 0 2 1
 ; CHECK-SPIRV: 3 Store [[#]] [[SinCos_ResultId]]
-; CHECK-LLVM: call i66 @intel_arbitrary_float_sincos.i66.i34(i34 %[[#]], i32 18, i32 20, i32 0, i32 2, i32 1)
+; CHECK-LLVM: call void @intel_arbitrary_float_sincos.i66.i34(i66 addrspace(4)* sret(i66) %[[#]], i34 %[[#]], i32 18, i32 20, i32 0, i32 2, i32 1)
   %8 = load i66, i66 addrspace(4)* %4, align 8
   store i66 %8, i66 addrspace(4)* %4, align 8
   %9 = bitcast i34* %1 to i8*
@@ -1612,7 +1612,7 @@ define linkonce_odr dso_local spir_func void @_Z14ap_float_atan2ILi7ELi16ELi7ELi
 ; CHECK-SPIRV-NEXT: 6 Load [[Ty_25]] [[ATan2_BId:[0-9]+]]
 ; CHECK-SPIRV-NEXT: 11 ArbitraryFloatATan2INTEL [[Ty_66]] [[ATan2_ResultId:[0-9]+]] [[ATan2_AId]] 16 [[ATan2_BId]] 17 18 0 2 1
 ; CHECK-SPIRV: 3 Store [[#]] [[ATan2_ResultId]]
-; CHECK-LLVM: call i66 @intel_arbitrary_float_atan2.i66.i24.i25(i24 %[[#]], i32 16, i25 %[[#]], i32 17, i32 18, i32 0, i32 2, i32 1)
+; CHECK-LLVM: call void @intel_arbitrary_float_atan2.i66.i24.i25(i66 addrspace(4)* sret(i66) %[[#]], i24 %[[#]], i32 16, i25 %[[#]], i32 17, i32 18, i32 0, i32 2, i32 1)
   %10 = load i66, i66 addrspace(4)* %4, align 8
   store i66 %10, i66 addrspace(4)* %4, align 8
   %11 = bitcast i66* %3 to i8*


### PR DESCRIPTION
This patch changes function call after reverse translation for ap/hls instructions with result type > 64 bit