### PR TITLE
Fix argument attributes for SPIRV -> OCL group builtins

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -539,6 +539,12 @@ void SPIRVToOCLBase::visitCallSPIRVGroupBuiltin(CallInst *CI, Op OC) {
 
   assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  SmallVector<AttributeSet, 2> ArgAttrs;
+  for (int I = (hasGroupOperation(OC) ? 2 : 1);
+       I < (int)Attrs.getNumAttrSets() - 2; I++)
+    ArgAttrs.push_back(Attrs.getParamAttrs(I));
+  Attrs = AttributeList::get(*Ctx, Attrs.getFnAttrs(), Attrs.getRetAttrs(),
+                             ArgAttrs);
   mutateCallInstOCL(M, CI, ModifyArguments, ModifyRetTy, &Attrs);
 }
 


### PR DESCRIPTION
The first argument or first two arguments are not used as arguments in
new call instruction to OCL group builtins, so the related attributes
should be removed from attributes of new call instruction.