### PR TITLE
Fix sret attribute to be valid LLVM IR

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2774,7 +2774,7 @@ void SPIRVToLLVM::transFunctionAttrs(SPIRVFunction *BF, Function *F) {
         AttrTy = cast<PointerType>(I->getType())->getPointerElementType();
         break;
       case Attribute::AttrKind::StructRet:
-        AttrTy = I->getType();
+        AttrTy = cast<PointerType>(I->getType())->getPointerElementType();
         break;
       default:
         break; // do nothing

--- a/test/DebugInfo/Generic/2010-10-01-crash.ll
+++ b/test/DebugInfo/Generic/2010-10-01-crash.ll
@@ -7,7 +7,7 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-define void @CGRectStandardize(i32* sret(i32*) %agg.result, i32* byval(i32) %rect) nounwind ssp !dbg !0 {
+define void @CGRectStandardize(i32* sret(i32) %agg.result, i32* byval(i32) %rect) nounwind ssp !dbg !0 {
 entry:
   call void @llvm.dbg.declare(metadata i32* %rect, metadata !23, metadata !DIExpression()), !dbg !24
   ret void

--- a/test/EnqueueEmptyKernel.ll
+++ b/test/EnqueueEmptyKernel.ll
@@ -38,7 +38,7 @@ define spir_kernel void @test_enqueue_empty() #0 !kernel_arg_addr_space !0 !kern
 entry:
   %tmp = alloca %struct.ndrange_t, align 8
   %call = call spir_func %opencl.queue_t* @_Z17get_default_queuev() #4
-  call spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp, i64 1) #4
+  call spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret(%struct.ndrange_t) %tmp, i64 1) #4
   %0 = call i32 @__enqueue_kernel_basic_events(%opencl.queue_t* %call, i32 1, %struct.ndrange_t* %tmp, i32 0, %opencl.clk_event_t* addrspace(4)* null, %opencl.clk_event_t* addrspace(4)* null, i8 addrspace(4)* addrspacecast (i8* bitcast (void (i8 addrspace(4)*)* @__test_enqueue_empty_block_invoke_kernel to i8*) to i8 addrspace(4)*), i8 addrspace(4)* addrspacecast (i8 addrspace(1)* bitcast ({ i32, i32 } addrspace(1)* @__block_literal_global to i8 addrspace(1)*) to i8 addrspace(4)*))
   ret void
 ; CHECK-SPIRV: Bitcast [[Int8Ptr]] [[Int8PtrBlock:[0-9]+]] [[Block]]
@@ -50,7 +50,7 @@ entry:
 declare spir_func %opencl.queue_t* @_Z17get_default_queuev() #1
 
 ; Function Attrs: convergent
-declare spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret(%struct.ndrange_t*), i64) #1
+declare spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret(%struct.ndrange_t), i64) #1
 
 ; Function Attrs: convergent nounwind
 define internal spir_func void @__test_enqueue_empty_block_invoke(i8 addrspace(4)* %.block_descriptor) #2 {

--- a/test/llvm-intrinsics/memcpy.align.ll
+++ b/test/llvm-intrinsics/memcpy.align.ll
@@ -42,7 +42,7 @@ target triple = "spir"
 @__const.bar.a = private unnamed_addr addrspace(2) constant %struct.A { i64 0, %struct.B { [2 x i32] [i32 1, i32 2] } }, align 8
 
 ; Function Attrs: convergent nounwind
-define spir_func void @foo(%struct.A* noalias sret(%struct.A*) %agg.result) #0 {
+define spir_func void @foo(%struct.A* noalias sret(%struct.A) %agg.result) #0 {
 entry:
   %b = alloca %struct.B, align 4
   %0 = bitcast %struct.B* %b to i8*
@@ -74,7 +74,7 @@ declare void @llvm.memcpy.p0i8.p0i8.i32(i8* nocapture writeonly, i8* nocapture r
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: convergent nounwind
-define spir_func void @bar(%struct.B* noalias sret(%struct.B*) %agg.result) #0 {
+define spir_func void @bar(%struct.B* noalias sret(%struct.B) %agg.result) #0 {
 entry:
   %a = alloca %struct.A, align 8
   %0 = bitcast %struct.A* %a to i8*

--- a/test/transcoding/BuildNDRange.ll
+++ b/test/transcoding/BuildNDRange.ll
@@ -30,11 +30,11 @@ target triple = "spir"
 ; Function Attrs: nounwind
 define spir_kernel void @test() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
   %ndrange = alloca %struct.ndrange_t, align 4
-  call spir_func void @_Z10ndrange_1Djj(%struct.ndrange_t* sret(%struct.ndrange_t*) %ndrange, i32 123, i32 456)
+  call spir_func void @_Z10ndrange_1Djj(%struct.ndrange_t* sret(%struct.ndrange_t) %ndrange, i32 123, i32 456)
   ret void
 }
 
-declare spir_func void @_Z10ndrange_1Djj(%struct.ndrange_t* sret(%struct.ndrange_t*), i32, i32) #1
+declare spir_func void @_Z10ndrange_1Djj(%struct.ndrange_t* sret(%struct.ndrange_t), i32, i32) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/transcoding/BuildNDRange_2.ll
+++ b/test/transcoding/BuildNDRange_2.ll
@@ -87,28 +87,28 @@ entry:
   %0 = bitcast [2 x i64]* %lsize2 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %0, i8* align 8 bitcast ([2 x i64]* @test_ndrange_2D3D.lsize2 to i8*), i64 16, i1 false)
   %arraydecay = getelementptr inbounds [2 x i64], [2 x i64]* %lsize2, i64 0, i64 0
-  call spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp, i64* %arraydecay) #2
+  call spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t) %tmp, i64* %arraydecay) #2
   %1 = bitcast [3 x i64]* %lsize3 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %1, i8* align 8 bitcast ([3 x i64]* @test_ndrange_2D3D.lsize3 to i8*), i64 24, i1 false)
   %arraydecay2 = getelementptr inbounds [3 x i64], [3 x i64]* %lsize3, i64 0, i64 0
-  call spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp3, i64* %arraydecay2) #2
+  call spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t) %tmp3, i64* %arraydecay2) #2
   ret void
 }
 
 ; Function Attrs: nounwind
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture, i8* nocapture readonly, i64, i1) #2
 
-declare spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*), i64*) #1
+declare spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t), i64*) #1
 
-declare spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*), i64*) #1
+declare spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t), i64*) #1
 
 ; Function Attrs: nounwind
 define spir_func void @test_ndrange_const_2D3D() #0 {
 entry:
   %tmp = alloca %struct.ndrange_t, align 8
   %tmp1 = alloca %struct.ndrange_t, align 8
-  call spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @test_ndrange_2D3D.lsize2, i64 0, i64 0)) #2
-  call spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t*) %tmp1, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @test_ndrange_2D3D.lsize3, i64 0, i64 0)) #2
+  call spir_func void @_Z10ndrange_2DPKm(%struct.ndrange_t* sret(%struct.ndrange_t) %tmp, i64* getelementptr inbounds ([2 x i64], [2 x i64]* @test_ndrange_2D3D.lsize2, i64 0, i64 0)) #2
+  call spir_func void @_Z10ndrange_3DPKm(%struct.ndrange_t* sret(%struct.ndrange_t) %tmp1, i64* getelementptr inbounds ([3 x i64], [3 x i64]* @test_ndrange_2D3D.lsize3, i64 0, i64 0)) #2
   ret void
 }
 


### PR DESCRIPTION
The sret attribute is supposed to indicate what would be the pointee type of the
parameter (to support the transition to opaque pointers). Somehow, the original
change to this code concluded it was supposed to be a pointer type instead,
however, for the sret attribute, while the byval attribute was correctly
handled.