### PR TITLE
Add --spirv-tools-dis option to disassemble using SPIRV-Tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ endif(NOT DEFINED BASE_LLVM_VERSION)
 set(LLVM_SPIRV_VERSION ${BASE_LLVM_VERSION}.0)
 
 include(FetchContent)
+include(FindPkgConfig)
 
 option(LLVM_SPIRV_INCLUDE_TESTS
   "Generate build targets for the llvm-spirv lit tests."
@@ -102,6 +103,12 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
 endif()
 
 set(LLVM_SPIRV_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+pkg_search_module(SPIRV_TOOLS SPIRV-Tools)
+if(NOT SPIRV_TOOLS_FOUND)
+  message(STATUS "SPIRV-Tools not found; project will be built without "
+          "--spirv-tools-dis support.")
+endif(NOT SPIRV_TOOLS_FOUND)
 
 add_subdirectory(lib/SPIRV)
 add_subdirectory(tools/llvm-spirv)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,3 @@
-include(FindPkgConfig)
-
 llvm_canonicalize_cmake_booleans(SPIRV_SKIP_CLANG_BUILD)
 llvm_canonicalize_cmake_booleans(SPIRV_SKIP_DEBUG_INFO_TESTS)
 
@@ -7,8 +5,6 @@ llvm_canonicalize_cmake_booleans(SPIRV_SKIP_DEBUG_INFO_TESTS)
 get_target_property(LLVM_SPIRV_DIR llvm-spirv BINARY_DIR)
 set(LLVM_SPIRV_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-# find spirv-val
-pkg_search_module(SPIRV_TOOLS SPIRV-Tools)
 if(SPIRV_TOOLS_FOUND)
   find_program(SPIRV_TOOLS_SPIRV_AS NAMES spirv-as PATHS ${SPIRV_TOOLS_PREFIX}/bin)
   if(SPIRV_TOOLS_SPIRV_AS)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -21,6 +21,9 @@ config.suffixes = ['.cl', '.ll', '.spt', '.spvasm']
 # excludes: A list of directories  and fles to exclude from the testsuite.
 config.excludes = ['CMakeLists.txt']
 
+if config.spirv_tools_found:
+    config.available_features.add('libspirv_dis')
+
 if not config.spirv_skip_debug_info_tests:
     # Direct object generation.
     config.available_features.add('object-emission')

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -15,6 +15,7 @@ config.target_triple = "@TARGET_TRIPLE@"
 config.host_arch = "@HOST_ARCH@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
+config.spirv_tools_found = @SPIRV_TOOLS_FOUND@
 config.spirv_tools_have_spirv_as = @SPIRV_TOOLS_SPIRV_AS_FOUND@
 config.spirv_tools_have_spirv_link = @SPIRV_TOOLS_SPIRV_LINK_FOUND@
 config.spirv_tools_have_spirv_val = @SPIRV_TOOLS_SPIRV_VAL_FOUND@

--- a/test/spirv-tools-dis.ll
+++ b/test/spirv-tools-dis.ll
@@ -1,0 +1,38 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-tools-dis -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc --spirv-tools-dis -o - | spirv-as
+
+; Verify that the --spirv-tools-dis options results in SPIRV-Tools compatible assembly.
+
+; REQUIRES: libspirv_dis, spirv-as
+
+; CHECK: %1 = OpExtInstImport "OpenCL.std"
+; CHECK: %uint = OpTypeInt 32 0
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @foo(i32 addrspace(1)* %a) !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+entry:
+  %a.addr = alloca i32 addrspace(1)*, align 4
+  store i32 addrspace(1)* %a, i32 addrspace(1)** %a.addr, align 4
+  %0 = load i32 addrspace(1)*, i32 addrspace(1)** %a.addr, align 4
+  store i32 0, i32 addrspace(1)* %0, align 4
+  ret void
+}
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!6}
+!opencl.used.extensions = !{!7}
+!opencl.used.optional.core.features = !{!7}
+!opencl.compiler.options = !{!7}
+
+!1 = !{i32 1}
+!2 = !{!"none"}
+!3 = !{!"int*"}
+!4 = !{!"int*"}
+!5 = !{!""}
+!6 = !{i32 1, i32 2}
+!7 = !{}

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -23,3 +23,9 @@ target_include_directories(llvm-spirv
     ${LLVM_INCLUDE_DIRS}
     ${LLVM_SPIRV_INCLUDE_DIRS}
 )
+
+if(SPIRV_TOOLS_FOUND)
+  target_compile_definitions(llvm-spirv PRIVATE LLVM_SPIRV_HAVE_SPIRV_TOOLS=1)
+  target_include_directories(llvm-spirv PRIVATE ${SPIRV_TOOLS_INCLUDE_DIRS})
+  target_link_libraries(llvm-spirv PRIVATE ${SPIRV_TOOLS_LDFLAGS})
+endif(SPIRV_TOOLS_FOUND)

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -59,6 +59,10 @@
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/ToolOutputFile.h"
 
+#ifdef LLVM_SPIRV_HAVE_SPIRV_TOOLS
+#include "spirv-tools/libspirv.hpp"
+#endif
+
 #ifndef _SPIRV_SUPPORT_TEXT_FMT
 #define _SPIRV_SUPPORT_TEXT_FMT
 #endif
@@ -144,6 +148,10 @@ static cl::opt<bool>
         cl::desc("Preserve OpenCL kernel_arg_type and kernel_arg_type_qual "
                  "metadata through OpString"));
 
+static cl::opt<bool>
+    SPIRVToolsDis("spirv-tools-dis", cl::init(false),
+                  cl::desc("Emit textual assembly using SPIRV-Tools"));
+
 using SPIRV::ExtensionID;
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
@@ -227,6 +235,30 @@ static std::string removeExt(const std::string &FileName) {
 
 static ExitOnError ExitOnErr;
 
+#ifdef LLVM_SPIRV_HAVE_SPIRV_TOOLS
+/// Stream buffer that captures written data into a vector and allows reading
+/// the data back as an array of uint32_t's.
+class StreambufToArray : public std::streambuf {
+public:
+  const uint32_t *data() const {
+    return reinterpret_cast<const uint32_t *>(Buffer.data());
+  }
+
+  size_t size() const { return Buffer.size() / sizeof(uint32_t); }
+
+protected:
+  std::streamsize xsputn(const char *s, std::streamsize count) override {
+    for (std::streamsize I = 0; I < count; I++) {
+      Buffer.push_back(s[I]);
+    }
+    return count;
+  }
+
+private:
+  std::vector<char> Buffer;
+};
+#endif // LLVM_SPIRV_HAVE_SPIRV_TOOLS
+
 static int convertLLVMToSPIRV(const SPIRV::TranslatorOpts &Opts) {
   LLVMContext Context;
 
@@ -244,6 +276,48 @@ static int convertLLVMToSPIRV(const SPIRV::TranslatorOpts &Opts) {
       OutputFile =
           removeExt(InputFile) +
           (SPIRV::SPIRVUseTextFormat ? kExt::SpirvText : kExt::SpirvBinary);
+  }
+
+  if (SPIRVToolsDis) {
+#ifdef LLVM_SPIRV_HAVE_SPIRV_TOOLS
+    auto DisMessagePrinter = [](spv_message_level_t Level, const char *source,
+                                const spv_position_t &position,
+                                const char *message) -> void {
+      errs() << source << ": " << message << "\n";
+    };
+    spvtools::SpirvTools SpvTool(SPV_ENV_OPENCL_2_0);
+    SpvTool.SetMessageConsumer(DisMessagePrinter);
+    std::string DisOutput;
+
+    // Serialize the SPIR-V module to a uint32_t array and then invoke the
+    // SPIR-V tools disassembler to obtain textual assembly.
+    std::string Err;
+    StreambufToArray OutStreamBuf;
+    std::ostream OutStream(&OutStreamBuf);
+    bool Success = writeSpirv(M.get(), Opts, OutStream, Err);
+    if (!Success) {
+      errs() << "Failed to translate SPIR-V: " << Err << '\n';
+      return -1;
+    }
+
+    if (!SpvTool.Disassemble(OutStreamBuf.data(), OutStreamBuf.size(),
+                             &DisOutput)) {
+      errs() << "Failed to generate textual assembly\n";
+      return -1;
+    }
+
+    if (OutputFile != "-") {
+      std::ofstream OutFile(OutputFile, std::ios::binary);
+      OutFile << DisOutput;
+    } else {
+      std::cout << DisOutput;
+    }
+
+    return 0;
+#else
+    errs() << "llvm-spirv was built without --spirv-tools-dis support\n";
+    return -1;
+#endif // LLVM_SPIRV_HAVE_SPIRV_TOOLS
   }
 
   std::string Err;


### PR DESCRIPTION
llvm-spirv's text rendering of a SPIR-V module uses an internal
non-standard format that is not compatible with any other tools.

Add support for emitting SPIR-V assembly using the more widely used
SPIR-V Tools format.  This is achieved by linking to SPIRV-Tools and
invoking its disassembler.  For now, this functionality is only
available if the SPIRV-Tools package is found at build configuration
time.

The main motivation for this change is the proposed integration of
llvm-spirv in Clang (https://reviews.llvm.org/D112404 and
https://reviews.llvm.org/D112410).  Particularly, we would like Clang invocations
such as `clang -S -target spirv` to produce the standard SPIR-V
assembly format instead of llvm-spirv's internal format.