### PR TITLE
Update for AttrBuilder LLVM API change

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2822,7 +2822,7 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF) {
       I->addAttr(A);
     });
 
-    AttrBuilder Builder;
+    AttrBuilder Builder(*Context);
     SPIRVWord MaxOffset = 0;
     if (BA->hasDecorate(DecorationMaxByteOffset, 0, &MaxOffset))
       Builder.addDereferenceableAttr(MaxOffset);


### PR DESCRIPTION
Update for LLVM commit d2cc6c2d0c2f ("Use a sorted array instead
of a map to store AttrBuilder string attributes", 2022-01-10).