### PR TITLE
Fix invalid substitutions in test

### DIFF
--- a/test/llvm-intrinsics/fmuladd.ll
+++ b/test/llvm-intrinsics/fmuladd.ll
@@ -1,12 +1,12 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %default.spv
-; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=true -o %replace.spv
-; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=false -o %break.spv
-; RUN: spirv-val %replace.spv
-; RUN: spirv-val %break.spv
-; RUN: llvm-spirv %default.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,REPLACE
-; RUN: llvm-spirv %replace.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,REPLACE
-; RUN: llvm-spirv %break.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,BREAK
+; RUN: llvm-spirv %t.bc -o %t-default.spv
+; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=true -o %t-replace.spv
+; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=false -o %t-break.spv
+; RUN: spirv-val %t-replace.spv
+; RUN: spirv-val %t-break.spv
+; RUN: llvm-spirv %t-default.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,REPLACE
+; RUN: llvm-spirv %t-replace.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,REPLACE
+; RUN: llvm-spirv %t-break.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,BREAK
 
 ; COMMON-NOT: llvm.fmuladd
 


### PR DESCRIPTION
`%break` etc are not valid substitutions for `llvm-lit`.