### PR TITLE
Fix the collection of entry point interfaces

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3570,6 +3570,12 @@ bool LLVMToSPIRVBase::isAnyFunctionReachableFromFunction(
 void LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF,
                                                   Function *F) {
   for (auto &GV : M->globals()) {
+    if (SF->getModule()->getSPIRVVersion() <
+        static_cast<uint32_t>(VersionNumber::SPIRV_1_4)) {
+      const auto AS = GV.getAddressSpace();
+      if (AS != SPIRAS_Input && AS != SPIRAS_Output)
+        continue;
+    }
     std::unordered_set<const Function *> Funcs;
 
     for (const auto &U : GV.uses()) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3575,7 +3575,7 @@ LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF, Function *F) {
       if (AS != SPIRAS_Input && AS != SPIRAS_Output)
         continue;
     } else {
-      BM->setSPIRVVersion(static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
+      BM->setMinSPIRVVersion(static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
     }
     std::unordered_set<const Function *> Funcs;
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3587,7 +3587,7 @@ LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF, Function *F) {
     if (isAnyFunctionReachableFromFunction(F, Funcs)) {
       SPIRVWord ModuleVersion = static_cast<SPIRVWord>(BM->getSPIRVVersion());
       if (AS != SPIRAS_Input && AS != SPIRAS_Output &&
-           ModuleVersion < static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4))
+          ModuleVersion < static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4))
         BM->setMinSPIRVVersion(
             static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
       Interface.push_back(ValueMap[&GV]->getId());

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3569,8 +3569,7 @@ std::vector<SPIRVId>
 LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF, Function *F) {
   std::vector<SPIRVId> Interface;
   for (auto &GV : M->globals()) {
-    if (SF->getModule()->getSPIRVVersion() <
-        static_cast<uint32_t>(VersionNumber::SPIRV_1_4)) {
+    if (!SF->getModule()->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
       const auto AS = GV.getAddressSpace();
       if (AS != SPIRAS_Input && AS != SPIRAS_Output)
         continue;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3567,13 +3567,9 @@ bool LLVMToSPIRVBase::isAnyFunctionReachableFromFunction(
   return false;
 }
 
-void LLVMToSPIRVBase::collectInputOutputVariables(SPIRVFunction *SF,
+void LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF,
                                                   Function *F) {
   for (auto &GV : M->globals()) {
-    const auto AS = GV.getAddressSpace();
-    if (AS != SPIRAS_Input && AS != SPIRAS_Output)
-      continue;
-
     std::unordered_set<const Function *> Funcs;
 
     for (const auto &U : GV.uses()) {
@@ -3692,7 +3688,7 @@ void LLVMToSPIRVBase::transFunction(Function *I) {
   bool IsKernelEntryPoint = isKernel(I);
 
   if (IsKernelEntryPoint) {
-    collectInputOutputVariables(BF, I);
+    collectEntryPointInterfaces(BF, I);
   }
 }
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3575,19 +3575,21 @@ LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF, Function *F) {
       if (AS != SPIRAS_Input && AS != SPIRAS_Output)
         continue;
     } else {
-      BM->setMinSPIRVVersion(static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
-    }
-    std::unordered_set<const Function *> Funcs;
+      std::unordered_set<const Function *> Funcs;
 
-    for (const auto &U : GV.uses()) {
-      const Instruction *Inst = dyn_cast<Instruction>(U.getUser());
-      if (!Inst)
-        continue;
-      Funcs.insert(Inst->getFunction());
-    }
+      for (const auto &U : GV.uses()) {
+        const Instruction *Inst = dyn_cast<Instruction>(U.getUser());
+        if (!Inst)
+          continue;
+        Funcs.insert(Inst->getFunction());
+      }
 
-    if (isAnyFunctionReachableFromFunction(F, Funcs)) {
-      Interface.push_back(ValueMap[&GV]->getId());
+      if (isAnyFunctionReachableFromFunction(F, Funcs)) {
+        if (static_cast<SPIRVWord>(BM->getSPIRVVersion()) <
+            static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4))
+          BM->setMinSPIRVVersion(static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
+        Interface.push_back(ValueMap[&GV]->getId());
+      }
     }
   }
   return Interface;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3569,10 +3569,13 @@ std::vector<SPIRVId>
 LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF, Function *F) {
   std::vector<SPIRVId> Interface;
   for (auto &GV : M->globals()) {
-    if (!SF->getModule()->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
+    SPIRVModule *BM = SF->getModule();
+    if (!BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
       const auto AS = GV.getAddressSpace();
       if (AS != SPIRAS_Input && AS != SPIRAS_Output)
         continue;
+    } else {
+      BM->setSPIRVVersion(static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
     }
     std::unordered_set<const Function *> Funcs;
 

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -216,7 +216,8 @@ private:
   bool isAnyFunctionReachableFromFunction(
       const Function *FS,
       const std::unordered_set<const Function *> Funcs) const;
-  void collectEntryPointInterfaces(SPIRVFunction *SF, Function *F);
+  std::vector<SPIRVId> collectEntryPointInterfaces(SPIRVFunction *BF,
+                                                   Function *F);
 };
 
 class LLVMToSPIRVPass : public PassInfoMixin<LLVMToSPIRVPass>,

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -216,7 +216,7 @@ private:
   bool isAnyFunctionReachableFromFunction(
       const Function *FS,
       const std::unordered_set<const Function *> Funcs) const;
-  void collectInputOutputVariables(SPIRVFunction *SF, Function *F);
+  void collectEntryPointInterfaces(SPIRVFunction *SF, Function *F);
 };
 
 class LLVMToSPIRVPass : public PassInfoMixin<LLVMToSPIRVPass>,

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -241,7 +241,6 @@ public:
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
     if (SPIRVUseTextFormat) {
       Encoder << getString(Literals.cbegin(), Literals.cend() - 1);
-      Encoder.OS << " ";
       Encoder << (SPIRVLinkageTypeKind)Literals.back();
     } else
 #endif

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -548,9 +548,7 @@ void SPIRVEntryPoint::decode(std::istream &I) {
   Variables.resize(WordCount - FixedWC - getSizeInWords(Name) + 1);
   getDecoder(I) >> Variables;
   Module->setName(getOrCreateTarget(), Name);
-  Module->addEntryPoint(ExecModel, Target);
-  if (!Variables.empty())
-    Module->addEntryPointInterfaces(Target, Variables);
+  Module->addEntryPoint(ExecModel, Target, Name, Variables);
 }
 
 void SPIRVExecutionMode::encode(spv_ostream &O) const {

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -542,9 +542,6 @@ void SPIRVEntryPoint::encode(spv_ostream &O) const {
 
 void SPIRVEntryPoint::decode(std::istream &I) {
   getDecoder(I) >> ExecModel >> Target >> Name;
-  // One fixed word is the name of the entry point. When we subtract FixedWC
-  // and getSizeInWords, we must take into account that the entry point's name
-  // has been subtracted twice, so we must add 1.
   Variables.resize(WordCount - FixedWC - getSizeInWords(Name) + 1);
   getDecoder(I) >> Variables;
   Module->setName(getOrCreateTarget(), Name);

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -541,9 +541,16 @@ void SPIRVEntryPoint::encode(spv_ostream &O) const {
 }
 
 void SPIRVEntryPoint::decode(std::istream &I) {
-  getDecoder(I) >> ExecModel >> Target >> Name >> Variables;
+  getDecoder(I) >> ExecModel >> Target >> Name;
+  // One fixed word is the name of the entry point. When we subtract FixedWC
+  // and getSizeInWords, we must take into account that the entry point's name
+  // has been subtracted twice, so we must add 1.
+  Variables.resize(WordCount - FixedWC - getSizeInWords(Name) + 1);
+  getDecoder(I) >> Variables;
   Module->setName(getOrCreateTarget(), Name);
   Module->addEntryPoint(ExecModel, Target);
+  if (!Variables.empty())
+    Module->addEntryPointInterfaces(Target, Variables);
 }
 
 void SPIRVExecutionMode::encode(spv_ostream &O) const {

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -524,6 +524,7 @@ public:
 
 class SPIRVEntryPoint : public SPIRVAnnotation<OpEntryPoint> {
 public:
+  static const SPIRVWord FixedWC = 4;
   SPIRVEntryPoint(SPIRVModule *TheModule, SPIRVExecutionModelKind,
                   SPIRVId TheId, const std::string &TheName,
                   std::vector<SPIRVId> Variables);

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -128,20 +128,6 @@ public:
   getValueTypes(const std::vector<SPIRVId> &) const override;
   SPIRVMemoryModelKind getMemoryModel() const override { return MemoryModel; }
   SPIRVConstant *getLiteralAsConstant(unsigned Literal) override;
-  unsigned getNumEntryPoints(SPIRVExecutionModelKind EM) const override {
-    auto Loc = EntryPointMapVec.find(EM);
-    if (Loc == EntryPointMapVec.end())
-      return 0;
-    return Loc->second.size();
-  }
-  SPIRVFunction *getEntryPoint(SPIRVExecutionModelKind EM,
-                               unsigned I) const override {
-    auto Loc = EntryPointMapVec.find(EM);
-    if (Loc == EntryPointMapVec.end())
-      return nullptr;
-    assert(I < Loc->second.size());
-    return get<SPIRVFunction>(Loc->second[I]);
-  }
   unsigned getNumFunctions() const override { return FuncVec.size(); }
   unsigned getNumVariables() const override { return VariableVec.size(); }
   SourceLanguage getSourceLanguage(SPIRVWord *Ver = nullptr) const override {
@@ -501,7 +487,6 @@ private:
   std::map<SPIRVExtInstSetKind, SPIRVId> ExtInstSetIds;
   typedef std::map<SPIRVId, SPIRVExtInstSetKind> SPIRVIdToBuiltinSetMap;
   typedef std::map<SPIRVExecutionModelKind, SPIRVIdSet> SPIRVExecModelIdSetMap;
-  typedef std::map<SPIRVExecutionModelKind, SPIRVIdVec> SPIRVExecModelIdVecMap;
   typedef std::unordered_map<std::string, SPIRVString *> SPIRVStringMap;
   typedef std::map<SPIRVTypeStruct *, std::vector<std::pair<unsigned, SPIRVId>>>
       SPIRVUnknownStructFieldMap;
@@ -527,7 +512,6 @@ private:
   SPIRVAsmTargetVector AsmTargetVec;
   SPIRVAsmVector AsmVec;
   SPIRVExecModelIdSetMap EntryPointSet;
-  SPIRVExecModelIdVecMap EntryPointMapVec;
   SPIRVEntryPointVec EntryPointVec;
   SPIRVStringMap StrMap;
   SPIRVCapMap CapMap;
@@ -1011,7 +995,6 @@ void SPIRVModuleImpl::addEntryPoint(SPIRVExecutionModelKind ExecModel,
       add(new SPIRVEntryPoint(this, ExecModel, EntryPoint, Name, Variables));
   EntryPointVec.push_back(EP);
   EntryPointSet[ExecModel].insert(EntryPoint);
-  EntryPointMapVec[ExecModel].push_back(EntryPoint);
   addCapabilities(SPIRV::getCapability(ExecModel));
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1848,7 +1848,8 @@ spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M) {
       // collectEntryPointInterfaces function. When translating SPIRV bitcode ->
       // SPIRV text the entry points are decoded from the bitcode and the
       // interfaces are stored to EntryPointInterfaces map to not to be lost.
-      std::vector<SPIRVId> Interfaces = M.get<SPIRVFunction>(II)->getVariables();
+      std::vector<SPIRVId> Interfaces =
+          M.get<SPIRVFunction>(II)->getVariables();
       if (Interfaces.empty())
         Interfaces = MI.EntryPointInterfaces[II];
       O << SPIRVEntryPoint(&M, I.first, II, M.get<SPIRVFunction>(II)->getName(),

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1007,8 +1007,8 @@ void SPIRVModuleImpl::addEntryPoint(SPIRVExecutionModelKind ExecModel,
                                     const std::vector<SPIRVId> &Variables) {
   assert(isValid(ExecModel) && "Invalid execution model");
   assert(EntryPoint != SPIRVID_INVALID && "Invalid entry point");
-  auto *EP = add(new SPIRVEntryPoint(this, ExecModel, EntryPoint, Name,
-                                    Variables));
+  auto *EP =
+      add(new SPIRVEntryPoint(this, ExecModel, EntryPoint, Name, Variables));
   EntryPointVec.push_back(EP);
   EntryPointSet[ExecModel].insert(EntryPoint);
   EntryPointMapVec[ExecModel].push_back(EntryPoint);
@@ -1843,7 +1843,7 @@ spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M) {
   O << MI.EntryPointVec;
 
   for (auto &I : MI.EntryPointVec)
-      MI.get<SPIRVFunction>(I->getTargetId())->encodeExecutionModes(O);
+    MI.get<SPIRVFunction>(I->getTargetId())->encodeExecutionModes(O);
 
   O << MI.StringVec;
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -526,10 +526,9 @@ private:
   SPIRVGroupDecVec GroupDecVec;
   SPIRVAsmTargetVector AsmTargetVec;
   SPIRVAsmVector AsmVec;
-  SPIRVExecModelIdSetMap EntryPointMapSet;
+  SPIRVExecModelIdSetMap EntryPointSet;
   SPIRVExecModelIdVecMap EntryPointMapVec;
   SPIRVEntryPointVec EntryPointVec;
-  std::map<SPIRVId, std::vector<SPIRVId>> EntryPointInterfaces;
   SPIRVStringMap StrMap;
   SPIRVCapMap CapMap;
   SPIRVUnknownStructFieldMap UnknownStructFieldMap;
@@ -780,8 +779,8 @@ bool SPIRVModuleImpl::isEntryPoint(SPIRVExecutionModelKind ExecModel,
                                    SPIRVId EP) const {
   assert(isValid(ExecModel) && "Invalid execution model");
   assert(EP != SPIRVID_INVALID && "Invalid function id");
-  auto Loc = EntryPointMapSet.find(ExecModel);
-  if (Loc == EntryPointMapSet.end())
+  auto Loc = EntryPointSet.find(ExecModel);
+  if (Loc == EntryPointSet.end())
     return false;
   return Loc->second.count(EP);
 }
@@ -1008,10 +1007,10 @@ void SPIRVModuleImpl::addEntryPoint(SPIRVExecutionModelKind ExecModel,
                                     const std::vector<SPIRVId> &Variables) {
   assert(isValid(ExecModel) && "Invalid execution model");
   assert(EntryPoint != SPIRVID_INVALID && "Invalid entry point");
-  auto EP = add(new SPIRVEntryPoint(this, ExecModel, EntryPoint, Name,
+  auto *EP = add(new SPIRVEntryPoint(this, ExecModel, EntryPoint, Name,
                                     Variables));
   EntryPointVec.push_back(EP);
-  EntryPointMapSet[ExecModel].insert(EntryPoint);
+  EntryPointSet[ExecModel].insert(EntryPoint);
   EntryPointMapVec[ExecModel].push_back(EntryPoint);
   addCapabilities(SPIRV::getCapability(ExecModel));
 }
@@ -1858,7 +1857,7 @@ spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M) {
   for (auto &I : MI.NamedId) {
     // Don't output name for entry point since it is redundant
     bool IsEntryPoint = false;
-    for (auto &EPS : MI.EntryPointMapSet)
+    for (auto &EPS : MI.EntryPointSet)
       if (EPS.second.count(I)) {
         IsEntryPoint = true;
         break;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -214,6 +214,8 @@ public:
   virtual SPIRVGroupDecorateGeneric *
   addGroupDecorateGeneric(SPIRVGroupDecorateGeneric *GDec) = 0;
   virtual void addEntryPoint(SPIRVExecutionModelKind, SPIRVId) = 0;
+  virtual void addEntryPointInterfaces(SPIRVId,
+                                       const std::vector<SPIRVId> &) = 0;
   virtual SPIRVForward *addForward(SPIRVType *Ty) = 0;
   virtual SPIRVForward *addForward(SPIRVId, SPIRVType *Ty) = 0;
   virtual SPIRVFunction *addFunction(SPIRVFunction *) = 0;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -133,14 +133,11 @@ public:
   virtual const SPIRVCapMap &getCapability() const = 0;
   virtual bool hasCapability(SPIRVCapabilityKind) const = 0;
   virtual SPIRVExtInstSetKind getBuiltinSet(SPIRVId) const = 0;
-  virtual SPIRVFunction *getEntryPoint(SPIRVExecutionModelKind,
-                                       unsigned) const = 0;
   virtual std::set<std::string> &getExtension() = 0;
   virtual SPIRVFunction *getFunction(unsigned) const = 0;
   virtual SPIRVVariable *getVariable(unsigned) const = 0;
   virtual SPIRVMemoryModelKind getMemoryModel() const = 0;
   virtual unsigned getNumFunctions() const = 0;
-  virtual unsigned getNumEntryPoints(SPIRVExecutionModelKind) const = 0;
   virtual unsigned getNumVariables() const = 0;
   virtual SourceLanguage getSourceLanguage(SPIRVWord *) const = 0;
   virtual std::set<std::string> &getSourceExtension() = 0;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -213,9 +213,9 @@ public:
                          const std::vector<SPIRVEntry *> &Targets) = 0;
   virtual SPIRVGroupDecorateGeneric *
   addGroupDecorateGeneric(SPIRVGroupDecorateGeneric *GDec) = 0;
-  virtual void addEntryPoint(SPIRVExecutionModelKind, SPIRVId) = 0;
-  virtual void addEntryPointInterfaces(SPIRVId,
-                                       const std::vector<SPIRVId> &) = 0;
+  virtual void addEntryPoint(SPIRVExecutionModelKind, SPIRVId,
+                             const std::string &,
+                             const std::vector<SPIRVId> &) = 0;
   virtual SPIRVForward *addForward(SPIRVType *Ty) = 0;
   virtual SPIRVForward *addForward(SPIRVId, SPIRVType *Ty) = 0;
   virtual SPIRVFunction *addFunction(SPIRVFunction *) = 0;

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -169,6 +169,7 @@ const SPIRVEncoder &operator<<(const SPIRVEncoder &O, const std::string &Str) {
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
   if (SPIRVUseTextFormat) {
     writeQuotedString(O.OS, Str);
+    O.OS << " ";
     return O;
   }
 #endif

--- a/test/ExecutionMode.ll
+++ b/test/ExecutionMode.ll
@@ -1,9 +1,6 @@
 ; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 
-; check for magic number followed by version 1.1
-; CHECK: 119734787 65792
-
 ; CHECK-DAG: TypeVoid [[VOID:[0-9]+]]
 
 ; CHECK-DAG: EntryPoint 6 [[WORKER:[0-9]+]] "worker"

--- a/test/copy_object.spt
+++ b/test/copy_object.spt
@@ -5,7 +5,7 @@
 2 Capability Int64
 2 Capability Int8
 3 MemoryModel 2 2
-8 EntryPoint 6 1 "copy_object"
+6 EntryPoint 6 1 "copy_object" 
 3 Source 3 102000
 3 Name 2 "in"
 4 Decorate 3 BuiltIn 28

--- a/test/entry-point-interfaces.ll
+++ b/test/entry-point-interfaces.ll
@@ -1,0 +1,52 @@
+; RUN: llvm-as %s -o %t.bc
+
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -to-text %t.spv -o %t.from.spv.spt
+; RUN: FileCheck < %t.from.spv.spt %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv -spirv-text %t.bc -o %t.from.bc.spt
+; RUN: FileCheck < %t.from.bc.spt %s --check-prefix=CHECK-SPIRV
+
+; CHECK-SPIRV: 7 EntryPoint 6 [[#]] "test" [[#Interface1:]] [[#Interface2:]]
+; CHECK-SPIRV: TypeInt [[#TypeInt:]] 32 0
+; CHECK-SPIRV: Constant [[#TypeInt]] [[#Constant1:]] 1
+; CHECK-SPIRV: Constant [[#TypeInt]] [[#Constant2:]] 3
+; CHECK-SPIRV: Variable [[#]] [[#Interface1]] 0 [[#Constant1]]
+; CHECK-SPIRV: Variable [[#]] [[#Interface2]] 0 [[#Constant2]]
+
+; ModuleID = 'source.cpp'
+source_filename = "source.cpp"
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir"
+
+@var = dso_local addrspace(2) constant i32 1, align 4
+@var2 = dso_local addrspace(2) constant i32 3, align 4
+@var.const = private unnamed_addr addrspace(2) constant i32 1, align 4
+@var2.const = private unnamed_addr addrspace(2) constant i32 3, align 4
+
+; Function Attrs: convergent noinline norecurse nounwind optnone
+define dso_local spir_kernel void @test() #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !2 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !2 !kernel_arg_host_accessible !2 !kernel_arg_pipe_depth !2 !kernel_arg_pipe_io !2 !kernel_arg_buffer_location !2 {
+entry:
+  %0 = load i32, i32 addrspace(2)* @var.const, align 4
+  %1 = load i32, i32 addrspace(2)* @var2.const, align 4
+  %mul = mul nsw i32 %0, %1
+  %mul1 = mul nsw i32 %mul, 2
+  ret void
+}
+
+attributes #0 = { convergent noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "uniform-work-group-size"="false" }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.ocl.version = !{!0}
+!opencl.spir.version = !{!0}
+!llvm.module.flags = !{!1}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!2}
+!opencl.compiler.options = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 2, i32 0}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{}
+!3 = !{!"Compiler"}

--- a/test/entry-point-interfaces.ll
+++ b/test/entry-point-interfaces.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as %s -o %t.bc
 
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: spirv-val %t.spv
+; RUN: spirv-val --target-env spv1.4 %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.from.spv.spt
 ; RUN: FileCheck < %t.from.spv.spt %s --check-prefix=CHECK-SPIRV
 

--- a/test/negative/unimplemented.spt
+++ b/test/negative/unimplemented.spt
@@ -2,7 +2,7 @@
 2 Capability Addresses
 2 Capability Shader
 3 MemoryModel 2 2
-6 EntryPoint 6 2 "foo"
+4 EntryPoint 6 2 "foo"
 3 Name 3 "res"
 2 TypeVoid 12
 3 TypeFloat 13 32

--- a/test/right_shift.spt
+++ b/test/right_shift.spt
@@ -4,7 +4,7 @@
 2 Capability Kernel
 2 Capability Int64
 3 MemoryModel 2 2
-10 EntryPoint 6 1 "shift_right_arithmetic"
+9 EntryPoint 6 1 "shift_right_arithmetic" 
 3 Source 3 102000
 3 Name 2 "in"
 4 Decorate 3 BuiltIn 28

--- a/test/transcoding/PipeStorage.ll
+++ b/test/transcoding/PipeStorage.ll
@@ -11,6 +11,9 @@
 ; CHECK-LLVM-DAG: [[CREATOR_NAME:[^ ]+]] = linkonce_odr addrspace(1) global %spirv.ConstantPipeStorage { i32 16, i32 16, i32 1 }, align 4
 ; CHECK-LLVM-DAG: @mygpipe = addrspace(1) global %"[[CL_PIPE_STORAGE_NAME]]" { %spirv.PipeStorage addrspace(1)* bitcast (%spirv.ConstantPipeStorage addrspace(1)* [[CREATOR_NAME]] to %spirv.PipeStorage addrspace(1)*) }, align 4
 
+; check for magic number followed by version 1.1
+; CHECK: 119734787 65792
+
 ; CHECK-SPIRV: 4 Name [[MYPIPE_ID:[0-9]+]] "mygpipe"
 
 ; CHECK-SPIRV: 2 TypePipeStorage [[PIPE_STORAGE_ID:[0-9]+]]

--- a/test/transcoding/PipeStorage.ll
+++ b/test/transcoding/PipeStorage.ll
@@ -12,7 +12,7 @@
 ; CHECK-LLVM-DAG: @mygpipe = addrspace(1) global %"[[CL_PIPE_STORAGE_NAME]]" { %spirv.PipeStorage addrspace(1)* bitcast (%spirv.ConstantPipeStorage addrspace(1)* [[CREATOR_NAME]] to %spirv.PipeStorage addrspace(1)*) }, align 4
 
 ; check for magic number followed by version 1.1
-; CHECK: 119734787 65792
+; CHECK-SPIRV: 119734787 65792
 
 ; CHECK-SPIRV: 4 Name [[MYPIPE_ID:[0-9]+]] "mygpipe"
 

--- a/test/transcoding/PipeStorage.ll
+++ b/test/transcoding/PipeStorage.ll
@@ -11,9 +11,6 @@
 ; CHECK-LLVM-DAG: [[CREATOR_NAME:[^ ]+]] = linkonce_odr addrspace(1) global %spirv.ConstantPipeStorage { i32 16, i32 16, i32 1 }, align 4
 ; CHECK-LLVM-DAG: @mygpipe = addrspace(1) global %"[[CL_PIPE_STORAGE_NAME]]" { %spirv.PipeStorage addrspace(1)* bitcast (%spirv.ConstantPipeStorage addrspace(1)* [[CREATOR_NAME]] to %spirv.PipeStorage addrspace(1)*) }, align 4
 
-; check for magic number followed by version 1.1
-; CHECK-SPIRV: 119734787 65792
-
 ; CHECK-SPIRV: 4 Name [[MYPIPE_ID:[0-9]+]] "mygpipe"
 
 ; CHECK-SPIRV: 2 TypePipeStorage [[PIPE_STORAGE_ID:[0-9]+]]

--- a/test/transcoding/SPV_INTEL_inline_assembly/inline_asm_clobbers.cl
+++ b/test/transcoding/SPV_INTEL_inline_assembly/inline_asm_clobbers.cl
@@ -20,7 +20,7 @@ size_t __ovld __cnfn get_global_id(unsigned int dimindx);
 // XCHECK-LLVM: [[STRUCTYPE:%[a-z0-9]+]] = type { i32, i32 }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @mem_clobber
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} """~{cc},~{memory}"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "" "~{cc},~{memory}"
 // CHECK-LLVM: [[VALUE:%[0-9]+]] = load i32 addrspace(1)*, i32 addrspace(1)**
 // CHECK-LLVM-NEXT: getelementptr inbounds i32, i32 addrspace(1)* [[VALUE]], i64 0
 // CHECK-LLVM-NEXT: store i32 1, i32 addrspace(1)*
@@ -34,7 +34,7 @@ kernel void mem_clobber(global int *x) {
 }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @out_clobber
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "earlyclobber_instruction_out $0""=&r"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "earlyclobber_instruction_out $0" "=&r"
 // CHECK-LLVM: barrier
 // CHECK-LLVM: store i32 %{{[a-z0-9]+}}, i32* [[VALUE:%[a-z0-9]+]], align 4
 // CHECK-LLVM-NEXT: [[STOREVAL:%[a-z0-9]+]] = call i32 asm "earlyclobber_instruction_out $0", "=&r"()
@@ -54,7 +54,7 @@ kernel void out_clobber(global int *x) {
 //       Or bug in clang FE. To investigate later, change xchecks to checks and enable
 
 // XCHECK-LLVM-LABEL: define spir_kernel void @in_clobber
-// XCHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "earlyclobber_instruction_in $0""&r"
+// XCHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "earlyclobber_instruction_in $0" "&r"
 // XCHECK-LLVM: barrier
 // XCHECK-LLVM: getelementptr
 // XCHECK-LLVM: store i32  %{{[a-z0-9]+}}, i32* [[LOADVAL:%[a-z0-9]+]], align 4
@@ -74,7 +74,7 @@ kernel void in_clobber(global int *x) {
 #endif
 
 // XCHECK-LLVM-LABEL: define spir_kernel void @mixed_clobber
-// XCHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "mixedclobber_instruction $0 $1 $2""=&r,=&r,&r,1,~{cc},~{memory}"
+// XCHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "mixedclobber_instruction $0 $1 $2" "=&r,=&r,&r,1,~{cc},~{memory}"
 
 #if 0
 kernel void mixed_clobber(global int *x, global int *y, global int *z) {

--- a/test/transcoding/SPV_INTEL_inline_assembly/inline_asm_constraints.cl
+++ b/test/transcoding/SPV_INTEL_inline_assembly/inline_asm_constraints.cl
@@ -24,7 +24,7 @@ size_t __ovld __cnfn get_global_id(unsigned int dimindx);
 // CHECK-LLVM: [[STRUCTYPE:%[a-z]+]] = type { i32, i8, float }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @test_int
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "intcommand $0 $1""=r,r"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "intcommand $0 $1" "=r,r"
 // CHECK-LLVM: [[VALUE:%[0-9]+]] = call i32 asm sideeffect "intcommand $0 $1", "=r,r"(i32 %{{[0-9]+}})
 // CHECK-LLVM-NEXT: store i32 [[VALUE]], i32 addrspace(1)*
 
@@ -34,7 +34,7 @@ kernel void test_int(global int *in, global int *out) {
 }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @test_float
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "floatcommand $0 $1""=r,r"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "floatcommand $0 $1" "=r,r"
 // CHECK-LLVM: [[VALUE:%[0-9]+]] = call float asm sideeffect "floatcommand $0 $1", "=r,r"(float %{{[0-9]+}})
 // CHECK-LLVM-NEXT: store float [[VALUE]], float addrspace(1)*
 
@@ -44,7 +44,7 @@ kernel void test_float(global float *in, global float *out) {
 }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @test_mixed_integral
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "mixed_integral_command $0 $3 $1 $2""=r,r,r,r"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "mixed_integral_command $0 $3 $1 $2" "=r,r,r,r"
 // CHECK-LLVM: [[VALUE:%[0-9]+]] = call i64 asm sideeffect "mixed_integral_command $0 $3 $1 $2", "=r,r,r,r"(i16 %{{[0-9]+}}, i32 %{{[0-9]+}}, i8 %{{[0-9]+}})
 // CHECK-LLVM-NEXT: store i64 [[VALUE]], i64 addrspace(1)*
 
@@ -55,7 +55,7 @@ kernel void test_mixed_integral(global uchar *A, global ushort *B, global uint *
 }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @test_mixed_floating
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "mixed_floating_command $0 $1 $2""=r,r,r"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "mixed_floating_command $0 $1 $2" "=r,r,r"
 // CHECK-LLVM: [[VALUE:%[0-9]+]] = call half asm sideeffect "mixed_floating_command $0 $1 $2", "=r,r,r"(double %{{[0-9]+}}, float %{{[0-9]+}})
 // CHECK-LLVM-NEXT: store half [[VALUE]], half addrspace(1)*
 
@@ -66,7 +66,7 @@ kernel void test_mixed_floating(global float *A, global half *B, global double *
 }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @test_mixed_all
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "mixed_all_command $0 $3 $1 $2""=r,r,r,r"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "mixed_all_command $0 $3 $1 $2" "=r,r,r,r"
 // CHECK-LLVM: [[VALUE:%[0-9]+]] = call i8 asm sideeffect "mixed_all_command $0 $3 $1 $2", "=r,r,r,r"(float %{{[0-9]+}}, i32 %{{[0-9]+}}, i8 %{{[0-9]+}})
 // CHECK-LLVM-NEXT: store i8 [[VALUE]], i8 addrspace(1)*
 
@@ -77,7 +77,7 @@ kernel void test_mixed_all(global uchar *A, global float *B, global uint *C, glo
 }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @test_multiple
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "multiple_command $0 $0 $1 $1 $2 $2""=r,=r,=r,0,1,2"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "multiple_command $0 $0 $1 $1 $2 $2" "=r,=r,=r,0,1,2"
 // CHECK-LLVM: [[VALUE:%[0-9]+]] = call [[STRUCTYPE]] asm sideeffect "multiple_command $0 $0 $1 $1 $2 $2", "=r,=r,=r,0,1,2"(i32 %{{[0-9]+}}, i8 %{{[0-9]+}}, float %{{[0-9]+}})
 // CHECK-LLVM-NEXT: extractvalue [[STRUCTYPE]] [[VALUE]], 0
 // CHECK-LLVM-NEXT: extractvalue [[STRUCTYPE]] [[VALUE]], 1
@@ -90,7 +90,7 @@ kernel void test_multiple(global uchar *A, global float *B, global uint *C) {
 }
 
 // CHECK-LLVM-LABEL: define spir_kernel void @test_constants
-// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "constcommand $0 $1""i,i"
+// CHECK-SPIRV: {{[0-9]+}} AsmINTEL {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} "constcommand $0 $1" "i,i"
 // CHECK-LLVM: call void asm sideeffect "constcommand $0 $1", "i,i"(i32 1, double 2.000000e+00)
 
 kernel void test_constants() {

--- a/test/transcoding/block_w_struct_return.cl
+++ b/test/transcoding/block_w_struct_return.cl
@@ -1,17 +1,7 @@
 // RUN: %clang_cc1 -triple spir -cl-std=cl2.0 -disable-llvm-passes -fdeclare-opencl-builtins -finclude-default-header %s -emit-llvm-bc -o %t.bc
-// TODO: currently max version is limited to 1.1 for this test. Issues here
-// that the SPIR-V module generated for blocks is invalid for versions starting
-// from 1.4, spirv-val is failing with:
-//   error: line 63: Interface variable id <13> is used by entry point
-//                   'block_kernel' id <24>, but is not listed as an interface
-//   %__block_literal_global = OpVariable %_ptr_CrossWorkgroup__struct_10
-//                         CrossWorkgroup %11
-// details can be found in:
-// – Public issue #35: OpEntryPoint must list all global variables in the
-//   interface. Additionally, duplication in the list is not allowed.
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o %t.spv.txt
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o %t.spv.txt
 // RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spv
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis %t.rev.bc

--- a/test/transcoding/block_w_struct_return.cl
+++ b/test/transcoding/block_w_struct_return.cl
@@ -1,9 +1,16 @@
 // RUN: %clang_cc1 -triple spir -cl-std=cl2.0 -disable-llvm-passes -fdeclare-opencl-builtins -finclude-default-header %s -emit-llvm-bc -o %t.bc
-// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o %t.spv.txt
-// RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spv
-// RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_1,CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spirv1.1.spv
+// RUN: spirv-val --target-env spv1.1 %t.spirv1.1.spv
+// RUN: llvm-spirv -r %t.spirv1.1.spv -o %t.rev.bc
+// RUN: llvm-dis %t.rev.bc
+// RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_4,CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spirv1.4.spv
+// RUN: spirv-val --target-env spv1.4 %t.spirv1.4.spv
+// RUN: llvm-spirv -r %t.spirv1.4.spv -o %t.rev.bc
 // RUN: llvm-dis %t.rev.bc
 // RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
@@ -23,6 +30,13 @@ kernel void block_ret_struct(__global int* res)
   aa.a = 5;
   res[tid] = kernelBlock(aa).a - 6;
 }
+
+// CHECK-SPIRV1_4: EntryPoint 6 [[#]] "block_ret_struct" [[#InterdaceId1:]] [[#InterdaceId2:]]
+// CHECK-SPIRV1_4: Name [[#InterdaceId1]] "__block_literal_global"
+// CHECK-SPIRV1_4: Name [[#InterdaceId2]] "__spirv_BuiltInGlobalInvocationId"
+
+// CHECK-SPIRV1_1: EntryPoint 6 [[#]] "block_ret_struct" [[#InterdaceId1:]]
+// CHECK-SPIRV1_1: Name [[#InterdaceId1]] "__spirv_BuiltInGlobalInvocationId"
 
 // CHECK-SPIRV: Name [[BlockInv:[0-9]+]] "__block_ret_struct_block_invoke"
 

--- a/test/transcoding/global_block.cl
+++ b/test/transcoding/global_block.cl
@@ -4,18 +4,8 @@
 // removed
 
 // RUN: %clang_cc1 -O0 -triple spir-unknown-unknown -cl-std=CL2.0 -x cl %s -emit-llvm-bc -o %t.bc
-// TODO: currently max version is limited to 1.1 for this test. Issues here
-// that the SPIR-V module generated for blocks is invalid for versions starting
-// from 1.4, spirv-val is failing with:
-//   error: line 63: Interface variable id <13> is used by entry point
-//                   'block_kernel' id <24>, but is not listed as an interface
-//   %__block_literal_global = OpVariable %_ptr_CrossWorkgroup__struct_10
-//                         CrossWorkgroup %11
-// details can be found in:
-// – Public issue #35: OpEntryPoint must list all global variables in the
-//   interface. Additionally, duplication in the list is not allowed.
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spv
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/transcoding/global_block.cl
+++ b/test/transcoding/global_block.cl
@@ -4,10 +4,16 @@
 // removed
 
 // RUN: %clang_cc1 -O0 -triple spir-unknown-unknown -cl-std=CL2.0 -x cl %s -emit-llvm-bc -o %t.bc
-// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spv
-// RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spirv1.1.spv
+// RUN: spirv-val --target-env spv1.1 %t.spirv1.1.spv
+// RUN: llvm-spirv -r %t.spirv1.1.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_4,CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spirv1.4.spv
+// RUN: spirv-val --target-env spv1.4 %t.spirv1.4.spv
+// RUN: llvm-spirv -r %t.spirv1.4.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
 kernel void block_kernel(__global int* res) {
   typedef int (^block_t)(int);
@@ -15,6 +21,8 @@ kernel void block_kernel(__global int* res) {
   *res = b1(5);
 }
 
+// CHECK-SPIRV1_4: EntryPoint 6 [[#]] "block_kernel" [[#InterdaceId:]]
+// CHECK-SPIRV1_4: Name [[#InterdaceId]] "__block_literal_global"
 // CHECK-SPIRV: Name [[block_invoke:[0-9]+]] "_block_invoke"
 // CHECK-SPIRV: TypeInt [[int:[0-9]+]] 32
 // CHECK-SPIRV: TypeInt [[int8:[0-9]+]] 8

--- a/test/transcoding/global_block.cl
+++ b/test/transcoding/global_block.cl
@@ -21,8 +21,8 @@ kernel void block_kernel(__global int* res) {
   *res = b1(5);
 }
 
-// CHECK-SPIRV1_4: EntryPoint 6 [[#]] "block_kernel" [[#InterdaceId:]]
-// CHECK-SPIRV1_4: Name [[#InterdaceId]] "__block_literal_global"
+// CHECK-SPIRV1_4: EntryPoint 6 [[#]] "block_kernel" [[#InterfaceId:]]
+// CHECK-SPIRV1_4: Name [[#InterfaceId]] "__block_literal_global"
 // CHECK-SPIRV: Name [[block_invoke:[0-9]+]] "_block_invoke"
 // CHECK-SPIRV: TypeInt [[int:[0-9]+]] 32
 // CHECK-SPIRV: TypeInt [[int8:[0-9]+]] 8


### PR DESCRIPTION
This is a patch to expand the collection of entry point interfaces.
In SPIR-V 1.4 and later OpEntryPoint must list all global variables in the
interface. Also fix quoted string output in SPIRV text format.
See: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1216