### PR TITLE
Implements spirv.Decorations and spirv.ParameterDecorations metadata translation

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -289,6 +289,9 @@ typedef SPIRVMap<spv::Scope, std::string> SPIRVMatrixScopeMap;
 #define SPIR_MD_KERNEL_ARG_TYPE_QUAL "kernel_arg_type_qual"
 #define SPIR_MD_KERNEL_ARG_NAME "kernel_arg_name"
 
+#define SPIRV_MD_PARAMETER_DECORATIONS "spirv.ParameterDecorations"
+#define SPIRV_MD_DECORATIONS "spirv.Decorations"
+
 #define OCL_TYPE_NAME_SAMPLER_T "sampler_t"
 #define SPIR_TYPE_NAME_EVENT_T "opencl.event_t"
 #define SPIR_TYPE_NAME_CLK_EVENT_T "opencl.clk_event_t"

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -160,7 +160,7 @@ static void addNamedMetadataStringSet(LLVMContext *Context, Module *M,
   NamedMD->addOperand(MDNode::get(*Context, ValueVec));
 }
 
-static void addOCLKernelArgumentMetadata(
+static void addKernelArgumentMetadata(
     LLVMContext *Context, const std::string &MDName, SPIRVFunction *BF,
     llvm::Function *Fn,
     std::function<Metadata *(SPIRVFunctionParameter *)> ForeachFnArg) {
@@ -3555,12 +3555,80 @@ void SPIRVToLLVM::transGlobalAnnotations() {
   }
 }
 
+static llvm::MDNode *
+transDecorationsToMetadataList(llvm::LLVMContext *Context,
+                               std::vector<SPIRVDecorate const *> Decorates) {
+  SmallVector<Metadata *, 4> MDs;
+  MDs.reserve(Decorates.size());
+  for (auto Deco : Decorates) {
+    std::vector<Metadata *> OPs;
+    auto KindMD = ConstantAsMetadata::get(
+        ConstantInt::get(Type::getInt32Ty(*Context), Deco->getDecorateKind()));
+    OPs.push_back(KindMD);
+    switch (static_cast<size_t>(Deco->getDecorateKind())) {
+    case DecorationLinkageAttributes: {
+      const auto LinkAttrDeco =
+          static_cast<const SPIRVDecorateLinkageAttr *>(Deco);
+      const auto LinkNameMD =
+          MDString::get(*Context, LinkAttrDeco->getLinkageName());
+      const auto LinkTypeMD = ConstantAsMetadata::get(ConstantInt::get(
+          Type::getInt32Ty(*Context), LinkAttrDeco->getLinkageType()));
+      OPs.push_back(LinkNameMD);
+      OPs.push_back(LinkTypeMD);
+      break;
+    }
+    case DecorationMergeINTEL: {
+      const auto MergeAttrLits = Deco->getVecLiteral();
+      std::string FirstString = getString(MergeAttrLits);
+      std::string SecondString =
+          getString(MergeAttrLits.cbegin() + getVec(FirstString).size(),
+                    MergeAttrLits.cend());
+      OPs.push_back(MDString::get(*Context, FirstString));
+      OPs.push_back(MDString::get(*Context, SecondString));
+      break;
+    }
+    case DecorationMemoryINTEL:
+    case DecorationUserSemantic:
+    case internal::DecorationFuncParamDescINTEL: {
+      const auto StrMD =
+          MDString::get(*Context, getString(Deco->getVecLiteral()));
+      OPs.push_back(StrMD);
+      break;
+    }
+    default: {
+      for (const SPIRVWord Lit : Deco->getVecLiteral()) {
+        const auto LitMD = ConstantAsMetadata::get(
+            ConstantInt::get(Type::getInt32Ty(*Context), Lit));
+        OPs.push_back(LitMD);
+      }
+      break;
+    }
+    }
+    MDs.push_back(MDNode::get(*Context, OPs));
+  }
+  return MDNode::get(*Context, MDs);
+}
+
+void SPIRVToLLVM::transVarDecorationsToMetadata(SPIRVValue *BV, Value *V) {
+  if (!BV->isVariable())
+    return;
+
+  if (auto *GV = dyn_cast<GlobalVariable>(V)) {
+    std::vector<SPIRVDecorate const *> Decorates = BV->getDecorations();
+    if (!Decorates.empty()) {
+      MDNode *MDList = transDecorationsToMetadataList(Context, Decorates);
+      GV->setMetadata(SPIRV_MD_DECORATIONS, MDList);
+    }
+  }
+}
+
 bool SPIRVToLLVM::transDecoration(SPIRVValue *BV, Value *V) {
   if (!transAlign(BV, V))
     return false;
 
   transIntelFPGADecorations(BV, V);
   transMemAliasingINTELDecorations(BV, V);
+  transVarDecorationsToMetadata(BV, V);
 
   DbgTran->transDbgInfo(BV, V);
   return true;
@@ -3693,6 +3761,23 @@ static bool transKernelArgTypeMedataFromString(LLVMContext *Ctx,
   return true;
 }
 
+void SPIRVToLLVM::transFunctionDecorationsToMetadata(SPIRVFunction *BF,
+                                                     Function *F) {
+  size_t TotalParameterDecorations = 0;
+  BF->foreachArgument([&](SPIRVFunctionParameter *Arg) {
+    TotalParameterDecorations += Arg->getNumDecorations();
+  });
+  if (TotalParameterDecorations == 0)
+    return;
+
+  // Generate metadata for spirv.ParameterDecorations
+  addKernelArgumentMetadata(Context, SPIRV_MD_PARAMETER_DECORATIONS, BF, F,
+                            [=](SPIRVFunctionParameter *Arg) {
+                              return transDecorationsToMetadataList(
+                                  Context, Arg->getDecorations());
+                            });
+}
+
 bool SPIRVToLLVM::transMetadata() {
   SmallVector<Function *, 2> CtorKernels;
   for (unsigned I = 0, E = BM->getNumFunctions(); I != E; ++I) {
@@ -3703,6 +3788,7 @@ bool SPIRVToLLVM::transMetadata() {
     transOCLMetadata(BF);
     transVectorComputeMetadata(BF);
     transFPGAFunctionMetadata(BF, F);
+    transFunctionDecorationsToMetadata(BF, F);
 
     if (BF->hasDecorate(internal::DecorationCallableFunctionINTEL))
       F->addFnAttr(kVCMetadata::VCCallable);
@@ -3808,7 +3894,7 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
     return true;
 
   // Generate metadata for kernel_arg_addr_space
-  addOCLKernelArgumentMetadata(
+  addKernelArgumentMetadata(
       Context, SPIR_MD_KERNEL_ARG_ADDR_SPACE, BF, F,
       [=](SPIRVFunctionParameter *Arg) {
         SPIRVType *ArgTy = Arg->getType();
@@ -3821,31 +3907,31 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
             ConstantInt::get(Type::getInt32Ty(*Context), AS));
       });
   // Generate metadata for kernel_arg_access_qual
-  addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_ACCESS_QUAL, BF, F,
-                               [=](SPIRVFunctionParameter *Arg) {
-                                 std::string Qual;
-                                 auto T = Arg->getType();
-                                 if (T->isTypeOCLImage()) {
-                                   auto ST = static_cast<SPIRVTypeImage *>(T);
-                                   Qual = transOCLImageTypeAccessQualifier(ST);
-                                 } else if (T->isTypePipe()) {
-                                   auto PT = static_cast<SPIRVTypePipe *>(T);
-                                   Qual = transOCLPipeTypeAccessQualifier(PT);
-                                 } else
-                                   Qual = "none";
-                                 return MDString::get(*Context, Qual);
-                               });
+  addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_ACCESS_QUAL, BF, F,
+                            [=](SPIRVFunctionParameter *Arg) {
+                              std::string Qual;
+                              auto T = Arg->getType();
+                              if (T->isTypeOCLImage()) {
+                                auto ST = static_cast<SPIRVTypeImage *>(T);
+                                Qual = transOCLImageTypeAccessQualifier(ST);
+                              } else if (T->isTypePipe()) {
+                                auto PT = static_cast<SPIRVTypePipe *>(T);
+                                Qual = transOCLPipeTypeAccessQualifier(PT);
+                              } else
+                                Qual = "none";
+                              return MDString::get(*Context, Qual);
+                            });
   // Generate metadata for kernel_arg_type
   if (!transKernelArgTypeMedataFromString(Context, BM, F,
                                           SPIR_MD_KERNEL_ARG_TYPE))
-    addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_TYPE, BF, F,
-                                 [=](SPIRVFunctionParameter *Arg) {
-                                   return transOCLKernelArgTypeName(Arg);
-                                 });
+    addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_TYPE, BF, F,
+                              [=](SPIRVFunctionParameter *Arg) {
+                                return transOCLKernelArgTypeName(Arg);
+                              });
   // Generate metadata for kernel_arg_type_qual
   if (!transKernelArgTypeMedataFromString(Context, BM, F,
                                           SPIR_MD_KERNEL_ARG_TYPE_QUAL))
-    addOCLKernelArgumentMetadata(
+    addKernelArgumentMetadata(
         Context, SPIR_MD_KERNEL_ARG_TYPE_QUAL, BF, F,
         [=](SPIRVFunctionParameter *Arg) {
           std::string Qual;
@@ -3863,17 +3949,16 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
           return MDString::get(*Context, Qual);
         });
   // Generate metadata for kernel_arg_base_type
-  addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_BASE_TYPE, BF, F,
-                               [=](SPIRVFunctionParameter *Arg) {
-                                 return transOCLKernelArgTypeName(Arg);
-                               });
+  addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_BASE_TYPE, BF, F,
+                            [=](SPIRVFunctionParameter *Arg) {
+                              return transOCLKernelArgTypeName(Arg);
+                            });
   // Generate metadata for kernel_arg_name
   if (BM->isGenArgNameMDEnabled()) {
-    addOCLKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_NAME, BF, F,
-                                 [=](SPIRVFunctionParameter *Arg) {
-                                   return MDString::get(*Context,
-                                                        Arg->getName());
-                                 });
+    addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_NAME, BF, F,
+                              [=](SPIRVFunctionParameter *Arg) {
+                                return MDString::get(*Context, Arg->getName());
+                              });
   }
   // Generate metadata for kernel_arg_buffer_location
   addBufferLocationMetadata(Context, BF, F, [=](SPIRVFunctionParameter *Arg) {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3627,7 +3627,10 @@ bool SPIRVToLLVM::transDecoration(SPIRVValue *BV, Value *V) {
 
   transIntelFPGADecorations(BV, V);
   transMemAliasingINTELDecorations(BV, V);
-  transVarDecorationsToMetadata(BV, V);
+
+  // Decoration metadata is only enabled in SPIR-V friendly mode
+  if (BM->getDesiredBIsRepresentation() == BIsRepresentation::SPIRVFriendlyIR)
+    transVarDecorationsToMetadata(BV, V);
 
   DbgTran->transDbgInfo(BV, V);
   return true;
@@ -3787,7 +3790,10 @@ bool SPIRVToLLVM::transMetadata() {
     transOCLMetadata(BF);
     transVectorComputeMetadata(BF);
     transFPGAFunctionMetadata(BF, F);
-    transFunctionDecorationsToMetadata(BF, F);
+
+    // Decoration metadata is only enabled in SPIR-V friendly mode
+    if (BM->getDesiredBIsRepresentation() == BIsRepresentation::SPIRVFriendlyIR)
+      transFunctionDecorationsToMetadata(BF, F);
 
     if (BF->hasDecorate(internal::DecorationCallableFunctionINTEL))
       F->addFnAttr(kVCMetadata::VCCallable);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3560,18 +3560,18 @@ transDecorationsToMetadataList(llvm::LLVMContext *Context,
                                std::vector<SPIRVDecorate const *> Decorates) {
   SmallVector<Metadata *, 4> MDs;
   MDs.reserve(Decorates.size());
-  for (auto Deco : Decorates) {
+  for (const auto *Deco : Decorates) {
     std::vector<Metadata *> OPs;
-    auto KindMD = ConstantAsMetadata::get(
+    auto *KindMD = ConstantAsMetadata::get(
         ConstantInt::get(Type::getInt32Ty(*Context), Deco->getDecorateKind()));
     OPs.push_back(KindMD);
     switch (static_cast<size_t>(Deco->getDecorateKind())) {
     case DecorationLinkageAttributes: {
-      const auto LinkAttrDeco =
+      const auto *const LinkAttrDeco =
           static_cast<const SPIRVDecorateLinkageAttr *>(Deco);
-      const auto LinkNameMD =
+      auto *const LinkNameMD =
           MDString::get(*Context, LinkAttrDeco->getLinkageName());
-      const auto LinkTypeMD = ConstantAsMetadata::get(ConstantInt::get(
+      auto *const LinkTypeMD = ConstantAsMetadata::get(ConstantInt::get(
           Type::getInt32Ty(*Context), LinkAttrDeco->getLinkageType()));
       OPs.push_back(LinkNameMD);
       OPs.push_back(LinkTypeMD);
@@ -3588,16 +3588,15 @@ transDecorationsToMetadataList(llvm::LLVMContext *Context,
       break;
     }
     case DecorationMemoryINTEL:
-    case DecorationUserSemantic:
-    case internal::DecorationFuncParamDescINTEL: {
-      const auto StrMD =
+    case DecorationUserSemantic: {
+      auto *const StrMD =
           MDString::get(*Context, getString(Deco->getVecLiteral()));
       OPs.push_back(StrMD);
       break;
     }
     default: {
       for (const SPIRVWord Lit : Deco->getVecLiteral()) {
-        const auto LitMD = ConstantAsMetadata::get(
+        auto *const LitMD = ConstantAsMetadata::get(
             ConstantInt::get(Type::getInt32Ty(*Context), Lit));
         OPs.push_back(LitMD);
       }
@@ -3910,12 +3909,12 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
   addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_ACCESS_QUAL, BF, F,
                             [=](SPIRVFunctionParameter *Arg) {
                               std::string Qual;
-                              auto T = Arg->getType();
+                              auto *T = Arg->getType();
                               if (T->isTypeOCLImage()) {
-                                auto ST = static_cast<SPIRVTypeImage *>(T);
+                                auto *ST = static_cast<SPIRVTypeImage *>(T);
                                 Qual = transOCLImageTypeAccessQualifier(ST);
                               } else if (T->isTypePipe()) {
-                                auto PT = static_cast<SPIRVTypePipe *>(T);
+                                auto *PT = static_cast<SPIRVTypePipe *>(T);
                                 Qual = transOCLPipeTypeAccessQualifier(PT);
                               } else
                                 Qual = "none";

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -243,6 +243,8 @@ private:
                          SmallVectorImpl<Function *> &Funcs);
   void transIntelFPGADecorations(SPIRVValue *BV, Value *V);
   void transMemAliasingINTELDecorations(SPIRVValue *BV, Value *V);
+  void transVarDecorationsToMetadata(SPIRVValue *BV, Value *V);
+  void transFunctionDecorationsToMetadata(SPIRVFunction *BF, Function *F);
 }; // class SPIRVToLLVM
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -535,7 +535,7 @@ DINode *SPIRVToLLVMDbgTran::transFunction(const SPIRVExtInst *DebugInst) {
     SPIRVFunction *BF = static_cast<SPIRVFunction *>(E);
     llvm::Function *F = SPIRVReader->transFunction(BF);
     assert(F && "Translation of function failed!");
-    if (!F->hasMetadata())
+    if (!F->hasMetadata("dbg"))
       F->setMetadata("dbg", DIS);
   }
   return DIS;
@@ -644,7 +644,7 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
     SPIRVValue *V = BM->get<SPIRVValue>(Ops[VariableIdx]);
     Value *Var = SPIRVReader->transValue(V, nullptr, nullptr);
     llvm::GlobalVariable *GV = dyn_cast_or_null<llvm::GlobalVariable>(Var);
-    if (GV && !GV->hasMetadata())
+    if (GV && !GV->hasMetadata("dbg"))
       GV->addMetadata("dbg", *VarDecl);
   }
   return VarDecl;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -106,6 +106,15 @@ static void foreachKernelArgMD(
   }
 }
 
+static void foreachKernelArgMD(
+    MDNode *MD, SPIRVFunction *BF,
+    std::function<void(Metadata *MDOp, SPIRVFunctionParameter *BA)> Func) {
+  for (unsigned I = 0, E = MD->getNumOperands(); I != E; ++I) {
+    SPIRVFunctionParameter *BA = BF->getArgument(I);
+    Func(MD->getOperand(I), BA);
+  }
+}
+
 static SPIRVMemoryModelKind getMemoryModel(Module &M) {
   auto *MemoryModelMD = M.getNamedMetadata(kSPIRVMD::MemoryModel);
   if (MemoryModelMD && (MemoryModelMD->getNumOperands() > 0)) {
@@ -2001,6 +2010,148 @@ void addFuncPointerCallArgumentAttributes(CallInst *CI,
   }
 }
 
+#define ONE_STRING_DECORATION_CASE(NAME, NAMESPACE)                            \
+  case NAMESPACE::Decoration##NAME: {                                          \
+    assert(NumOperands == 2 && #NAME " requires exactly 1 extra operand");     \
+    auto *StrDecoEO = dyn_cast<MDString>(DecoMD->getOperand(1));               \
+    assert(StrDecoEO &&#NAME " requires extra operand to be a string");        \
+    Target->addDecorate(                                                       \
+        new SPIRVDecorate##NAME##Attr(Target, StrDecoEO->getString().str()));  \
+    break;                                                                     \
+  }
+
+#define ONE_INT_DECORATION_CASE(NAME, NAMESPACE, TYPE)                         \
+  case NAMESPACE::Decoration##NAME: {                                          \
+    assert(NumOperands == 2 && #NAME " requires exactly 1 extra operand");     \
+    auto *IntDecoEO =                                                          \
+        mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));              \
+    assert(IntDecoEO &&#NAME " requires extra operand to be an integer");      \
+    Target->addDecorate(new SPIRVDecorate##NAME(                               \
+        Target, static_cast<TYPE>(IntDecoEO->getZExtValue())));                \
+    break;                                                                     \
+  }
+
+#define TWO_INT_DECORATION_CASE(NAME, NAMESPACE, TYPE1, TYPE2)                 \
+  case NAMESPACE::Decoration##NAME: {                                          \
+    assert(NumOperands == 3 && #NAME " requires exactly 2 extra operand");     \
+    auto *IntDecoEO1 =                                                         \
+        mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));              \
+    assert(IntDecoEO1 &&#NAME                                                  \
+           " requires first extra operand to be an integer");                  \
+    auto *IntDecoEO2 =                                                         \
+        mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(2));              \
+    assert(IntDecoEO2 &&#NAME                                                  \
+           " requires second extra operand to be an integer");                 \
+    Target->addDecorate(new SPIRVDecorate##NAME(                               \
+        Target, static_cast<TYPE1>(IntDecoEO1->getZExtValue()),                \
+        static_cast<TYPE2>(IntDecoEO2->getZExtValue())));                      \
+    break;                                                                     \
+  }
+
+static void transMetadataDecorations(Metadata *MD, SPIRVEntry *Target) {
+  auto ArgDecoMD = dyn_cast<MDNode>(MD);
+  assert(ArgDecoMD && "Decoration list must be a metadata node");
+  for (unsigned I = 0, E = ArgDecoMD->getNumOperands(); I != E; ++I) {
+    auto DecoMD = dyn_cast<MDNode>(ArgDecoMD->getOperand(I));
+    assert(DecoMD && "Decoration does not name metadata");
+    assert(DecoMD->getNumOperands() > 0 &&
+           "Decoration metadata must have at least one operand");
+    auto DecoKindConst =
+        mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(0));
+    assert(DecoKindConst && "First operand of decoration must be the kind");
+    auto DecoKind = static_cast<Decoration>(DecoKindConst->getZExtValue());
+
+    const size_t NumOperands = DecoMD->getNumOperands();
+    switch (static_cast<size_t>(DecoKind)) {
+      ONE_STRING_DECORATION_CASE(MemoryINTEL, spv)
+      ONE_STRING_DECORATION_CASE(UserSemantic, spv)
+      ONE_INT_DECORATION_CASE(AliasScopeINTEL, spv::internal, SPIRVId)
+      ONE_INT_DECORATION_CASE(NoAliasINTEL, spv::internal, SPIRVId)
+      ONE_INT_DECORATION_CASE(InitiationIntervalINTEL, spv::internal, SPIRVWord)
+      ONE_INT_DECORATION_CASE(MaxConcurrencyINTEL, spv::internal, SPIRVWord)
+      ONE_INT_DECORATION_CASE(PipelineEnableINTEL, spv::internal, SPIRVWord)
+      TWO_INT_DECORATION_CASE(FunctionRoundingModeINTEL, spv, SPIRVWord,
+                              FPRoundingMode);
+      TWO_INT_DECORATION_CASE(FunctionDenormModeINTEL, spv, SPIRVWord,
+                              FPDenormMode);
+      TWO_INT_DECORATION_CASE(FunctionFloatingPointModeINTEL, spv, SPIRVWord,
+                              FPOperationMode);
+      TWO_INT_DECORATION_CASE(FuseLoopsInFunctionINTEL, spv, SPIRVWord,
+                              SPIRVWord);
+      TWO_INT_DECORATION_CASE(MathOpDSPModeINTEL, spv::internal, SPIRVWord,
+                              SPIRVWord);
+    case internal::DecorationFuncParamDescINTEL: {
+      assert(NumOperands == 2 &&
+             "FuncParamDescINTEL requires exactly 1 extra operand");
+      auto *StrDecoEO = dyn_cast<MDString>(DecoMD->getOperand(1));
+      assert(StrDecoEO &&
+             "FuncParamDescINTEL requires extra operand to be a string");
+      Target->addDecorate(new SPIRVDecorateFuncParamDescAttr(
+          Target, StrDecoEO->getString().str()));
+      break;
+    }
+    case DecorationStallEnableINTEL: {
+      Target->addDecorate(new SPIRVDecorateStallEnableINTEL(Target));
+      break;
+    }
+    case DecorationMergeINTEL: {
+      assert(NumOperands == 3 && "MergeINTEL requires exactly 3 extra operand");
+      auto *Name = dyn_cast<MDString>(DecoMD->getOperand(1));
+      assert(Name && "MergeINTEL requires first extra operand to be a string");
+      auto *Direction = dyn_cast<MDString>(DecoMD->getOperand(2));
+      assert(Direction &&
+             "MergeINTEL requires second extra operand to be a string");
+      Target->addDecorate(new SPIRVDecorateMergeINTELAttr(
+          Target, Name->getString().str(), Direction->getString().str()));
+      break;
+    }
+    case DecorationLinkageAttributes: {
+      assert(NumOperands == 3 &&
+             "LinkageAttributes requires exactly 3 extra operand");
+      auto *Name = dyn_cast<MDString>(DecoMD->getOperand(1));
+      assert(Name &&
+             "LinkageAttributes requires first extra operand to be a string");
+      auto *Type = mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(2));
+      assert(Type &&
+             "LinkageAttributes requires second extra operand to be an int");
+      auto TypeKind = static_cast<SPIRVLinkageTypeKind>(Type->getZExtValue());
+      Target->addDecorate(new SPIRVDecorateLinkageAttr(
+          Target, Name->getString().str(), TypeKind));
+      break;
+    }
+    default: {
+      if (NumOperands == 1) {
+        Target->addDecorate(new SPIRVDecorate(DecoKind, Target));
+        break;
+      }
+
+      auto *DecoValEO1 =
+          mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
+      assert(DecoValEO1 &&
+             "First extra operand in default decoration case must be integer.");
+      if (NumOperands == 2) {
+        Target->addDecorate(
+            new SPIRVDecorate(DecoKind, Target, DecoValEO1->getZExtValue()));
+        break;
+      }
+
+      auto *DecoValEO2 =
+          mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(2));
+      assert(DecoValEO2 &&
+             "First extra operand in default decoration case must be integer.");
+      assert(NumOperands == 3 && "At most 2 extra operands expected.");
+      Target->addDecorate(new SPIRVDecorate(DecoKind, Target,
+                                            DecoValEO1->getZExtValue(),
+                                            DecoValEO2->getZExtValue()));
+    }
+    }
+  }
+}
+
+#undef ONE_STRING_DECORATION_CASE
+#undef ONE_INT_DECORATION_CASE
+#undef TWO_INT_DECORATION_CASE
+
 bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
   if (!transAlign(V, BV))
     return false;
@@ -2065,6 +2216,10 @@ bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
     if (OC == OpFunctionPointerCallINTEL)
       addFuncPointerCallArgumentAttributes(CI, BV);
   }
+
+  if (auto *GV = dyn_cast<GlobalVariable>(V))
+    if (auto *GVDecoMD = GV->getMetadata(SPIRV_MD_DECORATIONS))
+      transMetadataDecorations(GVDecoMD, BV);
 
   return true;
 }
@@ -4068,6 +4223,8 @@ bool LLVMToSPIRVBase::transOCLMetadata() {
             BM->setName(BA, Str);
           });
     }
+    if (auto *KernArgDecoMD = F.getMetadata(SPIRV_MD_PARAMETER_DECORATIONS))
+      foreachKernelArgMD(KernArgDecoMD, BF, transMetadataDecorations);
   }
   return true;
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2049,14 +2049,14 @@ void addFuncPointerCallArgumentAttributes(CallInst *CI,
   }
 
 static void transMetadataDecorations(Metadata *MD, SPIRVEntry *Target) {
-  auto ArgDecoMD = dyn_cast<MDNode>(MD);
+  auto *ArgDecoMD = dyn_cast<MDNode>(MD);
   assert(ArgDecoMD && "Decoration list must be a metadata node");
   for (unsigned I = 0, E = ArgDecoMD->getNumOperands(); I != E; ++I) {
-    auto DecoMD = dyn_cast<MDNode>(ArgDecoMD->getOperand(I));
+    auto *DecoMD = dyn_cast<MDNode>(ArgDecoMD->getOperand(I));
     assert(DecoMD && "Decoration does not name metadata");
     assert(DecoMD->getNumOperands() > 0 &&
            "Decoration metadata must have at least one operand");
-    auto DecoKindConst =
+    auto *DecoKindConst =
         mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(0));
     assert(DecoKindConst && "First operand of decoration must be the kind");
     auto DecoKind = static_cast<Decoration>(DecoKindConst->getZExtValue());
@@ -2080,16 +2080,6 @@ static void transMetadataDecorations(Metadata *MD, SPIRVEntry *Target) {
                               SPIRVWord);
       TWO_INT_DECORATION_CASE(MathOpDSPModeINTEL, spv::internal, SPIRVWord,
                               SPIRVWord);
-    case internal::DecorationFuncParamDescINTEL: {
-      assert(NumOperands == 2 &&
-             "FuncParamDescINTEL requires exactly 1 extra operand");
-      auto *StrDecoEO = dyn_cast<MDString>(DecoMD->getOperand(1));
-      assert(StrDecoEO &&
-             "FuncParamDescINTEL requires extra operand to be a string");
-      Target->addDecorate(new SPIRVDecorateFuncParamDescAttr(
-          Target, StrDecoEO->getString().str()));
-      break;
-    }
     case DecorationStallEnableINTEL: {
       Target->addDecorate(new SPIRVDecorateStallEnableINTEL(Target));
       break;

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -441,6 +441,14 @@ SPIRVEntry::getDecorations(Decoration Kind) const {
   return Decors;
 }
 
+std::vector<SPIRVDecorate const *> SPIRVEntry::getDecorations() const {
+  std::vector<SPIRVDecorate const *> Decors;
+  Decors.reserve(Decorates.size());
+  for (auto &DecoPair : Decorates)
+    Decors.push_back(DecoPair.second);
+  return Decors;
+}
+
 std::set<SPIRVId> SPIRVEntry::getDecorateId(Decoration Kind,
                                             size_t Index) const {
   auto Range = DecorateIds.equal_range(Kind);

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -297,6 +297,7 @@ public:
     return {};
   }
   const std::string &getName() const { return Name; }
+  size_t getNumDecorations() const { return Decorates.size(); }
   bool hasDecorate(Decoration Kind, size_t Index = 0,
                    SPIRVWord *Result = 0) const;
   bool hasDecorateId(Decoration Kind, size_t Index = 0,
@@ -314,6 +315,7 @@ public:
                                    SPIRVWord MemberNumber) const;
   std::set<SPIRVWord> getDecorate(Decoration Kind, size_t Index = 0) const;
   std::vector<SPIRVDecorate const *> getDecorations(Decoration Kind) const;
+  std::vector<SPIRVDecorate const *> getDecorations() const;
   std::set<SPIRVId> getDecorateId(Decoration Kind, size_t Index = 0) const;
   std::vector<SPIRVDecorateId const *> getDecorationIds(Decoration Kind) const;
   bool hasId() const { return !(Attrib & SPIRVEA_NOID); }

--- a/test/spirv_global_variable_decoration.ll
+++ b/test/spirv_global_variable_decoration.ll
@@ -1,0 +1,31 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+
+@v1 = addrspace(1) global i32 42, !spirv.Decorations !2
+@v2 = addrspace(1) global float 1.0, !spirv.Decorations !4
+
+; CHECK-SPIRV: Decorate [[PId1:[0-9]+]] Constant
+; CHECK-SPIRV: Decorate [[PId2:[0-9]+]] Constant
+; CHECK-SPIRV: Decorate [[PId2]] Binding 1
+; CHECK-SPIRV: Variable {{[0-9]+}} [[PId1]]
+; CHECK-SPIRV: Variable {{[0-9]+}} [[PId2]]
+
+!1 = !{i32 22}
+!2 = !{!1}
+!3 = !{i32 33, i32 1}
+!4 = !{!1, !3}
+
+; CHECK-LLVM: @v1 = addrspace(1) constant i32 42, !spirv.Decorations ![[Var1DecosId:[0-9]+]]
+; CHECK-LLVM: @v2 = addrspace(1) constant float 1.000000e+00, !spirv.Decorations ![[Var2DecosId:[0-9]+]]
+; CHECK-LLVM-DAG: ![[Var1DecosId]] = !{![[Deco1Id:[0-9]+]], ![[LinkageDeco1Id:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[Var2DecosId]] = !{![[Deco1Id]], ![[Deco2Id:[0-9]+]], ![[LinkageDeco2Id:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[Deco1Id]] = !{i32 22}
+; CHECK-LLVM-DAG: ![[Deco2Id]] = !{i32 33, i32 1}
+; CHECK-LLVM-DAG: ![[LinkageDeco1Id]] = !{i32 41, !"v1", i32 0}
+; CHECK-LLVM-DAG: ![[LinkageDeco2Id]] = !{i32 41, !"v2", i32 0}

--- a/test/spirv_global_variable_decoration.ll
+++ b/test/spirv_global_variable_decoration.ll
@@ -1,6 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
@@ -21,11 +23,16 @@ target triple = "spir"
 !3 = !{i32 33, i32 1}
 !4 = !{!1, !3}
 
-; CHECK-LLVM: @v1 = addrspace(1) constant i32 42, !spirv.Decorations ![[Var1DecosId:[0-9]+]]
-; CHECK-LLVM: @v2 = addrspace(1) constant float 1.000000e+00, !spirv.Decorations ![[Var2DecosId:[0-9]+]]
-; CHECK-LLVM-DAG: ![[Var1DecosId]] = !{![[Deco1Id:[0-9]+]], ![[LinkageDeco1Id:[0-9]+]]}
-; CHECK-LLVM-DAG: ![[Var2DecosId]] = !{![[Deco1Id]], ![[Deco2Id:[0-9]+]], ![[LinkageDeco2Id:[0-9]+]]}
-; CHECK-LLVM-DAG: ![[Deco1Id]] = !{i32 22}
-; CHECK-LLVM-DAG: ![[Deco2Id]] = !{i32 33, i32 1}
-; CHECK-LLVM-DAG: ![[LinkageDeco1Id]] = !{i32 41, !"v1", i32 0}
-; CHECK-LLVM-DAG: ![[LinkageDeco2Id]] = !{i32 41, !"v2", i32 0}
+; CHECK-SPV-IR: @v1 = addrspace(1) constant i32 42, !spirv.Decorations ![[Var1DecosId:[0-9]+]]
+; CHECK-SPV-IR: @v2 = addrspace(1) constant float 1.000000e+00, !spirv.Decorations ![[Var2DecosId:[0-9]+]]
+; CHECK-SPV-IR-DAG: ![[Var1DecosId]] = !{![[Deco1Id:[0-9]+]], ![[LinkageDeco1Id:[0-9]+]]}
+; CHECK-SPV-IR-DAG: ![[Var2DecosId]] = !{![[Deco1Id]], ![[Deco2Id:[0-9]+]], ![[LinkageDeco2Id:[0-9]+]]}
+; CHECK-SPV-IR-DAG: ![[Deco1Id]] = !{i32 22}
+; CHECK-SPV-IR-DAG: ![[Deco2Id]] = !{i32 33, i32 1}
+; CHECK-SPV-IR-DAG: ![[LinkageDeco1Id]] = !{i32 41, !"v1", i32 0}
+; CHECK-SPV-IR-DAG: ![[LinkageDeco2Id]] = !{i32 41, !"v2", i32 0}
+
+; CHECK-LLVM-NOT: @v1 = {{.*}}, !spirv.Decorations !{{[0-9]+}}
+; CHECK-LLVM-NOT: @v2 = {{.*}}, !spirv.Decorations !{{[0-9]+}}
+; CHECK-LLVM: @v1 = addrspace(1) constant i32 42
+; CHECK-LLVM: @v2 = addrspace(1) constant float 1.000000e+00

--- a/test/spirv_param_decorations.ll
+++ b/test/spirv_param_decorations.ll
@@ -1,0 +1,50 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+
+; Function Attrs: convergent nounwind
+define spir_kernel void @k(float %a, float %b, float %c) #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_type_qual !7 !kernel_arg_base_type !6 !spirv.ParameterDecorations !14 {
+entry:
+  ret void
+}
+
+; CHECK-SPIRV: Decorate [[PId1:[0-9]+]] Restrict
+; CHECK-SPIRV: Decorate [[PId1]] FPRoundingMode 2
+; CHECK-SPIRV: Decorate [[PId2:[0-9]+]] Volatile
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[PId1]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[PId2]]
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{i32 1, i32 2}
+!3 = !{!"clang version 14.0.0"}
+!4 = !{i32 0, i32 0, i32 0}
+!5 = !{!"none", !"none", !"none"}
+!6 = !{!"float", !"float", !"float"}
+!7 = !{!"", !"", !""}
+!8 = !{i32 19}
+!9 = !{i32 39, i32 2}
+!10 = !{i32 21}
+!11 = !{!8, !9}
+!12 = !{}
+!13 = !{!10}
+!14 = !{!11, !12, !13}
+
+; CHECK-LLVM: define spir_kernel void @k(float %a, float %b, float %c) {{.*}} !spirv.ParameterDecorations ![[ParamDecoListId:[0-9]+]] {
+; CHECK-LLVM-DAG: ![[ParamDecoListId]] = !{![[Param1DecoId:[0-9]+]], ![[Param2DecoId:[0-9]+]], ![[Param3DecoId:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[Param1DecoId]] = !{![[Deco1Id:[0-9]+]], ![[Deco2Id:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[Param2DecoId]] = !{}
+; CHECK-LLVM-DAG: ![[Param3DecoId]] = !{![[Deco3Id:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[Deco1Id]] = !{i32 19}
+; CHECK-LLVM-DAG: ![[Deco2Id]] = !{i32 39, i32 2}
+; CHECK-LLVM-DAG: ![[Deco3Id]] = !{i32 21}

--- a/test/spirv_param_decorations.ll
+++ b/test/spirv_param_decorations.ll
@@ -1,7 +1,9 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -40,11 +42,14 @@ entry:
 !13 = !{!10}
 !14 = !{!11, !12, !13}
 
-; CHECK-LLVM: define spir_kernel void @k(float %a, float %b, float %c) {{.*}} !spirv.ParameterDecorations ![[ParamDecoListId:[0-9]+]] {
-; CHECK-LLVM-DAG: ![[ParamDecoListId]] = !{![[Param1DecoId:[0-9]+]], ![[Param2DecoId:[0-9]+]], ![[Param3DecoId:[0-9]+]]}
-; CHECK-LLVM-DAG: ![[Param1DecoId]] = !{![[Deco1Id:[0-9]+]], ![[Deco2Id:[0-9]+]]}
-; CHECK-LLVM-DAG: ![[Param2DecoId]] = !{}
-; CHECK-LLVM-DAG: ![[Param3DecoId]] = !{![[Deco3Id:[0-9]+]]}
-; CHECK-LLVM-DAG: ![[Deco1Id]] = !{i32 19}
-; CHECK-LLVM-DAG: ![[Deco2Id]] = !{i32 39, i32 2}
-; CHECK-LLVM-DAG: ![[Deco3Id]] = !{i32 21}
+; CHECK-SPV-IR: define spir_kernel void @k(float %a, float %b, float %c) {{.*}} !spirv.ParameterDecorations ![[ParamDecoListId:[0-9]+]] {
+; CHECK-SPV-IR-DAG: ![[ParamDecoListId]] = !{![[Param1DecoId:[0-9]+]], ![[Param2DecoId:[0-9]+]], ![[Param3DecoId:[0-9]+]]}
+; CHECK-SPV-IR-DAG: ![[Param1DecoId]] = !{![[Deco1Id:[0-9]+]], ![[Deco2Id:[0-9]+]]}
+; CHECK-SPV-IR-DAG: ![[Param2DecoId]] = !{}
+; CHECK-SPV-IR-DAG: ![[Param3DecoId]] = !{![[Deco3Id:[0-9]+]]}
+; CHECK-SPV-IR-DAG: ![[Deco1Id]] = !{i32 19}
+; CHECK-SPV-IR-DAG: ![[Deco2Id]] = !{i32 39, i32 2}
+; CHECK-SPV-IR-DAG: ![[Deco3Id]] = !{i32 21}
+
+; CHECK-LLVM-NOT: define spir_kernel void @k(float %a, float %b, float %c) {{.*}} !spirv.ParameterDecorations ![[ParamDecoListId:[0-9]+]] {
+; CHECK-LLVM: define spir_kernel void @k(float %a, float %b, float %c) {{.*}} {

--- a/test/spirv_param_decorations_quals.ll
+++ b/test/spirv_param_decorations_quals.ll
@@ -1,0 +1,42 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+
+; Function Attrs: convergent nounwind
+define spir_kernel void @k(i32 addrspace(1)* %a) #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_type_qual !7 !kernel_arg_base_type !6 !spirv.ParameterDecorations !10 {
+entry:
+  ret void
+}
+
+; CHECK-SPIRV: Decorate [[PId:[0-9]+]] Volatile
+; CHECK-SPIRV: Decorate [[PId]] FuncParamAttr 4
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[PId]]
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!2}
+!llvm.ident = !{!3}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 1, i32 0}
+!2 = !{i32 1, i32 2}
+!3 = !{!"clang version 14.0.0"}
+!4 = !{i32 0, i32 0, i32 0}
+!5 = !{!"none"}
+!6 = !{!"int*"}
+!7 = !{!"volatile"}
+!8 = !{i32 38, i32 4} ; FuncParamAttr NoAlias
+!9 = !{!8}
+!10 = !{!9}
+
+; CHECK-LLVM: define spir_kernel void @k(i32 addrspace(1)* noalias %a) {{.*}} !kernel_arg_type_qual ![[KernelArgTypeQual:[0-9]+]] {{.*}} !spirv.ParameterDecorations ![[ParamDecoListId:[0-9]+]] {
+; CHECK-LLVM-DAG: ![[ParamDecoListId]] = !{![[ParamDecoId:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[ParamDecoId]] = !{![[VolatileDecoId:[0-9]+]], ![[NoAliasDecoId:[0-9]+]]}
+; CHECK-LLVM-DAG: ![[NoAliasDecoId]] = !{i32 38, i32 4}
+; CHECK-LLVM-DAG: ![[VolatileDecoId]] = !{i32 21}
+; CHECK-LLVM-DAG: ![[KernelArgTypeQual]] = !{!"volatile restrict"}


### PR DESCRIPTION
This patch adds translation to and from `spirv.Decorations` and `spirv.ParameterDecorations` metadata. These metadata nodes represent global variable and function parameter decorations respectively, allowing explicit decoration in LLVM IR.

Documentation: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1319