### PR TITLE
Fix memory leak after OpInBoundsPtrAccessChain

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -244,8 +244,12 @@ SPIRVInstruction *createInstFromSpecConstantOp(SPIRVSpecConstantOp *Inst) {
   assert(isSpecConstantOpAllowedOp(OC) &&
          "Op code not allowed for OpSpecConstantOp");
   Ops.erase(Ops.begin(), Ops.begin() + 1);
-  return SPIRVInstTemplateBase::create(OC, Inst->getType(), Inst->getId(), Ops,
-                                       nullptr, Inst->getModule());
+  auto *BM = Inst->getModule();
+  auto *RetInst = SPIRVInstTemplateBase::create(
+      OC, Inst->getType(), Inst->getId(), Ops, nullptr, BM);
+  // Instruction that creates from OpSpecConstantOp has the same Id
+  BM->insertEntryNoId(RetInst);
+  return RetInst;
 }
 
 } // namespace SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -180,6 +180,7 @@ public:
   void setGeneratorId(unsigned short Id) override { GeneratorId = Id; }
   void setGeneratorVer(unsigned short Ver) override { GeneratorVer = Ver; }
   void resolveUnknownStructFields() override;
+  void insertEntryNoId(SPIRVEntry *Entry) override { EntryNoId.insert(Entry); }
 
   void setSPIRVVersion(SPIRVWord Ver) override {
     assert(this->isAllowedToUseVersion(static_cast<VersionNumber>(Ver)));

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -177,6 +177,7 @@ public:
   virtual void setGeneratorVer(unsigned short) = 0;
   virtual void resolveUnknownStructFields() = 0;
   virtual void setSPIRVVersion(SPIRVWord) = 0;
+  virtual void insertEntryNoId(SPIRVEntry *Entry) = 0;
 
   void setMinSPIRVVersion(SPIRVWord Ver) {
     setSPIRVVersion(std::max(Ver, getSPIRVVersion()));


### PR DESCRIPTION
There was memory leak after creating `OpInBoundsPtrAccessChain` instruction during reverse translation. This patch fixes it.
Note: `OpInBoundsPtrAccessChain` creates from `OpSpecConstantOp` with same ID, so we can't add it to `IdEntryMap`
