### PR TITLE
Remove more getPointerElementType queries.

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -580,10 +580,8 @@ void SPIRVToOCLBase::visitCallSPIRVPipeBuiltin(CallInst *CI, Op OC) {
         auto &P = Args[Args.size() - 3];
         auto T = P->getType();
         assert(isa<PointerType>(T));
-        auto ET = T->getPointerElementType();
-        if (!ET->isIntegerTy(8) ||
-            T->getPointerAddressSpace() != SPIRAS_Generic) {
-          auto NewTy = PointerType::getInt8PtrTy(*Ctx, SPIRAS_Generic);
+        auto *NewTy = PointerType::getInt8PtrTy(*Ctx, SPIRAS_Generic);
+        if (T != NewTy) {
           P = CastInst::CreatePointerBitCastOrAddrSpaceCast(P, NewTy, "", CI);
         }
         return DemangledName;
@@ -926,15 +924,17 @@ void SPIRVToOCLBase::visitCallSPIRVAvcINTELEvaluateBuiltIn(CallInst *CI,
         // reference image
         // 3. With single reference image - uses one OpVmeImageINTEL opcode for
         // reference image
-        int NumImages = std::count_if(Args.begin(), Args.end(), [](Value *Arg) {
-          if (auto *PT = dyn_cast<PointerType>(Arg->getType())) {
-            if (auto *ST = dyn_cast<StructType>(PT->getPointerElementType())) {
-              if (ST->getName().startswith("spirv.VmeImageINTEL"))
-                return true;
-            }
-          }
-          return false;
-        });
+        StringRef FnName = CI->getCalledFunction()->getName();
+        int NumImages = 0;
+        if (FnName.contains("SingleReference"))
+          NumImages = 2;
+        else if (FnName.contains("DualReference"))
+          NumImages = 3;
+        else if (FnName.contains("MultiReference"))
+          NumImages = 1;
+        else if (FnName.contains("EvaluateIpe"))
+          NumImages = 1;
+
         auto EraseVmeImageCall = [](CallInst *CI) {
           if (CI->hasOneUse()) {
             CI->replaceAllUsesWith(UndefValue::get(CI->getType()));


### PR DESCRIPTION
Most of this tranche of calls were being used to disambiguate between different
built-ins that share the same or similar names.

The exception is the change in visitCallSPIRVPipeBuiltin, which is a convoluted
way of adding a cast to i8 addrspace(4)* if not already i8 addrspace(4)*, so it
is instead rewritten to check if a cast needs to be added without querying
getPointerElementType.