### PR TITLE
Remove Bitcast -> llvm.memset optimization in reverse translation

### DIFF
--- a/test/llvm-intrinsics/memset.ll
+++ b/test/llvm-intrinsics/memset.ll
@@ -68,7 +68,7 @@ define spir_func void @_Z5foo11v(%struct.S1 addrspace(4)* noalias nocapture sret
   %x.bc = bitcast [4 x i8]* %x to i8*
   %1 = bitcast %struct.S1 addrspace(4)* %agg.result to i8 addrspace(4)*
   tail call void @llvm.memset.p4i8.i32(i8 addrspace(4)* align 4 %1, i8 0, i32 12, i1 false)
-; CHECK-LLVM: call void @llvm.memset.p4i8.i32(i8 addrspace(4)* align 4 %1, i8 0, i32 12, i1 false)
+; CHECK-LLVM: call void @llvm.memcpy.p4i8.p2i8.i32(i8 addrspace(4)* align 4 %1, i8 addrspace(2)* align 4 %2, i32 12, i1 false)
   tail call void @llvm.memset.p0i8.i32(i8* align 4 %x.bc, i8 21, i32 4, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p0i8.p2i8.i32(i8* align 4 %x.bc, i8 addrspace(2)* align 4 %3, i32 4, i1 false)
 

--- a/test/transcoding/intrinsic_result_store.ll
+++ b/test/transcoding/intrinsic_result_store.ll
@@ -9,12 +9,15 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
+; CHECK-LLVM: [[ZERO_INIT:@[0-9]+]] = {{.*}} addrspace(2) constant [8 x i8] zeroinitializer
+
 ; Function Attrs: convergent noinline nounwind optnone
 define spir_kernel void @test_memset(i32 addrspace(1)* %data, i32 %input) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {
 entry:
 ; CHECK-LLVM: %[[BITCAST_RES:[[:alnum:].]+]] = bitcast i32 addrspace(1)* %{{[[:alnum:].]+}} to i8 addrspace(1)*
   %ptr = bitcast i32 addrspace(1)* %data to i8 addrspace(1)*
-; CHECK-LLVM: call void @llvm.memset.p1i8.i64(i8 addrspace(1)* align 8 %[[BITCAST_RES]], i8 0, i64 8, i1 false)
+; CHECK-LLVM: %[[#ZERO_INIT_BITCAST:]] = bitcast [8 x i8] addrspace(2)* [[ZERO_INIT]] to i8 addrspace(2)*
+; CHECK-LLVM: call void @llvm.memcpy.p1i8.p2i8.i64(i8 addrspace(1)* align 8 %[[BITCAST_RES]], i8 addrspace(2)* align 8 %[[#ZERO_INIT_BITCAST]], i64 8, i1 false)
   call void @llvm.memset.p1i8.i64(i8 addrspace(1)* align 8 %ptr, i8 0, i64 8, i1 false)
 ; CHECK-LLVM: store i8 0, i8 addrspace(1)* %[[BITCAST_RES]]
   store i8 0, i8 addrspace(1)* %ptr

--- a/test/transcoding/sycl_array_zero_init.ll
+++ b/test/transcoding/sycl_array_zero_init.ll
@@ -23,8 +23,9 @@ define weak_odr dso_local spir_kernel void @main() #0 comdat !kernel_arg_addr_sp
   %5 = bitcast [3 x i64] addrspace(4)* %4 to i8 addrspace(4)*
 ; CHECK: %[[V_ARR:[0-9]+]] = bitcast [3 x i64] addrspace(4)* %{{[0-9]+}} to i8 addrspace(4)*
   %6 = bitcast [3 x i64] addrspace(4)* @constinit to i8 addrspace(4)*
+; CHECK: %[[#CONST_INIT:]] = bitcast [3 x i64] addrspace(4)* @constinit to i8 addrspace(4)*
   call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 8 %5, i8 addrspace(4)* align 8 %6, i64 24, i1 false), !tbaa.struct !7
-; CHECK: call void @llvm.memset.p4i8.i64(i8 addrspace(4)* align 8 %[[V_ARR]], i8 0, i64 24, i1 false)
+; CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 8 %[[V_ARR]], i8 addrspace(4)* align 8 %[[#CONST_INIT]], i64 24, i1 false)
   %7 = bitcast %array* %1  to i8*
   call void @llvm.lifetime.end.p0i8(i64 24, i8* %7) #2
   ret void


### PR DESCRIPTION
The change is done in order to avoid `llvm.memcpy` -> `llvm.memset` transformation 
which can be an incorrect assumption.

Details:
SPIR-V does not have a memset instruction, there is a direct mapping only for
`llvm.memcpy` to `OpCopyMemory*`.
To handle `llvm.memset`, the input LLVM IR is lowered by `SPIRVRegularizeLLVM`
pass. The mentioned optimization tried to restore the memset instruction but it
surely does not cover all the possible cases (e.g., memcpy is not a memset inst).

Possibly, the number of follow-up fixes for different corner cases can prove
that the optimization is not absolutely correct, and it's better to rely on
regularize pass.