### PR TITLE
Replace signed createExpression with unsigned

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -841,7 +841,7 @@ DINode *SPIRVToLLVMDbgTran::transModule(const SPIRVExtInst *DebugInst) {
 
 MDNode *SPIRVToLLVMDbgTran::transExpression(const SPIRVExtInst *DebugInst) {
   const SPIRVWordVec &Args = DebugInst->getArguments();
-  std::vector<int64_t> Ops;
+  std::vector<uint64_t> Ops;
   for (SPIRVId A : Args) {
     SPIRVExtInst *O = BM->get<SPIRVExtInst>(A);
     const SPIRVWordVec &Operands = O->getArguments();
@@ -851,7 +851,7 @@ MDNode *SPIRVToLLVMDbgTran::transExpression(const SPIRVExtInst *DebugInst) {
       Ops.push_back(Operands[I]);
     }
   }
-  ArrayRef<int64_t> Addr(Ops.data(), Ops.size());
+  ArrayRef<uint64_t> Addr(Ops.data(), Ops.size());
   return Builder.createExpression(Addr);
 }
 


### PR DESCRIPTION
 The signed version of createExpression was removed in
 https://github.com/intel/llvm/commit/ec501f15a8b8ace2b283732740d6d65d40d82e09