### PR TITLE
Fix handling of complex constant expression vectors inside metadata

### DIFF
--- a/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -139,7 +139,7 @@ void SPIRVLowerConstExprBase::visit(Module *M) {
       auto II = WorkList.front();
 
       auto LowerOp = [&II, &FBegin, &I](Value *V) -> Value * {
-        if (isa<Function>(V))
+        if (isa<Function>(V) || !isa<ConstantExpr>(V))
           return V;
         auto *CE = cast<ConstantExpr>(V);
         SPIRVDBG(dbgs() << "[lowerConstantExpressions] " << *CE;)
@@ -170,7 +170,7 @@ void SPIRVLowerConstExprBase::visit(Module *M) {
       auto LowerConstantVec = [&II, &LowerOp, &WorkList,
                                &M](ConstantVector *Vec,
                                    unsigned NumOfOp) -> Value * {
-        if (std::all_of(Vec->op_begin(), Vec->op_end(), [](Value *V) {
+        if (std::any_of(Vec->op_begin(), Vec->op_end(), [](Value *V) {
               return isa<ConstantExpr>(V) || isa<Function>(V);
             })) {
           // Expand a vector of constexprs and construct it back with

--- a/test/vector-metadata-constexpr.ll
+++ b/test/vector-metadata-constexpr.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
-; RUN: llvm-spirv %t.bc
+; RUN: llvm-spirv -s --spirv-ext=+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_vector_compute %t.bc -o - | llvm-dis -o - | FileCheck %s
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_vector_compute %t.bc
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
@@ -8,8 +8,18 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind ssp uwtable
 define void @foo() #0 !dbg !4 {
 entry:
-  call void @llvm.dbg.value(metadata <3 x i8> <i8 add (i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 0), i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 0)), i8 add (i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 1), i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 1)), i8 add (i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 2), i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 2))>, metadata !12, metadata !DIExpression()), !dbg !18
-  ret void, !dbg !20
+  call void @llvm.dbg.value(
+    metadata <3 x i8> <
+      i8 add (
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 0),
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 0)),
+      i8 add (
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 1),
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 1)),
+      i8 add (
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 2),
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 2))>,
+      metadata !12, metadata !DIExpression()), !dbg !18
 ; CHECK: %0 = bitcast <2 x i32> <i32 65793, i32 65793> to <8 x i8>
 ; CHECK: %1 = extractelement <8 x i8> %0, i32 0
 ; CHECK: %2 = bitcast <2 x i32> <i32 131586, i32 131586> to <8 x i8>
@@ -29,6 +39,40 @@ entry:
 ; CHECK: %16 = insertelement <3 x i8> %15, i8 %9, i32 1
 ; CHECK: %17 = insertelement <3 x i8> %16, i8 %14, i32 2
 ; CHECK: call void @llvm.dbg.value(metadata <3 x i8> %17, metadata !{{[0-9]+}}, metadata !DIExpression()), !dbg !{{[0-9]+}}
+  call void @llvm.dbg.value(
+    metadata <4 x half> <
+    half fadd (
+      half extractelement (<4 x half> bitcast (<1 x i64> <i64 65971704314880> to <4 x half>), i32 0),
+      half extractelement (<4 x half> bitcast (<1 x i64> <i64 70369817935872> to <4 x half>), i32 0)),
+    half fadd (
+      half extractelement (<4 x half> bitcast (<1 x i64> <i64 65971704314880> to <4 x half>), i32 1),
+      half extractelement (<4 x half> bitcast (<1 x i64> <i64 70369817935872> to <4 x half>), i32 1)),
+    half fadd (
+      half extractelement (<4 x half> bitcast (<1 x i64> <i64 65971704314880> to <4 x half>), i32 2),
+      half extractelement (<4 x half> bitcast (<1 x i64> <i64 70369817935872> to <4 x half>), i32 2)),
+    half undef>,
+    metadata !23, metadata !DIExpression()), !dbg !20
+; CHECK: %18 = bitcast <1 x i64> <i64 65971704314880> to <4 x half>
+; CHECK: %19 = extractelement <4 x half> %18, i32 0
+; CHECK: %20 = bitcast <1 x i64> <i64 70369817935872> to <4 x half>
+; CHECK: %21 = extractelement <4 x half> %20, i32 0
+; CHECK: %22 = fadd half %19, %21
+; CHECK: %23 = bitcast <1 x i64> <i64 65971704314880> to <4 x half>
+; CHECK: %24 = extractelement <4 x half> %23, i32 1
+; CHECK: %25 = bitcast <1 x i64> <i64 70369817935872> to <4 x half>
+; CHECK: %26 = extractelement <4 x half> %25, i32 1
+; CHECK: %27 = fadd half %24, %26
+; CHECK: %28 = bitcast <1 x i64> <i64 65971704314880> to <4 x half>
+; CHECK: %29 = extractelement <4 x half> %28, i32 2
+; CHECK: %30 = bitcast <1 x i64> <i64 70369817935872> to <4 x half>
+; CHECK: %31 = extractelement <4 x half> %30, i32 2
+; CHECK: %32 = fadd half %29, %31
+; CHECK: %33 = insertelement <4 x half> undef, half %22, i32 0
+; CHECK: %34 = insertelement <4 x half> %33, half %27, i32 1
+; CHECK: %35 = insertelement <4 x half> %34, half %32, i32 2
+; CHECK: %36 = insertelement <4 x half> %35, half undef, i32 3
+; CHECK: call void @llvm.dbg.value(metadata <4 x half> %36, metadata ![[#]], metadata !DIExpression()), !dbg ![[#]]
+  ret void, !dbg !22
 }
 
 ; Function Attrs: nounwind readnone
@@ -38,7 +82,7 @@ attributes #0 = { nounwind ssp uwtable  }
 attributes #2 = { nounwind readnone }
 attributes #3 = { nounwind }
 
-!llvm.dbg.cu = !{!0}
+!llvm.dbg.cu = !{!0, !26}
 !llvm.module.flags = !{!13, !14, !15}
 !llvm.ident = !{!16}
 
@@ -61,4 +105,11 @@ attributes #3 = { nounwind }
 !17 = !DIExpression()
 !18 = !DILocation(line: 2, column: 52, scope: !7, inlinedAt: !19)
 !19 = distinct !DILocation(line: 4, column: 3, scope: !4)
-!20 = !DILocation(line: 6, column: 1, scope: !4)
+!20 = !DILocation(line: 5, scope: !4, inlinedAt: !21)
+!21 = !DILocation(line: 1, column: 0, scope: !4)
+!22 = !DILocation(line: 6, column: 1, scope: !4)
+!23 = !DILocalVariable(name: "resVec", scope: !4, file: !24, line: 1, type: !25)
+!24 = !DIFile(filename: "main.cpp", directory: "/export/users")
+!25 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "vec<cl::sycl::detail::half_impl::half, 3>", scope: !4, file: !24, line: 1, size: 64, flags: DIFlagTypePassByValue, elements: !2, identifier: "_ZTSN2cl4sycl3vecINS0_6detail9half_impl4halfELi3EEE")
+!26 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !27, producer: "clang version 13.0.0 (https://github.com/intel/llvm.git)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
+!27 = !DIFile(filename: "<stdin>", directory: "/export/users")

--- a/test/vector-metadata-constexpr.ll
+++ b/test/vector-metadata-constexpr.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -s --spirv-ext=+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_vector_compute %t.bc -o - | llvm-dis -o - | FileCheck %s
-; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_vector_compute %t.bc
+; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc
 
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
@@ -42,29 +42,29 @@ entry:
   call void @llvm.dbg.value(
     metadata <4 x half> <
     half fadd (
-      half extractelement (<4 x half> bitcast (<1 x i64> <i64 65971704314880> to <4 x half>), i32 0),
-      half extractelement (<4 x half> bitcast (<1 x i64> <i64 70369817935872> to <4 x half>), i32 0)),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 0),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 0)),
     half fadd (
-      half extractelement (<4 x half> bitcast (<1 x i64> <i64 65971704314880> to <4 x half>), i32 1),
-      half extractelement (<4 x half> bitcast (<1 x i64> <i64 70369817935872> to <4 x half>), i32 1)),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 1),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 1)),
     half fadd (
-      half extractelement (<4 x half> bitcast (<1 x i64> <i64 65971704314880> to <4 x half>), i32 2),
-      half extractelement (<4 x half> bitcast (<1 x i64> <i64 70369817935872> to <4 x half>), i32 2)),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 2),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 2)),
     half undef>,
     metadata !23, metadata !DIExpression()), !dbg !20
-; CHECK: %18 = bitcast <1 x i64> <i64 65971704314880> to <4 x half>
+; CHECK: %18 = bitcast <2 x i32> <i32 65793, i32 65793> to <4 x half>
 ; CHECK: %19 = extractelement <4 x half> %18, i32 0
-; CHECK: %20 = bitcast <1 x i64> <i64 70369817935872> to <4 x half>
+; CHECK: %20 = bitcast <2 x i32> <i32 131586, i32 131586> to <4 x half>
 ; CHECK: %21 = extractelement <4 x half> %20, i32 0
 ; CHECK: %22 = fadd half %19, %21
-; CHECK: %23 = bitcast <1 x i64> <i64 65971704314880> to <4 x half>
+; CHECK: %23 = bitcast <2 x i32> <i32 65793, i32 65793> to <4 x half>
 ; CHECK: %24 = extractelement <4 x half> %23, i32 1
-; CHECK: %25 = bitcast <1 x i64> <i64 70369817935872> to <4 x half>
+; CHECK: %25 = bitcast <2 x i32> <i32 131586, i32 131586> to <4 x half>
 ; CHECK: %26 = extractelement <4 x half> %25, i32 1
 ; CHECK: %27 = fadd half %24, %26
-; CHECK: %28 = bitcast <1 x i64> <i64 65971704314880> to <4 x half>
+; CHECK: %28 = bitcast <2 x i32> <i32 65793, i32 65793> to <4 x half>
 ; CHECK: %29 = extractelement <4 x half> %28, i32 2
-; CHECK: %30 = bitcast <1 x i64> <i64 70369817935872> to <4 x half>
+; CHECK: %30 = bitcast <2 x i32> <i32 131586, i32 131586> to <4 x half>
 ; CHECK: %31 = extractelement <4 x half> %30, i32 2
 ; CHECK: %32 = fadd half %29, %31
 ; CHECK: %33 = insertelement <4 x half> undef, half %22, i32 0


### PR DESCRIPTION
Removed restriction for all the vector elements to be constant expressions as some of them might be `undef`.