### PR TITLE
Fix SPIRV -> OCL barrier call argument attributes

### DIFF
--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -97,8 +97,10 @@ void SPIRVToOCL20Base::visitCallSPIRVMemoryBarrier(CallInst *CI) {
 
 void SPIRVToOCL20Base::visitCallSPIRVControlBarrier(CallInst *CI) {
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  SmallVector<AttributeSet, 2> ArgAttrs = {Attrs.getParamAttrs(1), Attrs.getParamAttrs(2)};
-  AttributeList NewAttrs = AttributeList::get(*Ctx, Attrs.getFnAttrs(), Attrs.getRetAttrs(), ArgAttrs);
+  SmallVector<AttributeSet, 2> ArgAttrs = {Attrs.getParamAttrs(1),
+                                           Attrs.getParamAttrs(2)};
+  AttributeList NewAttrs = AttributeList::get(*Ctx, Attrs.getFnAttrs(),
+                                              Attrs.getRetAttrs(), ArgAttrs);
   mutateCallInstOCL(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -97,6 +97,8 @@ void SPIRVToOCL20Base::visitCallSPIRVMemoryBarrier(CallInst *CI) {
 
 void SPIRVToOCL20Base::visitCallSPIRVControlBarrier(CallInst *CI) {
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  SmallVector<AttributeSet, 2> ArgAttrs = {Attrs.getParamAttrs(1), Attrs.getParamAttrs(2)};
+  AttributeList NewAttrs = AttributeList::get(*Ctx, Attrs.getFnAttrs(), Attrs.getRetAttrs(), ArgAttrs);
   mutateCallInstOCL(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {
@@ -116,7 +118,7 @@ void SPIRVToOCL20Base::visitCallSPIRVControlBarrier(CallInst *CI) {
         return (ExecScope == ScopeWorkgroup) ? kOCLBuiltinName::WorkGroupBarrier
                                              : kOCLBuiltinName::SubGroupBarrier;
       },
-      &Attrs);
+      &NewAttrs);
 }
 
 std::string SPIRVToOCL20Base::mapFPAtomicName(Op OC) {


### PR DESCRIPTION
The first arg of CI is not used as arg in NewCI. So its attribute should
be removed from attributes of NewCI.

For instance, before SPIRVToOCL20Legacy pass:
`
tail call spir_func void @_Z22__spirv_ControlBarrierjjj(i32 noundef 2, i32 noundef 2, i32 noundef 272)
`
after SPIRVToOCL20Legacy pass:
`
call spir_func void @_Z18work_group_barrierj12memory_scope(i32 noundef 1, i32 noundef 1)
`
NewCI's argument attributes should only contain two elements.

I'm not able to provide a lit test because currently noundef attribute is not preserved in spirv.