### PR TITLE
Use Function storage class by default in debug info for pointers

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -526,7 +526,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgPointerType(const DIDerivedType *PT) {
   SPIRVWordVec Ops(OperandCount);
   SPIRVEntry *Base = transDbgEntry(PT->getBaseType());
   Ops[BaseTypeIdx] = Base->getId();
-  Ops[StorageClassIdx] = ~0U; // all ones denote no address space
+  Ops[StorageClassIdx] = spv::StorageClassFunction;
   Optional<unsigned> AS = PT->getDWARFAddressSpace();
   if (AS.hasValue()) {
     SPIRAddressSpace SPIRAS = static_cast<SPIRAddressSpace>(AS.getValue());

--- a/test/DebugInfo/X86/dwarf-public-names.ll
+++ b/test/DebugInfo/X86/dwarf-public-names.ll
@@ -50,7 +50,7 @@ target triple = "spir64-unknown-unknown"
 
 ; Skip the output to the header of the pubnames section.
 ; LINUX: debug_pubnames
-; LINUX-NEXT: unit_size = 0x0000012b
+; LINUX-NEXT: unit_size = 0x00000133
 
 ; Check for each name in the output.
 ; LINUX-DAG: "ns"


### PR DESCRIPTION
Signed-off-by: Alexey Sotkin <alexey.sotkin@intel.com>