### PR TITLE
Drop outdated FIXME from test; NFC

### DIFF
--- a/test/spirv-ocl-builtins-version.spt
+++ b/test/spirv-ocl-builtins-version.spt
@@ -64,5 +64,4 @@
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 784) [[attr]]
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2320) [[attr]]
 ; CHECK-LLVM-SPV-IR: call spir_func void @_Z22__spirv_ControlBarrieriii(i32 2, i32 2, i32 2832) [[attr]]
-; FIXME: shall we apply convergent attribute to SPIR-V friendly IR representaiton as well?
 ; CHECK-LLVM-SPV-IR: attributes [[attr]] = { convergent nounwind }


### PR DESCRIPTION
This has been addressed in commit 4ccb1b29 ("Add convergent attribute
during reverse translation of OpControlBarrier (#1195)", 2021-09-06) by @KornevNikita .