### PR TITLE
Support complex recursive types that use an array of pointers

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -475,6 +475,12 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool IsClassMember) {
         getSPIRVTypeName(kSPIRVTypeName::JointMatrixINTEL, SS.str());
     return mapType(T, getOrCreateOpaquePtrType(M, Name));
   }
+  case OpTypeForwardPointer: {
+    SPIRVTypeForwardPointer *FP =
+        static_cast<SPIRVTypeForwardPointer *>(static_cast<SPIRVEntry *>(T));
+    return mapType(T, transType(static_cast<SPIRVType *>(
+                          BM->getEntry(FP->getPointerId()))));
+  }
 
   default: {
     auto OC = T->getOpCode();

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -694,7 +694,7 @@ SPIRVEntry *SPIRVModuleImpl::addEntry(SPIRVEntry *Entry) {
     } else
       IdEntryMap[Id] = Entry;
   } else {
-    // Collect entries with no ID to de-allocate them at end.
+    // Collect entries with no ID to de-allocate them at the end.
     // Entry of OpLine will be deleted by std::shared_ptr automatically.
     if (Entry->getOpCode() != OpLine)
       EntryNoId.insert(Entry);
@@ -1736,6 +1736,11 @@ class TopologicalSort {
       return true;
     State = Discovered;
     for (SPIRVEntry *Op : E->getNonLiteralOperands()) {
+      if (Op->getOpCode() == OpTypeForwardPointer) {
+        SPIRVEntry *FP = E->getModule()->getEntry(
+            static_cast<SPIRVTypeForwardPointer *>(Op)->getPointerId());
+        Op = FP;
+      }
       if (EntryStateMap[Op] == Visited)
         continue;
       if (visit(Op)) {

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -763,7 +763,7 @@ SPIRVEntry *SPIRVModuleImpl::getEntry(SPIRVId Id) const {
   if (LocFwd != IdTypeForwardMap.end()) {
     return LocFwd->second;
   }
-  assert("Id is not in map");
+  assert(false && "Id is not in map");
   return nullptr;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1749,7 +1749,7 @@ class TopologicalSort {
           SPIRVTypePointer *Ptr = static_cast<SPIRVTypePointer *>(E);
           SPIRVModule *BM = E->getModule();
           ForwardPointerSet.insert(BM->add(new SPIRVTypeForwardPointer(
-              BM, Ptr, Ptr->getPointerStorageClass())));
+              BM, Ptr->getId(), Ptr->getPointerStorageClass())));
           return false;
         }
         return true;
@@ -1780,11 +1780,11 @@ public:
       : ForwardPointerSet(
             16, // bucket count
             [](const SPIRVTypeForwardPointer *Ptr) {
-              return std::hash<SPIRVId>()(Ptr->getPointer()->getId());
+              return std::hash<SPIRVId>()(Ptr->getPointerId());
             },
             [](const SPIRVTypeForwardPointer *Ptr1,
                const SPIRVTypeForwardPointer *Ptr2) {
-              return Ptr1->getPointer()->getId() == Ptr2->getPointer()->getId();
+              return Ptr1->getPointerId() == Ptr2->getPointerId();
             }),
         EntryStateMap([](SPIRVEntry *A, SPIRVEntry *B) -> bool {
           return A->getId() < B->getId();

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -123,13 +123,11 @@ template <class T> const SPIRVEncoder &encode(const SPIRVEncoder &O, T V) {
 
 template <>
 const SPIRVEncoder &operator<<(const SPIRVEncoder &O, SPIRVType *P) {
-  if (P->hasId())
-    return O << P->getId();
-  else if (P->getOpCode() == OpTypeForwardPointer)
+  if (!P->hasId() && P->getOpCode() == OpTypeForwardPointer)
     return O << static_cast<SPIRVTypeForwardPointer *>(
                     static_cast<SPIRVEntry *>(P))
                     ->getPointerId();
-  assert(false && "Unexpected SPIRV type");
+  return O << P->getId();
 }
 
 #define SPIRV_DEF_ENCDEC(Type)                                                 \

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -121,6 +121,17 @@ template <class T> const SPIRVEncoder &encode(const SPIRVEncoder &O, T V) {
   return O << static_cast<SPIRVWord>(V);
 }
 
+template <>
+const SPIRVEncoder &operator<<(const SPIRVEncoder &O, SPIRVType *P) {
+  if (P->hasId())
+    return O << P->getId();
+  else if (P->getOpCode() == OpTypeForwardPointer)
+    return O << static_cast<SPIRVTypeForwardPointer *>(
+                    static_cast<SPIRVEntry *>(P))
+                    ->getPointerId();
+  assert(false && "Unexpected SPIRV type");
+}
+
 #define SPIRV_DEF_ENCDEC(Type)                                                 \
   const SPIRVDecoder &operator>>(const SPIRVDecoder &I, Type &V) {             \
     return decode(I, V);                                                       \

--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -193,6 +193,7 @@ template <typename T>
 const SPIRVEncoder &operator<<(const SPIRVEncoder &O, T *P) {
   return O << P->getId();
 }
+template <> const SPIRVEncoder &operator<<(const SPIRVEncoder &O, SPIRVType *P);
 
 template <typename T>
 const SPIRVEncoder &operator<<(const SPIRVEncoder &O, const std::vector<T> &V) {

--- a/lib/SPIRV/libSPIRV/SPIRVType.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVType.cpp
@@ -271,7 +271,6 @@ void SPIRVTypeForwardPointer::encode(spv_ostream &O) const {
 
 void SPIRVTypeForwardPointer::decode(std::istream &I) {
   auto Decoder = getDecoder(I);
-  SPIRVId PointerId;
   Decoder >> PointerId >> SC;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVType.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVType.cpp
@@ -266,7 +266,7 @@ SPIRVConstant *SPIRVTypeArray::getLength() const {
 _SPIRV_IMP_ENCDEC3(SPIRVTypeArray, Id, ElemType, Length)
 
 void SPIRVTypeForwardPointer::encode(spv_ostream &O) const {
-  getEncoder(O) << Pointer << SC;
+  getEncoder(O) << PointerId << SC;
 }
 
 void SPIRVTypeForwardPointer::decode(std::istream &I) {

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -282,9 +282,11 @@ public:
       : Pointer(nullptr), SC(StorageClassUniformConstant) {}
 
   SPIRVTypePointer *getPointer() const { return Pointer; }
+  SPIRVId getPointerId() const { return PointerId; }
   _SPIRV_DCL_ENCDEC
 private:
   SPIRVTypePointer *Pointer;
+  SPIRVId PointerId;
   SPIRVStorageClassKind SC;
 };
 

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -276,10 +276,12 @@ class SPIRVTypeForwardPointer : public SPIRVEntryNoId<OpTypeForwardPointer> {
 public:
   SPIRVTypeForwardPointer(SPIRVModule *M, SPIRVTypePointer *Pointer,
                           SPIRVStorageClassKind SC)
-      : SPIRVEntryNoId(M, 3), Pointer(Pointer), SC(SC) {}
+      : SPIRVEntryNoId(M, 3), Pointer(Pointer), PointerId(SPIRVID_INVALID),
+        SC(SC) {}
 
   SPIRVTypeForwardPointer()
-      : Pointer(nullptr), SC(StorageClassUniformConstant) {}
+      : Pointer(nullptr), PointerId(SPIRVID_INVALID),
+        SC(StorageClassUniformConstant) {}
 
   SPIRVTypePointer *getPointer() const { return Pointer; }
   SPIRVId getPointerId() const { return PointerId; }

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -274,20 +274,18 @@ private:
 
 class SPIRVTypeForwardPointer : public SPIRVEntryNoId<OpTypeForwardPointer> {
 public:
-  SPIRVTypeForwardPointer(SPIRVModule *M, SPIRVTypePointer *Pointer,
+  SPIRVTypeForwardPointer(SPIRVModule *M, SPIRVId PointerId,
                           SPIRVStorageClassKind SC)
-      : SPIRVEntryNoId(M, 3), Pointer(Pointer), PointerId(SPIRVID_INVALID),
+      : SPIRVEntryNoId(M, 3), PointerId(PointerId),
         SC(SC) {}
 
   SPIRVTypeForwardPointer()
-      : Pointer(nullptr), PointerId(SPIRVID_INVALID),
+      : PointerId(SPIRVID_INVALID),
         SC(StorageClassUniformConstant) {}
 
-  SPIRVTypePointer *getPointer() const { return Pointer; }
   SPIRVId getPointerId() const { return PointerId; }
   _SPIRV_DCL_ENCDEC
 private:
-  SPIRVTypePointer *Pointer;
   SPIRVId PointerId;
   SPIRVStorageClassKind SC;
 };

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -276,12 +276,10 @@ class SPIRVTypeForwardPointer : public SPIRVEntryNoId<OpTypeForwardPointer> {
 public:
   SPIRVTypeForwardPointer(SPIRVModule *M, SPIRVId PointerId,
                           SPIRVStorageClassKind SC)
-      : SPIRVEntryNoId(M, 3), PointerId(PointerId),
-        SC(SC) {}
+      : SPIRVEntryNoId(M, 3), PointerId(PointerId), SC(SC) {}
 
   SPIRVTypeForwardPointer()
-      : PointerId(SPIRVID_INVALID),
-        SC(StorageClassUniformConstant) {}
+      : PointerId(SPIRVID_INVALID), SC(StorageClassUniformConstant) {}
 
   SPIRVId getPointerId() const { return PointerId; }
   _SPIRV_DCL_ENCDEC

--- a/test/transcoding/RecursiveType.ll
+++ b/test/transcoding/RecursiveType.ll
@@ -13,24 +13,33 @@ target triple = "spir-unknown-unknown"
 %struct.C = type { i32, %struct.B }
 %struct.B = type { i32, %struct.A addrspace(4)* }
 %struct.Node = type { %struct.Node addrspace(1)*, i32 }
+%struct.Flag = type { [3 x %struct.Flag addrspace(4)*] }
 
+; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[FlagFwdPtr:[0-9]+]] 8
 ; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[NodeFwdPtr:[0-9]+]] 5
 ; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[AFwdPtr:[0-9]+]] 8
 ; CHECK-SPIRV: 4 TypeInt [[IntID:[0-9]+]] 32 0
 ; CHECK-SPIRV: 4 TypeStruct [[BID:[0-9]+]] {{[0-9]+}} [[AFwdPtr]]
 ; CHECK-SPIRV: 4 TypeStruct [[CID:[0-9]+]] {{[0-9]+}} [[BID]]
 ; CHECK-SPIRV: 4 TypeStruct [[AID:[0-9]+]] {{[0-9]+}} [[CID]]
+
 ; CHECK-SPIRV: 4 TypePointer [[AFwdPtr]] 8 [[AID:[0-9]+]]
 ; CHECK-SPIRV: 4 TypeStruct [[NodeID:[0-9]+]] [[NodeFwdPtr]]
+
 ; CHECK-SPIRV: 4 TypePointer [[NodeFwdPtr]] 5 [[NodeID]]
+; CHECK-SPIRV: 4 TypeArray [[FlagID:[0-9]+]] [[FlagFwdPtr]]
+; CHECK-SPIRV: 3 TypeStruct [[FlagStructID:[0-9]+]] [[FlagID]]
+
+; CHECK-SPIRV: 4 TypePointer [[FlagFwdPtr]] 8 [[FlagStructID]]
 
 ; CHECK-LLVM: %struct.A = type { i32, %struct.C }
 ; CHECK-LLVM: %struct.C = type { i32, %struct.B }
 ; CHECK-LLVM: %struct.B = type { i32, %struct.A addrspace(4)* }
 ; CHECK-LLVM: %struct.Node = type { %struct.Node addrspace(1)*, i32 }
+; CHECK-LLVM: %struct.Flag = type { [3 x %struct.Flag addrspace(4)*] }
 
 ; Function Attrs: nounwind
-define spir_kernel void @test(%struct.A addrspace(1)* %result, %struct.Node addrspace(1)* %node) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @test(%struct.A addrspace(1)* %result, %struct.Node addrspace(1)* %node, %struct.Flag addrspace(1)* %flag) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
   ret void
 }
 

--- a/test/transcoding/RecursiveType.ll
+++ b/test/transcoding/RecursiveType.ll
@@ -13,9 +13,9 @@ target triple = "spir-unknown-unknown"
 %struct.C = type { i32, %struct.B }
 %struct.B = type { i32, %struct.A addrspace(4)* }
 %struct.Node = type { %struct.Node addrspace(1)*, i32 }
-%struct.Flag = type { [3 x %struct.Flag addrspace(4)*] }
+%struct.Flag = type { [3 x %struct.Flag addrspace(3)*] }
 
-; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[FlagFwdPtr:[0-9]+]] 8
+; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[FlagFwdPtr:[0-9]+]] 4
 ; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[NodeFwdPtr:[0-9]+]] 5
 ; CHECK-SPIRV-DAG: 3 TypeForwardPointer [[AFwdPtr:[0-9]+]] 8
 ; CHECK-SPIRV: 4 TypeInt [[IntID:[0-9]+]] 32 0
@@ -30,7 +30,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: 4 TypeArray [[FlagID:[0-9]+]] [[FlagFwdPtr]]
 ; CHECK-SPIRV: 3 TypeStruct [[FlagStructID:[0-9]+]] [[FlagID]]
 
-; CHECK-SPIRV: 4 TypePointer [[FlagFwdPtr]] 8 [[FlagStructID]]
+; CHECK-SPIRV: 4 TypePointer [[FlagFwdPtr]] 4 [[FlagStructID]]
 
 ; CHECK-LLVM: %struct.A = type { i32, %struct.C }
 ; CHECK-LLVM: %struct.C = type { i32, %struct.B }

--- a/test/transcoding/RecursiveType.ll
+++ b/test/transcoding/RecursiveType.ll
@@ -3,7 +3,13 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; RUN: llvm-spirv -r %t.spt -spirv-text -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -36,7 +42,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-LLVM: %struct.C = type { i32, %struct.B }
 ; CHECK-LLVM: %struct.B = type { i32, %struct.A addrspace(4)* }
 ; CHECK-LLVM: %struct.Node = type { %struct.Node addrspace(1)*, i32 }
-; CHECK-LLVM: %struct.Flag = type { [3 x %struct.Flag addrspace(4)*] }
+; CHECK-LLVM: %struct.Flag = type { [3 x %struct.Flag addrspace(3)*] }
 
 ; Function Attrs: nounwind
 define spir_kernel void @test(%struct.A addrspace(1)* %result, %struct.Node addrspace(1)* %node, %struct.Flag addrspace(1)* %flag) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {


### PR DESCRIPTION
The use of pointer arrays inside the recursive type leads to the SPIR-V IR, where
the TypePointer is declared after TypeArray. In turn, TypeArray can't handle the
unknown element type, because the info from TypeForwardPointer is not used.

Now the translator stores forward declared IDs to use them in backward
translation. It actually means that the translator "knows" about the type but it
would be handled later.