### PR TITLE
[CI] Temporarily allow use of deprecated functions

### DIFF
--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -75,7 +75,7 @@ jobs:
           mkdir build && cd build
           cmake ${{ github.workspace }}/SPIRV-LLVM-Translator \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_CXX_FLAGS="-Werror" \
+            -DCMAKE_CXX_FLAGS="-Werror -Wno-error=deprecated-declarations" \
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_EXTERNAL_LIT="/usr/lib/llvm-${{ env.LLVM_VERSION }}/build/utils/lit/lit.py" \
             -DLLVM_EXTERNAL_PROJECTS="SPIRV-Headers" \


### PR DESCRIPTION
LLVM commit c99424f76560 ("[IR] Deprecate
Type::getPointerElementType() (NFC)", 2022-04-20) caused out-of-tree
builds to fail (as these use `-Werror`).  Replacing all
`Type::getPointerElementType` calls is a longer term effort so turn
deprecation errors back into warnings to resume out-of-tree builds.