### PR TITLE
Added support of SPIR-V triple from LLVM.

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -79,7 +79,7 @@ cl::opt<bool, true> EnableDbgOutput("spirv-debug",
                                     cl::location(SPIRVDbgEnable));
 #endif
 
-bool isSupportedTriple(Triple T) { return T.isSPIR(); }
+bool isSupportedTriple(Triple T) { return T.isSPIR() || T.isSPIRV(); }
 
 void addFnAttr(CallInst *Call, Attribute::AttrKind Attr) {
   Call->addFnAttr(Attr);

--- a/test/spirv-triple.ll
+++ b/test/spirv-triple.ll
@@ -1,0 +1,3 @@
+; RUN: llvm-as < %s | llvm-spirv -o %t
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-unknown-unknown"


### PR DESCRIPTION
The translator should accept LLVM modules compiled for SPIR-V triple too.