### PR TITLE
Implement forward translation for llvm.fence

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3467,21 +3467,21 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
 
 SPIRVValue *LLVMToSPIRVBase::transFenceInst(FenceInst *FI,
                                             SPIRVBasicBlock *BB) {
-  SPIRVWord MemorySemantics = static_cast<SPIRVWord>(FI->getOrdering());
+  SPIRVWord MemorySemantics;
   // Fence ordering may only be Acquire, Release, AcquireRelease, or
   // SequentiallyConsistent
-  switch (MemorySemantics) {
-  case 4:
-    MemorySemantics = 0x2;
+  switch (FI->getOrdering()) {
+  case llvm::AtomicOrdering::Acquire:
+    MemorySemantics = MemorySemanticsAcquireMask;
     break;
-  case 5:
-    MemorySemantics = 0x4;
+  case llvm::AtomicOrdering::Release:
+    MemorySemantics = MemorySemanticsReleaseMask;
     break;
-  case 6:
-    MemorySemantics = 0x8;
+  case llvm::AtomicOrdering::AcquireRelease:
+    MemorySemantics = MemorySemanticsAcquireReleaseMask;
     break;
-  case 7:
-    MemorySemantics = 0x10;
+  case llvm::AtomicOrdering::SequentiallyConsistent:
+    MemorySemantics = MemorySemanticsSequentiallyConsistentMask;
     break;
   default:
     assert(false && "Unexpected fence ordering");

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3490,7 +3490,8 @@ SPIRVValue *LLVMToSPIRVBase::transFenceInst(FenceInst *FI,
   }
 
   Module *M = FI->getParent()->getModule();
-  SPIRVValue *RetScope = transConstant(getUInt32(M, 0));
+  // Treat all llvm.fence instructions as having CrossDevice scope:
+  SPIRVValue *RetScope = transConstant(getUInt32(M, ScopeCrossDevice));
   SPIRVValue *Val = transConstant(getUInt32(M, MemorySemantics));
   return BM->addMemoryBarrierInst(static_cast<Scope>(RetScope->getId()),
                                   Val->getId(), BB);

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -101,6 +101,7 @@ public:
   bool transWorkItemBuiltinCallsToVariables();
   bool isKnownIntrinsic(Intrinsic::ID Id);
   SPIRVValue *transIntrinsicInst(IntrinsicInst *Intrinsic, SPIRVBasicBlock *BB);
+  SPIRVValue *transFenceInst(FenceInst *FI, SPIRVBasicBlock *BB);
   SPIRVValue *transCallInst(CallInst *Call, SPIRVBasicBlock *BB);
   SPIRVValue *transDirectCallInst(CallInst *Call, SPIRVBasicBlock *BB);
   SPIRVValue *transIndirectCallInst(CallInst *Call, SPIRVBasicBlock *BB);

--- a/test/transcoding/fence_inst.ll
+++ b/test/transcoding/fence_inst.ll
@@ -1,0 +1,67 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_runtime_aligned -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; RUN: llvm-spirv -spirv-text -r %t.spt -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: TypeInt [[#UINT:]] 32 0
+
+; 0x0 CrossDevice
+; CHECK-SPIRV: Constant [[#UINT]] [[#CD:]] 0
+
+; CHECK-SPIRV: Constant [[#UINT]] [[#ID1:]] 2
+; CHECK-SPIRV: Constant [[#UINT]] [[#ID2:]] 4
+; CHECK-SPIRV: Constant [[#UINT]] [[#ID3:]] 8
+; CHECK-SPIRV: Constant [[#UINT]] [[#ID4:]] 16
+
+; CHECK-SPIRV: MemoryBarrier [[#CD]] [[#ID1]]
+; CHECK-SPIRV: MemoryBarrier [[#CD]] [[#ID2]]
+; CHECK-SPIRV: MemoryBarrier [[#CD]] [[#ID3]]
+; CHECK-SPIRV: MemoryBarrier [[#CD]] [[#ID4]]
+
+
+; CHECK-LLVM: define spir_kernel void @fence_test_kernel1{{.*}} #0 {{.*}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z9mem_fencej(i32 0)
+
+; CHECK-LLVM: define spir_kernel void @fence_test_kernel2{{.*}} #0 {{.*}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z9mem_fencej(i32 0)
+
+; CHECK-LLVM: define spir_kernel void @fence_test_kernel3{{.*}} #0 {{.*}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z9mem_fencej(i32 0)
+
+; CHECK-LLVM: define spir_kernel void @fence_test_kernel4{{.*}} #0 {{.*}}
+; CHECK-LLVM-NEXT: call spir_func void @_Z9mem_fencej(i32 0)
+
+; ModuleID = 'fence_inst.bc'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64"
+
+; Function Attrs: noinline nounwind
+define spir_kernel void @fence_test_kernel1(i32 addrspace(1)* noalias %s.ascast) {
+  fence acquire
+  ret void
+}
+
+; Function Attrs: noinline nounwind
+define spir_kernel void @fence_test_kernel2(i32 addrspace(1)* noalias %s.ascast) {
+  fence release
+  ret void
+}
+
+; Function Attrs: noinline nounwind
+define spir_kernel void @fence_test_kernel3(i32 addrspace(1)* noalias %s.ascast) {
+  fence acq_rel
+  ret void
+}
+
+; Function Attrs: noinline nounwind
+define spir_kernel void @fence_test_kernel4(i32 addrspace(1)* noalias %s.ascast) {
+  fence syncscope("singlethread") seq_cst
+  ret void
+}
+


### PR DESCRIPTION
This patch adds forward translation for fence instruction.
Reverse translation uses OCL builtin for OpMemoryBarrier.

Signed-off-by: Leonid Pauzin leonid.pauzin@intel.com