### PR TITLE
Expand annotation-carried decoration parsing

### DIFF
--- a/docs/SPIRVRepresentationInLLVM.rst
+++ b/docs/SPIRVRepresentationInLLVM.rst
@@ -461,6 +461,76 @@ with extra operands ``"v"`` and ``Export`` in SPIR-V.
 decorates the argument ``b`` of ``k`` with ``Restrict`` in SPIR-V while not
 adding any decoration to argument ``a``.
 
+Member decoration through pointer annotations
+---------------------------------------------
+
+Class members can be decorated using the ``llvm.ptr.annotation`` LLVM IR
+intrinsic. Member decorations specified in ``llvm.ptr.annotation`` must be in
+the second argument and must have the format ``{X}`` or ``{X:Y}`` where ``X`` is
+either one of the reserved names or an integer literal representing the SPIR-V
+decoration identifier and ``Y`` is 1 or more arguments separated by ",", where
+each argument must be either a word (including numbers) or a string enclosed by
+quotation marks. The ``llvm.ptr.annotation`` can contain any number decorations
+following this format.
+
+For example, both ``{5835:1,2,3}`` and ``{bank_bits:1,2,3}`` will result in the
+``BankwidthINTEL`` decoration with literals 1, 2, and 3 attached to the
+annotated member.
+
+The translator accepts a number of reserved names that correspond to SPIR-V
+member decorations.
+
++-----------------------+------------------+-----------------------------------+
+| Decoration            | Reserved Name    | Note                              |
++=======================+==================+===================================+
+| RegisterINTEL         | register         | Additional arguments are ignored, |
+|                       |                  | but reverse translation will add  |
+|                       |                  | a 1 argument, i.e.                |
+|                       |                  | ``{register:1}``.                 |
++-----------------------+------------------+-----------------------------------+
+| MemoryINTEL           | memory           |                                   |
++-----------------------+------------------+-----------------------------------+
+| NumbanksINTEL         | numbanks         |                                   |
++-----------------------+------------------+-----------------------------------+
+| BankwidthINTEL        | bankwidth        |                                   |
++-----------------------+------------------+-----------------------------------+
+| MaxPrivateCopiesINTEL | private_copies   |                                   |
++-----------------------+------------------+-----------------------------------+
+| SinglepumpINTEL       | pump             | Reserved name is shared with      |
+|                       |                  | DoublepumpINTEL. SinglepumpINTEL  |
+|                       |                  | will be selected if the argument  |
+|                       |                  | is 2, i.e ``{pump:1}``.           |
++-----------------------+------------------+-----------------------------------+
+| DoublepumpINTEL       | pump             | Reserved name is shared with      |
+|                       |                  | SinglepumpINTEL. DoublepumpINTEL  |
+|                       |                  | will be selected if the argument  |
+|                       |                  | is 2, i.e ``{pump:2}``.           |
++-----------------------+------------------+-----------------------------------+
+| MaxReplicatesINTEL    | max_replicates   |                                   |
++-----------------------+------------------+-----------------------------------+
+| SimpleDualPortINTEL   | simple_dual_port | Additional arguments are ignored, |
+|                       |                  | but reverse translation will add  |
+|                       |                  | a 1 argument, i.e.                |
+|                       |                  | ``{simple_dual_port:1}``.         |
++-----------------------+------------------+-----------------------------------+
+| MergeINTEL            | merge            | Arguments of this are separated by|
+|                       |                  | ":" rather than ",", i.e.         |
+|                       |                  | ``{merge:X:Y}``.                  |
++-----------------------+------------------+-----------------------------------+
+| BankBitsINTEL         | bank_bits        |                                   |
++-----------------------+------------------+-----------------------------------+
+| ForcePow2DepthINTEL   | force_pow2_depth |                                   |
++-----------------------+------------------+-----------------------------------+
+
+None of the special requirements imposed from using the reserved names apply to
+using decoration identifiers directly.
+
+During reverse translation, the translator prioritizes reserved names over
+decoration identifiers, even if the member decoration was generated using the
+corresponding decoration identifier. For example, this means that translating
+``{5825}`` to SPIR-V and back to LLVM IR will result in ``{register:1}`` being
+in the annotation string argument instead of the initial value.
+
 Debug information extension
 ===========================
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2836,7 +2836,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
     switch (I.first) {
     case DecorationUserSemantic:
       M->getErrorLog().checkError(I.second.size() == 1,
-                                  SPIRVEC_InvalidDecoration,
+                                  SPIRVEC_InvalidLlvmModule,
                                   "UserSemantic requires a single argument.");
       E->addDecorate(new SPIRVDecorateUserSemanticAttr(E, I.second[0]));
       break;
@@ -2844,7 +2844,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
       if (M->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
         M->getErrorLog().checkError(I.second.size() == 1,
-                                    SPIRVEC_InvalidDecoration,
+                                    SPIRVEC_InvalidLlvmModule,
                                     "MemoryINTEL requires a single argument.");
         E->addDecorate(new SPIRVDecorateMemoryINTELAttr(E, I.second[0]));
       }
@@ -2853,8 +2853,9 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
       if (M->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
         M->getErrorLog().checkError(I.second.size() == 2,
-                                    SPIRVEC_InvalidDecoration,
+                                    SPIRVEC_InvalidLlvmModule,
                                     "MergeINTEL requires two arguments.");
+        // First argument is the name and the second argument is the direction.
         E->addDecorate(
             new SPIRVDecorateMergeINTELAttr(E, I.second[0], I.second[1]));
       }
@@ -2863,7 +2864,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
       if (M->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
         M->getErrorLog().checkError(
-            I.second.size() > 0, SPIRVEC_InvalidDecoration,
+            I.second.size() > 0, SPIRVEC_InvalidLlvmModule,
             "BankBitsINTEL requires at least one argument.");
         E->addDecorate(new SPIRVDecorateBankBitsINTELAttr(
             E, getBankBitsFromStrings(I.second)));
@@ -2875,7 +2876,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
     case DecorationSimpleDualPortINTEL: {
       if (M->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
-        M->getErrorLog().checkError(I.second.empty(), SPIRVEC_InvalidDecoration,
+        M->getErrorLog().checkError(I.second.empty(), SPIRVEC_InvalidLlvmModule,
                                     "Decoration takes no arguments.");
         E->addDecorate(I.first);
       }
@@ -2884,7 +2885,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
     case DecorationDontStaticallyCoalesceINTEL: {
       if (M->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_fpga_memory_accesses)) {
-        M->getErrorLog().checkError(I.second.empty(), SPIRVEC_InvalidDecoration,
+        M->getErrorLog().checkError(I.second.empty(), SPIRVEC_InvalidLlvmModule,
                                     "Decoration takes no arguments.");
         E->addDecorate(I.first);
       }
@@ -2897,7 +2898,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
       if (M->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
         M->getErrorLog().checkError(I.second.size() == 1,
-                                    SPIRVEC_InvalidDecoration,
+                                    SPIRVEC_InvalidLlvmModule,
                                     "Decoration requires a single argument.");
         SPIRVWord Result = 0;
         StringRef(I.second[0]).getAsInteger(10, Result);
@@ -2909,7 +2910,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
       if (M->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_fpga_memory_accesses)) {
         M->getErrorLog().checkError(I.second.size() == 1,
-                                    SPIRVEC_InvalidDecoration,
+                                    SPIRVEC_InvalidLlvmModule,
                                     "Decoration requires a single argument.");
         SPIRVWord Result = 0;
         StringRef(I.second[0]).getAsInteger(10, Result);
@@ -2938,21 +2939,21 @@ void addAnnotationDecorationsForStructMember(SPIRVEntry *E,
     switch (I.first) {
     case DecorationUserSemantic:
       M->getErrorLog().checkError(I.second.size() == 1,
-                                  SPIRVEC_InvalidMemberDecoration,
+                                  SPIRVEC_InvalidLlvmModule,
                                   "UserSemantic requires a single argument.");
       E->addMemberDecorate(new SPIRVMemberDecorateUserSemanticAttr(
           E, MemberNumber, I.second[0]));
       break;
     case DecorationMemoryINTEL:
       M->getErrorLog().checkError(I.second.size() == 1,
-                                  SPIRVEC_InvalidMemberDecoration,
+                                  SPIRVEC_InvalidLlvmModule,
                                   "MemoryINTEL requires a single argument.");
       E->addMemberDecorate(
           new SPIRVMemberDecorateMemoryINTELAttr(E, MemberNumber, I.second[0]));
       break;
     case DecorationMergeINTEL: {
       M->getErrorLog().checkError(I.second.size() == 2,
-                                  SPIRVEC_InvalidMemberDecoration,
+                                  SPIRVEC_InvalidLlvmModule,
                                   "MergeINTEL requires two arguments.");
       // First argument is the name, the other is the direction.
       E->addMemberDecorate(new SPIRVMemberDecorateMergeINTELAttr(
@@ -2960,7 +2961,7 @@ void addAnnotationDecorationsForStructMember(SPIRVEntry *E,
     } break;
     case DecorationBankBitsINTEL:
       M->getErrorLog().checkError(
-          I.second.size() > 0, SPIRVEC_InvalidMemberDecoration,
+          I.second.size() > 0, SPIRVEC_InvalidLlvmModule,
           "BankBitsINTEL requires at least one argument.");
       E->addMemberDecorate(new SPIRVMemberDecorateBankBitsINTELAttr(
           E, MemberNumber, getBankBitsFromStrings(I.second)));
@@ -2969,8 +2970,7 @@ void addAnnotationDecorationsForStructMember(SPIRVEntry *E,
     case DecorationSinglepumpINTEL:
     case DecorationDoublepumpINTEL:
     case DecorationSimpleDualPortINTEL:
-      M->getErrorLog().checkError(I.second.empty(),
-                                  SPIRVEC_InvalidMemberDecoration,
+      M->getErrorLog().checkError(I.second.empty(), SPIRVEC_InvalidLlvmModule,
                                   "Member decoration takes no arguments.");
       E->addMemberDecorate(MemberNumber, I.first);
       break;
@@ -2982,7 +2982,7 @@ void addAnnotationDecorationsForStructMember(SPIRVEntry *E,
     // DecorationForcePow2DepthINTEL
     default:
       M->getErrorLog().checkError(
-          I.second.size() == 1, SPIRVEC_InvalidMemberDecoration,
+          I.second.size() == 1, SPIRVEC_InvalidLlvmModule,
           "Member decoration requires a single argument.");
       SPIRVWord Result = 0;
       StringRef(I.second[0]).getAsInteger(10, Result);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2710,7 +2710,7 @@ AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
     StringRef Name = Split.first, ValueStr = Split.second;
 
     unsigned DecorationKind = 0;
-    if(!Name.getAsInteger(10, DecorationKind)) {
+    if (!Name.getAsInteger(10, DecorationKind)) {
       // If the name is a number it represents the decoration by its kind.
       std::vector<std::string> DecValues;
       if (tryParseAnnotationDecoValues(ValueStr, DecValues)) {
@@ -2770,8 +2770,8 @@ AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
         else if (Dec == DecorationMergeINTEL) {
           ValidDecorationFound = true;
           std::pair<StringRef, StringRef> MergeValues = ValueStr.split(':');
-          DecValues = std::vector<std::string>({MergeValues.first.str(),
-                                                MergeValues.second.str()});
+          DecValues = std::vector<std::string>(
+              {MergeValues.first.str(), MergeValues.second.str()});
         } else if (Dec == DecorationBankBitsINTEL) {
           ValidDecorationFound = true;
           SmallVector<StringRef, 4> BitsStrs;
@@ -2841,7 +2841,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
     case DecorationBankBitsINTEL: {
       if (M->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_fpga_memory_attributes)) {
-      assert(I.second.size() > 0);
+        assert(I.second.size() > 0);
         E->addDecorate(new SPIRVDecorateBankBitsINTELAttr(
             E, getBankBitsFromStrings(I.second)));
       }

--- a/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
@@ -19,5 +19,3 @@ _SPIRV_OP(InvalidWordCount,
 _SPIRV_OP(Requires1_1, "Feature requires SPIR-V 1.1 or greater:")
 _SPIRV_OP(RequiresExtension,
           "Feature requires the following SPIR-V extension:\n")
-_SPIRV_OP(InvalidDecoration, "Invalid decoration:\n")
-_SPIRV_OP(InvalidMemberDecoration, "Invalid member decoration:\n")

--- a/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
@@ -19,3 +19,5 @@ _SPIRV_OP(InvalidWordCount,
 _SPIRV_OP(Requires1_1, "Feature requires SPIR-V 1.1 or greater:")
 _SPIRV_OP(RequiresExtension,
           "Feature requires the following SPIR-V extension:\n")
+_SPIRV_OP(InvalidDecoration, "Invalid decoration:\n")
+_SPIRV_OP(InvalidMemberDecoration, "Invalid member decoration:\n")

--- a/test/transcoding/annotation_generic_decoration.ll
+++ b/test/transcoding/annotation_generic_decoration.ll
@@ -1,0 +1,52 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+%struct.S = type { i32* }
+
+@.str = private unnamed_addr constant [114 x i8] c"{5825}{5826:\22testmem\22}{5828:42}{5827:\2241\22}{5829:3}{5831}{5830}{5832:2}{5834:str1,\22str2\22}{5835:\221\22,3,\222\22}{5836:24}\00", section "llvm.metadata"
+@.str.1 = private unnamed_addr constant [14 x i8] c"<invalid loc>\00", section "llvm.metadata"
+
+define dso_local noundef i32 @main() {
+  %1 = alloca i32, align 4
+  %2 = alloca %struct.S, align 8
+  store i32 0, i32* %1, align 4
+  %3 = getelementptr inbounds %struct.S, %struct.S* %2, i32 0, i32 0
+  %4 = bitcast i32** %3 to i8*
+  %5 = call i8* @llvm.ptr.annotation.p0i8(i8* %4, i8* getelementptr inbounds ([114 x i8], [114 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str.1, i32 0, i32 0), i32 3, i8* null)
+  %6 = bitcast i8* %5 to i32**
+  %7 = load i32*, i32** %6, align 8
+  ret i32 0
+}
+
+declare i8* @llvm.ptr.annotation.p0i8(i8*, i8*, i8*, i32, i8*)
+
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 RegisterINTEL
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 MemoryINTEL "testmem"
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 BankwidthINTEL 42
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 NumbanksINTEL 41
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 MaxPrivateCopiesINTEL 3
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 DoublepumpINTEL
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 SinglepumpINTEL
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 MaxReplicatesINTEL 2
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 MergeINTEL "str1" "str2"
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 BankBitsINTEL 1 3 2
+; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 ForcePow2DepthINTEL 24
+
+; CHECK-LLVM: @{{.*}} = private unnamed_addr constant [163 x i8] c"
+; CHECK-LLVM-DAG: {register:1}
+; CHECK-LLVM-DAG: {memory:testmem}
+; CHECK-LLVM-DAG: {bankwidth:42}
+; CHECK-LLVM-DAG: {numbanks:41}
+; CHECK-LLVM-DAG: {private_copies:3}
+; CHECK-LLVM-DAG: {pump:2}
+; CHECK-LLVM-DAG: {pump:1}
+; CHECK-LLVM-DAG: {max_replicates:2}
+; CHECK-LLVM-DAG: {merge:str1:str2}
+; CHECK-LLVM-DAG: {bank_bits:1,3,2}
+; CHECK-LLVM-DAG: {force_pow2_depth:24}


### PR DESCRIPTION
The SPIR-V translator currently allows LLVM IR annotation intrinsics to carry a selection of INTEL extension decorations as part of the string in its second argument. These changes expand the parsing of these to allow generic parsing of decorations in annotation strings, identifying the decorations by their SPIR-V integer identifiers rather than reserved names.

It is legal to have decorations with reserved named specified by their SPIR-V integer identifiers, but to allow backwards compatibility the reverse translation will use the reserved names for all decorations with them.