### PR TITLE
[NFC] The appropriate patch was reverted in llvm.org

### DIFF
--- a/test/DebugInfo/Generic/imported-name-inlined.ll
+++ b/test/DebugInfo/Generic/imported-name-inlined.ll
@@ -22,17 +22,21 @@ target triple = "spir64-unknown-unknown"
 ; Ensure that top level imported declarations don't produce an extra degenerate
 ; concrete subprogram definition.
 
+; FIXME: imported entities should only be emitted to the abstract origin if one is present
+
 ; CHECK: DW_TAG_compile_unit
 ; CHECK:   DW_TAG_subprogram
 ; CHECK:     DW_AT_name {{.*}} "f1"
 ; CHECK:     DW_TAG_imported_declaration
 ; CHECK:     NULL
+; CHECK:   DW_TAG_namespace
+; CHECK:     DW_TAG_subprogram
+; CHECK:     NULL
 ; CHECK:   DW_TAG_subprogram
 ; CHECK:     DW_AT_name {{.*}} "f2"
 ; CHECK:     DW_TAG_inlined_subroutine
-; CHECK:     NULL
-; CHECK:   DW_TAG_namespace
-; CHECK:     DW_TAG_subprogram
+; CHECK:       DW_TAG_imported_declaration
+; CHECK:       NULL
 ; CHECK:     NULL
 ; CHECK:   NULL
 


### PR DESCRIPTION
See:
62a6b9e9ab3e Revert [DwarfDebug] Support emitting function-local declaration for a lexical
block" & dependent patches

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>