### PR TITLE
Move OpenCL relational builtin translation to SPIRVToOCL

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2362,16 +2362,15 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpAll:
   case OpAny:
-    return mapValue(BV,
-                    transOCLAllAny(static_cast<SPIRVInstruction *>(BV), BB));
+    return mapValue(BV, transAllAny(static_cast<SPIRVInstruction *>(BV), BB));
 
   case OpIsFinite:
   case OpIsInf:
   case OpIsNan:
   case OpIsNormal:
   case OpSignBitSet:
-    return mapValue(
-        BV, transOCLRelational(static_cast<SPIRVInstruction *>(BV), BB));
+    return mapValue(BV,
+                    transRelational(static_cast<SPIRVInstruction *>(BV), BB));
   case OpGetKernelWorkGroupSize:
   case OpGetKernelPreferredWorkGroupSizeMultiple:
     return mapValue(
@@ -4240,68 +4239,51 @@ SPIRVToLLVM::transLinkageType(const SPIRVValue *V) {
   }
 }
 
-Instruction *SPIRVToLLVM::transOCLAllAny(SPIRVInstruction *I, BasicBlock *BB) {
+Instruction *SPIRVToLLVM::transAllAny(SPIRVInstruction *I, BasicBlock *BB) {
   CallInst *CI = cast<CallInst>(transSPIRVBuiltinFromInst(I, BB));
   assert(CI->getCalledFunction() && "Unexpected indirect call");
+  BuiltinFuncMangleInfo BtnInfo;
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   return cast<Instruction>(mapValue(
-      I, mutateCallInstOCL(
+      I, mutateCallInst(
              M, CI,
-             [=](CallInst *, std::vector<Value *> &Args, llvm::Type *&RetTy) {
-               Type *Int32Ty = Type::getInt32Ty(*Context);
-               auto OldArg = CI->getOperand(0);
-               auto NewArgTy = FixedVectorType::get(
-                   Int32Ty,
+             [=](CallInst *, std::vector<Value *> &Args) {
+               auto *OldArg = CI->getOperand(0);
+               auto *NewArgTy = FixedVectorType::get(
+                   Type::getInt8Ty(*Context),
                    cast<FixedVectorType>(OldArg->getType())->getNumElements());
-               auto NewArg =
+               auto *NewArg =
                    CastInst::CreateSExtOrBitCast(OldArg, NewArgTy, "", CI);
                Args[0] = NewArg;
-               RetTy = Int32Ty;
                return getSPIRVFuncName(I->getOpCode(), getSPIRVFuncSuffix(I));
              },
-             [=](CallInst *NewCI) -> Instruction * {
-               return CastInst::CreateTruncOrBitCast(
-                   NewCI, Type::getInt1Ty(*Context), "", NewCI->getNextNode());
-             },
-             &Attrs, /*TakeFuncName=*/true)));
+             &BtnInfo, &Attrs, /*TakeFuncName=*/true)));
 }
 
-Instruction *SPIRVToLLVM::transOCLRelational(SPIRVInstruction *I,
-                                             BasicBlock *BB) {
+Instruction *SPIRVToLLVM::transRelational(SPIRVInstruction *I, BasicBlock *BB) {
   CallInst *CI = cast<CallInst>(transSPIRVBuiltinFromInst(I, BB));
   assert(CI->getCalledFunction() && "Unexpected indirect call");
+  BuiltinFuncMangleInfo BtnInfo;
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   return cast<Instruction>(mapValue(
-      I, mutateCallInstOCL(
+      I, mutateCallInst(
              M, CI,
              [=](CallInst *, std::vector<Value *> &Args, llvm::Type *&RetTy) {
-               Type *IntTy = Type::getInt32Ty(*Context);
-               RetTy = IntTy;
                if (CI->getType()->isVectorTy()) {
-                 if (cast<FixedVectorType>(CI->getOperand(0)->getType())
-                         ->getElementType()
-                         ->isDoubleTy())
-                   IntTy = Type::getInt64Ty(*Context);
-                 if (cast<FixedVectorType>(CI->getOperand(0)->getType())
-                         ->getElementType()
-                         ->isHalfTy())
-                   IntTy = Type::getInt16Ty(*Context);
                  RetTy = FixedVectorType::get(
-                     IntTy,
+                     Type::getInt8Ty(*Context),
                      cast<FixedVectorType>(CI->getType())->getNumElements());
                }
                return getSPIRVFuncName(I->getOpCode(), getSPIRVFuncSuffix(I));
              },
              [=](CallInst *NewCI) -> Instruction * {
-               Type *RetTy = Type::getInt1Ty(*Context);
-               if (NewCI->getType()->isVectorTy())
-                 RetTy = FixedVectorType::get(
-                     Type::getInt1Ty(*Context),
-                     cast<FixedVectorType>(NewCI->getType())->getNumElements());
+               Type *RetTy = CI->getType();
+               if (RetTy == NewCI->getType())
+                 return NewCI;
                return CastInst::CreateTruncOrBitCast(NewCI, RetTy, "",
                                                      NewCI->getNextNode());
              },
-             &Attrs, /*TakeFuncName=*/true)));
+             &BtnInfo, &Attrs, /*TakeFuncName=*/true)));
 }
 
 std::unique_ptr<SPIRVModule> readSpirvModule(std::istream &IS,

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -231,8 +231,8 @@ private:
                                                  int64_t Parameter);
   template <class Source, class Func> bool foreachFuncCtlMask(Source, Func);
   llvm::GlobalValue::LinkageTypes transLinkageType(const SPIRVValue *V);
-  Instruction *transOCLAllAny(SPIRVInstruction *BI, BasicBlock *BB);
-  Instruction *transOCLRelational(SPIRVInstruction *BI, BasicBlock *BB);
+  Instruction *transAllAny(SPIRVInstruction *BI, BasicBlock *BB);
+  Instruction *transRelational(SPIRVInstruction *BI, BasicBlock *BB);
 
   void transUserSemantic(SPIRV::SPIRVFunction *Fun);
   void transGlobalAnnotations();

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -185,6 +185,21 @@ void SPIRVToOCLBase::visitCallInst(CallInst &CI) {
     visitCallSPIRVGenericPtrMemSemantics(&CI);
     return;
   }
+  // Check if OC is OpenCL relational builtin except bitselect and select.
+  auto IsOclRelationalOp = [](Op OC) {
+    return isUnaryPredicateOpCode(OC) || OC == OpOrdered || OC == OpUnordered ||
+           OC == OpFOrdEqual || OC == OpFUnordNotEqual ||
+           OC == OpFOrdGreaterThan || OC == OpFOrdGreaterThanEqual ||
+           OC == OpFOrdLessThan || OC == OpFOrdLessThanEqual ||
+           OC == OpFOrdNotEqual;
+  };
+  if (IsOclRelationalOp(OC)) {
+    if (OC == OpAny || OC == OpAll)
+      visitCallSPIRVAnyAll(&CI, OC);
+    else
+      visitCallSPIRVRelational(&CI, OC);
+    return;
+  }
   if (OCLSPIRVBuiltinMap::rfind(OC))
     visitCallSPIRVBuiltin(&CI, OC);
 }
@@ -1086,6 +1101,57 @@ void SPIRVToOCLBase::visitCallSPIRVPrintf(CallInst *CI, OCLExtOpKind Kind) {
     NewCI->setCalledFunction(F);
   else
     NewCI->getCalledFunction()->setName(TargetName);
+}
+
+void SPIRVToOCLBase::visitCallSPIRVAnyAll(CallInst *CI, Op OC) {
+  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  mutateCallInstOCL(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> &Args, Type *&RetTy) {
+        Type *Int8Ty = Type::getInt8Ty(*Ctx);
+        auto *OldArg = CI->getOperand(0);
+        auto *OldArgTy = cast<FixedVectorType>(OldArg->getType());
+        if (Int8Ty != OldArgTy->getElementType()) {
+          auto *NewArgTy =
+              FixedVectorType::get(Int8Ty, OldArgTy->getNumElements());
+          auto *NewArg =
+              CastInst::CreateSExtOrBitCast(OldArg, NewArgTy, "", CI);
+          Args[0] = NewArg;
+        }
+        RetTy = Type::getInt32Ty(*Ctx);
+        return OCLSPIRVBuiltinMap::rmap(OC);
+      },
+      [=](CallInst *NewCI) -> Instruction * {
+        return CastInst::CreateTruncOrBitCast(NewCI, CI->getType(), "",
+                                              NewCI->getNextNode());
+      },
+      &Attrs);
+}
+
+void SPIRVToOCLBase::visitCallSPIRVRelational(CallInst *CI, Op OC) {
+  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  mutateCallInstOCL(
+      M, CI,
+      [=](CallInst *, std::vector<Value *> & /*Args*/, Type *&RetTy) {
+        Type *IntTy = Type::getInt32Ty(*Ctx);
+        RetTy = IntTy;
+        if (CI->getType()->isVectorTy()) {
+          auto *OpElemTy = cast<FixedVectorType>(CI->getOperand(0)->getType())
+                               ->getElementType();
+          if (OpElemTy->isDoubleTy())
+            IntTy = Type::getInt64Ty(*Ctx);
+          if (OpElemTy->isHalfTy())
+            IntTy = Type::getInt16Ty(*Ctx);
+          RetTy = FixedVectorType::get(
+              IntTy, cast<FixedVectorType>(CI->getType())->getNumElements());
+        }
+        return OCLSPIRVBuiltinMap::rmap(OC);
+      },
+      [=](CallInst *NewCI) -> Instruction * {
+        return CastInst::CreateTruncOrBitCast(NewCI, CI->getType(), "",
+                                              NewCI->getNextNode());
+      },
+      &Attrs);
 }
 
 std::string SPIRVToOCLBase::getGroupBuiltinPrefix(CallInst *CI) {

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -218,6 +218,12 @@ public:
   /// Transform __spirv_EnqueueKernel to __enqueue_kernel
   virtual void visitCallSPIRVEnqueueKernel(CallInst *CI, Op OC) = 0;
 
+  /// Transform __spirv_Any and __spirv_All to OpenCL builtin.
+  void visitCallSPIRVAnyAll(CallInst *CI, Op OC);
+
+  /// Transform relational builtin, e.g. __spirv_IsNan, to OpenCL builtin.
+  void visitCallSPIRVRelational(CallInst *CI, Op OC);
+
   /// Conduct generic mutations for all atomic builtins
   virtual CallInst *mutateCommonAtomicArguments(CallInst *CI, Op OC) = 0;
 

--- a/test/relationals.ll
+++ b/test/relationals.ll
@@ -14,17 +14,17 @@ declare dso_local spir_func <4 x i8> @_Z16__spirv_IsFiniteIDv4_aDv4_fET_T0_(<4 x
 declare dso_local spir_func <4 x i8> @_Z16__spirv_IsNormalIDv4_aDv4_fET_T0_(<4 x float>)
 declare dso_local spir_func <4 x i8> @_Z18__spirv_SignBitSetIDv4_aDv4_fET_T0_(<4 x float>)
 
-; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z13__spirv_IsNanDv4_f
-; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z13__spirv_IsInfDv4_f
-; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z16__spirv_IsFiniteDv4_f
-; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z16__spirv_IsNormalDv4_f
-; CHECK-SPV-LLVM: call spir_func <4 x i32> @_Z18__spirv_SignBitSetDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i8> @_Z13__spirv_IsNanDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i8> @_Z13__spirv_IsInfDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i8> @_Z16__spirv_IsFiniteDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i8> @_Z16__spirv_IsNormalDv4_f
+; CHECK-SPV-LLVM: call spir_func <4 x i8> @_Z18__spirv_SignBitSetDv4_f
 
-; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z13__spirv_IsNanDv4_f(<4 x float>)
-; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z13__spirv_IsInfDv4_f(<4 x float>)
-; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z16__spirv_IsFiniteDv4_f(<4 x float>)
-; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z16__spirv_IsNormalDv4_f(<4 x float>)
-; CHECK-SPV-LLVM: declare spir_func <4 x i32> @_Z18__spirv_SignBitSetDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i8> @_Z13__spirv_IsNanDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i8> @_Z13__spirv_IsInfDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i8> @_Z16__spirv_IsFiniteDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i8> @_Z16__spirv_IsNormalDv4_f(<4 x float>)
+; CHECK-SPV-LLVM: declare spir_func <4 x i8> @_Z18__spirv_SignBitSetDv4_f(<4 x float>)
 
 ; CHECK-SPIRV: {{[0-9]+}} TypeBool [[TBool:[0-9]+]]
 ; CHECK-SPIRV: {{[0-9]+}} TypeVector [[TBoolVec:[0-9]+]] [[TBool]]

--- a/test/transcoding/OpAllAny.ll
+++ b/test/transcoding/OpAllAny.ll
@@ -3,54 +3,104 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.spv.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.spv.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
-; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-LLVM
 
-; CHECK-LLVM: call spir_func i32 @_Z3allDv2_i(
-; CHECK-LLVM: call spir_func i32 @_Z3anyDv2_i(
-
-; CHECK-SPV-LLVM: call spir_func i32 @_Z11__spirv_AllDv2_i(
-; CHECK-SPV-LLVM: call spir_func i32 @_Z11__spirv_AnyDv2_i(
-
-; CHECK-SPV-LLVM: declare spir_func i32 @_Z11__spirv_AllDv2_i(<2 x i32>)
-; CHECK-SPV-LLVM: declare spir_func i32 @_Z11__spirv_AnyDv2_i(<2 x i32>)
+; This test checks SYCL relational builtin any and all with vector input types.
 
 ; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
-; CHECK-SPIRV: 4 All [[BoolTypeID]]
+
 ; CHECK-SPIRV: 4 Any [[BoolTypeID]]
+; CHECK-SPIRV: 4 Any [[BoolTypeID]]
+; CHECK-SPIRV: 4 Any [[BoolTypeID]]
+; CHECK-SPIRV: 4 Any [[BoolTypeID]]
+; CHECK-SPIRV: 4 All [[BoolTypeID]]
+; CHECK-SPIRV: 4 All [[BoolTypeID]]
+; CHECK-SPIRV: 4 All [[BoolTypeID]]
+; CHECK-SPIRV: 4 All [[BoolTypeID]]
+
+; CHECK-SPV-IR: call spir_func i1 @_Z11__spirv_AnyDv2_c(<2 x i8>
+; CHECK-SPV-IR: call spir_func i1 @_Z11__spirv_AnyDv2_c(<2 x i8>
+; CHECK-SPV-IR: call spir_func i1 @_Z11__spirv_AnyDv2_c(<2 x i8>
+; CHECK-SPV-IR: call spir_func i1 @_Z11__spirv_AnyDv2_c(<2 x i8>
+; CHECK-SPV-IR: call spir_func i1 @_Z11__spirv_AllDv2_c(<2 x i8>
+; CHECK-SPV-IR: call spir_func i1 @_Z11__spirv_AllDv2_c(<2 x i8>
+; CHECK-SPV-IR: call spir_func i1 @_Z11__spirv_AllDv2_c(<2 x i8>
+; CHECK-SPV-IR: call spir_func i1 @_Z11__spirv_AllDv2_c(<2 x i8>
+
+; CHECK-LLVM: call spir_func i32 @_Z3anyDv2_c(<2 x i8>
+; CHECK-LLVM: call spir_func i32 @_Z3anyDv2_c(<2 x i8>
+; CHECK-LLVM: call spir_func i32 @_Z3anyDv2_c(<2 x i8>
+; CHECK-LLVM: call spir_func i32 @_Z3anyDv2_c(<2 x i8>
+; CHECK-LLVM: call spir_func i32 @_Z3allDv2_c(<2 x i8>
+; CHECK-LLVM: call spir_func i32 @_Z3allDv2_c(<2 x i8>
+; CHECK-LLVM: call spir_func i32 @_Z3allDv2_c(<2 x i8>
+; CHECK-LLVM: call spir_func i32 @_Z3allDv2_c(<2 x i8>
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
-target triple = "spir-unknown-unknown"
+target triple = "spir"
 
-; Function Attrs: nounwind
-define spir_kernel void @testKernel() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
+; Function Attrs: convergent mustprogress nofree norecurse nounwind willreturn writeonly
+define dso_local spir_func void @test_vector(i32 addrspace(4)* nocapture writeonly %out, <2 x i8> %c, <2 x i16> %s, <2 x i32> %i, <2 x i64> %l) local_unnamed_addr #0 {
 entry:
-  %cmp = icmp ne <2 x i64> zeroinitializer, <i64 1, i64 1>
-  %sext = sext <2 x i1> %cmp to <2 x i64>
-  %call = call spir_func i32 @_Z3allDv2_l(<2 x i64> %sext)
-  %0 = insertelement <2 x i64> <i64 1, i64 1>, i64 0, i32 0
-  %cmp1 = icmp ne <2 x i64> zeroinitializer, %0
-  %sext2 = sext <2 x i1> %cmp1 to <2 x i64>
-  %call3 = call spir_func i32 @_Z3anyDv2_l(<2 x i64> %sext2)
+  %call = tail call spir_func i32 @_Z3anyDv2_c(<2 x i8> %c) #2
+  %call1 = tail call spir_func i32 @_Z3anyDv2_s(<2 x i16> %s) #2
+  %add = add nsw i32 %call1, %call
+  %call2 = tail call spir_func i32 @_Z3anyDv2_i(<2 x i32> %i) #2
+  %add3 = add nsw i32 %add, %call2
+  %call4 = tail call spir_func i32 @_Z3anyDv2_l(<2 x i64> %l) #2
+  %add5 = add nsw i32 %add3, %call4
+  %call6 = tail call spir_func i32 @_Z3allDv2_c(<2 x i8> %c) #2
+  %add7 = add nsw i32 %add5, %call6
+  %call8 = tail call spir_func i32 @_Z3allDv2_s(<2 x i16> %s) #2
+  %add9 = add nsw i32 %add7, %call8
+  %call10 = tail call spir_func i32 @_Z3allDv2_i(<2 x i32> %i) #2
+  %add11 = add nsw i32 %add9, %call10
+  %call12 = tail call spir_func i32 @_Z3allDv2_l(<2 x i64> %l) #2
+  %add13 = add nsw i32 %add11, %call12
+  store i32 %add13, i32 addrspace(4)* %out, align 4, !tbaa !3
   ret void
 }
 
-declare spir_func i32 @_Z3allDv2_l(<2 x i64>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z3anyDv2_c(<2 x i8>) local_unnamed_addr #1
 
-declare spir_func i32 @_Z3anyDv2_l(<2 x i64>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z3anyDv2_s(<2 x i16>) local_unnamed_addr #1
 
-attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z3anyDv2_i(<2 x i32>) local_unnamed_addr #1
 
-!opencl.enable.FP_CONTRACT = !{}
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z3anyDv2_l(<2 x i64>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z3allDv2_c(<2 x i8>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z3allDv2_s(<2 x i16>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z3allDv2_i(<2 x i32>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z3allDv2_l(<2 x i64>) local_unnamed_addr #1
+
+attributes #0 = { convergent mustprogress nofree norecurse nounwind willreturn writeonly "frame-pointer"="none" "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #1 = { convergent mustprogress nofree nounwind readnone willreturn "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #2 = { convergent nounwind readnone willreturn }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
 !opencl.spir.version = !{!1}
-!opencl.ocl.version = !{!2}
-!opencl.used.extensions = !{!0}
-!opencl.used.optional.core.features = !{!0}
-!opencl.compiler.options = !{!0}
+!llvm.ident = !{!2}
 
-!0 = !{}
-!1 = !{i32 1, i32 2}
-!2 = !{i32 2, i32 0}
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 14.0.0"}
+!3 = !{!4, !4, i64 0}
+!4 = !{!"int", !5, i64 0}
+!5 = !{!"omnipotent char", !6, i64 0}
+!6 = !{!"Simple C/C++ TBAA"}

--- a/test/transcoding/relationals_double.ll
+++ b/test/transcoding/relationals_double.ll
@@ -3,68 +3,279 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.spv.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.spv.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-SPIRV: 4 TypeInt [[IntTypeID:[0-9]+]] 64
-; CHECK-SPIRV: 4 TypeVector [[Int64VectorTypeID:[0-9]+]] [[IntTypeID]] 2
+; This test checks following SYCL relational builtins with double and double2
+; types:
+;   isfinite, isinf, isnan, isnormal, signbit, isequal, isnotequal, isgreater
+;   isgreaterequal, isless, islessequal, islessgreater, isordered, isunordered
 
-; CHECK-SPIRV: 6 Select [[Int64VectorTypeID]]
-; CHECK-SPIRV: 6 Select [[Int64VectorTypeID]]
-; CHECK-SPIRV: 6 Select [[Int64VectorTypeID]]
-; CHECK-SPIRV: 6 Select [[Int64VectorTypeID]]
+; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
+; CHECK-SPIRV: 4 TypeVector [[BoolVectorTypeID:[0-9]+]] [[BoolTypeID]] 2
 
+; CHECK-SPIRV: 4 IsFinite [[BoolTypeID]]
+; CHECK-SPIRV: 4 IsInf [[BoolTypeID]]
+; CHECK-SPIRV: 4 IsNan [[BoolTypeID]]
+; CHECK-SPIRV: 4 IsNormal [[BoolTypeID]]
+; CHECK-SPIRV: 4 SignBitSet [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FUnordNotEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThan [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThanEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThan [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThanEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdNotEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 Ordered [[BoolTypeID]]
+; CHECK-SPIRV: 5 Unordered [[BoolTypeID]]
+
+; CHECK-SPIRV: 4 IsFinite [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 IsInf [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 IsNormal [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 SignBitSet [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FUnordNotEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThan [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThanEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThan [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThanEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdNotEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 Ordered [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 Unordered [[BoolVectorTypeID]]
+
+; CHECK-SPV-IR: call spir_func i1 @_Z16__spirv_IsFinited(double
+; CHECK-SPV-IR: call spir_func i1 @_Z13__spirv_IsInfd(double
+; CHECK-SPV-IR: call spir_func i1 @_Z13__spirv_IsNand(double
+; CHECK-SPV-IR: call spir_func i1 @_Z16__spirv_IsNormald(double
+; CHECK-SPV-IR: call spir_func i1 @_Z18__spirv_SignBitSetd(double
+; CHECK-SPV-IR: fcmp oeq double
+; CHECK-SPV-IR: fcmp une double
+; CHECK-SPV-IR: fcmp ogt double
+; CHECK-SPV-IR: fcmp oge double
+; CHECK-SPV-IR: fcmp olt double
+; CHECK-SPV-IR: fcmp ole double
+; CHECK-SPV-IR: fcmp one double
+; CHECK-SPV-IR: fcmp ord double
+; CHECK-SPV-IR: fcmp uno double
+
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z16__spirv_IsFiniteDv2_d(<2 x double>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z13__spirv_IsInfDv2_d(<2 x double>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z13__spirv_IsNanDv2_d(<2 x double>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z16__spirv_IsNormalDv2_d(<2 x double>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z18__spirv_SignBitSetDv2_d(<2 x double>
+; CHECK-SPV-IR: fcmp oeq <2 x double>
+; CHECK-SPV-IR: fcmp une <2 x double>
+; CHECK-SPV-IR: fcmp ogt <2 x double>
+; CHECK-SPV-IR: fcmp oge <2 x double>
+; CHECK-SPV-IR: fcmp olt <2 x double>
+; CHECK-SPV-IR: fcmp ole <2 x double>
+; CHECK-SPV-IR: fcmp one <2 x double>
+; CHECK-SPV-IR: fcmp ord <2 x double>
+; CHECK-SPV-IR: fcmp uno <2 x double>
+
+; CHECK-LLVM: call spir_func i32 @_Z8isfinited(double
+; CHECK-LLVM: call spir_func i32 @_Z5isinfd(double
+; CHECK-LLVM: call spir_func i32 @_Z5isnand(double
+; CHECK-LLVM: call spir_func i32 @_Z8isnormald(double
+; CHECK-LLVM: call spir_func i32 @_Z7signbitd(double
+; CHECK-LLVM: fcmp oeq double
+; CHECK-LLVM: fcmp une double
+; CHECK-LLVM: fcmp ogt double
+; CHECK-LLVM: fcmp oge double
+; CHECK-LLVM: fcmp olt double
+; CHECK-LLVM: fcmp ole double
+; CHECK-LLVM: fcmp one double
+; CHECK-LLVM: fcmp ord double
+; CHECK-LLVM: fcmp uno double
+
+; CHECK-LLVM: call spir_func <2 x i64> @_Z8isfiniteDv2_d(<2 x double>
 ; CHECK-LLVM: call spir_func <2 x i64> @_Z5isinfDv2_d(<2 x double>
 ; CHECK-LLVM: call spir_func <2 x i64> @_Z5isnanDv2_d(<2 x double>
 ; CHECK-LLVM: call spir_func <2 x i64> @_Z8isnormalDv2_d(<2 x double>
-; CHECK-LLVM: call spir_func <2 x i64> @_Z8isfiniteDv2_d(<2 x double>
+; CHECK-LLVM: call spir_func <2 x i64> @_Z7signbitDv2_d(<2 x double>
+; CHECK-LLVM: fcmp oeq <2 x double>
+; CHECK-LLVM: fcmp une <2 x double>
+; CHECK-LLVM: fcmp ogt <2 x double>
+; CHECK-LLVM: fcmp oge <2 x double>
+; CHECK-LLVM: fcmp olt <2 x double>
+; CHECK-LLVM: fcmp ole <2 x double>
+; CHECK-LLVM: fcmp one <2 x double>
+; CHECK-LLVM: fcmp ord <2 x double>
+; CHECK-LLVM: fcmp uno <2 x double>
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
-target triple = "spir-unknown-unknown"
+target triple = "spir"
 
-; Function Attrs: nounwind
-define spir_kernel void @test_vector_double(<2 x i64> addrspace(1)* nocapture %out, <2 x double> %in) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
-  %1 = tail call spir_func <2 x i64> @_Z5isinfDv2_d(<2 x double> %in) #2
-  %2 = tail call spir_func <2 x i64> @_Z5isnanDv2_d(<2 x double> %in) #2
-  %3 = add <2 x i64> %1, %2
-  %4 = tail call spir_func <2 x i64> @_Z8isnormalDv2_d(<2 x double> %in) #2
-  %5 = add <2 x i64> %3, %4
-  %6 = tail call spir_func <2 x i64> @_Z8isfiniteDv2_d(<2 x double> %in) #2
-  %7 = add <2 x i64> %5, %6
-  store <2 x i64> %7, <2 x i64> addrspace(1)* %out, align 16, !tbaa !11
+; Function Attrs: convergent mustprogress nofree norecurse nounwind willreturn writeonly
+define dso_local spir_func void @test_scalar(i32 addrspace(4)* nocapture writeonly %out, double %d) local_unnamed_addr #0 {
+entry:
+  %call = tail call spir_func i32 @_Z8isfinited(double %d) #3
+  %call1 = tail call spir_func i32 @_Z5isinfd(double %d) #3
+  %add = add nsw i32 %call1, %call
+  %call2 = tail call spir_func i32 @_Z5isnand(double %d) #3
+  %add3 = add nsw i32 %add, %call2
+  %call4 = tail call spir_func i32 @_Z8isnormald(double %d) #3
+  %add5 = add nsw i32 %add3, %call4
+  %call6 = tail call spir_func i32 @_Z7signbitd(double %d) #3
+  %add7 = add nsw i32 %add5, %call6
+  %call8 = tail call spir_func i32 @_Z7isequaldd(double %d, double %d) #3
+  %add9 = add nsw i32 %add7, %call8
+  %call10 = tail call spir_func i32 @_Z10isnotequaldd(double %d, double %d) #3
+  %add11 = add nsw i32 %add9, %call10
+  %call12 = tail call spir_func i32 @_Z9isgreaterdd(double %d, double %d) #3
+  %add13 = add nsw i32 %add11, %call12
+  %call14 = tail call spir_func i32 @_Z14isgreaterequaldd(double %d, double %d) #3
+  %add15 = add nsw i32 %add13, %call14
+  %call16 = tail call spir_func i32 @_Z6islessdd(double %d, double %d) #3
+  %add17 = add nsw i32 %add15, %call16
+  %call18 = tail call spir_func i32 @_Z11islessequaldd(double %d, double %d) #3
+  %add19 = add nsw i32 %add17, %call18
+  %call20 = tail call spir_func i32 @_Z13islessgreaterdd(double %d, double %d) #3
+  %add21 = add nsw i32 %add19, %call20
+  %call22 = tail call spir_func i32 @_Z9isordereddd(double %d, double %d) #3
+  %add23 = add nsw i32 %add21, %call22
+  %call24 = tail call spir_func i32 @_Z11isunordereddd(double %d, double %d) #3
+  %add25 = add nsw i32 %add23, %call24
+  store i32 %add25, i32 addrspace(4)* %out, align 4, !tbaa !3
   ret void
 }
 
-declare spir_func <2 x i64> @_Z5isinfDv2_d(<2 x double>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z8isfinited(double) local_unnamed_addr #1
 
-declare spir_func <2 x i64> @_Z5isnanDv2_d(<2 x double>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z5isinfd(double) local_unnamed_addr #1
 
-declare spir_func <2 x i64> @_Z8isnormalDv2_d(<2 x double>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z5isnand(double) local_unnamed_addr #1
 
-declare spir_func <2 x i64> @_Z8isfiniteDv2_d(<2 x double>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z8isnormald(double) local_unnamed_addr #1
 
-attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind }
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z7signbitd(double) local_unnamed_addr #1
 
-!opencl.enable.FP_CONTRACT = !{}
-!opencl.spir.version = !{!6}
-!opencl.ocl.version = !{!7}
-!opencl.used.extensions = !{!8}
-!opencl.used.optional.core.features = !{!9}
-!opencl.compiler.options = !{!8}
-!llvm.ident = !{!10}
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z7isequaldd(double, double) local_unnamed_addr #1
 
-!1 = !{i32 1, i32 0}
-!2 = !{!"none", !"none"}
-!3 = !{!"long2*", !"double2"}
-!4 = !{!"long2*", !"double2"}
-!5 = !{!"", !""}
-!6 = !{i32 1, i32 2}
-!7 = !{i32 2, i32 0}
-!8 = !{}
-!9 = !{!"cl_doubles"}
-!10 = !{!"clang version 3.6.1 "}
-!11 = !{!12, !12, i64 0}
-!12 = !{!"omnipotent char", !13, i64 0}
-!13 = !{!"Simple C/C++ TBAA"}
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z10isnotequaldd(double, double) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z9isgreaterdd(double, double) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z14isgreaterequaldd(double, double) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z6islessdd(double, double) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z11islessequaldd(double, double) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z13islessgreaterdd(double, double) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z9isordereddd(double, double) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z11isunordereddd(double, double) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree norecurse nounwind willreturn writeonly
+define dso_local spir_func void @test_vector(<2 x i64> addrspace(4)* nocapture writeonly %out, <2 x double> %d) local_unnamed_addr #2 {
+entry:
+  %call = tail call spir_func <2 x i64> @_Z8isfiniteDv2_d(<2 x double> %d) #3
+  %call1 = tail call spir_func <2 x i64> @_Z5isinfDv2_d(<2 x double> %d) #3
+  %add = add <2 x i64> %call1, %call
+  %call2 = tail call spir_func <2 x i64> @_Z5isnanDv2_d(<2 x double> %d) #3
+  %add3 = add <2 x i64> %add, %call2
+  %call4 = tail call spir_func <2 x i64> @_Z8isnormalDv2_d(<2 x double> %d) #3
+  %add5 = add <2 x i64> %add3, %call4
+  %call6 = tail call spir_func <2 x i64> @_Z7signbitDv2_d(<2 x double> %d) #3
+  %add7 = add <2 x i64> %add5, %call6
+  %call8 = tail call spir_func <2 x i64> @_Z7isequalDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add9 = add <2 x i64> %add7, %call8
+  %call10 = tail call spir_func <2 x i64> @_Z10isnotequalDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add11 = add <2 x i64> %add9, %call10
+  %call12 = tail call spir_func <2 x i64> @_Z9isgreaterDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add13 = add <2 x i64> %add11, %call12
+  %call14 = tail call spir_func <2 x i64> @_Z14isgreaterequalDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add15 = add <2 x i64> %add13, %call14
+  %call16 = tail call spir_func <2 x i64> @_Z6islessDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add17 = add <2 x i64> %add15, %call16
+  %call18 = tail call spir_func <2 x i64> @_Z11islessequalDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add19 = add <2 x i64> %add17, %call18
+  %call20 = tail call spir_func <2 x i64> @_Z13islessgreaterDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add21 = add <2 x i64> %add19, %call20
+  %call22 = tail call spir_func <2 x i64> @_Z9isorderedDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add23 = add <2 x i64> %add21, %call22
+  %call24 = tail call spir_func <2 x i64> @_Z11isunorderedDv2_dS_(<2 x double> %d, <2 x double> %d) #3
+  %add25 = add <2 x i64> %add23, %call24
+  store <2 x i64> %add25, <2 x i64> addrspace(4)* %out, align 16, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z8isfiniteDv2_d(<2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z5isinfDv2_d(<2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z5isnanDv2_d(<2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z8isnormalDv2_d(<2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z7signbitDv2_d(<2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z7isequalDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z10isnotequalDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z9isgreaterDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z14isgreaterequalDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z6islessDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z11islessequalDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z13islessgreaterDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z9isorderedDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i64> @_Z11isunorderedDv2_dS_(<2 x double>, <2 x double>) local_unnamed_addr #1
+
+attributes #0 = { convergent mustprogress nofree norecurse nounwind willreturn writeonly "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #1 = { convergent mustprogress nofree nounwind readnone willreturn "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #2 = { convergent mustprogress nofree norecurse nounwind willreturn writeonly "frame-pointer"="none" "min-legal-vector-width"="128" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #3 = { convergent nounwind readnone willreturn }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 14.0.0"}
+!3 = !{!4, !4, i64 0}
+!4 = !{!"int", !5, i64 0}
+!5 = !{!"omnipotent char", !6, i64 0}
+!6 = !{!"Simple C/C++ TBAA"}
+!7 = !{!5, !5, i64 0}

--- a/test/transcoding/relationals_float.ll
+++ b/test/transcoding/relationals_float.ll
@@ -3,139 +3,279 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.spv.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.spv.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: call spir_func i32 @_Z8isfinitef(
-; CHECK-LLVM: call spir_func i32 @_Z5isnanf(
-; CHECK-LLVM: call spir_func i32 @_Z5isinff(
-; CHECK-LLVM: call spir_func i32 @_Z8isnormalf(
-; CHECK-LLVM: call spir_func i32 @_Z7signbitf(
-; CHECK-LLVM: fcmp one float
-; CHECK-LLVM: fcmp ord float
-; CHECK-LLVM: fcmp uno float
-
-; CHECK-LLVM: call spir_func <2 x i32> @_Z8isfiniteDv2_f(
-; CHECK-LLVM: call spir_func <2 x i32> @_Z5isnanDv2_f(
-; CHECK-LLVM: call spir_func <2 x i32> @_Z5isinfDv2_f(
-; CHECK-LLVM: call spir_func <2 x i32> @_Z8isnormalDv2_f(
-; CHECK-LLVM: fcmp one <2 x float>
-; CHECK-LLVM: fcmp ord <2 x float>
-; CHECK-LLVM: fcmp uno <2 x float>
+; This test checks following SYCL relational builtins with float and float2
+; types:
+;   isfinite, isinf, isnan, isnormal, signbit, isequal, isnotequal, isgreater
+;   isgreaterequal, isless, islessequal, islessgreater, isordered, isunordered
 
 ; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
 ; CHECK-SPIRV: 4 TypeVector [[BoolVectorTypeID:[0-9]+]] [[BoolTypeID]] 2
 
 ; CHECK-SPIRV: 4 IsFinite [[BoolTypeID]]
-; CHECK-SPIRV: 4 IsNan [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsInf [[BoolTypeID]]
+; CHECK-SPIRV: 4 IsNan [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolTypeID]]
 ; CHECK-SPIRV: 4 SignBitSet [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FUnordNotEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThan [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThanEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThan [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThanEqual [[BoolTypeID]]
 ; CHECK-SPIRV: 5 FOrdNotEqual [[BoolTypeID]]
 ; CHECK-SPIRV: 5 Ordered [[BoolTypeID]]
 ; CHECK-SPIRV: 5 Unordered [[BoolTypeID]]
 
 ; CHECK-SPIRV: 4 IsFinite [[BoolVectorTypeID]]
-; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsInf [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 SignBitSet [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FUnordNotEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThan [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThanEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThan [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThanEqual [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 FOrdNotEqual [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 Ordered [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 Unordered [[BoolVectorTypeID]]
 
+; CHECK-SPV-IR: call spir_func i1 @_Z16__spirv_IsFinitef(float
+; CHECK-SPV-IR: call spir_func i1 @_Z13__spirv_IsInff(float
+; CHECK-SPV-IR: call spir_func i1 @_Z13__spirv_IsNanf(float
+; CHECK-SPV-IR: call spir_func i1 @_Z16__spirv_IsNormalf(float
+; CHECK-SPV-IR: call spir_func i1 @_Z18__spirv_SignBitSetf(float
+; CHECK-SPV-IR: fcmp oeq float
+; CHECK-SPV-IR: fcmp une float
+; CHECK-SPV-IR: fcmp ogt float
+; CHECK-SPV-IR: fcmp oge float
+; CHECK-SPV-IR: fcmp olt float
+; CHECK-SPV-IR: fcmp ole float
+; CHECK-SPV-IR: fcmp one float
+; CHECK-SPV-IR: fcmp ord float
+; CHECK-SPV-IR: fcmp uno float
+
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z16__spirv_IsFiniteDv2_f(<2 x float>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z13__spirv_IsInfDv2_f(<2 x float>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z13__spirv_IsNanDv2_f(<2 x float>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z16__spirv_IsNormalDv2_f(<2 x float>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z18__spirv_SignBitSetDv2_f(<2 x float>
+; CHECK-SPV-IR: fcmp oeq <2 x float>
+; CHECK-SPV-IR: fcmp une <2 x float>
+; CHECK-SPV-IR: fcmp ogt <2 x float>
+; CHECK-SPV-IR: fcmp oge <2 x float>
+; CHECK-SPV-IR: fcmp olt <2 x float>
+; CHECK-SPV-IR: fcmp ole <2 x float>
+; CHECK-SPV-IR: fcmp one <2 x float>
+; CHECK-SPV-IR: fcmp ord <2 x float>
+; CHECK-SPV-IR: fcmp uno <2 x float>
+
+; CHECK-LLVM: call spir_func i32 @_Z8isfinitef(float
+; CHECK-LLVM: call spir_func i32 @_Z5isinff(float
+; CHECK-LLVM: call spir_func i32 @_Z5isnanf(float
+; CHECK-LLVM: call spir_func i32 @_Z8isnormalf(float
+; CHECK-LLVM: call spir_func i32 @_Z7signbitf(float
+; CHECK-LLVM: fcmp oeq float
+; CHECK-LLVM: fcmp une float
+; CHECK-LLVM: fcmp ogt float
+; CHECK-LLVM: fcmp oge float
+; CHECK-LLVM: fcmp olt float
+; CHECK-LLVM: fcmp ole float
+; CHECK-LLVM: fcmp one float
+; CHECK-LLVM: fcmp ord float
+; CHECK-LLVM: fcmp uno float
+
+; CHECK-LLVM: call spir_func <2 x i32> @_Z8isfiniteDv2_f(<2 x float>
+; CHECK-LLVM: call spir_func <2 x i32> @_Z5isinfDv2_f(<2 x float>
+; CHECK-LLVM: call spir_func <2 x i32> @_Z5isnanDv2_f(<2 x float>
+; CHECK-LLVM: call spir_func <2 x i32> @_Z8isnormalDv2_f(<2 x float>
+; CHECK-LLVM: call spir_func <2 x i32> @_Z7signbitDv2_f(<2 x float>
+; CHECK-LLVM: fcmp oeq <2 x float>
+; CHECK-LLVM: fcmp une <2 x float>
+; CHECK-LLVM: fcmp ogt <2 x float>
+; CHECK-LLVM: fcmp oge <2 x float>
+; CHECK-LLVM: fcmp olt <2 x float>
+; CHECK-LLVM: fcmp ole <2 x float>
+; CHECK-LLVM: fcmp one <2 x float>
+; CHECK-LLVM: fcmp ord <2 x float>
+; CHECK-LLVM: fcmp uno <2 x float>
+
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
-target triple = "spir-unknown-unknown"
+target triple = "spir"
 
-; Function Attrs: nounwind
-define spir_kernel void @test_scalar(i32 addrspace(1)* nocapture %out, float %f) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+; Function Attrs: convergent mustprogress nofree norecurse nounwind willreturn writeonly
+define dso_local spir_func void @test_scalar(i32 addrspace(4)* nocapture writeonly %out, float %f) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i32 @_Z8isfinitef(float %f) #2
-  %call1 = tail call spir_func i32 @_Z5isnanf(float %f) #2
+  %call = tail call spir_func i32 @_Z8isfinitef(float %f) #3
+  %call1 = tail call spir_func i32 @_Z5isinff(float %f) #3
   %add = add nsw i32 %call1, %call
-  %call2 = tail call spir_func i32 @_Z5isinff(float %f) #2
+  %call2 = tail call spir_func i32 @_Z5isnanf(float %f) #3
   %add3 = add nsw i32 %add, %call2
-  %call4 = tail call spir_func i32 @_Z8isnormalf(float %f) #2
+  %call4 = tail call spir_func i32 @_Z8isnormalf(float %f) #3
   %add5 = add nsw i32 %add3, %call4
-  %call6 = tail call spir_func i32 @_Z7signbitf(float %f) #2
+  %call6 = tail call spir_func i32 @_Z7signbitf(float %f) #3
   %add7 = add nsw i32 %add5, %call6
-  %call8 = tail call spir_func i32 @_Z13islessgreaterff(float %f, float %f) #2
+  %call8 = tail call spir_func i32 @_Z7isequalff(float %f, float %f) #3
   %add9 = add nsw i32 %add7, %call8
-  %call10 = tail call spir_func i32 @_Z9isorderedff(float %f, float %f) #2
+  %call10 = tail call spir_func i32 @_Z10isnotequalff(float %f, float %f) #3
   %add11 = add nsw i32 %add9, %call10
-  %call12 = tail call spir_func i32 @_Z11isunorderedff(float %f, float %f) #2
+  %call12 = tail call spir_func i32 @_Z9isgreaterff(float %f, float %f) #3
   %add13 = add nsw i32 %add11, %call12
-  store i32 %add13, i32 addrspace(1)* %out, align 4
+  %call14 = tail call spir_func i32 @_Z14isgreaterequalff(float %f, float %f) #3
+  %add15 = add nsw i32 %add13, %call14
+  %call16 = tail call spir_func i32 @_Z6islessff(float %f, float %f) #3
+  %add17 = add nsw i32 %add15, %call16
+  %call18 = tail call spir_func i32 @_Z11islessequalff(float %f, float %f) #3
+  %add19 = add nsw i32 %add17, %call18
+  %call20 = tail call spir_func i32 @_Z13islessgreaterff(float %f, float %f) #3
+  %add21 = add nsw i32 %add19, %call20
+  %call22 = tail call spir_func i32 @_Z9isorderedff(float %f, float %f) #3
+  %add23 = add nsw i32 %add21, %call22
+  %call24 = tail call spir_func i32 @_Z11isunorderedff(float %f, float %f) #3
+  %add25 = add nsw i32 %add23, %call24
+  store i32 %add25, i32 addrspace(4)* %out, align 4, !tbaa !3
   ret void
 }
 
-declare spir_func i32 @_Z8isfinitef(float) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z8isfinitef(float) local_unnamed_addr #1
 
-declare spir_func i32 @_Z5isnanf(float) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z5isinff(float) local_unnamed_addr #1
 
-declare spir_func i32 @_Z5isinff(float) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z5isnanf(float) local_unnamed_addr #1
 
-declare spir_func i32 @_Z8isnormalf(float) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z8isnormalf(float) local_unnamed_addr #1
 
-declare spir_func i32 @_Z7signbitf(float) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z7signbitf(float) local_unnamed_addr #1
 
-declare spir_func i32 @_Z13islessgreaterff(float, float) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z7isequalff(float, float) local_unnamed_addr #1
 
-declare spir_func i32 @_Z9isorderedff(float, float) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z10isnotequalff(float, float) local_unnamed_addr #1
 
-declare spir_func i32 @_Z11isunorderedff(float, float) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z9isgreaterff(float, float) local_unnamed_addr #1
 
-; Function Attrs: nounwind
-define spir_kernel void @test_vector(<2 x i32> addrspace(1)* nocapture %out, <2 x float> %f) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !7 !kernel_arg_base_type !8 !kernel_arg_type_qual !5 {
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z14isgreaterequalff(float, float) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z6islessff(float, float) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z11islessequalff(float, float) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z13islessgreaterff(float, float) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z9isorderedff(float, float) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z11isunorderedff(float, float) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree norecurse nounwind willreturn writeonly
+define dso_local spir_func void @test_vector(<2 x i32> addrspace(4)* nocapture writeonly %out, <2 x float> %f) local_unnamed_addr #2 {
 entry:
-  %call = tail call spir_func <2 x i32> @_Z8isfiniteDv2_f(<2 x float> %f) #2
-  %call1 = tail call spir_func <2 x i32> @_Z5isnanDv2_f(<2 x float> %f) #2
-  %add = add <2 x i32> %call, %call1
-  %call2 = tail call spir_func <2 x i32> @_Z5isinfDv2_f(<2 x float> %f) #2
+  %call = tail call spir_func <2 x i32> @_Z8isfiniteDv2_f(<2 x float> %f) #3
+  %call1 = tail call spir_func <2 x i32> @_Z5isinfDv2_f(<2 x float> %f) #3
+  %add = add <2 x i32> %call1, %call
+  %call2 = tail call spir_func <2 x i32> @_Z5isnanDv2_f(<2 x float> %f) #3
   %add3 = add <2 x i32> %add, %call2
-  %call4 = tail call spir_func <2 x i32> @_Z8isnormalDv2_f(<2 x float> %f) #2
+  %call4 = tail call spir_func <2 x i32> @_Z8isnormalDv2_f(<2 x float> %f) #3
   %add5 = add <2 x i32> %add3, %call4
-  %call6 = tail call spir_func <2 x i32> @_Z13islessgreaterDv2_fS_(<2 x float> %f, <2 x float> %f) #2
+  %call6 = tail call spir_func <2 x i32> @_Z7signbitDv2_f(<2 x float> %f) #3
   %add7 = add <2 x i32> %add5, %call6
-  %call8 = tail call spir_func <2 x i32> @_Z9isorderedDv2_fS_(<2 x float> %f, <2 x float> %f) #2
+  %call8 = tail call spir_func <2 x i32> @_Z7isequalDv2_fS_(<2 x float> %f, <2 x float> %f) #3
   %add9 = add <2 x i32> %add7, %call8
-  %call10 = tail call spir_func <2 x i32> @_Z11isunorderedDv2_fS_(<2 x float> %f, <2 x float> %f) #2
+  %call10 = tail call spir_func <2 x i32> @_Z10isnotequalDv2_fS_(<2 x float> %f, <2 x float> %f) #3
   %add11 = add <2 x i32> %add9, %call10
-  store <2 x i32> %add11, <2 x i32> addrspace(1)* %out, align 8
+  %call12 = tail call spir_func <2 x i32> @_Z9isgreaterDv2_fS_(<2 x float> %f, <2 x float> %f) #3
+  %add13 = add <2 x i32> %add11, %call12
+  %call14 = tail call spir_func <2 x i32> @_Z14isgreaterequalDv2_fS_(<2 x float> %f, <2 x float> %f) #3
+  %add15 = add <2 x i32> %add13, %call14
+  %call16 = tail call spir_func <2 x i32> @_Z6islessDv2_fS_(<2 x float> %f, <2 x float> %f) #3
+  %add17 = add <2 x i32> %add15, %call16
+  %call18 = tail call spir_func <2 x i32> @_Z11islessequalDv2_fS_(<2 x float> %f, <2 x float> %f) #3
+  %add19 = add <2 x i32> %add17, %call18
+  %call20 = tail call spir_func <2 x i32> @_Z13islessgreaterDv2_fS_(<2 x float> %f, <2 x float> %f) #3
+  %add21 = add <2 x i32> %add19, %call20
+  %call22 = tail call spir_func <2 x i32> @_Z9isorderedDv2_fS_(<2 x float> %f, <2 x float> %f) #3
+  %add23 = add <2 x i32> %add21, %call22
+  %call24 = tail call spir_func <2 x i32> @_Z11isunorderedDv2_fS_(<2 x float> %f, <2 x float> %f) #3
+  %add25 = add <2 x i32> %add23, %call24
+  store <2 x i32> %add25, <2 x i32> addrspace(4)* %out, align 8, !tbaa !7
   ret void
 }
 
-declare spir_func <2 x i32> @_Z8isfiniteDv2_f(<2 x float>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z8isfiniteDv2_f(<2 x float>) local_unnamed_addr #1
 
-declare spir_func <2 x i32> @_Z5isnanDv2_f(<2 x float>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z5isinfDv2_f(<2 x float>) local_unnamed_addr #1
 
-declare spir_func <2 x i32> @_Z5isinfDv2_f(<2 x float>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z5isnanDv2_f(<2 x float>) local_unnamed_addr #1
 
-declare spir_func <2 x i32> @_Z8isnormalDv2_f(<2 x float>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z8isnormalDv2_f(<2 x float>) local_unnamed_addr #1
 
-declare spir_func <2 x i32> @_Z13islessgreaterDv2_fS_(<2 x float>, <2 x float>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z7signbitDv2_f(<2 x float>) local_unnamed_addr #1
 
-declare spir_func <2 x i32> @_Z9isorderedDv2_fS_(<2 x float>, <2 x float>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z7isequalDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
 
-declare spir_func <2 x i32> @_Z11isunorderedDv2_fS_(<2 x float>, <2 x float>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z10isnotequalDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
 
-attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind }
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z9isgreaterDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
 
-!opencl.enable.FP_CONTRACT = !{}
-!opencl.spir.version = !{!9}
-!opencl.ocl.version = !{!10}
-!opencl.used.extensions = !{!11}
-!opencl.used.optional.core.features = !{!11}
-!opencl.compiler.options = !{!11}
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z14isgreaterequalDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
 
-!1 = !{i32 1, i32 0}
-!2 = !{!"none", !"none"}
-!3 = !{!"int*", !"float"}
-!4 = !{!"int*", !"float"}
-!5 = !{!"", !""}
-!7 = !{!"int2*", !"float2"}
-!8 = !{!"int2*", !"float2"}
-!9 = !{i32 1, i32 2}
-!10 = !{i32 2, i32 0}
-!11 = !{}
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z6islessDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z11islessequalDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z13islessgreaterDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z9isorderedDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i32> @_Z11isunorderedDv2_fS_(<2 x float>, <2 x float>) local_unnamed_addr #1
+
+attributes #0 = { convergent mustprogress nofree norecurse nounwind willreturn writeonly "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #1 = { convergent mustprogress nofree nounwind readnone willreturn "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #2 = { convergent mustprogress nofree norecurse nounwind willreturn writeonly "frame-pointer"="none" "min-legal-vector-width"="64" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #3 = { convergent nounwind readnone willreturn }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 14.0.0"}
+!3 = !{!4, !4, i64 0}
+!4 = !{!"int", !5, i64 0}
+!5 = !{!"omnipotent char", !6, i64 0}
+!6 = !{!"Simple C/C++ TBAA"}
+!7 = !{!5, !5, i64 0}

--- a/test/transcoding/relationals_half.ll
+++ b/test/transcoding/relationals_half.ll
@@ -3,139 +3,278 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.spv.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.spv.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: call spir_func i32 @_Z8isfiniteDh(
-; CHECK-LLVM: call spir_func i32 @_Z5isnanDh(
-; CHECK-LLVM: call spir_func i32 @_Z5isinfDh(
-; CHECK-LLVM: call spir_func i32 @_Z8isnormalDh(
-; CHECK-LLVM: call spir_func i32 @_Z7signbitDh(
-; CHECK-LLVM: fcmp one half
-; CHECK-LLVM: fcmp ord half
-; CHECK-LLVM: fcmp uno half
-
-; CHECK-LLVM: call spir_func <2 x i16> @_Z8isfiniteDv2_Dh(
-; CHECK-LLVM: call spir_func <2 x i16> @_Z5isnanDv2_Dh(
-; CHECK-LLVM: call spir_func <2 x i16> @_Z5isinfDv2_Dh(
-; CHECK-LLVM: call spir_func <2 x i16> @_Z8isnormalDv2_Dh(
-; CHECK-LLVM: fcmp one <2 x half>
-; CHECK-LLVM: fcmp ord <2 x half>
-; CHECK-LLVM: fcmp uno <2 x half>
+; This test checks following SYCL relational builtins with half and half2 types:
+;   isfinite, isinf, isnan, isnormal, signbit, isequal, isnotequal, isgreater
+;   isgreaterequal, isless, islessequal, islessgreater, isordered, isunordered
 
 ; CHECK-SPIRV: 2 TypeBool [[BoolTypeID:[0-9]+]]
 ; CHECK-SPIRV: 4 TypeVector [[BoolVectorTypeID:[0-9]+]] [[BoolTypeID]] 2
 
 ; CHECK-SPIRV: 4 IsFinite [[BoolTypeID]]
-; CHECK-SPIRV: 4 IsNan [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsInf [[BoolTypeID]]
+; CHECK-SPIRV: 4 IsNan [[BoolTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolTypeID]]
 ; CHECK-SPIRV: 4 SignBitSet [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FUnordNotEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThan [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThanEqual [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThan [[BoolTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThanEqual [[BoolTypeID]]
 ; CHECK-SPIRV: 5 FOrdNotEqual [[BoolTypeID]]
 ; CHECK-SPIRV: 5 Ordered [[BoolTypeID]]
 ; CHECK-SPIRV: 5 Unordered [[BoolTypeID]]
 
 ; CHECK-SPIRV: 4 IsFinite [[BoolVectorTypeID]]
-; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsInf [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 IsNan [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 4 IsNormal [[BoolVectorTypeID]]
+; CHECK-SPIRV: 4 SignBitSet [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FUnordNotEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThan [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdGreaterThanEqual [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThan [[BoolVectorTypeID]]
+; CHECK-SPIRV: 5 FOrdLessThanEqual [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 FOrdNotEqual [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 Ordered [[BoolVectorTypeID]]
 ; CHECK-SPIRV: 5 Unordered [[BoolVectorTypeID]]
 
+; CHECK-SPV-IR: call spir_func i1 @_Z16__spirv_IsFiniteDh(half
+; CHECK-SPV-IR: call spir_func i1 @_Z13__spirv_IsInfDh(half
+; CHECK-SPV-IR: call spir_func i1 @_Z13__spirv_IsNanDh(half
+; CHECK-SPV-IR: call spir_func i1 @_Z16__spirv_IsNormalDh(half
+; CHECK-SPV-IR: call spir_func i1 @_Z18__spirv_SignBitSetDh(half
+; CHECK-SPV-IR: fcmp oeq half
+; CHECK-SPV-IR: fcmp une half
+; CHECK-SPV-IR: fcmp ogt half
+; CHECK-SPV-IR: fcmp oge half
+; CHECK-SPV-IR: fcmp olt half
+; CHECK-SPV-IR: fcmp ole half
+; CHECK-SPV-IR: fcmp one half
+; CHECK-SPV-IR: fcmp ord half
+; CHECK-SPV-IR: fcmp uno half
+
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z16__spirv_IsFiniteDv2_Dh(<2 x half>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z13__spirv_IsInfDv2_Dh(<2 x half>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z13__spirv_IsNanDv2_Dh(<2 x half>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z16__spirv_IsNormalDv2_Dh(<2 x half>
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z18__spirv_SignBitSetDv2_Dh(<2 x half>
+; CHECK-SPV-IR: fcmp oeq <2 x half>
+; CHECK-SPV-IR: fcmp une <2 x half>
+; CHECK-SPV-IR: fcmp ogt <2 x half>
+; CHECK-SPV-IR: fcmp oge <2 x half>
+; CHECK-SPV-IR: fcmp olt <2 x half>
+; CHECK-SPV-IR: fcmp ole <2 x half>
+; CHECK-SPV-IR: fcmp one <2 x half>
+; CHECK-SPV-IR: fcmp ord <2 x half>
+; CHECK-SPV-IR: fcmp uno <2 x half>
+
+; CHECK-LLVM: call spir_func i32 @_Z8isfiniteDh(half
+; CHECK-LLVM: call spir_func i32 @_Z5isinfDh(half
+; CHECK-LLVM: call spir_func i32 @_Z5isnanDh(half
+; CHECK-LLVM: call spir_func i32 @_Z8isnormalDh(half
+; CHECK-LLVM: call spir_func i32 @_Z7signbitDh(half
+; CHECK-LLVM: fcmp oeq half
+; CHECK-LLVM: fcmp une half
+; CHECK-LLVM: fcmp ogt half
+; CHECK-LLVM: fcmp oge half
+; CHECK-LLVM: fcmp olt half
+; CHECK-LLVM: fcmp ole half
+; CHECK-LLVM: fcmp one half
+; CHECK-LLVM: fcmp ord half
+; CHECK-LLVM: fcmp uno half
+
+; CHECK-LLVM: call spir_func <2 x i16> @_Z8isfiniteDv2_Dh(<2 x half>
+; CHECK-LLVM: call spir_func <2 x i16> @_Z5isinfDv2_Dh(<2 x half>
+; CHECK-LLVM: call spir_func <2 x i16> @_Z5isnanDv2_Dh(<2 x half>
+; CHECK-LLVM: call spir_func <2 x i16> @_Z8isnormalDv2_Dh(<2 x half>
+; CHECK-LLVM: call spir_func <2 x i16> @_Z7signbitDv2_Dh(<2 x half>
+; CHECK-LLVM: fcmp oeq <2 x half>
+; CHECK-LLVM: fcmp une <2 x half>
+; CHECK-LLVM: fcmp ogt <2 x half>
+; CHECK-LLVM: fcmp oge <2 x half>
+; CHECK-LLVM: fcmp olt <2 x half>
+; CHECK-LLVM: fcmp ole <2 x half>
+; CHECK-LLVM: fcmp one <2 x half>
+; CHECK-LLVM: fcmp ord <2 x half>
+; CHECK-LLVM: fcmp uno <2 x half>
+
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
-target triple = "spir-unknown-unknown"
+target triple = "spir"
 
-; Function Attrs: nounwind
-define spir_kernel void @test_scalar(i32 addrspace(1)* nocapture %out, half %f) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+; Function Attrs: convergent mustprogress nofree norecurse nounwind willreturn writeonly
+define dso_local spir_func void @test_scalar(i32 addrspace(4)* nocapture writeonly %out, half %h) local_unnamed_addr #0 {
 entry:
-  %call = tail call spir_func i32 @_Z8isfiniteDh(half %f) #2
-  %call1 = tail call spir_func i32 @_Z5isnanDh(half %f) #2
+  %call = tail call spir_func i32 @_Z8isfiniteDh(half %h) #3
+  %call1 = tail call spir_func i32 @_Z5isinfDh(half %h) #3
   %add = add nsw i32 %call1, %call
-  %call2 = tail call spir_func i32 @_Z5isinfDh(half %f) #2
+  %call2 = tail call spir_func i32 @_Z5isnanDh(half %h) #3
   %add3 = add nsw i32 %add, %call2
-  %call4 = tail call spir_func i32 @_Z8isnormalDh(half %f) #2
+  %call4 = tail call spir_func i32 @_Z8isnormalDh(half %h) #3
   %add5 = add nsw i32 %add3, %call4
-  %call6 = tail call spir_func i32 @_Z7signbitDh(half %f) #2
+  %call6 = tail call spir_func i32 @_Z7signbitDh(half %h) #3
   %add7 = add nsw i32 %add5, %call6
-  %call8 = tail call spir_func i32 @_Z13islessgreaterDhDh(half %f, half %f) #2
+  %call8 = tail call spir_func i32 @_Z7isequalDhDh(half %h, half %h) #3
   %add9 = add nsw i32 %add7, %call8
-  %call10 = tail call spir_func i32 @_Z9isorderedDhDh(half %f, half %f) #2
+  %call10 = tail call spir_func i32 @_Z10isnotequalDhDh(half %h, half %h) #3
   %add11 = add nsw i32 %add9, %call10
-  %call12 = tail call spir_func i32 @_Z11isunorderedDhDh(half %f, half %f) #2
+  %call12 = tail call spir_func i32 @_Z9isgreaterDhDh(half %h, half %h) #3
   %add13 = add nsw i32 %add11, %call12
-  store i32 %add13, i32 addrspace(1)* %out, align 4
+  %call14 = tail call spir_func i32 @_Z14isgreaterequalDhDh(half %h, half %h) #3
+  %add15 = add nsw i32 %add13, %call14
+  %call16 = tail call spir_func i32 @_Z6islessDhDh(half %h, half %h) #3
+  %add17 = add nsw i32 %add15, %call16
+  %call18 = tail call spir_func i32 @_Z11islessequalDhDh(half %h, half %h) #3
+  %add19 = add nsw i32 %add17, %call18
+  %call20 = tail call spir_func i32 @_Z13islessgreaterDhDh(half %h, half %h) #3
+  %add21 = add nsw i32 %add19, %call20
+  %call22 = tail call spir_func i32 @_Z9isorderedDhDh(half %h, half %h) #3
+  %add23 = add nsw i32 %add21, %call22
+  %call24 = tail call spir_func i32 @_Z11isunorderedDhDh(half %h, half %h) #3
+  %add25 = add nsw i32 %add23, %call24
+  store i32 %add25, i32 addrspace(4)* %out, align 4, !tbaa !3
   ret void
 }
 
-declare spir_func i32 @_Z8isfiniteDh(half) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z8isfiniteDh(half) local_unnamed_addr #1
 
-declare spir_func i32 @_Z5isnanDh(half) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z5isinfDh(half) local_unnamed_addr #1
 
-declare spir_func i32 @_Z5isinfDh(half) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z5isnanDh(half) local_unnamed_addr #1
 
-declare spir_func i32 @_Z8isnormalDh(half) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z8isnormalDh(half) local_unnamed_addr #1
 
-declare spir_func i32 @_Z7signbitDh(half) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z7signbitDh(half) local_unnamed_addr #1
 
-declare spir_func i32 @_Z13islessgreaterDhDh(half, half) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z7isequalDhDh(half, half) local_unnamed_addr #1
 
-declare spir_func i32 @_Z9isorderedDhDh(half, half) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z10isnotequalDhDh(half, half) local_unnamed_addr #1
 
-declare spir_func i32 @_Z11isunorderedDhDh(half, half) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z9isgreaterDhDh(half, half) local_unnamed_addr #1
 
-; Function Attrs: nounwind
-define spir_kernel void @test_vector(<2 x i16> addrspace(1)* nocapture %out, <2 x half> %f) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !7 !kernel_arg_base_type !8 !kernel_arg_type_qual !5 {
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z14isgreaterequalDhDh(half, half) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z6islessDhDh(half, half) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z11islessequalDhDh(half, half) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z13islessgreaterDhDh(half, half) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z9isorderedDhDh(half, half) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func i32 @_Z11isunorderedDhDh(half, half) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree norecurse nounwind willreturn writeonly
+define dso_local spir_func void @test_vector(<2 x i16> addrspace(4)* nocapture writeonly %out, <2 x half> %h) local_unnamed_addr #2 {
 entry:
-  %call = tail call spir_func <2 x i16> @_Z8isfiniteDv2_Dh(<2 x half> %f) #2
-  %call1 = tail call spir_func <2 x i16> @_Z5isnanDv2_Dh(<2 x half> %f) #2
-  %add = add <2 x i16> %call, %call1
-  %call2 = tail call spir_func <2 x i16> @_Z5isinfDv2_Dh(<2 x half> %f) #2
+  %call = tail call spir_func <2 x i16> @_Z8isfiniteDv2_Dh(<2 x half> %h) #3
+  %call1 = tail call spir_func <2 x i16> @_Z5isinfDv2_Dh(<2 x half> %h) #3
+  %add = add <2 x i16> %call1, %call
+  %call2 = tail call spir_func <2 x i16> @_Z5isnanDv2_Dh(<2 x half> %h) #3
   %add3 = add <2 x i16> %add, %call2
-  %call4 = tail call spir_func <2 x i16> @_Z8isnormalDv2_Dh(<2 x half> %f) #2
+  %call4 = tail call spir_func <2 x i16> @_Z8isnormalDv2_Dh(<2 x half> %h) #3
   %add5 = add <2 x i16> %add3, %call4
-  %call6 = tail call spir_func <2 x i16> @_Z13islessgreaterDv2_DhS_(<2 x half> %f, <2 x half> %f) #2
+  %call6 = tail call spir_func <2 x i16> @_Z7signbitDv2_Dh(<2 x half> %h) #3
   %add7 = add <2 x i16> %add5, %call6
-  %call8 = tail call spir_func <2 x i16> @_Z9isorderedDv2_DhS_(<2 x half> %f, <2 x half> %f) #2
+  %call8 = tail call spir_func <2 x i16> @_Z7isequalDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
   %add9 = add <2 x i16> %add7, %call8
-  %call10 = tail call spir_func <2 x i16> @_Z11isunorderedDv2_DhS_(<2 x half> %f, <2 x half> %f) #2
+  %call10 = tail call spir_func <2 x i16> @_Z10isnotequalDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
   %add11 = add <2 x i16> %add9, %call10
-  store <2 x i16> %add11, <2 x i16> addrspace(1)* %out, align 8
+  %call12 = tail call spir_func <2 x i16> @_Z9isgreaterDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
+  %add13 = add <2 x i16> %add11, %call12
+  %call14 = tail call spir_func <2 x i16> @_Z14isgreaterequalDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
+  %add15 = add <2 x i16> %add13, %call14
+  %call16 = tail call spir_func <2 x i16> @_Z6islessDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
+  %add17 = add <2 x i16> %add15, %call16
+  %call18 = tail call spir_func <2 x i16> @_Z11islessequalDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
+  %add19 = add <2 x i16> %add17, %call18
+  %call20 = tail call spir_func <2 x i16> @_Z13islessgreaterDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
+  %add21 = add <2 x i16> %add19, %call20
+  %call22 = tail call spir_func <2 x i16> @_Z9isorderedDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
+  %add23 = add <2 x i16> %add21, %call22
+  %call24 = tail call spir_func <2 x i16> @_Z11isunorderedDv2_DhS_(<2 x half> %h, <2 x half> %h) #3
+  %add25 = add <2 x i16> %add23, %call24
+  store <2 x i16> %add25, <2 x i16> addrspace(4)* %out, align 4, !tbaa !7
   ret void
 }
 
-declare spir_func <2 x i16> @_Z8isfiniteDv2_Dh(<2 x half>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z8isfiniteDv2_Dh(<2 x half>) local_unnamed_addr #1
 
-declare spir_func <2 x i16> @_Z5isnanDv2_Dh(<2 x half>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z5isinfDv2_Dh(<2 x half>) local_unnamed_addr #1
 
-declare spir_func <2 x i16> @_Z5isinfDv2_Dh(<2 x half>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z5isnanDv2_Dh(<2 x half>) local_unnamed_addr #1
 
-declare spir_func <2 x i16> @_Z8isnormalDv2_Dh(<2 x half>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z8isnormalDv2_Dh(<2 x half>) local_unnamed_addr #1
 
-declare spir_func <2 x i16> @_Z13islessgreaterDv2_DhS_(<2 x half>, <2 x half>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z7signbitDv2_Dh(<2 x half>) local_unnamed_addr #1
 
-declare spir_func <2 x i16> @_Z9isorderedDv2_DhS_(<2 x half>, <2 x half>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z7isequalDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
 
-declare spir_func <2 x i16> @_Z11isunorderedDv2_DhS_(<2 x half>, <2 x half>) #1
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z10isnotequalDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
 
-attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind }
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z9isgreaterDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
 
-!opencl.enable.FP_CONTRACT = !{}
-!opencl.spir.version = !{!9}
-!opencl.ocl.version = !{!10}
-!opencl.used.extensions = !{!11}
-!opencl.used.optional.core.features = !{!11}
-!opencl.compiler.options = !{!11}
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z14isgreaterequalDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
 
-!1 = !{i32 1, i32 0}
-!2 = !{!"none", !"none"}
-!3 = !{!"int*", !"half"}
-!4 = !{!"int*", !"half"}
-!5 = !{!"", !""}
-!7 = !{!"short2*", !"half2"}
-!8 = !{!"short2*", !"half2"}
-!9 = !{i32 1, i32 2}
-!10 = !{i32 2, i32 0}
-!11 = !{}
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z6islessDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z11islessequalDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z13islessgreaterDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z9isorderedDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
+
+; Function Attrs: convergent mustprogress nofree nounwind readnone willreturn
+declare spir_func <2 x i16> @_Z11isunorderedDv2_DhS_(<2 x half>, <2 x half>) local_unnamed_addr #1
+
+attributes #0 = { convergent mustprogress nofree norecurse nounwind willreturn writeonly "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #1 = { convergent mustprogress nofree nounwind readnone willreturn "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #2 = { convergent mustprogress nofree norecurse nounwind willreturn writeonly "frame-pointer"="none" "min-legal-vector-width"="32" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #3 = { convergent nounwind readnone willreturn }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 14.0.0"}
+!3 = !{!4, !4, i64 0}
+!4 = !{!"int", !5, i64 0}
+!5 = !{!"omnipotent char", !6, i64 0}
+!6 = !{!"Simple C/C++ TBAA"}
+!7 = !{!5, !5, i64 0}


### PR DESCRIPTION
Move OpenCL relational builtin translation to SPIRVToOCL

Motivation is to let standalone use of SPIRVToOCL20Legacy pass support translating relational builtin in Spirv Friendly IR.
Standalones use of SPIRVToOCL20Legacy pass may receive IR in spirv friendly IR:
```
 %call3.i.i.i = tail call spir_func <16 x i8> @_Z20__spirv_FOrdLessThanDv16_dS_(<16 x double> %1, <16 x double> %2)
```
Previously "Translate SPIR-V builtins to OCL 2.0 builtins (spvtoocl20)" pass will transform it into:
```
%call3.i.i.i = call spir_func <16 x i8> @_Z6islessDv16_dS_(<16 x double> %1, <16 x double> %2)
```
After this patch, the pass will transform it into:
```
%call3.i.i.i11 = call spir_func <16 x i64> @_Z6islessDv16_dS_(<16 x double> %1, <16 x double> %2) 
```

This patch also aligns relational builtin in SPIRV Friendly IR with spirv spec. i8 is used for vector boolean type, since clang frontend can't generate i1 vector type for spirv builtin yet.
E.g.
```
  i32 @_Z11__spirv_AnyDv2_i(<2 x i32>
```
is changed to
```
  i1 @_Z11__spirv_AnyDv2_c(<2 x i8>
```