### PR TITLE
Fix build fail after LLVM upstream change

### DIFF
--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -47,6 +47,7 @@
 
 #include "llvm/Bitcode/BitcodeReader.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/IR/Constants.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Verifier.h"


### PR DESCRIPTION
This header is required after

  commit a5bbc6ef99bbc7fcf321326df2889e063ed77004
  Author: Bill Wendling <isanbard@gmail.com>
  Date:   Wed Feb 23 01:20:48 2022 -0800

  [NFC] Remove unnecessary "#include"s from header files