### PR TITLE
[Backport][120] Use IRBuilder for folding

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -959,19 +959,26 @@ static void applyFPFastMathModeDecorations(const SPIRVValue *BV,
   }
 }
 
-BinaryOperator *SPIRVToLLVM::transShiftLogicalBitwiseInst(SPIRVValue *BV,
-                                                          BasicBlock *BB,
-                                                          Function *F) {
+Value *SPIRVToLLVM::transShiftLogicalBitwiseInst(SPIRVValue *BV, BasicBlock *BB,
+                                                 Function *F) {
   SPIRVBinary *BBN = static_cast<SPIRVBinary *>(BV);
-  assert(BB && "Invalid BB");
   Instruction::BinaryOps BO;
   auto OP = BBN->getOpCode();
   if (isLogicalOpCode(OP))
     OP = IntBoolOpMap::rmap(OP);
   BO = static_cast<Instruction::BinaryOps>(OpCodeMap::rmap(OP));
-  auto Inst = BinaryOperator::Create(BO, transValue(BBN->getOperand(0), F, BB),
-                                     transValue(BBN->getOperand(1), F, BB),
-                                     BV->getName(), BB);
+
+  auto *Op0Constant = dyn_cast<Constant>(transValue(BBN->getOperand(0), F, BB));
+  auto *Op1Constant = dyn_cast<Constant>(transValue(BBN->getOperand(1), F, BB));
+  if (Op0Constant && Op1Constant) {
+    // If both operands are constant, create a constant expression.
+    // This can be used for initializers.
+    return ConstantExpr::get(BO, Op0Constant, Op1Constant);
+  }
+  assert(BB && "Invalid BB");
+  auto *Inst = BinaryOperator::Create(BO, transValue(BBN->getOperand(0), F, BB),
+                                      transValue(BBN->getOperand(1), F, BB),
+                                      BV->getName(), BB);
   applyNoIntegerWrapDecorations(BV, Inst);
   applyFPFastMathModeDecorations(BV, Inst);
   return Inst;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -968,20 +968,20 @@ Value *SPIRVToLLVM::transShiftLogicalBitwiseInst(SPIRVValue *BV, BasicBlock *BB,
     OP = IntBoolOpMap::rmap(OP);
   BO = static_cast<Instruction::BinaryOps>(OpCodeMap::rmap(OP));
 
-  auto *Op0Constant = dyn_cast<Constant>(transValue(BBN->getOperand(0), F, BB));
-  auto *Op1Constant = dyn_cast<Constant>(transValue(BBN->getOperand(1), F, BB));
-  if (Op0Constant && Op1Constant) {
-    // If both operands are constant, create a constant expression.
-    // This can be used for initializers.
-    return ConstantExpr::get(BO, Op0Constant, Op1Constant);
+  Value *Op0 = transValue(BBN->getOperand(0), F, BB);
+  Value *Op1 = transValue(BBN->getOperand(1), F, BB);
+
+  IRBuilder<> Builder(*Context);
+  if (BB) {
+    Builder.SetInsertPoint(BB);
   }
-  assert(BB && "Invalid BB");
-  auto *Inst = BinaryOperator::Create(BO, transValue(BBN->getOperand(0), F, BB),
-                                      transValue(BBN->getOperand(1), F, BB),
-                                      BV->getName(), BB);
-  applyNoIntegerWrapDecorations(BV, Inst);
-  applyFPFastMathModeDecorations(BV, Inst);
-  return Inst;
+
+  Value *NewOp = Builder.CreateBinOp(BO, Op0, Op1, BV->getName());
+  if (auto *Inst = dyn_cast<Instruction>(NewOp)) {
+    applyNoIntegerWrapDecorations(BV, Inst);
+    applyFPFastMathModeDecorations(BV, Inst);
+  }
+  return NewOp;
 }
 
 Instruction *SPIRVToLLVM::transCmpInst(SPIRVValue *BV, BasicBlock *BB,

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -192,8 +192,8 @@ private:
   SPIRVErrorLog &getErrorLog();
   void setCallingConv(CallInst *Call);
   Type *transFPType(SPIRVType *T);
-  BinaryOperator *transShiftLogicalBitwiseInst(SPIRVValue *BV, BasicBlock *BB,
-                                               Function *F);
+  Value *transShiftLogicalBitwiseInst(SPIRVValue *BV, BasicBlock *BB,
+                                      Function *F);
   Instruction *transCmpInst(SPIRVValue *BV, BasicBlock *BB, Function *F);
   void transOCLBuiltinFromInstPreproc(SPIRVInstruction *BI, Type *&RetTy,
                                       std::vector<SPIRVValue *> &Args);

--- a/test/specconstantop-init.spvasm
+++ b/test/specconstantop-init.spvasm
@@ -1,0 +1,34 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+; Verify that an OpVariable initializer containing an OpSpecConstantOp is supported.
+
+; CHECK: @var = addrspace(2) constant i32 8, align 4
+
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %15 "foo"
+               OpName %var "var"
+               OpName %entry "entry"
+               OpDecorate %var Constant
+               OpDecorate %var LinkageAttributes "var" Export
+               OpDecorate %var Alignment 4
+       %uint = OpTypeInt 32 0
+     %uint_4 = OpConstant %uint 4
+     %uint_8 = OpSpecConstantOp %uint IAdd %uint_4 %uint_4
+  %_ptr_uint = OpTypePointer UniformConstant %uint
+       %void = OpTypeVoid
+         %14 = OpTypeFunction %void
+
+        %var = OpVariable %_ptr_uint UniformConstant %uint_8
+
+         %15 = OpFunction %void Pure %14
+      %entry = OpLabel
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
Rely on the IRBuilder to fold into constant expressions if possible.