### PR TITLE
[Backport][100] Fix wrong translation for FP-typed atomic_fetch_sub

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -129,12 +129,11 @@ bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
     return false;
 
   return llvm::StringSwitch<bool>(DemangledName)
+      .EndsWith("sub", true)
       .EndsWith("atomic_add", true)
-      .EndsWith("atomic_sub", true)
       .EndsWith("atomic_min", true)
       .EndsWith("atomic_max", true)
       .EndsWith("atom_add", true)
-      .EndsWith("atom_sub", true)
       .EndsWith("atom_min", true)
       .EndsWith("atom_max", true)
       .EndsWith("inc", true)
@@ -143,6 +142,7 @@ bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
       .EndsWith("and", true)
       .EndsWith("or", true)
       .EndsWith("xor", true)
+      .EndsWith("sub_explicit", true)
       .EndsWith("or_explicit", true)
       .EndsWith("xor_explicit", true)
       .EndsWith("and_explicit", true)

--- a/test/AtomicBuiltinsFloat.ll
+++ b/test/AtomicBuiltinsFloat.ll
@@ -1,4 +1,6 @@
 ; Check that translator generate atomic instructions for atomic builtins
+; FP-typed atomic_fetch_sub and atomic_fetch_sub_explicit should be translated
+; to FunctionCall
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
@@ -9,6 +11,7 @@
 ; CHECK-COUNT-3: AtomicStore
 ; CHECK-COUNT-3: AtomicLoad
 ; CHECK-COUNT-3: AtomicExchange
+; CHECK-COUNT-3: FunctionCall
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
@@ -27,6 +30,9 @@ entry:
   %call3 = tail call spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
   %call4 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)* %0, float 1.000000e+00, i32 0) #2
   %call5 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)* %0, float 1.000000e+00, i32 0, i32 1) #2
+  %call6 = tail call spir_func float @_Z16atomic_fetch_subPU3AS3VU7_Atomicff(float addrspace(3)* %ff, float 1.000000e+00) #2
+  %call7 = tail call spir_func float @_Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicff12memory_order(float addrspace(3)* %ff, float 1.000000e+00, i32 0) #2
+  %call8 = tail call spir_func float @_Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicff12memory_order12memory_scope(float addrspace(3)* %ff, float 1.000000e+00, i32 0, i32 1) #2
   ret void
 }
 
@@ -59,6 +65,15 @@ declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_
 
 ; Function Attrs: convergent
 declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)*, float, i32, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare spir_func float @_Z16atomic_fetch_subPU3AS3VU7_Atomicff(float addrspace(3)*, float) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare spir_func float @_Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicff12memory_order(float addrspace(3)*, float, i32) local_unnamed_addr #1
+
+; Function Attrs: convergent
+declare spir_func float @_Z25atomic_fetch_sub_explicitPU3AS3VU7_Atomicff12memory_order12memory_scope(float addrspace(3)*, float, i32, i32) local_unnamed_addr #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "frame-pointer"="none" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }


### PR DESCRIPTION
This is bug fix for cl_ext_float_atomics support which will align with
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1116

Signed-off-by: Haonan Yang <haonan.yang@intel.com>