### PR TITLE
.clang-tidy: allow recursion

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
-WarningsAsErrors: 'llvm-*,misc-*,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
+WarningsAsErrors: 'llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase
@@ -17,4 +17,3 @@ CheckOptions:
     value:           CamelCase
   - key:             llvm-namespace-comment.ShortNamespaceLines
     value:           '25'
-


### PR DESCRIPTION
The code already uses recursion in various places and this check fails
whenever a change is made in the recursion chain.