### PR TITLE
[Backport][120] cherry-pick for ConstExpr Binary operators

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -888,7 +888,7 @@ SPIRVInstruction *LLVMToSPIRV::transBinaryInst(BinaryOperator *B,
       transBoolOpCode(Op0, OpCodeMap::map(LLVMOC)), transType(B->getType()),
       Op0, transValue(B->getOperand(1), BB), BB);
 
-// BinaryOperator can have no parent if it is handled as an expression inside
+  // BinaryOperator can have no parent if it is handled as an expression inside
   // another instruction.
   if (B->getParent() && isUnfusedMulAdd(B)) {
     Function *F = B->getFunction();

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -868,7 +868,7 @@ SPIRVValue *LLVMToSPIRV::transValue(Value *V, SPIRVBasicBlock *BB,
 
   SPIRVDBG(dbgs() << "[transValue] " << *V << '\n');
   assert((!isa<Instruction>(V) || isa<GetElementPtrInst>(V) ||
-          isa<CastInst>(V) || BB) &&
+          isa<CastInst>(V) || isa<BinaryOperator>(V) || BB) &&
          "Invalid SPIRV BB");
 
   auto BV = transValueWithoutDecoration(V, BB, CreateForward, FuncTrans);
@@ -888,7 +888,9 @@ SPIRVInstruction *LLVMToSPIRV::transBinaryInst(BinaryOperator *B,
       transBoolOpCode(Op0, OpCodeMap::map(LLVMOC)), transType(B->getType()),
       Op0, transValue(B->getOperand(1), BB), BB);
 
-  if (isUnfusedMulAdd(B)) {
+// BinaryOperator can have no parent if it is handled as an expression inside
+  // another instruction.
+  if (B->getParent() && isUnfusedMulAdd(B)) {
     Function *F = B->getFunction();
     SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
                     << ": possible fma candidate " << *B << '\n');


### PR DESCRIPTION
This is partial cherry-pick of c3c3c68bd0438058b92abd00f0704afe1d7fb63e (https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1335),
intended to enable translation of binary operators inside constant expressions.

This is done due to original commit is too complex and depends on a chain of commits that need to be backported prior to fully backporting entire commit. For a short term, I suppose it is better to partially cherry-pick to unblock some needed functionality. It can be fully backported later on. 