### PR TITLE
Update for LLVM ElementCount API change

### DIFF
--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -105,8 +105,8 @@ bool lowerBitCastToNonStdVec(Instruction *OldInst, Value *NewInst,
       }
       // Handle extractelement instruction which is following the load
       else if (auto *EEI = dyn_cast<ExtractElementInst>(U)) {
-        uint64_t NumElemsInOldVec = OldVecTy->getElementCount().getValue();
-        uint64_t NumElemsInNewVec = NewVecTy->getElementCount().getValue();
+        uint64_t NumElemsInOldVec = OldVecTy->getElementCount().getFixedValue();
+        uint64_t NumElemsInNewVec = NewVecTy->getElementCount().getFixedValue();
         uint64_t OldElemIdx =
             cast<ConstantInt>(EEI->getIndexOperand())->getZExtValue();
         uint64_t NewElemIdx =
@@ -168,7 +168,8 @@ public:
           continue;
         VectorType *SrcVecTy = getVectorType(BC->getSrcTy());
         if (SrcVecTy) {
-          uint64_t NumElemsInSrcVec = SrcVecTy->getElementCount().getValue();
+          uint64_t NumElemsInSrcVec =
+              SrcVecTy->getElementCount().getFixedValue();
           if (!isValidVectorSize(NumElemsInSrcVec))
             report_fatal_error(
                 llvm::Twine("Unsupported vector type with the size of: " +
@@ -177,7 +178,8 @@ public:
         }
         VectorType *DestVecTy = getVectorType(BC->getDestTy());
         if (DestVecTy) {
-          uint64_t NumElemsInDestVec = DestVecTy->getElementCount().getValue();
+          uint64_t NumElemsInDestVec =
+              DestVecTy->getElementCount().getFixedValue();
           if (!isValidVectorSize(NumElemsInDestVec))
             BCastsToNonStdVec.push_back(&I);
         }

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -1025,7 +1025,7 @@ void SPIRVToOCLBase::visitCallSPIRVVStore(CallInst *CI, OCLExtOpKind Kind) {
             Kind == OpenCLLIB::Vstorea_halfn ||
             Kind == OpenCLLIB::Vstorea_halfn_r || Kind == OpenCLLIB::Vstoren) {
           if (auto DataType = dyn_cast<VectorType>(Args[0]->getType())) {
-            uint64_t NumElements = DataType->getElementCount().getValue();
+            uint64_t NumElements = DataType->getElementCount().getFixedValue();
             assert((NumElements == 2 || NumElements == 3 || NumElements == 4 ||
                     NumElements == 8 || NumElements == 16) &&
                    "Unsupported vector size for vstore instruction!");


### PR DESCRIPTION
Update after LLVM commit 1ea4296208e6 ("[NFC] Remove from
UnivariateLinearPolyBase::getValue().", 2021-11-04).