### PR TITLE
Added option to choose program address space in emitted LLVM IR

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -181,6 +181,14 @@ public:
     PreserveOCLKernelArgTypeMetadataThroughString = Value;
   }
 
+  void setProgramAddressSpace(unsigned Value) { ProgramAddressSpace = Value; }
+
+  bool hasProgramAddressSpace() const { return ProgramAddressSpace.hasValue(); }
+
+  unsigned getProgramAddressSpace() const {
+    return ProgramAddressSpace.getValue();
+  }
+
 private:
   // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
@@ -207,6 +215,9 @@ private:
   // Unknown LLVM intrinsics will be translated as external function calls in
   // SPIR-V
   llvm::Optional<ArgList> SPIRVAllowUnknownIntrinsics{};
+
+  // Override program address space in module data layout
+  llvm::Optional<unsigned> ProgramAddressSpace;
 
   // Enable support for extra DIExpression opcodes not listed in the SPIR-V
   // DebugInfo specification.

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -488,6 +488,14 @@ public:
     return TranslationOpts.isAllowedToUseExtension(RequestedExtension);
   }
 
+  bool hasProgramAddressSpace() const {
+    return TranslationOpts.hasProgramAddressSpace();
+  }
+
+  unsigned getProgramAddressSpace() const {
+    return TranslationOpts.getProgramAddressSpace();
+  }
+
   virtual bool isGenArgNameMDEnabled() const final {
     return TranslationOpts.isGenArgNameMDEnabled();
   }

--- a/test/program-addrspace-option.ll
+++ b/test/program-addrspace-option.ll
@@ -1,0 +1,25 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_function_pointers
+; RUN: llvm-spirv -r %t.spv -o %t.bc --override-program-address-space=3
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck %s --input-file %t.ll
+
+; ModuleID = 'tmp_back.bc'
+; CHECK: target datalayout
+; CHECK-SAME: P3
+
+target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: @test
+; CHECK-SAME: addrspace(3)
+; CHECK: %p
+; CHECK-SAME: addrspace(3)
+
+define spir_kernel void @test() {
+entry:
+  %p = alloca void () *, align 8
+  store void () * @test, void () ** %p, align 8
+  ret void
+}
+

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -152,6 +152,9 @@ static cl::opt<bool>
     SPIRVToolsDis("spirv-tools-dis", cl::init(false),
                   cl::desc("Emit textual assembly using SPIRV-Tools"));
 
+static cl::opt<unsigned> SPIRVProgramAddressSpace(
+    "override-program-address-space", cl::init(0),
+    cl::desc("Override program address space when reading from SPIRV"));
 using SPIRV::ExtensionID;
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
@@ -706,6 +709,10 @@ int main(int Ac, char **Av) {
     } else {
       Opts.setDebugInfoEIS(DebugEIS);
     }
+  }
+
+  if (SPIRVProgramAddressSpace.getNumOccurrences() != 0) {
+    Opts.setProgramAddressSpace(SPIRVProgramAddressSpace);
   }
 
   if (PreserveOCLKernelArgTypeMetadataThroughString.getNumOccurrences() != 0)


### PR DESCRIPTION
SPIRV does not specify storage class for functions, although llvm does.
This patch enables choise of address space for function in data layout
of emitted LLVM module.