### PR TITLE
Remove more uses of getPointerElementType (part of issue #1444).

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1260,22 +1260,18 @@ public:
       else
         addUnsignedArg(1);
     } else if (NameRef.startswith("intel_sub_group_block_write")) {
-      // distinguish write to image and other data types as position
-      // of uint argument is different though name is the same.
-      auto *Arg0Ty = getArgTy(0);
-      if (Arg0Ty->isPointerTy() &&
-          Arg0Ty->getPointerElementType()->isIntegerTy()) {
+      // distinguish write to image and other data types based on number of
+      // arguments--images have one more argument.
+      if (F->getFunctionType()->getNumParams() == 2) {
         addUnsignedArg(0);
         addUnsignedArg(1);
       } else {
         addUnsignedArg(2);
       }
     } else if (NameRef.startswith("intel_sub_group_block_read")) {
-      // distinguish read from image and other data types as position
-      // of uint argument is different though name is the same.
-      auto *Arg0Ty = getArgTy(0);
-      if (Arg0Ty->isPointerTy() &&
-          Arg0Ty->getPointerElementType()->isIntegerTy()) {
+      // distinguish read from image and other data types based on number of
+      // arguments--images have one more argument.
+      if (F->getFunctionType()->getNumParams() == 1) {
         setArgAttr(0, SPIR::ATTR_CONST);
         addUnsignedArg(0);
       }

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3411,9 +3411,10 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
         if (!AnnotStr.empty()) {
           auto *GS = Builder.CreateGlobalStringPtr(AnnotStr);
 
-          auto GEP = Builder.CreateConstInBoundsGEP2_32(AllocatedTy, AL, 0, I);
+          auto *GEP = cast<GetElementPtrInst>(
+              Builder.CreateConstInBoundsGEP2_32(AllocatedTy, AL, 0, I));
 
-          Type *IntTy = GEP->getType()->getPointerElementType()->isIntegerTy()
+          Type *IntTy = GEP->getResultElementType()->isIntegerTy()
                             ? GEP->getType()
                             : Int8PtrTyPrivate;
 

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -350,6 +350,7 @@ void SPIRVRegularizeLLVMBase::lowerUMulWithOverflow(
 
 void SPIRVRegularizeLLVMBase::expandVEDWithSYCLTypeSRetArg(Function *F) {
   auto Attrs = F->getAttributes();
+  StructType *SRetTy = cast<StructType>(Attrs.getParamStructRetType(0));
   Attrs = Attrs.removeParamAttribute(F->getContext(), 0, Attribute::StructRet);
   std::string Name = F->getName().str();
   CallInst *OldCall = nullptr;
@@ -357,17 +358,14 @@ void SPIRVRegularizeLLVMBase::expandVEDWithSYCLTypeSRetArg(Function *F) {
       F,
       [=, &OldCall](CallInst *CI, std::vector<Value *> &Args, Type *&RetTy) {
         Args.erase(Args.begin());
-        auto *SRetPtrTy = cast<PointerType>(CI->getOperand(0)->getType());
-        auto *ET = SRetPtrTy->getPointerElementType();
-        RetTy = cast<StructType>(ET)->getElementType(0);
+        RetTy = SRetTy->getElementType(0);
         OldCall = CI;
         return Name;
       },
       [=, &OldCall](CallInst *NewCI) {
         IRBuilder<> Builder(OldCall);
-        auto *SRetPtrTy = cast<PointerType>(OldCall->getOperand(0)->getType());
-        auto *ET = SRetPtrTy->getPointerElementType();
-        Value *Target = Builder.CreateStructGEP(ET, OldCall->getOperand(0), 0);
+        Value *Target =
+            Builder.CreateStructGEP(SRetTy, OldCall->getOperand(0), 0);
         return Builder.CreateStore(NewCI, Target);
       },
       nullptr, &Attrs, true);
@@ -375,16 +373,15 @@ void SPIRVRegularizeLLVMBase::expandVEDWithSYCLTypeSRetArg(Function *F) {
 
 void SPIRVRegularizeLLVMBase::expandVIDWithSYCLTypeByValComp(Function *F) {
   auto Attrs = F->getAttributes();
+  auto *CompPtrTy = cast<StructType>(Attrs.getParamByValType(1));
   Attrs = Attrs.removeParamAttribute(F->getContext(), 1, Attribute::ByVal);
   std::string Name = F->getName().str();
   mutateFunction(
       F,
       [=](CallInst *CI, std::vector<Value *> &Args) {
-        auto *CompPtrTy = cast<PointerType>(CI->getOperand(1)->getType());
-        auto *ET = CompPtrTy->getPointerElementType();
-        Type *HalfTy = cast<StructType>(ET)->getElementType(0);
+        Type *HalfTy = CompPtrTy->getElementType(0);
         IRBuilder<> Builder(CI);
-        auto *Target = Builder.CreateStructGEP(ET, CI->getOperand(1), 0);
+        auto *Target = Builder.CreateStructGEP(CompPtrTy, CI->getOperand(1), 0);
         Args[1] = Builder.CreateLoad(HalfTy, Target);
         return Name;
       },
@@ -398,9 +395,8 @@ void SPIRVRegularizeLLVMBase::expandSYCLTypeUsing(Module *M) {
   for (auto &F : *M) {
     if (F.getName().startswith("_Z28__spirv_VectorExtractDynamic") &&
         F.hasStructRetAttr()) {
-      auto *SRetPtrTy = cast<PointerType>(F.getArg(0)->getType());
-      if (isSYCLHalfType(SRetPtrTy->getPointerElementType()) ||
-          isSYCLBfloat16Type(SRetPtrTy->getPointerElementType()))
+      auto *SRetTy = F.getParamStructRetType(0);
+      if (isSYCLHalfType(SRetTy) || isSYCLBfloat16Type(SRetTy))
         ToExpandVEDWithSYCLTypeSRetArg.push_back(&F);
       else
         llvm_unreachable("The return type of the VectorExtractDynamic "
@@ -409,8 +405,7 @@ void SPIRVRegularizeLLVMBase::expandSYCLTypeUsing(Module *M) {
     }
     if (F.getName().startswith("_Z27__spirv_VectorInsertDynamic") &&
         F.getArg(1)->getType()->isPointerTy()) {
-      auto *CompPtrTy = cast<PointerType>(F.getArg(1)->getType());
-      auto *ET = CompPtrTy->getPointerElementType();
+      auto *ET = F.getParamByValType(1);
       if (isSYCLHalfType(ET) || isSYCLBfloat16Type(ET))
         ToExpandVIDWithSYCLTypeByValComp.push_back(&F);
       else

--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -151,9 +151,9 @@ Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicLoad(CallInst *CI) {
         Args.resize(1);
         // There is no atomic_load in OpenCL 1.2 spec.
         // Emit this builtin via call of atomic_add(*p, 0).
-        Type *ptrElemTy = Args[0]->getType()->getPointerElementType();
-        Args.push_back(Constant::getNullValue(ptrElemTy));
-        return mapAtomicName(OpAtomicIAdd, ptrElemTy);
+        Type *PtrElemTy = CI->getType();
+        Args.push_back(Constant::getNullValue(PtrElemTy));
+        return mapAtomicName(OpAtomicIAdd, PtrElemTy);
       },
       &Attrs);
 }
@@ -165,9 +165,9 @@ Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicStore(CallInst *CI) {
       [=](CallInst *, std::vector<Value *> &Args, Type *&RetTy) {
         std::swap(Args[1], Args[3]);
         Args.resize(2);
-        // The type of the value pointed to by Pointer (1st argument)
-        // must be the same as Result Type.
-        RetTy = Args[0]->getType()->getPointerElementType();
+        // The type of the value pointed to by Pointer (1st argument), or the
+        // value being exchanged (2nd argument) must be the same as Result Type.
+        RetTy = Args[1]->getType();
         return mapAtomicName(OpAtomicExchange, RetTy);
       },
       [=](CallInst *CI) -> Instruction * { return CI; }, &Attrs);

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -183,9 +183,7 @@ Instruction *SPIRVToOCL20Base::visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) {
         // = 1.
         auto Name = OCLSPIRVBuiltinMap::rmap(
             OC == OpAtomicIIncrement ? OpAtomicIAdd : OpAtomicISub);
-        auto Ptr = findFirstPtr(Args);
-        Type *ValueTy =
-            cast<PointerType>(Args[Ptr]->getType())->getPointerElementType();
+        Type *ValueTy = CI->getType();
         assert(ValueTy->isIntegerTy());
         Args.insert(Args.begin() + 1, llvm::ConstantInt::get(ValueTy, 1));
         return Name;
@@ -241,6 +239,8 @@ Instruction *SPIRVToOCL20Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   Instruction *PInsertBefore = CI;
 
+  Type *MemTy = CI->getType();
+
   return mutateCallInstOCL(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args, Type *&RetTy) {
@@ -250,13 +250,12 @@ Instruction *SPIRVToOCL20Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
         // OCL built-ins returns boolean value and stores a new/original
         // value by pointer passed as 2nd argument (aka expected) while SPIR-V
         // instructions returns this new/original value as a resulting value.
-        AllocaInst *PExpected = new AllocaInst(CI->getType(), 0, "expected",
+        AllocaInst *PExpected = new AllocaInst(MemTy, 0, "expected",
                                                &(*PInsertBefore->getParent()
                                                       ->getParent()
                                                       ->getEntryBlock()
                                                       .getFirstInsertionPt()));
-        PExpected->setAlignment(
-            Align(CI->getType()->getScalarSizeInBits() / 8));
+        PExpected->setAlignment(Align(MemTy->getScalarSizeInBits() / 8));
         new StoreInst(Args[1], PExpected, PInsertBefore);
         unsigned AddrSpc = SPIRAS_Generic;
         Type *PtrTyAS = PointerType::getWithSamePointeeType(
@@ -276,9 +275,8 @@ Instruction *SPIRVToOCL20Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
         // returning it has to be loaded from the memory where 'expected'
         // value is stored. This memory must contain the needed value after a
         // call to OCL built-in is completed.
-        return new LoadInst(
-            CI->getArgOperand(1)->getType()->getPointerElementType(),
-            CI->getArgOperand(1), "original", PInsertBefore);
+        return new LoadInst(MemTy, CI->getArgOperand(1), "original",
+                            PInsertBefore);
       },
       &Attrs);
 }

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1859,7 +1859,7 @@ bool lowerBuiltinVariableToCall(GlobalVariable *GV,
 
       Value *Ptr = LD->getPointerOperand();
 
-      if (isa<FixedVectorType>(Ptr->getType()->getPointerElementType())) {
+      if (isa<FixedVectorType>(LD->getType())) {
         LD->replaceAllUsesWith(Vectors.back());
       } else {
         auto *GEP = dyn_cast<GetElementPtrInst>(Ptr);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4677,7 +4677,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     // the original return type.
     if (CI->hasStructRetAttr()) {
       assert(ResTy->isVoidTy() && "Return type is not void");
-      ResTy = cast<PointerType>(OpItr->getType())->getPointerElementType();
+      ResTy = CI->getParamStructRetType(0);
       OpItr++;
     }
 
@@ -4768,7 +4768,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     // the original return type.
     if (CI->hasStructRetAttr()) {
       assert(ResTy->isVoidTy() && "Return type is not void");
-      ResTy = cast<PointerType>(OpItr->getType())->getPointerElementType();
+      ResTy = CI->getParamStructRetType(0);
       OpItr++;
     }
 
@@ -4845,7 +4845,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     // the original return type.
     if (CI->hasStructRetAttr()) {
       assert(ResTy->isVoidTy() && "Return type is not void");
-      ResTy = cast<PointerType>(OpItr->getType())->getPointerElementType();
+      ResTy = CI->getParamStructRetType(0);
       OpItr++;
     }
 
@@ -4950,7 +4950,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       if (!RetTy->isVoidTy()) {
         SPRetTy = transType(RetTy);
       } else if (Args.size() > 0 && F->arg_begin()->hasStructRetAttr()) {
-        SPRetTy = transType(F->arg_begin()->getType()->getPointerElementType());
+        SPRetTy = transType(F->getParamStructRetType(0));
         Args.erase(Args.begin());
       }
       auto *SPI = SPIRVInstTemplateBase::create(OC);


### PR DESCRIPTION
This is the easiest tranche of changes: where the pointer element type is
usually retrieved by looking a little further afield for the element type, or
via scavenging from sret/byval parameters.