### PR TITLE
Extend bool arg of shift operations

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -128,7 +128,7 @@ public:
   // i1 operands, they are treated as a bool. We need to extend them to i32 to
   // comply with the specification. For example: "%shift = lshr i1 0, 1";
   // The bit instruction should be changed to the extended version
-  // "%shift = i32 0, 1" so the args are treated as int operands.
+  // "%shift = lshr i32 0, 1" so the args are treated as int operands.
   Value *extendBitInstBoolArg(Instruction *OldInst);
 
   static std::string lowerLLVMIntrinsicName(IntrinsicInst *II);

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -123,6 +123,18 @@ public:
   void expandVEDWithSYCLTypeSRetArg(Function *F);
   void expandVIDWithSYCLTypeByValComp(Function *F);
 
+  // According to the specification, the operands of a shift instruction must be
+  // a scalar/vector of integer. When LLVM-IR contains a shift instruction with
+  // i1 operands, they are treated as a bool. We need to extend them to i32 to
+  // comply with the specification. For example:
+  // %21 = load i1, i1 addrspace(4)* %20
+  // %22 = load i32, i32 addrspace(4)* %9
+  // %23 = trunc i32 %22 to i1
+  // %24 = lshr i1 %21, %23
+  // %25 = zext i1 %24 to i32
+  // %24 should be changed to take (i32(%21), %22); %25 users should use %24
+  Value *extendBitInstBoolArg(Instruction *OldInst);
+
   static std::string lowerLLVMIntrinsicName(IntrinsicInst *II);
   void adaptStructTypes(StructType *ST);
   static char ID;
@@ -418,6 +430,13 @@ void SPIRVRegularizeLLVMBase::expandSYCLTypeUsing(Module *M) {
     expandVIDWithSYCLTypeByValComp(F);
 }
 
+Value *SPIRVRegularizeLLVMBase::extendBitInstBoolArg(Instruction *II) {
+  IRBuilder<> Builder(II);
+  auto *NewBase = Builder.CreateZExt(II->getOperand(0), Builder.getInt32Ty());
+  auto *ShiftInt32 = cast<User>(II->getOperand(1))->getOperand(0);
+  return Builder.CreateLShr(NewBase, ShiftInt32);
+}
+
 void SPIRVRegularizeLLVMBase::adaptStructTypes(StructType *ST) {
   if (!ST->hasName())
     return;
@@ -560,6 +579,19 @@ bool SPIRVRegularizeLLVMBase::regularize() {
               lowerFunnelShift(II);
             else if (II->getIntrinsicID() == Intrinsic::umul_with_overflow)
               lowerUMulWithOverflow(II);
+          }
+        }
+
+        if (II.isLogicalShift() &&
+            II.getOperand(0)->getType()->isIntegerTy(1)) {
+          if (II.getOpcode() == Instruction::LShr) {
+            auto *NewLSHR = extendBitInstBoolArg(&II);
+            for (auto U : II.users()) {
+              U->replaceAllUsesWith(NewLSHR);
+              ToErase.push_back(cast<Instruction>(U));
+            }
+            ToErase.push_back(&II);
+            ToErase.push_back(cast<Instruction>(II.getOperand(1)));
           }
         }
 

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -428,14 +428,14 @@ Value *SPIRVRegularizeLLVMBase::extendBitInstBoolArg(Instruction *II) {
   auto *ArgTy = II->getOperand(0)->getType();
   Type *NewArgType = nullptr;
   if (ArgTy->isIntegerTy()) {
-   NewArgType = Builder.getInt32Ty();
+    NewArgType = Builder.getInt32Ty();
   } else {
     unsigned NumElements = cast<FixedVectorType>(ArgTy)->getNumElements();
     NewArgType = VectorType::get(Builder.getInt32Ty(), NumElements, false);
   }
   auto *NewBase = Builder.CreateZExt(II->getOperand(0), NewArgType);
   auto *NewShift = Builder.CreateZExt(II->getOperand(1), NewArgType);
-  switch(II->getOpcode()) {
+  switch (II->getOpcode()) {
   case Instruction::LShr:
     return Builder.CreateLShr(NewBase, NewShift);
   case Instruction::Shl:

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -603,6 +603,7 @@ bool SPIRVRegularizeLLVMBase::regularize() {
           auto *NewInst = extendBitInstBoolArg(&II);
           for (auto *U : II.users()) {
             if (cast<Instruction>(U)->getOpcode() == Instruction::ZExt) {
+              U->dropAllReferences();
               U->replaceAllUsesWith(NewInst);
               ToErase.push_back(cast<Instruction>(U));
             }

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -586,7 +586,7 @@ bool SPIRVRegularizeLLVMBase::regularize() {
             II.getOperand(0)->getType()->isIntegerTy(1)) {
           if (II.getOpcode() == Instruction::LShr) {
             auto *NewLSHR = extendBitInstBoolArg(&II);
-            for (auto U : II.users()) {
+            for (auto *U : II.users()) {
               U->replaceAllUsesWith(NewLSHR);
               ToErase.push_back(cast<Instruction>(U));
             }

--- a/test/ExtendBitBoolArg.ll
+++ b/test/ExtendBitBoolArg.ll
@@ -1,0 +1,38 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv -s %t.bc -o %t.regulzarized.bc
+; RUN: llvm-dis %t.regulzarized.bc -o %t.regulzarized.ll
+; RUN: FileCheck < %t.regulzarized.ll %s
+
+; Translation cycle should be successfull:
+; RUN: llvm-spirv %t.regulzarized.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+
+; CHECK: %[[#Base:]] = load i1, i1 addrspace(4)*{{.*}}, align 1
+; CHECK: %[[#Shift:]] = load i32, i32 addrspace(4)*{{.*}} align 4
+; CHECK: %[[#ExtBase:]] = select i1 %[[#Base]], i32 1, i32 0
+; CHECK: %[[#LSHR:]] = lshr i32 %[[#ExtBase]], %[[#Shift]]
+; CHECK: and i32 %[[#LSHR]], 1
+
+; ModuleID = 'source.bc'
+source_filename = "source.cpp"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+%"class.ac" = type { i1 }
+
+; Function Attrs: convergent mustprogress norecurse nounwind
+define linkonce_odr dso_local spir_func void @foo() align 2 {
+  %1 = alloca %"class.ac" addrspace(4)*, align 8
+  %2 = alloca i32, align 4
+  %3 = addrspacecast %"class.ac" addrspace(4)** %1 to %"class.ac" addrspace(4)* addrspace(4)*
+  %4 = addrspacecast i32* %2 to i32 addrspace(4)*
+  %5 = load %"class.ac" addrspace(4)*, %"class.ac" addrspace(4)* addrspace(4)* %3, align 8
+  %6 = getelementptr inbounds %"class.ac", %"class.ac" addrspace(4)* %5, i32 0, i32 0
+  %7 = load i1, i1 addrspace(4)* %6, align 1
+  %8 = load i32, i32 addrspace(4)* %4, align 4
+  %9 = trunc i32 %8 to i1
+  %10 = lshr i1 %7, %9
+  %11 = zext i1 %10 to i32
+  %12 = and i32 %11, 1
+  ret void
+}


### PR DESCRIPTION
This is a patch to regularize lshr instruction with an i1 argument.
According to the SPIR-V specification OpShiftRightLogical operands
should be of integer type.