### PR TITLE
Explicitly add 'sret' parameter attribute for builtins

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1956,6 +1956,9 @@ bool postProcessBuiltinReturningStruct(Function *F) {
       auto Args = getArguments(CI);
       Args.insert(Args.begin(), ST->getPointerOperand());
       auto *NewCI = CallInst::Create(NewF, Args, CI->getName(), CI);
+      NewCI->addParamAttr(0, Attribute::get(*Context,
+                                            Attribute::AttrKind::StructRet,
+                                            F->getReturnType()));
       NewCI->setCallingConv(CI->getCallingConv());
       InstToRemove.push_back(ST);
       InstToRemove.push_back(CI);


### PR DESCRIPTION
It's required after:
commit 2182665305d90ae7d0d2b573dced9ef0ef414a9a
Author: Nikita Popov <npopov@redhat.com>
Date:   Fri Mar 11 17:30:34 2022 +0100

    [Bitcode] Don't confuse type attributes on declaration and call

    We should not be using APIs here that try to fetch the attribute
    from both the call attributes and the function attributes. Otherwise
    we'll try to upgrade a non-existent sret attribute on the call using
    the attribute on the function.

The patch fixes following failures:
Failed Tests (2):
  LLVM_SPIRV :: transcoding/BuildNDRange.ll
  LLVM_SPIRV :: transcoding/BuildNDRange_2.ll

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>