### PR TITLE
Change matrix joint type processing

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -325,59 +325,97 @@ void SPIRVRegularizeLLVMBase::adaptStructTypes(StructType *ST) {
     return;
   StringRef STName = ST->getName();
   STName.consume_front("struct.");
+  STName.consume_front("__spv::");
   StringRef MangledName = STName.substr(0, STName.find('.'));
 
-  // Demangle the name of a template struct and parse the template
-  // parameters which look like:
-  // <signed char, 2ul, 2ul, (spv::MatrixLayout)0, (spv::Scope)3>
+  // Representation in LLVM IR before the translator is a pointer array wrapped
+  // in a structure:
+  // %struct.__spirv_JointMatrixINTEL = type { [R x [C x [L x [S x type]]]]* }
+  // where R = Rows, C = Columnts, L = Layout + 1, S = Scope + 1
+  // this '+1' for the Layout and Scope is required because both of them can
+  // be '0', but array size can not be '0'.
   // The result should look like SPIR-V friendly LLVM IR:
   // %spirv.JointMatrixINTEL._char_2_2_0_3
-  if (MangledName.startswith("_ZTSN5__spv24__spirv_JointMatrixINTEL")) {
-    std::string DemangledName = llvm::demangle(MangledName.str());
-    StringRef Name(DemangledName);
-    Name = Name.slice(Name.find('<') + 1, Name.rfind('>'));
-    std::stringstream SPVName;
-    // Name = signed char, 2ul, 2ul, (spv::MatrixLayout)0, (spv::Scope)3
-    auto P = Name.split(", ");
-    // P.first = "signed char
-    // P.second = "2ul, 2ul, (spv::MatrixLayout)0, (spv::Scope)3"
-    StringRef ElemType = P.first;
-    // remove possile qualifiers, like "const" or "signed"
-    ElemType.consume_back(" const");
-    size_t Space = ElemType.rfind(' ');
-    if (Space != StringRef::npos)
-      ElemType = ElemType.substr(Space + 1);
-    // Half type is special: because of https://github.com/intel/llvm/pull/1089
-    // in DPC++ we use `class half` instead of `half` type natively supported by
-    // Clang. After demangling we get the type name qualified with parent
-    // namespaces, which we should remove.
-    // In anticipation of https://github.com/intel/llvm/pull/4460 we provide
-    // for 2 possible prefixes(top level namespaces).
-    if ((ElemType.startswith("cl::sycl::") ||
-         ElemType.startswith("__sycl_internal::")) &&
-        ElemType.endswith("::half"))
-      ElemType = ElemType.take_back(/*strlen("half")*/ 4);
-    P = P.second.split(", ");
-    // P.first = "2ul"
-    // P.second = "2ul, (spv::MatrixLayout)0, (spv::Scope)3"
-    StringRef Rows = P.first.take_while(llvm::isDigit);
-    P = P.second.split(", ");
-    // P.first = "2ul"
-    // P.second = "(spv::MatrixLayout)0, (spv::Scope)3"
-    StringRef Cols = P.first.take_while(llvm::isDigit);
-    P = P.second.split(", ");
-    // P.first = "(spv::MatrixLayout)0"
-    // P.second = "(spv::Scope)3"
-    StringRef Layout = P.first.substr(P.first.rfind(')') + 1);
-    StringRef Scope = P.second.substr(P.second.rfind(')') + 1);
+  // Here we check the structure name yet again. Another option would be to
+  // check SPIR-V friendly function calls (by their name) and obtain return
+  // or their parameter types, assuming, that the appropriate types are Matrix
+  // structure type. But in the near future, we will reuse Composite
+  // instructions to do, for example, matrix initialization directly on AMX
+  // register by OpCompositeConstruct. And we can't claim, that the Result type
+  // of OpCompositeConstruct instruction is always the joint matrix type, it's
+  // simply not true.
+  if (MangledName == "__spirv_JointMatrixINTEL") {
+    auto *PtrTy = dyn_cast<PointerType>(ST->getElementType(0));
+    assert(PtrTy &&
+           "Expected a pointer to an array to represent joint matrix type");
+    size_t TypeLayout[4] = { 0, 0, 0, 0 };
+    ArrayType *ArrayTy;
+    auto getTypeLayout = [&](auto *Ty) -> size_t {
+      ArrayTy = dyn_cast<ArrayType>(Ty->getElementType());
+      assert(ArrayTy &&
+             "Expected a pointer to an array to represent joint matrix type");
+      return ArrayTy->getNumElements();
+    };
+    TypeLayout[0] = getTypeLayout(PtrTy);
+    for (size_t I = 1; I != 4; ++I)
+      TypeLayout[I] = getTypeLayout(ArrayTy);
 
+    auto *ElemTy = ArrayTy->getElementType();
+    std::string ElemTyStr;
+    if (ElemTy->isIntegerTy()) {
+      auto *IntElemTy = cast<IntegerType>(ElemTy);
+      switch (IntElemTy->getBitWidth()) {
+      case 8:
+        ElemTyStr = "char";
+        break;
+      case 16:
+        ElemTyStr = "short";
+        break;
+      case 32:
+        ElemTyStr = "int";
+        break;
+      case 64:
+        ElemTyStr = "long";
+        break;
+      default:
+        ElemTyStr = "i" + std::to_string(IntElemTy->getBitWidth());
+      }
+    }
+    // Check half type like this as well, but in DPC++ it most likelly will
+    // be a class
+    else if (ElemTy->isHalfTy())
+      ElemTyStr = "half";
+    else if (ElemTy->isFloatTy())
+      ElemTyStr = "float";
+    else if (ElemTy->isDoubleTy())
+      ElemTyStr = "double";
+    else {
+      // Half type is special: in DPC++ we use `class half` instead of `half`
+      // type natively supported by Clang.
+      auto *STElemTy = dyn_cast<StructType>(ElemTy);
+      if (!STElemTy && !STElemTy->hasName())
+        llvm_unreachable("Unexpected type for matrix!");
+      StringRef STElemTyName = STElemTy->getName();
+      STElemTyName.consume_front("class.");
+      if ((STElemTyName.startswith("cl::sycl::") ||
+           STElemTyName.startswith("__sycl_internal::")) &&
+          STElemTyName.endswith("::half"))
+        ElemTyStr = "half";
+      if (ElemTyStr.size() == 0)
+        llvm_unreachable("Unexpected type for matrix!");
+    }
+    std::stringstream SPVName;
     SPVName << kSPIRVTypeName::PrefixAndDelim
             << kSPIRVTypeName::JointMatrixINTEL << kSPIRVTypeName::Delimiter
-            << kSPIRVTypeName::PostfixDelim << ElemType.str()
-            << kSPIRVTypeName::PostfixDelim << Rows.str()
-            << kSPIRVTypeName::PostfixDelim << Cols.str()
-            << kSPIRVTypeName::PostfixDelim << Layout.str()
-            << kSPIRVTypeName::PostfixDelim << Scope.str();
+            << kSPIRVTypeName::PostfixDelim << ElemTyStr
+            << kSPIRVTypeName::PostfixDelim << std::to_string(TypeLayout[0])
+            << kSPIRVTypeName::PostfixDelim << std::to_string(TypeLayout[1])
+            << kSPIRVTypeName::PostfixDelim << std::to_string(TypeLayout[2] - 1)
+            << kSPIRVTypeName::PostfixDelim
+            << std::to_string(TypeLayout[3] - 1);
+    // Note, that this structure is not opaque and there is no way to make it
+    // opaque but to recreate it entirely and replace it everywhere. Lets
+    // keep the structure as is, dealing with it during SPIR-V generation.
     ST->setName(SPVName.str());
   }
 }

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -348,17 +348,17 @@ void SPIRVRegularizeLLVMBase::adaptStructTypes(StructType *ST) {
     auto *PtrTy = dyn_cast<PointerType>(ST->getElementType(0));
     assert(PtrTy &&
            "Expected a pointer to an array to represent joint matrix type");
-    size_t TypeLayout[4] = { 0, 0, 0, 0 };
+    size_t TypeLayout[4] = {0, 0, 0, 0};
     ArrayType *ArrayTy;
-    auto getTypeLayout = [&](auto *Ty) -> size_t {
+    auto GetTypeLayout = [&](auto *Ty) -> size_t {
       ArrayTy = dyn_cast<ArrayType>(Ty->getElementType());
       assert(ArrayTy &&
              "Expected a pointer to an array to represent joint matrix type");
       return ArrayTy->getNumElements();
     };
-    TypeLayout[0] = getTypeLayout(PtrTy);
+    TypeLayout[0] = GetTypeLayout(PtrTy);
     for (size_t I = 1; I != 4; ++I)
-      TypeLayout[I] = getTypeLayout(ArrayTy);
+      TypeLayout[I] = GetTypeLayout(ArrayTy);
 
     auto *ElemTy = ArrayTy->getElementType();
     std::string ElemTyStr;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -531,36 +531,36 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
 // simply not true.
 SPIRVType *LLVMToSPIRVBase::transSPIRVJointMatrixINTELType(
     Type *T, SmallVector<std::string, 8> Postfixes) {
-   Type *ElemTy = nullptr;
-   StringRef Ty{Postfixes[0]};
-   auto NumBits = llvm::StringSwitch<unsigned>(Ty)
-                      .Case("char", 8)
-                      .Case("short", 16)
-                      .Case("int", 32)
-                      .Case("long", 64)
-                      .Default(0);
-   if (NumBits)
-     ElemTy = IntegerType::get(M->getContext(), NumBits);
-   else if (Ty == "half")
-     ElemTy = Type::getHalfTy(M->getContext());
-   else if (Ty == "float")
-     ElemTy = Type::getFloatTy(M->getContext());
-   else if (Ty == "double")
-     ElemTy = Type::getDoubleTy(M->getContext());
-   else
-     llvm_unreachable("Unexpected type for matrix!");
+  Type *ElemTy = nullptr;
+  StringRef Ty{Postfixes[0]};
+  auto NumBits = llvm::StringSwitch<unsigned>(Ty)
+                     .Case("char", 8)
+                     .Case("short", 16)
+                     .Case("int", 32)
+                     .Case("long", 64)
+                     .Default(0);
+  if (NumBits)
+    ElemTy = IntegerType::get(M->getContext(), NumBits);
+  else if (Ty == "half")
+    ElemTy = Type::getHalfTy(M->getContext());
+  else if (Ty == "float")
+    ElemTy = Type::getFloatTy(M->getContext());
+  else if (Ty == "double")
+    ElemTy = Type::getDoubleTy(M->getContext());
+  else
+    llvm_unreachable("Unexpected type for matrix!");
 
-   auto ParseInteger = [this](StringRef Postfix) -> ConstantInt * {
-     unsigned long long N = 0;
-     consumeUnsignedInteger(Postfix, 10, N);
-     return getUInt32(M, N);
-   };
-   SPIRVValue *Rows = transConstant(ParseInteger(Postfixes[1]));
-   SPIRVValue *Columns = transConstant(ParseInteger(Postfixes[2]));
-   SPIRVValue *Layout = transConstant(ParseInteger(Postfixes[3]));
-   SPIRVValue *Scope = transConstant(ParseInteger(Postfixes[4]));
-   return mapType(T, BM->addJointMatrixINTELType(transType(ElemTy), Rows,
-                                                 Columns, Layout, Scope));
+  auto ParseInteger = [this](StringRef Postfix) -> ConstantInt * {
+    unsigned long long N = 0;
+    consumeUnsignedInteger(Postfix, 10, N);
+    return getUInt32(M, N);
+  };
+  SPIRVValue *Rows = transConstant(ParseInteger(Postfixes[1]));
+  SPIRVValue *Columns = transConstant(ParseInteger(Postfixes[2]));
+  SPIRVValue *Layout = transConstant(ParseInteger(Postfixes[3]));
+  SPIRVValue *Scope = transConstant(ParseInteger(Postfixes[4]));
+  return mapType(T, BM->addJointMatrixINTELType(transType(ElemTy), Rows,
+                                                Columns, Layout, Scope));
 }
 
 SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(Type *T) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -376,6 +376,19 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
                                   transType(ET)));
       }
     } else {
+      // JointMatrixINTEL type is not necessarily an opaque type, it can be
+      // represented as a structure with pointer to a multidimensional array
+      // member.
+      if (ST && ST->hasName()) {
+        StringRef STName = ST->getName();
+        if (STName.startswith(kSPIRVTypeName::PrefixAndDelim)) {
+          SmallVector<std::string, 8> Postfixes;
+          auto TN = decodeSPIRVTypeName(STName, Postfixes);
+          if (TN == kSPIRVTypeName::JointMatrixINTEL) {
+            return transSPIRVJointMatrixINTELType(T, Postfixes);
+          }
+        }
+      }
       SPIRVType *ElementType = transType(ET);
       // ET, as a recursive type, may contain exactly the same pointer T, so it
       // may happen that after translation of ET we already have translated T,
@@ -500,6 +513,56 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
   return 0;
 }
 
+// Representation in LLVM IR before the translator is a pointer array wrapped
+// in a structure:
+// %struct.__spirv_JointMatrixINTEL = type { [R x [C x [L x [S x type]]]]* }
+// where R = Rows, C = Columnts, L = Layout + 1, S = Scope + 1
+// this '+1' for the Layout and Scope is required because both of them can
+// be '0', but array size can not be '0'.
+// The result should look like SPIR-V friendly LLVM IR:
+// %spirv.JointMatrixINTEL._char_2_2_0_3
+// Here we check the structure name yet again. Another option would be to
+// check SPIR-V friendly function calls (by their name) and obtain return
+// or their parameter types, assuming, that the appropriate types are Matrix
+// structure type. But in the near future, we will reuse Composite
+// instructions to do, for example, matrix initialization directly on AMX
+// register by OpCompositeConstruct. And we can't claim, that the Result type
+// of OpCompositeConstruct instruction is always the joint matrix type, it's
+// simply not true.
+SPIRVType *LLVMToSPIRVBase::transSPIRVJointMatrixINTELType(
+    Type *T, SmallVector<std::string, 8> Postfixes) {
+   Type *ElemTy = nullptr;
+   StringRef Ty{Postfixes[0]};
+   auto NumBits = llvm::StringSwitch<unsigned>(Ty)
+                      .Case("char", 8)
+                      .Case("short", 16)
+                      .Case("int", 32)
+                      .Case("long", 64)
+                      .Default(0);
+   if (NumBits)
+     ElemTy = IntegerType::get(M->getContext(), NumBits);
+   else if (Ty == "half")
+     ElemTy = Type::getHalfTy(M->getContext());
+   else if (Ty == "float")
+     ElemTy = Type::getFloatTy(M->getContext());
+   else if (Ty == "double")
+     ElemTy = Type::getDoubleTy(M->getContext());
+   else
+     llvm_unreachable("Unexpected type for matrix!");
+
+   auto ParseInteger = [this](StringRef Postfix) -> ConstantInt * {
+     unsigned long long N = 0;
+     consumeUnsignedInteger(Postfix, 10, N);
+     return getUInt32(M, N);
+   };
+   SPIRVValue *Rows = transConstant(ParseInteger(Postfixes[1]));
+   SPIRVValue *Columns = transConstant(ParseInteger(Postfixes[2]));
+   SPIRVValue *Layout = transConstant(ParseInteger(Postfixes[3]));
+   SPIRVValue *Scope = transConstant(ParseInteger(Postfixes[4]));
+   return mapType(T, BM->addJointMatrixINTELType(transType(ElemTy), Rows,
+                                                 Columns, Layout, Scope));
+}
+
 SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(Type *T) {
   auto ET = T->getPointerElementType();
   auto ST = cast<StructType>(ET);
@@ -551,36 +614,7 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(Type *T) {
   else if (TN == kSPIRVTypeName::PipeStorage)
     return mapType(T, BM->addPipeStorageType());
   else if (TN == kSPIRVTypeName::JointMatrixINTEL) {
-    Type *ElemTy = nullptr;
-    StringRef Ty{Postfixes[0]};
-    auto NumBits = llvm::StringSwitch<unsigned>(Ty)
-                       .Case("char", 8)
-                       .Case("short", 16)
-                       .Case("int", 32)
-                       .Case("long", 64)
-                       .Default(0);
-    if (NumBits)
-      ElemTy = IntegerType::get(M->getContext(), NumBits);
-    else if (Ty == "half")
-      ElemTy = Type::getHalfTy(M->getContext());
-    else if (Ty == "float")
-      ElemTy = Type::getFloatTy(M->getContext());
-    else if (Ty == "double")
-      ElemTy = Type::getDoubleTy(M->getContext());
-    else
-      llvm_unreachable("Unexpected type for matrix!");
-
-    auto ParseInteger = [this](StringRef Postfix) -> ConstantInt * {
-      unsigned long long N = 0;
-      consumeUnsignedInteger(Postfix, 10, N);
-      return getUInt32(M, N);
-    };
-    SPIRVValue *Rows = transConstant(ParseInteger(Postfixes[1]));
-    SPIRVValue *Columns = transConstant(ParseInteger(Postfixes[2]));
-    SPIRVValue *Layout = transConstant(ParseInteger(Postfixes[3]));
-    SPIRVValue *Scope = transConstant(ParseInteger(Postfixes[4]));
-    return mapType(T, BM->addJointMatrixINTELType(transType(ElemTy), Rows,
-                                                  Columns, Layout, Scope));
+    return transSPIRVJointMatrixINTELType(T, Postfixes);
   } else
     return mapType(T,
                    BM->addOpaqueGenericType(SPIRVOpaqueTypeOpCodeMap::map(TN)));

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -81,6 +81,8 @@ public:
 
   SPIRVType *transType(Type *T);
   SPIRVType *transSPIRVOpaqueType(Type *T);
+  SPIRVType *transSPIRVJointMatrixINTELType(
+      Type *T, SmallVector<std::string, 8> Postfixes);
 
   SPIRVValue *getTranslatedValue(const Value *) const;
 

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -81,8 +81,9 @@ public:
 
   SPIRVType *transType(Type *T);
   SPIRVType *transSPIRVOpaqueType(Type *T);
-  SPIRVType *transSPIRVJointMatrixINTELType(
-      Type *T, SmallVector<std::string, 8> Postfixes);
+  SPIRVType *
+  transSPIRVJointMatrixINTELType(Type *T,
+                                 SmallVector<std::string, 8> Postfixes);
 
   SPIRVValue *getTranslatedValue(const Value *) const;
 

--- a/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix.ll
+++ b/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix.ll
@@ -7,9 +7,9 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-PRE: %spirv.JointMatrixINTEL._short_2_2_0_3 = type opaque
-; CHECK-PRE: %spirv.JointMatrixINTEL._char_2_16_0_3 = type opaque
-; CHECK-PRE: %spirv.JointMatrixINTEL._char_16_2_3_3 = type opaque
+; CHECK-PRE: %spirv.JointMatrixINTEL._short_2_2_0_3
+; CHECK-PRE: %spirv.JointMatrixINTEL._char_2_16_0_3
+; CHECK-PRE: %spirv.JointMatrixINTEL._char_16_2_3_3
 
 ; CHECK-SPIRV: Capability JointMatrixINTEL
 ; CHECK-SPIRV: Extension "SPV_INTEL_joint_matrix"
@@ -42,9 +42,9 @@
 
 ; CHECK-SPIRV: JointMatrixStoreINTEL [[#Cptr:]] [[#C]] [[#Stride]] [[#Zero]] [[#Three]] [[#Zero]]
 
-; CHECK-LLVM: %spirv.JointMatrixINTEL._short_2_2_0_3 = type opaque
-; CHECK-LLVM: %spirv.JointMatrixINTEL._char_2_16_0_3 = type opaque
-; CHECK-LLVM: %spirv.JointMatrixINTEL._char_16_2_3_3 = type opaque
+; CHECK-LLVM: %spirv.JointMatrixINTEL._short_2_2_0_3
+; CHECK-LLVM: %spirv.JointMatrixINTEL._char_2_16_0_3
+; CHECK-LLVM: %spirv.JointMatrixINTEL._char_16_2_3_3
 
 ; CHECK-LLVM: [[CLoaded:%.*]] = call spir_func %spirv.JointMatrixINTEL._short_2_2_0_3 addrspace(1)* @_Z77__spirv_JointMatrixLoadINTEL_RPU3AS139__spirv_JointMatrixINTEL__short_2_2_0_3PU3AS4sliii(i16 addrspace(4)* [[CPtr:%.*]], i64 [[Stride:%.*]], i32 0, i32 3, i32 0)
 ; CHECK-LLVM: [[C:%.*]] = phi %spirv.JointMatrixINTEL._short_2_2_0_3 addrspace(1)* [ [[CLoaded]], %entry ], [ [[CMad:%.*]], %for.body.i ]
@@ -60,9 +60,9 @@ source_filename = "./joint_matrix_test.cpp"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" = type opaque
-%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" = type opaque
-%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" = type opaque
+%"struct.__spv::__spirv_JointMatrixINTEL" = type { [2 x [2 x [1 x [4 x i16]]]]* }
+%"struct.__spv::__spirv_JointMatrixINTEL.0" = type { [2 x [16 x [1 x [4 x i8]]]]* }
+%"struct.__spv::__spirv_JointMatrixINTEL.2" = type { [16 x [2 x [4 x [4 x i8]]]]* }
 
 $_ZTSZ4mainE11matrix_test = comdat any
 
@@ -92,14 +92,14 @@ entry:
   %add.ptr.i51 = getelementptr inbounds i16, i16 addrspace(1)* %_arg_, i64 %mul6.i
   %add.ptr7.i52 = getelementptr inbounds i16, i16 addrspace(1)* %add.ptr.i51, i64 %sub5.i
   %add.ptr7.i = addrspacecast i16 addrspace(1)* %add.ptr7.i52 to i16 addrspace(4)*
-  %call8.i = tail call spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIsLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i16 addrspace(4)* %add.ptr7.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
+  %call8.i = tail call spir_func %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIsLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i16 addrspace(4)* %add.ptr7.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
   %add.ptr11.i53 = getelementptr inbounds i8, i8 addrspace(1)* %_arg_3, i64 %mul6.i
   %add.ptr16.i55 = getelementptr inbounds i8, i8 addrspace(1)* %_arg_5, i64 %sub5.i
   br label %for.cond.i
 
 for.cond.i:                                       ; preds = %for.body.i, %entry
   %k.0.i = phi i32 [ 0, %entry ], [ %add.i, %for.body.i ]
-  %C.0.i = phi %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* [ %call8.i, %entry ], [ %call19.i, %for.body.i ]
+  %C.0.i = phi %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* [ %call8.i, %entry ], [ %call19.i, %for.body.i ]
   %cmp.i = icmp ult i32 %k.0.i, 32
   br i1 %cmp.i, label %for.body.i, label %_ZZ4mainENKUlN2cl4sycl7nd_itemILi2EEEE_clES2_.exit
 
@@ -107,35 +107,35 @@ for.body.i:                                       ; preds = %for.cond.i
   %idx.ext.i = zext i32 %k.0.i to i64
   %add.ptr12.i54 = getelementptr inbounds i8, i8 addrspace(1)* %add.ptr11.i53, i64 %idx.ext.i
   %add.ptr12.i = addrspacecast i8 addrspace(1)* %add.ptr12.i54 to i8 addrspace(4)*
-  %call13.i = tail call spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIaLm2ELm16ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i8 addrspace(4)* %add.ptr12.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
+  %call13.i = tail call spir_func %"struct.__spv::__spirv_JointMatrixINTEL.0" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIaLm2ELm16ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i8 addrspace(4)* %add.ptr12.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
   %mul14.i = shl nuw nsw i32 %k.0.i, 5
   %idx.ext15.i = zext i32 %mul14.i to i64
   %add.ptr17.i56 = getelementptr inbounds i8, i8 addrspace(1)* %add.ptr16.i55, i64 %idx.ext15.i
   %add.ptr17.i = addrspacecast i8 addrspace(1)* %add.ptr17.i56 to i8 addrspace(4)*
-  %call18.i = tail call spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIaLm16ELm2ELN5__spv12MatrixLayoutE3ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i8 addrspace(4)* %add.ptr17.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
-  %call19.i = tail call spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z27__spirv_JointMatrixMadINTELIasLm2ELm16ELm2ELN5__spv12MatrixLayoutE0ELS1_3ELS1_0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT0_XT1_EXT3_EXT6_EXT7_EEEPNS4_IT_XT1_EXT2_EXT4_EXT7_EEEPNS4_IS8_XT2_EXT3_EXT5_EXT7_EEES7_S3_(%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %call13.i, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %call18.i, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %C.0.i, i32 3) #3
+  %call18.i = tail call spir_func %"struct.__spv::__spirv_JointMatrixINTEL.2" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIaLm16ELm2ELN5__spv12MatrixLayoutE3ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i8 addrspace(4)* %add.ptr17.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
+  %call19.i = tail call spir_func %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z27__spirv_JointMatrixMadINTELIasLm2ELm16ELm2ELN5__spv12MatrixLayoutE0ELS1_3ELS1_0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT0_XT1_EXT3_EXT6_EXT7_EEEPNS4_IT_XT1_EXT2_EXT4_EXT7_EEEPNS4_IS8_XT2_EXT3_EXT5_EXT7_EEES7_S3_(%"struct.__spv::__spirv_JointMatrixINTEL.0" addrspace(4)* %call13.i, %"struct.__spv::__spirv_JointMatrixINTEL.2" addrspace(4)* %call18.i, %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %C.0.i, i32 3) #3
   %add.i = add nuw nsw i32 %k.0.i, 16
   br label %for.cond.i, !llvm.loop !19
 
 _ZZ4mainENKUlN2cl4sycl7nd_itemILi2EEEE_clES2_.exit: ; preds = %for.cond.i
-  tail call spir_func void @_Z29__spirv_JointMatrixStoreINTELIsLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEvPT_PNS0_24__spirv_JointMatrixINTELIS4_XT0_EXT1_EXT2_EXT3_EEEmS1_S3_i(i16 addrspace(4)* %add.ptr7.i, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %C.0.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
+  tail call spir_func void @_Z29__spirv_JointMatrixStoreINTELIsLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEvPT_PNS0_24__spirv_JointMatrixINTELIS4_XT0_EXT1_EXT2_EXT3_EEEmS1_S3_i(i16 addrspace(4)* %add.ptr7.i, %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %C.0.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
   ret void
 }
 
 ; Function Attrs: convergent
-declare dso_local spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIsLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i16 addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
+declare dso_local spir_func %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIsLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i16 addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare dso_local spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIaLm2ELm16ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i8 addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
+declare dso_local spir_func %"struct.__spv::__spirv_JointMatrixINTEL.0" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIaLm2ELm16ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i8 addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare dso_local spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIaLm16ELm2ELN5__spv12MatrixLayoutE3ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i8 addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
+declare dso_local spir_func %"struct.__spv::__spirv_JointMatrixINTEL.2" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIaLm16ELm2ELN5__spv12MatrixLayoutE3ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(i8 addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare dso_local spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z27__spirv_JointMatrixMadINTELIasLm2ELm16ELm2ELN5__spv12MatrixLayoutE0ELS1_3ELS1_0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT0_XT1_EXT3_EXT6_EXT7_EEEPNS4_IT_XT1_EXT2_EXT4_EXT7_EEEPNS4_IS8_XT2_EXT3_EXT5_EXT7_EEES7_S3_(%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIaLm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, i32) local_unnamed_addr #1
+declare dso_local spir_func %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z27__spirv_JointMatrixMadINTELIasLm2ELm16ELm2ELN5__spv12MatrixLayoutE0ELS1_3ELS1_0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT0_XT1_EXT3_EXT6_EXT7_EEEPNS4_IT_XT1_EXT2_EXT4_EXT7_EEEPNS4_IS8_XT2_EXT3_EXT5_EXT7_EEES7_S3_(%"struct.__spv::__spirv_JointMatrixINTEL.0" addrspace(4)*, %"struct.__spv::__spirv_JointMatrixINTEL.2" addrspace(4)*, %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare dso_local spir_func void @_Z29__spirv_JointMatrixStoreINTELIsLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEvPT_PNS0_24__spirv_JointMatrixINTELIS4_XT0_EXT1_EXT2_EXT3_EEEmS1_S3_i(i16 addrspace(4)*, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIsLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
+declare dso_local spir_func void @_Z29__spirv_JointMatrixStoreINTELIsLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEvPT_PNS0_24__spirv_JointMatrixINTELIS4_XT0_EXT1_EXT2_EXT3_EEEmS1_S3_i(i16 addrspace(4)*, %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
 declare void @llvm.assume(i1 noundef) #2

--- a/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_half.ll
+++ b/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_half.ll
@@ -7,9 +7,9 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-PRE: %spirv.JointMatrixINTEL._float_2_2_0_3 = type opaque
-; CHECK-PRE: %spirv.JointMatrixINTEL._half_2_16_0_3 = type opaque
-; CHECK-PRE: %spirv.JointMatrixINTEL._half_16_2_3_3 = type opaque
+; CHECK-PRE: %spirv.JointMatrixINTEL._float_2_2_0_3
+; CHECK-PRE: %spirv.JointMatrixINTEL._half_2_16_0_3
+; CHECK-PRE: %spirv.JointMatrixINTEL._half_16_2_3_3
 
 ; CHECK-SPIRV-DAG: TypeFloat [[#FloatTy:]] 32
 ; CHECK-SPIRV-DAG: TypeFloat [[#HalfTy:]] 16
@@ -22,9 +22,9 @@
 ; CHECK-SPIRV: TypeJointMatrixINTEL [[#ATy:]] [[#HalfTy]] [[#Two]] [[#Sixteen]] [[#Zero]] [[#Three]]
 ; CHECK-SPIRV: TypeJointMatrixINTEL [[#BTy:]] [[#HalfTy]] [[#Sixteen]] [[#Two]] [[#Three]] [[#Three]]
 
-; CHECK-LLVM: %spirv.JointMatrixINTEL._float_2_2_0_3 = type opaque
-; CHECK-LLVM: %spirv.JointMatrixINTEL._half_2_16_0_3 = type opaque
-; CHECK-LLVM: %spirv.JointMatrixINTEL._half_16_2_3_3 = type opaque
+; CHECK-LLVM: %spirv.JointMatrixINTEL._float_2_2_0_3
+; CHECK-LLVM: %spirv.JointMatrixINTEL._half_2_16_0_3
+; CHECK-LLVM: %spirv.JointMatrixINTEL._half_16_2_3_3
 
 ; ModuleID = 'joint_matrix_test-sycl-spir64-unknown-unknown.bc'
 source_filename = "joint_matrix_test.cpp"
@@ -35,10 +35,10 @@ target triple = "spir64-unknown-unknown"
 %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range" = type { %"class._ZTSN2cl4sycl6detail5arrayILi1EEE.cl::sycl::detail::array" }
 %"class._ZTSN2cl4sycl6detail5arrayILi1EEE.cl::sycl::detail::array" = type { [1 x i64] }
 %"class._ZTSN2cl4sycl2idILi1EEE.cl::sycl::id" = type { %"class._ZTSN2cl4sycl6detail5arrayILi1EEE.cl::sycl::detail::array" }
-%"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" = type { half }
-%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" = type opaque
-%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" = type opaque
-%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" = type opaque
+%"class.cl::sycl::detail::half_impl::half" = type { half }
+%"struct.__spv::__spirv_JointMatrixINTEL" = type { [2 x [2 x [1 x [4 x float]]]]* }
+%"struct.__spv::__spirv_JointMatrixINTEL.0" = type { [2 x [16 x [1 x [4 x %"class.cl::sycl::detail::half_impl::half"]]]]* }
+%"struct.__spv::__spirv_JointMatrixINTEL.1" = type { [16 x [2 x [4 x [4 x %"class.cl::sycl::detail::half_impl::half"]]]]* }
 
 $_ZTSN2cl4sycl6detail16AssertInfoCopierE = comdat any
 
@@ -64,7 +64,7 @@ entry:
 declare extern_weak dso_local spir_func void @__devicelib_assert_read(i8 addrspace(4)*) local_unnamed_addr #1
 
 ; Function Attrs: convergent norecurse
-define weak_odr dso_local spir_kernel void @_ZTSZ4mainE11matrix_test(float addrspace(1)* %_arg_, i64 %_arg_1, %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(1)* %_arg_3, %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(1)* %_arg_5) local_unnamed_addr #0 comdat !kernel_arg_buffer_location !6 !intel_reqd_sub_group_size !7 {
+define weak_odr dso_local spir_kernel void @_ZTSZ4mainE11matrix_test(float addrspace(1)* %_arg_, i64 %_arg_1, %"class.cl::sycl::detail::half_impl::half" addrspace(1)* %_arg_3, %"class.cl::sycl::detail::half_impl::half" addrspace(1)* %_arg_5) local_unnamed_addr #0 comdat !kernel_arg_buffer_location !6 !intel_reqd_sub_group_size !7 {
 entry:
   %0 = load <3 x i64>, <3 x i64> addrspace(4)* addrspacecast (<3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <3 x i64> addrspace(4)*), align 32, !noalias !8
   %1 = extractelement <3 x i64> %0, i64 1
@@ -86,50 +86,50 @@ entry:
   %add.ptr.i51 = getelementptr inbounds float, float addrspace(1)* %_arg_, i64 %mul6.i
   %add.ptr7.i52 = getelementptr inbounds float, float addrspace(1)* %add.ptr.i51, i64 %sub5.i
   %add.ptr7.i = addrspacecast float addrspace(1)* %add.ptr7.i52 to float addrspace(4)*
-  %call8.i = tail call spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIfLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(float addrspace(4)* %add.ptr7.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
-  %add.ptr11.i53 = getelementptr inbounds %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half", %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(1)* %_arg_3, i64 %mul6.i
-  %add.ptr16.i55 = getelementptr inbounds %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half", %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(1)* %_arg_5, i64 %sub5.i
+  %call8.i = tail call spir_func %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIfLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(float addrspace(4)* %add.ptr7.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
+  %add.ptr11.i53 = getelementptr inbounds %"class.cl::sycl::detail::half_impl::half", %"class.cl::sycl::detail::half_impl::half" addrspace(1)* %_arg_3, i64 %mul6.i
+  %add.ptr16.i55 = getelementptr inbounds %"class.cl::sycl::detail::half_impl::half", %"class.cl::sycl::detail::half_impl::half" addrspace(1)* %_arg_5, i64 %sub5.i
   br label %for.cond.i
 
 for.cond.i:                                       ; preds = %for.body.i, %entry
   %k.0.i = phi i32 [ 0, %entry ], [ %add.i, %for.body.i ]
-  %C.0.i = phi %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* [ %call8.i, %entry ], [ %call19.i, %for.body.i ]
+  %C.0.i = phi %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* [ %call8.i, %entry ], [ %call19.i, %for.body.i ]
   %cmp.i = icmp ult i32 %k.0.i, 32
   br i1 %cmp.i, label %for.body.i, label %_ZZ4mainENKUlN2cl4sycl7nd_itemILi2EEEE_clES2_.exit
 
 for.body.i:                                       ; preds = %for.cond.i
   %idx.ext46.i = zext i32 %k.0.i to i64
-  %add.ptr12.i54 = getelementptr inbounds %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half", %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(1)* %add.ptr11.i53, i64 %idx.ext46.i
-  %add.ptr12.i = addrspacecast %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(1)* %add.ptr12.i54 to %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(4)*
-  %call13.i = tail call spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELN5__spv12MatrixLayoutE0ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPSA_mS6_S8_i(%"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(4)* %add.ptr12.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
+  %add.ptr12.i54 = getelementptr inbounds %"class.cl::sycl::detail::half_impl::half", %"class.cl::sycl::detail::half_impl::half" addrspace(1)* %add.ptr11.i53, i64 %idx.ext46.i
+  %add.ptr12.i = addrspacecast %"class.cl::sycl::detail::half_impl::half" addrspace(1)* %add.ptr12.i54 to %"class.cl::sycl::detail::half_impl::half" addrspace(4)*
+  %call13.i = tail call spir_func %"struct.__spv::__spirv_JointMatrixINTEL.0" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELN5__spv12MatrixLayoutE0ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPSA_mS6_S8_i(%"class.cl::sycl::detail::half_impl::half" addrspace(4)* %add.ptr12.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
   %mul14.i = shl nuw nsw i32 %k.0.i, 5
   %idx.ext1547.i = zext i32 %mul14.i to i64
-  %add.ptr17.i56 = getelementptr inbounds %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half", %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(1)* %add.ptr16.i55, i64 %idx.ext1547.i
-  %add.ptr17.i = addrspacecast %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(1)* %add.ptr17.i56 to %"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(4)*
-  %call18.i = tail call spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELN5__spv12MatrixLayoutE3ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPSA_mS6_S8_i(%"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(4)* %add.ptr17.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
-  %call19.i = tail call spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z27__spirv_JointMatrixMadINTELIN2cl4sycl6detail9half_impl4halfEfLm2ELm16ELm2ELN5__spv12MatrixLayoutE0ELS6_3ELS6_0ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT0_XT1_EXT3_EXT6_EXT7_EEEPNS9_IT_XT1_EXT2_EXT4_EXT7_EEEPNS9_ISD_XT2_EXT3_EXT5_EXT7_EEESC_S8_(%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %call13.i, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %call18.i, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %C.0.i, i32 3) #3
+  %add.ptr17.i56 = getelementptr inbounds %"class.cl::sycl::detail::half_impl::half", %"class.cl::sycl::detail::half_impl::half" addrspace(1)* %add.ptr16.i55, i64 %idx.ext1547.i
+  %add.ptr17.i = addrspacecast %"class.cl::sycl::detail::half_impl::half" addrspace(1)* %add.ptr17.i56 to %"class.cl::sycl::detail::half_impl::half" addrspace(4)*
+  %call18.i = tail call spir_func %"struct.__spv::__spirv_JointMatrixINTEL.1" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELN5__spv12MatrixLayoutE3ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPSA_mS6_S8_i(%"class.cl::sycl::detail::half_impl::half" addrspace(4)* %add.ptr17.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
+  %call19.i = tail call spir_func %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z27__spirv_JointMatrixMadINTELIN2cl4sycl6detail9half_impl4halfEfLm2ELm16ELm2ELN5__spv12MatrixLayoutE0ELS6_3ELS6_0ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT0_XT1_EXT3_EXT6_EXT7_EEEPNS9_IT_XT1_EXT2_EXT4_EXT7_EEEPNS9_ISD_XT2_EXT3_EXT5_EXT7_EEESC_S8_(%"struct.__spv::__spirv_JointMatrixINTEL.0" addrspace(4)* %call13.i, %"struct.__spv::__spirv_JointMatrixINTEL.1" addrspace(4)* %call18.i, %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %C.0.i, i32 3) #3
   %add.i = add nuw nsw i32 %k.0.i, 16
   br label %for.cond.i, !llvm.loop !20
 
 _ZZ4mainENKUlN2cl4sycl7nd_itemILi2EEEE_clES2_.exit: ; preds = %for.cond.i
-  tail call spir_func void @_Z29__spirv_JointMatrixStoreINTELIfLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEvPT_PNS0_24__spirv_JointMatrixINTELIS4_XT0_EXT1_EXT2_EXT3_EEEmS1_S3_i(float addrspace(4)* %add.ptr7.i, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %C.0.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
+  tail call spir_func void @_Z29__spirv_JointMatrixStoreINTELIfLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEvPT_PNS0_24__spirv_JointMatrixINTELIS4_XT0_EXT1_EXT2_EXT3_EEEmS1_S3_i(float addrspace(4)* %add.ptr7.i, %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* %C.0.i, i64 %_arg_1, i32 0, i32 3, i32 0) #3
   ret void
 }
 
 ; Function Attrs: convergent
-declare dso_local spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIfLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(float addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
+declare dso_local spir_func %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIfLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEPNS0_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPS5_mS1_S3_i(float addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare dso_local spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELN5__spv12MatrixLayoutE0ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPSA_mS6_S8_i(%"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
+declare dso_local spir_func %"struct.__spv::__spirv_JointMatrixINTEL.0" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELN5__spv12MatrixLayoutE0ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPSA_mS6_S8_i(%"class.cl::sycl::detail::half_impl::half" addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare dso_local spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELN5__spv12MatrixLayoutE3ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPSA_mS6_S8_i(%"class._ZTSN2cl4sycl6detail9half_impl4halfE.cl::sycl::detail::half_impl::half" addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
+declare dso_local spir_func %"struct.__spv::__spirv_JointMatrixINTEL.1" addrspace(4)* @_Z28__spirv_JointMatrixLoadINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELN5__spv12MatrixLayoutE3ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT_XT0_EXT1_EXT2_EXT3_EEEPSA_mS6_S8_i(%"class.cl::sycl::detail::half_impl::half" addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare dso_local spir_func %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z27__spirv_JointMatrixMadINTELIN2cl4sycl6detail9half_impl4halfEfLm2ELm16ELm2ELN5__spv12MatrixLayoutE0ELS6_3ELS6_0ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT0_XT1_EXT3_EXT6_EXT7_EEEPNS9_IT_XT1_EXT2_EXT4_EXT7_EEEPNS9_ISD_XT2_EXT3_EXT5_EXT7_EEESC_S8_(%"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm2ELm16ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIN2cl4sycl6detail9half_impl4halfELm16ELm2ELNS_12MatrixLayoutE3ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, i32) local_unnamed_addr #1
+declare dso_local spir_func %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)* @_Z27__spirv_JointMatrixMadINTELIN2cl4sycl6detail9half_impl4halfEfLm2ELm16ELm2ELN5__spv12MatrixLayoutE0ELS6_3ELS6_0ELNS5_5Scope4FlagE3EEPNS5_24__spirv_JointMatrixINTELIT0_XT1_EXT3_EXT6_EXT7_EEEPNS9_IT_XT1_EXT2_EXT4_EXT7_EEEPNS9_ISD_XT2_EXT3_EXT5_EXT7_EEESC_S8_(%"struct.__spv::__spirv_JointMatrixINTEL.0" addrspace(4)*, %"struct.__spv::__spirv_JointMatrixINTEL.1" addrspace(4)*, %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare dso_local spir_func void @_Z29__spirv_JointMatrixStoreINTELIfLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEvPT_PNS0_24__spirv_JointMatrixINTELIS4_XT0_EXT1_EXT2_EXT3_EEEmS1_S3_i(float addrspace(4)*, %"struct._ZTSN5__spv24__spirv_JointMatrixINTELIfLm2ELm2ELNS_12MatrixLayoutE0ELNS_5Scope4FlagE3EEE.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
+declare dso_local spir_func void @_Z29__spirv_JointMatrixStoreINTELIfLm2ELm2ELN5__spv12MatrixLayoutE0ELNS0_5Scope4FlagE3EEvPT_PNS0_24__spirv_JointMatrixINTELIS4_XT0_EXT1_EXT2_EXT3_EEEmS1_S3_i(float addrspace(4)*, %"struct.__spv::__spirv_JointMatrixINTEL" addrspace(4)*, i64, i32, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
 declare void @llvm.assume(i1 noundef) #2


### PR DESCRIPTION
Previously we relied on the structure type (which represented matrix
type) mangling to obtain its layout. Now, when DPCPP magling scheme is
aligned with C++, thus the structure lost their usual mangling. Yet we
want to preserve the desired information within the matrix type, coming
from DPCPP headers. To achive this the 'Matrix structure' was changed
form:
template <typename T, int R, int C, int L, int S>
struct __spirv_JointMatrixINTEL;
to
template <typename T, int R, int C, int L, int S>
struct __spirv_JointMatrixINTEL {
  T (*Value)[R][C][L + 1][S + 1];
};

so it's no longer an opaque structure and now it look like this in
LLVM IR:
%struct.__spirv_JointMatrixINTEL = type { [42 x [6 x [2 x [1 x i32]]]]* }

Here we encode the number of Rows, Cols, Layout and Scope as sizes of an
array (which element type is the same as the base matrix's type), which
is a bit odd, but it's probably the best way we can preserve the information now
without having the matrix type itself in LLVM.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>