### PR TITLE
Restrict special handling of sampler OpVariable only to UniformConstant

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1496,13 +1496,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     SPIRVStorageClassKind BS = BVar->getStorageClass();
     SPIRVValue *Init = BVar->getInitializer();
 
-    if (isSPIRVSamplerType(Ty)) {
+    if (isSPIRVSamplerType(Ty) && BS == StorageClassUniformConstant) {
       // Skip generating llvm code during translation of a variable definition,
       // generate code only for its uses
       if (!BB)
         return nullptr;
 
-      assert(Init && "OpVariable with sampler type must have an initializer!");
+      assert(Init && "UniformConstant OpVariable with sampler type must have "
+                     "an initializer!");
       return transValue(Init, F, BB);
     }
 


### PR DESCRIPTION
This is a fixup for aaa3cb328dfc1f56804da28ff949c7428678a00d.