### PR TITLE
Update SPV_INTEL_hw_thread_queries to rev 2

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -95,7 +95,7 @@ void SPIRVToOCLBase::visitCallInst(CallInst &CI) {
     if (static_cast<uint32_t>(BuiltinKind) >=
             internal::BuiltInSubDeviceIDINTEL &&
         static_cast<uint32_t>(BuiltinKind) <=
-            internal::BuiltInMaxHWThreadIDPerSubDeviceINTEL)
+            internal::BuiltInGlobalHWThreadIDINTEL)
       return;
 
     visitCallSPIRVBuiltin(&CI, BuiltinKind);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1529,7 +1529,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       return BVar;
     if (static_cast<uint32_t>(Builtin) >= internal::BuiltInSubDeviceIDINTEL &&
         static_cast<uint32_t>(Builtin) <=
-            internal::BuiltInMaxHWThreadIDPerSubDeviceINTEL) {
+            internal::BuiltInGlobalHWThreadIDINTEL) {
       if (!BM->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_hw_thread_queries)) {
         std::string ErrorStr = "Intel HW thread queries must be enabled by "

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -492,9 +492,7 @@ template <> inline void SPIRVMap<BuiltIn, SPIRVCapVec>::init() {
   ADD_VEC_INIT(BuiltInInstanceIndex, {CapabilityShader});
   ADD_VEC_INIT(internal::BuiltInSubDeviceIDINTEL,
                {internal::CapabilityHWThreadQueryINTEL});
-  ADD_VEC_INIT(internal::BuiltInHWThreadIDINTEL,
-               {internal::CapabilityHWThreadQueryINTEL});
-  ADD_VEC_INIT(internal::BuiltInMaxHWThreadIDPerSubDeviceINTEL,
+  ADD_VEC_INIT(internal::BuiltInGlobalHWThreadIDINTEL,
                {internal::CapabilityHWThreadQueryINTEL});
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -274,8 +274,7 @@ inline bool isValid(spv::BuiltIn V) {
   case BuiltInWarpIDNV:
   case BuiltInSMIDNV:
   case internal::BuiltInSubDeviceIDINTEL:
-  case internal::BuiltInHWThreadIDINTEL:
-  case internal::BuiltInMaxHWThreadIDPerSubDeviceINTEL:
+  case internal::BuiltInGlobalHWThreadIDINTEL:
     return true;
   default:
     return false;

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -307,9 +307,7 @@ template <> inline void SPIRVMap<BuiltIn, std::string>::init() {
   add(BuiltInSMIDNV, "BuiltInSMIDNV");
   add(BuiltInMax, "BuiltInMax");
   add(internal::BuiltInSubDeviceIDINTEL, "BuiltInSubDeviceIDINTEL");
-  add(internal::BuiltInHWThreadIDINTEL, "BuiltInHWThreadIDINTEL");
-  add(internal::BuiltInMaxHWThreadIDPerSubDeviceINTEL,
-      "BuiltInMaxHWThreadIDPerSubDeviceINTEL");
+  add(internal::BuiltInGlobalHWThreadIDINTEL, "BuiltInGlobalHWThreadIDINTEL");
 }
 SPIRV_DEF_NAMEMAP(BuiltIn, SPIRVBuiltInNameMap)
 

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -97,8 +97,7 @@ enum InternalJointMatrixLayout { RowMajor, ColumnMajor, PackedA, PackedB };
 
 enum InternalBuiltIn {
   IBuiltInSubDeviceIDINTEL = 6135,
-  IBuiltInHWThreadIDINTEL = 6136,
-  IBuiltInMaxHWThreadIDPerSubDeviceINTEL = 6137
+  IBuiltInGlobalHWThreadIDINTEL = 6136,
 };
 
 #define _SPIRV_OP(x, y) constexpr x x##y = static_cast<x>(I##x##y);
@@ -110,8 +109,7 @@ _SPIRV_OP(Op, JointMatrixMadINTEL)
 
 _SPIRV_OP(Capability, HWThreadQueryINTEL)
 _SPIRV_OP(BuiltIn, SubDeviceIDINTEL)
-_SPIRV_OP(BuiltIn, HWThreadIDINTEL)
-_SPIRV_OP(BuiltIn, MaxHWThreadIDPerSubDeviceINTEL)
+_SPIRV_OP(BuiltIn, GlobalHWThreadIDINTEL)
 #undef _SPIRV_OP
 
 constexpr Op OpForward = static_cast<Op>(IOpForward);

--- a/test/transcoding/SPV_INTEL_hw_thread_queries/intel_hw_thread_queries_function_call.ll
+++ b/test/transcoding/SPV_INTEL_hw_thread_queries/intel_hw_thread_queries_function_call.ll
@@ -14,10 +14,8 @@
 ; CHECK-SPIRV: Extension "SPV_INTEL_hw_thread_queries"
 ; CHECK-SPIRV: Decorate [[#Id1:]] BuiltIn 6135
 ; CHECK-SPIRV: Decorate [[#Id2:]] BuiltIn 6136
-; CHECK-SPIRV: Decorate [[#Id3:]] BuiltIn 6137
 ; CHECK-SPIRV: Variable [[#]] [[#Id1]]
 ; CHECK-SPIRV: Variable [[#]] [[#Id2]]
-; CHECK-SPIRV: Variable [[#]] [[#Id3]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
@@ -26,16 +24,12 @@ target triple = "spir-unknown-unknown"
 define spir_kernel void @foo() {
 entry:
   %0 = call spir_func i32 @_Z31__spirv_BuiltInSubDeviceIDINTELv() #1
-  %1 = call spir_func i32 @_Z30__spirv_BuiltInHWThreadIDINTELv() #1
-  %2 = call spir_func i32 @_Z45__spirv_BuiltInMaxHWThreadIDPerSubDeviceINTELv() #1
+  %1 = call spir_func i32 @_Z36__spirv_BuiltInGlobalHWThreadIDINTELv() #1
   ; CHECK-LLVM: call spir_func i32 @_Z31__spirv_BuiltInSubDeviceIDINTELv() #1
-  ; CHECK-LLVM: call spir_func i32 @_Z30__spirv_BuiltInHWThreadIDINTELv() #1
-  ; CHECK-LLVM: call spir_func i32 @_Z45__spirv_BuiltInMaxHWThreadIDPerSubDeviceINTELv() #1
+  ; CHECK-LLVM: call spir_func i32 @_Z36__spirv_BuiltInGlobalHWThreadIDINTELv() #1
   ret void
 }
 
 declare dso_local spir_func i32 @_Z31__spirv_BuiltInSubDeviceIDINTELv()
 
-declare dso_local spir_func i32 @_Z30__spirv_BuiltInHWThreadIDINTELv()
-
-declare dso_local spir_func i32 @_Z45__spirv_BuiltInMaxHWThreadIDPerSubDeviceINTELv()
+declare dso_local spir_func i32 @_Z36__spirv_BuiltInGlobalHWThreadIDINTELv()

--- a/test/transcoding/SPV_INTEL_hw_thread_queries/intel_hw_thread_queries_load_from_global.ll
+++ b/test/transcoding/SPV_INTEL_hw_thread_queries/intel_hw_thread_queries_load_from_global.ll
@@ -14,26 +14,21 @@
 ; CHECK-SPIRV: Extension "SPV_INTEL_hw_thread_queries"
 ; CHECK-SPIRV: Decorate [[#Id1:]] BuiltIn 6135
 ; CHECK-SPIRV: Decorate [[#Id2:]] BuiltIn 6136
-; CHECK-SPIRV: Decorate [[#Id3:]] BuiltIn 6137
 ; CHECK-SPIRV: Variable [[#]] [[#Id1]]
 ; CHECK-SPIRV: Variable [[#]] [[#Id2]]
-; CHECK-SPIRV: Variable [[#]] [[#Id3]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
 @__spirv_BuiltInSubDeviceIDINTEL = external addrspace(1) global i32
-@__spirv_BuiltInHWThreadIDINTEL = external addrspace(1) global i32
-@__spirv_BuiltInMaxHWThreadIDPerSubDeviceINTEL = external addrspace(1) global i32
+@__spirv_BuiltInGlobalHWThreadIDINTEL = external addrspace(1) global i32
 
 ; Function Attrs: nounwind readnone
 define spir_kernel void @foo() {
 entry:
   %0 = load i32, i32 addrspace(4)* addrspacecast (i32 addrspace(1)* @__spirv_BuiltInSubDeviceIDINTEL to i32 addrspace(4)*), align 4
-  %1 = load i32, i32 addrspace(4)* addrspacecast (i32 addrspace(1)* @__spirv_BuiltInHWThreadIDINTEL to i32 addrspace(4)*), align 4
-  %2 = load i32, i32 addrspace(4)* addrspacecast (i32 addrspace(1)* @__spirv_BuiltInMaxHWThreadIDPerSubDeviceINTEL to i32 addrspace(4)*), align 4
+  %1 = load i32, i32 addrspace(4)* addrspacecast (i32 addrspace(1)* @__spirv_BuiltInGlobalHWThreadIDINTEL to i32 addrspace(4)*), align 4
   ; CHECK-LLVM: call spir_func i32 @_Z31__spirv_BuiltInSubDeviceIDINTELv() #1
-  ; CHECK-LLVM: call spir_func i32 @_Z30__spirv_BuiltInHWThreadIDINTELv() #1
-  ; CHECK-LLVM: call spir_func i32 @_Z45__spirv_BuiltInMaxHWThreadIDPerSubDeviceINTELv() #1
+  ; CHECK-LLVM: call spir_func i32 @_Z36__spirv_BuiltInGlobalHWThreadIDINTELv() #1
   ret void
 }


### PR DESCRIPTION
Replace local id with global id.
Rev 2:
https://github.com/intel/llvm/blob/713c3d3782c6e1b071235671097becf92ce82098/sycl/doc/extensions/SPIRV/SPV_INTEL_hw_thread_queries.asciidoc

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>