### PR TITLE
Modify getPointerElementType calls

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -967,7 +967,7 @@ getOCLOpaqueTypeAddrSpace(SPIR::TypePrimitiveEnum Prim) {
 static FunctionType *getBlockInvokeTy(Function *F, unsigned BlockIdx) {
   auto Params = F->getFunctionType()->params();
   PointerType *FuncPtr = cast<PointerType>(Params[BlockIdx]);
-  return cast<FunctionType>(FuncPtr->getPointerElementType());
+  return FunctionType::get(FuncPtr, Params, false);
 }
 
 class OCLBuiltinFuncMangleInfo : public SPIRV::BuiltinFuncMangleInfo {

--- a/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerSPIRBlocks.cpp
@@ -362,7 +362,7 @@ private:
       Type *T = G.getInitializer()->getType();
       if (!T->isPointerTy())
         continue;
-      T = cast<PointerType>(T)->getPointerElementType();
+      T = G.getValueType();
       if (!T->isStructTy())
         continue;
       StringRef STName = cast<StructType>(T)->getName();

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -634,9 +634,8 @@ bool SPIRVRegularizeLLVMBase::regularize() {
           Type *SrcTy = ASCast->getSrcTy();
           if (DestTy->getPointerElementType() !=
               SrcTy->getPointerElementType()) {
-            PointerType *InterTy =
-                PointerType::get(DestTy->getPointerElementType(),
-                                 SrcTy->getPointerAddressSpace());
+            PointerType *InterTy = PointerType::getWithSamePointeeType(
+                cast<PointerType>(DestTy), SrcTy->getPointerAddressSpace());
             BitCastInst *NewBCast = new BitCastInst(
                 ASCast->getPointerOperand(), InterTy, /*NameStr=*/"", ASCast);
             AddrSpaceCastInst *NewASCast =

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -205,8 +205,8 @@ CallInst *SPIRVToOCL20Base::mutateCommonAtomicArguments(CallInst *CI, Op OC) {
           Type *PtrArgTy = PtrArg->getType();
           if (PtrArgTy->isPointerTy()) {
             if (PtrArgTy->getPointerAddressSpace() != SPIRAS_Generic) {
-              Type *FixedPtr = PtrArgTy->getPointerElementType()->getPointerTo(
-                  SPIRAS_Generic);
+              Type *FixedPtr = PointerType::getWithSamePointeeType(
+                  cast<PointerType>(PtrArgTy), SPIRAS_Generic);
               Args[I] = CastInst::CreatePointerBitCastOrAddrSpaceCast(
                   PtrArg, FixedPtr, PtrArg->getName() + ".as", CI);
             }
@@ -259,9 +259,8 @@ Instruction *SPIRVToOCL20Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
             Align(CI->getType()->getScalarSizeInBits() / 8));
         new StoreInst(Args[1], PExpected, PInsertBefore);
         unsigned AddrSpc = SPIRAS_Generic;
-        Type *PtrTyAS =
-            PExpected->getType()->getPointerElementType()->getPointerTo(
-                AddrSpc);
+        Type *PtrTyAS = PointerType::getWithSamePointeeType(
+            cast<PointerType>(PExpected->getType()), AddrSpc);
         Args[1] = CastInst::CreatePointerBitCastOrAddrSpaceCast(
             PExpected, PtrTyAS, PExpected->getName() + ".as", PInsertBefore);
         std::swap(Args[3], Args[4]);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1789,7 +1789,7 @@ bool lowerBuiltinVariableToCall(GlobalVariable *GV,
   Module *M = GV->getParent();
   LLVMContext &C = M->getContext();
   std::string FuncName = GV->getName().str();
-  Type *GVTy = GV->getType()->getPointerElementType();
+  Type *GVTy = GV->getValueType();
   Type *ReturnTy = GVTy;
   // Some SPIR-V builtin variables are translated to a function with an index
   // argument.

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -337,8 +337,8 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
     if (!BM->isAllowedToUseExtension(
             ExtensionID::SPV_INTEL_usm_storage_classes) &&
         ((AddrSpc == SPIRAS_GlobalDevice) || (AddrSpc == SPIRAS_GlobalHost))) {
-      auto NewType =
-          PointerType::get(T->getPointerElementType(), SPIRAS_Global);
+      auto NewType = PointerType::getWithSamePointeeType(cast<PointerType>(T),
+                                                         SPIRAS_Global);
       return mapType(T, transType(NewType));
     }
     if (ST && !ST->isSized()) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -337,8 +337,8 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
     if (!BM->isAllowedToUseExtension(
             ExtensionID::SPV_INTEL_usm_storage_classes) &&
         ((AddrSpc == SPIRAS_GlobalDevice) || (AddrSpc == SPIRAS_GlobalHost))) {
-      auto NewType = PointerType::getWithSamePointeeType(cast<PointerType>(T),
-                                                         SPIRAS_Global);
+      auto *NewType = PointerType::getWithSamePointeeType(cast<PointerType>(T),
+                                                          SPIRAS_Global);
       return mapType(T, transType(NewType));
     }
     if (ST && !ST->isSized()) {


### PR DESCRIPTION
This patch changes some of getPointerElementType calls.
It's needed for opaque pointers.