### PR TITLE
Restore asserts accidentally removed in 7452422

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -447,9 +447,13 @@ void SPIRVRegularizeLLVMBase::adaptStructTypes(StructType *ST) {
            "Expected a pointer to an array to represent joint matrix type");
     size_t TypeLayout[4] = {0, 0, 0, 0};
     ArrayType *ArrayTy = dyn_cast<ArrayType>(PtrTy->getPointerElementType());
+    assert(ArrayTy && "Expected a pointer element type of an array type to "
+                      "represent joint matrix type");
     TypeLayout[0] = ArrayTy->getNumElements();
     for (size_t I = 1; I != 4; ++I) {
       ArrayTy = dyn_cast<ArrayType>(ArrayTy->getElementType());
+      assert(ArrayTy &&
+             "Expected a element type to represent joint matrix type");
       TypeLayout[I] = ArrayTy->getNumElements();
     }
 


### PR DESCRIPTION
The original change (74759ef) introduced assertions in case `dyn_cast` returns `nullptr`.
Restore them back after being removed in 7452422.

https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/74759ef334182a32fddf1defa6f3830a87ab1f2b#diff-f8b80fcd2438a87e6b6ec7219f0cd5240975c6eea3a111afa0a4e9332a01f55dR355-R356
