### PR TITLE
Small cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 #==============================================================================#
 # This file specifies intentionally untracked files that git should ignore.
 # See: http://www.kernel.org/pub/software/scm/git/docs/gitignore.html
-#
-# This file is intentionally different from the output of `git svn show-ignore`,
-# as most of those are useless.
 #==============================================================================#
 
 build/
@@ -40,29 +37,3 @@ cscope.out
 autoconf/aclocal.m4
 autoconf/autom4te.cache
 compile_commands.json
-
-#==============================================================================#
-# Directories to ignore (do not add trailing '/'s, they skip symlinks).
-#==============================================================================#
-# External projects that are tracked independently.
-projects/*
-!projects/CMakeLists.txt
-!projects/Makefile
-# Clang, which is tracked independently.
-tools/clang
-# LLDB, which is tracked independently.
-tools/lldb
-# lld, which is tracked independently.
-tools/lld
-# llgo, which is tracked independently.
-tools/llgo
-# Polly, which is tracked independently.
-tools/polly
-# Sphinx build tree, if building in-source dir.
-docs/_build
-
-#==============================================================================#
-# Files created in tree by the Go bindings.
-#==============================================================================#
-bindings/go/llvm/llvm_config.go
-bindings/go/llvm/workdir

--- a/test/transcoding/OpenCL/mem_fence.cl
+++ b/test/transcoding/OpenCL/mem_fence.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
@@ -7,25 +7,9 @@
 // This test checks that the translator is capable to correctly translate
 // mem_fence OpenCL C 1.2 built-in function [1] into corresponding SPIR-V
 // instruction and vice-versa.
-//
-// Forward declarations and defines below are based on the following sources:
-// - llvm/llvm-project [2]:
-//   - clang/lib/Headers/opencl-c-base.h
-//   - clang/lib/Headers/opencl-c.h
-// - OpenCL C 1.2 reference pages [1]
-// TODO: remove these and switch to using -fdeclare-opencl-builtins once
-// mem_fence is supported by this flag
 
-typedef unsigned int cl_mem_fence_flags;
-
-#define CLK_LOCAL_MEM_FENCE 0x01
-#define CLK_GLOBAL_MEM_FENCE 0x02
 // Strictly speaking, this flag is not supported by mem_fence in OpenCL 1.2
 #define CLK_IMAGE_MEM_FENCE 0x04
-
-void __attribute__((overloadable)) mem_fence(cl_mem_fence_flags);
-void __attribute__((overloadable)) read_mem_fence(cl_mem_fence_flags);
-void __attribute__((overloadable)) write_mem_fence(cl_mem_fence_flags);
 
 __kernel void test_mem_fence_const_flags() {
   mem_fence(CLK_LOCAL_MEM_FENCE);
@@ -53,8 +37,8 @@ __kernel void test_mem_fence_non_const_flags(cl_mem_fence_flags flags) {
 // CHECK-SPIRV: EntryPoint {{[0-9]+}} [[TEST_CONST_FLAGS:[0-9]+]] "test_mem_fence_const_flags"
 // CHECK-SPIRV: TypeInt [[UINT:[0-9]+]] 32 0
 //
-// In SPIR-V, mem_fence is represented as OpMemoryBarrier [3] and OpenCL
-// cl_mem_fence_flags are represented as part of Memory Semantics [4], which
+// In SPIR-V, mem_fence is represented as OpMemoryBarrier [2] and OpenCL
+// cl_mem_fence_flags are represented as part of Memory Semantics [3], which
 // also includes memory order constraints. The translator applies some default
 // memory order for OpMemoryBarrier and therefore, constants below include a
 // bit more information than original source
@@ -119,6 +103,5 @@ __kernel void test_mem_fence_non_const_flags(cl_mem_fence_flags flags) {
 
 // References:
 // [1]: https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/mem_fence.html
-// [2]: https://github.com/llvm/llvm-project
-// [3]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpMemoryBarrier
-// [4]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_memory_semantics__id_a_memory_semantics_lt_id_gt
+// [2]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#OpMemoryBarrier
+// [3]: https://www.khronos.org/registry/spir-v/specs/unified1/SPIRV.html#_a_id_memory_semantics__id_a_memory_semantics_lt_id_gt

--- a/test/transcoding/cl_khr_extended_bit_ops.cl
+++ b/test/transcoding/cl_khr_extended_bit_ops.cl
@@ -4,16 +4,6 @@
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-// TODO: remove prototypes once bit op builtins are available in clang.
-#define __ovld __attribute__((overloadable))
-
-int2 __ovld bitfield_insert(int2, int2, uint, uint);
-short __ovld bitfield_extract_signed(short, uint, uint);
-short __ovld bitfield_extract_signed(ushort, uint, uint);
-uchar8 __ovld bitfield_extract_unsigned(char8, uint, uint);
-uchar8 __ovld bitfield_extract_unsigned(uchar8, uint, uint);
-ulong4 __ovld bit_reverse(ulong4);
-
 // CHECK-SPIRV: Capability BitInstructions
 // CHECK-SPIRV: Extension "SPV_KHR_bit_instructions"
 


### PR DESCRIPTION
* Tidy up .gitignore
* Remove builtin prototypes from tests. Clang has these prototypes since 85eb12eefdf6 ("[OpenCL] Add declarations with enum/typedef args", 2021-02-24) and 724f0e2abb0c ("[OpenCL] Add cl_khr_extended_bit_ops", 2021-07-21).