### PR TITLE
[NFC] Align debug tests with recent LLVM community updates

### DIFF
--- a/test/DebugInfo/Generic/imported-name-inlined.ll
+++ b/test/DebugInfo/Generic/imported-name-inlined.ll
@@ -22,21 +22,17 @@ target triple = "spir64-unknown-unknown"
 ; Ensure that top level imported declarations don't produce an extra degenerate
 ; concrete subprogram definition.
 
-; FIXME: imported entities should only be emitted to the abstract origin if one is present
-
 ; CHECK: DW_TAG_compile_unit
 ; CHECK:   DW_TAG_subprogram
 ; CHECK:     DW_AT_name {{.*}} "f1"
 ; CHECK:     DW_TAG_imported_declaration
 ; CHECK:     NULL
-; CHECK:   DW_TAG_namespace
-; CHECK:     DW_TAG_subprogram
-; CHECK:     NULL
 ; CHECK:   DW_TAG_subprogram
 ; CHECK:     DW_AT_name {{.*}} "f2"
 ; CHECK:     DW_TAG_inlined_subroutine
-; CHECK:       DW_TAG_imported_declaration
-; CHECK:       NULL
+; CHECK:     NULL
+; CHECK:   DW_TAG_namespace
+; CHECK:     DW_TAG_subprogram
 ; CHECK:     NULL
 ; CHECK:   NULL
 

--- a/test/DebugInfo/X86/2011-09-26-GlobalVarContext.ll
+++ b/test/DebugInfo/X86/2011-09-26-GlobalVarContext.ll
@@ -53,17 +53,17 @@ attributes #1 = { nounwind readnone }
 
 ; CHECK: DW_TAG_variable
 ; CHECK-NOT: DW_TAG
-; CHECK: DW_AT_name [DW_FORM_strp]       ( .debug_str[0x{{[0-9a-f]*}}] = "GLB")
+; CHECK: DW_AT_name [DW_FORM_strp]   ( .debug_str[0x{{[0-9a-f]*}}] = "LOC")
+; CHECK-NOT: DW_TAG
+; CHECK: DW_AT_decl_file [DW_FORM_data1]    ("/work/llvm/vanilla/test/DebugInfo{{[/\\]}}test.c")
+; CHECK-NOT: DW_TAG
+; CHECK: DW_AT_decl_line [DW_FORM_data1]      (4)
+
+; CHECK: DW_TAG_variable
+; CHECK-NOT: DW_TAG
+; CHECK: DW_AT_name [DW_FORM_strp]      ( .debug_str[0x{{[0-9a-f]*}}] = "GLB")
 ; CHECK-NOT: DW_TAG
 ; CHECK: DW_AT_decl_file [DW_FORM_data1] ("/work/llvm/vanilla/test/DebugInfo{{[/\\]}}test.c")
 ; CHECK-NOT: DW_TAG
 ; CHECK: DW_AT_decl_line [DW_FORM_data1] (1)
-
-; CHECK: DW_TAG_variable
-; CHECK-NOT: DW_TAG
-; CHECK: DW_AT_name [DW_FORM_strp]   ( .debug_str[0x{{[0-9a-f]*}}] = "LOC")
-; CHECK-NOT: DW_TAG
-; CHECK: DW_AT_decl_file [DW_FORM_data1]     ("/work/llvm/vanilla/test/DebugInfo{{[/\\]}}test.c")
-; CHECK-NOT: DW_TAG
-; CHECK: DW_AT_decl_line [DW_FORM_data1]     (4)
 

--- a/test/DebugInfo/X86/debug-info-access.ll
+++ b/test/DebugInfo/X86/debug-info-access.ll
@@ -37,6 +37,10 @@
 ;   A a;
 ;   B b;
 ;   U u;
+;
+; CHECK: DW_TAG_subprogram
+; CHECK:     DW_AT_name {{.*}}"free")
+; CHECK-NOT: DW_AT_accessibility
 
 ; CHECK: DW_TAG_member
 ; CHECK:     DW_AT_name {{.*}}"pub_default_static")
@@ -80,12 +84,6 @@
 ; CHECK: DW_TAG_subprogram
 ; CHECK:     DW_AT_name {{.*}}"union_pub_default")
 ; CHECK: DW_AT_accessibility
-; CHECK: DW_TAG
-;
-; CHECK: DW_TAG_subprogram
-; CHECK:     DW_AT_name {{.*}}"free")
-; CHECK-NOT: DW_AT_accessibility
-; CHECK-NOT: DW_TAG
 ;
 ; ModuleID = '/llvm/tools/clang/test/CodeGenCXX/debug-info-access.cpp'
 source_filename = "test/DebugInfo/X86/debug-info-access.ll"

--- a/test/DebugInfo/X86/dwarf-linkage-names.ll
+++ b/test/DebugInfo/X86/dwarf-linkage-names.ll
@@ -24,10 +24,10 @@ target triple = "spir64-unknown-unknown"
 
 ; This assumes the variable will appear before the function.
 ; LINKAGE1: .section .debug_info
-; LINKAGE1: DW_TAG_variable
+; LINKAGE1: DW_TAG_subprogram
 ; LINKAGE1-NOT: DW_TAG
 ; LINKAGE1: {{DW_AT_(MIPS_)?linkage_name}}
-; LINKAGE1: DW_TAG_subprogram
+; LINKAGE1: DW_TAG_variable
 ; LINKAGE1-NOT: DW_TAG
 ; LINKAGE1: {{DW_AT_(MIPS_)?linkage_name}}
 ; LINKAGE1: .section

--- a/test/DebugInfo/X86/lexical-block-file-inline.ll
+++ b/test/DebugInfo/X86/lexical-block-file-inline.ll
@@ -39,8 +39,6 @@ target triple = "spir64-unknown-unknown"
 ; CHECK:      DW_TAG_lexical_block
 ; CHECK-NOT: {{DW_TAG|NULL}}
 ; CHECK:        DW_TAG_variable
-; CHECK-NOT: {{DW_TAG|NULL}}
-; CHECK:        DW_TAG_imported_module
 
 ;; Abstract "bar" function
 ; CHECK:    [[Offset_bar]]: DW_TAG_subprogram
@@ -53,7 +51,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-NOT: {{DW_TAG|NULL}}
 ; CHECK:        DW_TAG_variable
 ; CHECK-NOT: {{DW_TAG|NULL}}
-; CHECK:        DW_TAG_imported_module
+; CHECK:          DW_TAG_imported_module
 
 ; CHECK:    DW_TAG_subprogram
 ; CHECK-NOT: {{DW_TAG|NULL}}
@@ -67,8 +65,6 @@ target triple = "spir64-unknown-unknown"
 ; CHECK:        DW_TAG_lexical_block
 ; CHECK-NOT: {{DW_TAG|NULL}}
 ; CHECK:          DW_TAG_variable
-; CHECK-NOT: {{DW_TAG|NULL}}
-; CHECK:          DW_TAG_imported_module
 
 
 ; Function Attrs: alwaysinline nounwind

--- a/test/DebugInfo/X86/lexical-block-file-inline.ll
+++ b/test/DebugInfo/X86/lexical-block-file-inline.ll
@@ -51,7 +51,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-NOT: {{DW_TAG|NULL}}
 ; CHECK:        DW_TAG_variable
 ; CHECK-NOT: {{DW_TAG|NULL}}
-; CHECK:          DW_TAG_imported_module
+; CHECK:        DW_TAG_imported_module
 
 ; CHECK:    DW_TAG_subprogram
 ; CHECK-NOT: {{DW_TAG|NULL}}

--- a/test/DebugInfo/X86/linkage-name.ll
+++ b/test/DebugInfo/X86/linkage-name.ll
@@ -8,7 +8,7 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-; CHECK: DW_TAG_subprogram [9] *
+; CHECK: DW_TAG_subprogram [8] *
 ; CHECK-NOT: DW_AT_{{(MIPS_)?}}linkage_name
 ; CHECK: DW_AT_specification
 


### PR DESCRIPTION
75b622a795 "Reland [DwarfDebug] Support emitting function-local
declaration for a lexical block"
and
0ac75e82f
Reland [DwarfDebug] Move emission of global vars, types and imports
to endModule()

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>