### PR TITLE
Recover SPIR-V opaque types from demangling function names.

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -1200,9 +1200,9 @@ void OCLToSPIRVBase::visitCallReadImageWithSampler(CallInst *CI,
   mutateCallInstSPIRV(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args, Type *&Ret) {
-        auto ImageTy = OCLTypeToSPIRVPtr->getAdaptedType(Args[0]);
-        if (isOCLImageType(ImageTy))
-          ImageTy = getSPIRVImageTypeFromOCL(M, ImageTy);
+        auto *ImageTy =
+            OCLTypeToSPIRVPtr->getAdaptedType(Args[0])->getPointerElementType();
+        ImageTy = adaptSPIRVImageType(M, ImageTy);
         auto SampledImgTy = getSPIRVTypeByChangeBaseTypeName(
             M, ImageTy, kSPIRVTypeName::Image, kSPIRVTypeName::SampledImg);
         Value *SampledImgArgs[] = {Args[0], Args[1]};
@@ -1251,7 +1251,9 @@ void OCLToSPIRVBase::visitCallGetImageSize(CallInst *CI,
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   StringRef TyName;
   SmallVector<StringRef, 4> SubStrs;
-  auto IsImg = isOCLImageType(CI->getArgOperand(0)->getType(), &TyName);
+  SmallVector<StructType *, 4> ParamTys;
+  getParameterTypes(CI, ParamTys);
+  auto IsImg = isOCLImageStructType(ParamTys[0], &TyName);
   (void)IsImg;
   assert(IsImg);
   std::string ImageTyName = getImageBaseTypeName(TyName);
@@ -1696,7 +1698,9 @@ static void processSubgroupBlockReadWriteINTEL(CallInst *CI,
 // reads and vector block reads.
 void OCLToSPIRVBase::visitSubgroupBlockReadINTEL(CallInst *CI) {
   OCLBuiltinTransInfo Info;
-  if (isOCLImageType(CI->getArgOperand(0)->getType()))
+  SmallVector<StructType *, 2> ParamTys;
+  getParameterTypes(CI, ParamTys);
+  if (isOCLImageStructType(ParamTys[0]))
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupImageBlockReadINTEL);
   else
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupBlockReadINTEL);
@@ -1709,7 +1713,9 @@ void OCLToSPIRVBase::visitSubgroupBlockReadINTEL(CallInst *CI) {
 // instructions.
 void OCLToSPIRVBase::visitSubgroupBlockWriteINTEL(CallInst *CI) {
   OCLBuiltinTransInfo Info;
-  if (isOCLImageType(CI->getArgOperand(0)->getType()))
+  SmallVector<StructType *, 3> ParamTys;
+  getParameterTypes(CI, ParamTys);
+  if (isOCLImageStructType(ParamTys[0]))
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupImageBlockWriteINTEL);
   else
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupBlockWriteINTEL);
@@ -1894,21 +1900,27 @@ void OCLToSPIRVBase::visitSubgroupAVCBuiltinCallWithSampler(
   mutateCallInstSPIRV(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {
-        auto SamplerIt = std::find_if(Args.begin(), Args.end(), [](Value *V) {
-          return OCLUtil::isSamplerTy(V->getType());
-        });
-        assert(SamplerIt != Args.end() &&
+        SmallVector<StructType *, 4> ParamTys;
+        getParameterTypes(CI, ParamTys);
+        auto *TyIt =
+            std::find_if(ParamTys.begin(), ParamTys.end(), [](StructType *Ty) {
+              return Ty && Ty->hasName() &&
+                     Ty->getName() == kSPR2TypeName::Sampler;
+            });
+        assert(TyIt != ParamTys.end() &&
                "Invalid Subgroup AVC Intel built-in call");
+        auto SamplerIt = Args.begin() + (TyIt - ParamTys.begin());
         auto *SamplerVal = *SamplerIt;
         Args.erase(SamplerIt);
+        ParamTys.erase(TyIt);
 
         for (unsigned I = 0, E = Args.size(); I < E; ++I) {
-          if (!isOCLImageType(Args[I]->getType()))
+          if (!isOCLImageStructType(ParamTys[I]))
             continue;
 
-          auto *ImageTy = OCLTypeToSPIRVPtr->getAdaptedType(Args[I]);
-          if (isOCLImageType(ImageTy))
-            ImageTy = getSPIRVImageTypeFromOCL(M, ImageTy);
+          auto *ImageTy = OCLTypeToSPIRVPtr->getAdaptedType(Args[I])
+                              ->getPointerElementType();
+          ImageTy = adaptSPIRVImageType(M, ImageTy);
           auto *SampledImgTy = getSPIRVTypeByChangeBaseTypeName(
               M, ImageTy, kSPIRVTypeName::Image, kSPIRVTypeName::VmeImageINTEL);
 

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -1903,10 +1903,7 @@ void OCLToSPIRVBase::visitSubgroupAVCBuiltinCallWithSampler(
         SmallVector<StructType *, 4> ParamTys;
         getParameterTypes(CI, ParamTys);
         auto *TyIt =
-            std::find_if(ParamTys.begin(), ParamTys.end(), [](StructType *Ty) {
-              return Ty && Ty->hasName() &&
-                     Ty->getName() == kSPR2TypeName::Sampler;
-            });
+            std::find_if(ParamTys.begin(), ParamTys.end(), isSamplerStructTy);
         assert(TyIt != ParamTys.end() &&
                "Invalid Subgroup AVC Intel built-in call");
         auto SamplerIt = Args.begin() + (TyIt - ParamTys.begin());

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -204,7 +204,9 @@ void OCLTypeToSPIRVBase::adaptArgumentsBySamplerUse(Module &M) {
           AdaptedTy.count(SamplerArg) != 0) // Already traced this, move on.
         continue;
 
-      if (isSPIRVType(SamplerArg->getType(), kSPIRVTypeName::Sampler))
+      if (SamplerArg->getType()->isPointerTy() &&
+          isSPIRVStructType(SamplerArg->getType()->getPointerElementType(),
+                            kSPIRVTypeName::Sampler))
         return;
 
       addAdaptedType(SamplerArg, getSamplerType(&M));
@@ -263,19 +265,15 @@ void OCLTypeToSPIRVBase::adaptArgumentsByMetadata(Function *F) {
   if (!TypeMD)
     return;
   bool Changed = false;
-  auto FT = F->getFunctionType();
-  auto PI = FT->param_begin();
   auto Arg = F->arg_begin();
-  for (unsigned I = 0, E = TypeMD->getNumOperands(); I != E; ++I, ++PI, ++Arg) {
+  for (unsigned I = 0, E = TypeMD->getNumOperands(); I != E; ++I, ++Arg) {
     auto OCLTyStr = getMDOperandAsString(TypeMD, I);
-    auto NewTy = *PI;
-    if (OCLTyStr == OCL_TYPE_NAME_SAMPLER_T && !NewTy->isStructTy()) {
+    if (OCLTyStr == OCL_TYPE_NAME_SAMPLER_T) {
       addAdaptedType(&(*Arg), getSamplerType(M));
       Changed = true;
-    } else if (isPointerToOpaqueStructType(NewTy)) {
-      auto STName = NewTy->getPointerElementType()->getStructName();
-      if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
-        auto Ty = STName.str();
+    } else if (OCLTyStr.startswith("image") && OCLTyStr.endswith("_t")) {
+      auto Ty = (Twine("opencl.") + OCLTyStr).str();
+      if (StructType::getTypeByName(F->getContext(), Ty)) {
         auto AccMD = F->getMetadata(SPIR_MD_KERNEL_ARG_ACCESS_QUAL);
         assert(AccMD && "Invalid access qualifier metadata");
         auto AccStr = getMDOperandAsString(AccMD, I);

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1369,6 +1369,10 @@ bool isSpecialTypeInitializer(Instruction *Inst) {
   return isSamplerInitializer(Inst) || isPipeStorageInitializer(Inst);
 }
 
+bool isSamplerStructTy(StructType *STy) {
+  return STy && STy->hasName() && STy->getName() == kSPR2TypeName::Sampler;
+}
+
 bool isPipeOrAddressSpaceCastBI(const StringRef MangledName) {
   return MangledName == "write_pipe_2" || MangledName == "read_pipe_2" ||
          MangledName == "write_pipe_2_bl" || MangledName == "read_pipe_2_bl" ||

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1369,15 +1369,6 @@ bool isSpecialTypeInitializer(Instruction *Inst) {
   return isSamplerInitializer(Inst) || isPipeStorageInitializer(Inst);
 }
 
-bool isSamplerTy(Type *Ty) {
-  auto PTy = dyn_cast<PointerType>(Ty);
-  if (!PTy)
-    return false;
-
-  auto *STy = dyn_cast<StructType>(PTy->getPointerElementType());
-  return STy && STy->hasName() && STy->getName() == kSPR2TypeName::Sampler;
-}
-
 bool isPipeOrAddressSpaceCastBI(const StringRef MangledName) {
   return MangledName == "write_pipe_2" || MangledName == "read_pipe_2" ||
          MangledName == "write_pipe_2_bl" || MangledName == "read_pipe_2_bl" ||

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -509,6 +509,9 @@ bool isPipeOrAddressSpaceCastBI(const StringRef MangledName);
 bool isEnqueueKernelBI(const StringRef MangledName);
 bool isKernelQueryBI(const StringRef MangledName);
 
+/// Check that the type is the sampler_t
+bool isSamplerStructTy(StructType *Ty);
+
 // Checks if the binary operator is an unfused fmul + fadd instruction.
 bool isUnfusedMulAdd(BinaryOperator *B);
 

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -509,9 +509,6 @@ bool isPipeOrAddressSpaceCastBI(const StringRef MangledName);
 bool isEnqueueKernelBI(const StringRef MangledName);
 bool isKernelQueryBI(const StringRef MangledName);
 
-/// Check that the type is the sampler_t
-bool isSamplerTy(Type *Ty);
-
 // Checks if the binary operator is an unfused fmul + fadd instruction.
 bool isUnfusedMulAdd(BinaryOperator *B);
 

--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -272,7 +272,7 @@ void PreprocessMetadataBase::visit(Module *M) {
       // !ip_interface !N
       // !N = !{!"streaming", !"stall_free_return"}
       for (size_t I = 0; I != Interface->getNumOperands(); ++I)
-        InterfaceStrSet.insert(getMDOperandAsString(Interface, I));
+        InterfaceStrSet.insert(getMDOperandAsString(Interface, I).str());
       if (InterfaceStrSet.find("streaming") != InterfaceStrSet.end()) {
         int32_t InterfaceMode = 0;
         if (InterfaceStrSet.find("stall_free_return") != InterfaceStrSet.end())

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -608,6 +608,7 @@ SPIRVValue *addDecorations(SPIRVValue *Target,
 
 PointerType *getOrCreateOpaquePtrType(Module *M, const std::string &Name,
                                       unsigned AddrSpace = SPIRAS_Global);
+StructType *getOrCreateOpaqueStructType(Module *M, StringRef Name);
 PointerType *getSamplerType(Module *M);
 PointerType *getPipeStorageType(Module *M);
 PointerType *getSPIRVOpaquePtrType(Module *M, Op OC);
@@ -653,14 +654,15 @@ bool isPointerToOpaqueStructType(llvm::Type *Ty, const std::string &Name);
 /// Check if a type is SPIRV sampler type.
 bool isSPIRVSamplerType(llvm::Type *Ty);
 
-/// Check if a type is OCL image type.
+/// Check if a type is OCL image type (if pointed to).
 /// \return type name without "opencl." prefix.
-bool isOCLImageType(llvm::Type *Ty, StringRef *Name = nullptr);
+bool isOCLImageStructType(llvm::Type *Ty, StringRef *Name = nullptr);
 
 /// \param BaseTyName is the type name as in spirv.BaseTyName.Postfixes
 /// \param Postfix contains postfixes extracted from the SPIR-V image
 ///   type name as spirv.BaseTyName.Postfixes.
-bool isSPIRVType(llvm::Type *Ty, StringRef BaseTyName, StringRef *Postfix = 0);
+bool isSPIRVStructType(llvm::Type *Ty, StringRef BaseTyName,
+                       StringRef *Postfix = 0);
 
 bool isSYCLHalfType(llvm::Type *Ty);
 
@@ -856,7 +858,7 @@ ConstantInt *getSizet(Module *M, uint64_t Value);
 int64_t getMDOperandAsInt(MDNode *N, unsigned I);
 
 /// Get metadata operand as string.
-std::string getMDOperandAsString(MDNode *N, unsigned I);
+StringRef getMDOperandAsString(MDNode *N, unsigned I);
 
 /// Get metadata operand as another metadata node
 MDNode *getMDOperandAsMDNode(MDNode *N, unsigned I);
@@ -935,7 +937,7 @@ std::string getSPIRVImageSampledTypeName(SPIRVType *Ty);
 
 /// Translates OpenCL image type names to SPIR-V.
 /// E.g. %opencl.image1d_rw_t -> %spirv.Image._void_0_0_0_0_0_0_2
-Type *getSPIRVImageTypeFromOCL(Module *M, Type *T);
+Type *adaptSPIRVImageType(Module *M, Type *PointeeType);
 
 /// Get LLVM type for sampled type of SPIR-V image type by postfix.
 Type *getLLVMTypeForSPIRVImageSampledTypePostfix(StringRef Postfix,
@@ -997,6 +999,15 @@ bool containsUnsignedAtomicType(StringRef Name);
 ///    return IA64 mangled name.
 std::string mangleBuiltin(StringRef UniqName, ArrayRef<Type *> ArgTypes,
                           BuiltinFuncMangleInfo *BtnInfo);
+
+/// Extract the pointee types of arguments from a mangled function name. If the
+/// corresponding type is not a pointer to a struct type, its value will be a
+/// nullptr instead.
+void getParameterTypes(Function *F, SmallVectorImpl<StructType *> &ArgTys);
+inline void getParameterTypes(CallInst *CI,
+                              SmallVectorImpl<StructType *> &ArgTys) {
+  return getParameterTypes(CI->getCalledFunction(), ArgTys);
+}
 
 /// Mangle a function from OpenCL extended instruction set in SPIR-V friendly IR
 /// manner

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -651,9 +651,6 @@ Decoration getArgAsDecoration(CallInst *CI, unsigned I);
 bool isPointerToOpaqueStructType(llvm::Type *Ty);
 bool isPointerToOpaqueStructType(llvm::Type *Ty, const std::string &Name);
 
-/// Check if a type is SPIRV sampler type.
-bool isSPIRVSamplerType(llvm::Type *Ty);
-
 /// Check if a type is OCL image type (if pointed to).
 /// \return type name without "opencl." prefix.
 bool isOCLImageStructType(llvm::Type *Ty, StringRef *Name = nullptr);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1492,13 +1492,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpVariable: {
     auto BVar = static_cast<SPIRVVariable *>(BV);
-    auto Ty = transType(BVar->getType()->getPointerElementType());
+    auto *PreTransTy = BVar->getType()->getPointerElementType();
+    auto *Ty = transType(PreTransTy);
     bool IsConst = BVar->isConstant();
     llvm::GlobalValue::LinkageTypes LinkageTy = transLinkageType(BVar);
     SPIRVStorageClassKind BS = BVar->getStorageClass();
     SPIRVValue *Init = BVar->getInitializer();
 
-    if (isSPIRVSamplerType(Ty) && BS == StorageClassUniformConstant) {
+    if (PreTransTy->isTypeSampler() && BS == StorageClassUniformConstant) {
       // Skip generating llvm code during translation of a variable definition,
       // generate code only for its uses
       if (!BB)

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -250,13 +250,12 @@ void SPIRVToOCLBase::visitCastInst(CastInst &Cast) {
 }
 
 void SPIRVToOCLBase::visitCallSPRIVImageQuerySize(CallInst *CI) {
-  Function *Func = CI->getCalledFunction();
   // Get image type
-  Type *ArgTy = Func->getFunctionType()->getParamType(0);
-  assert(ArgTy->isPointerTy() &&
-         "argument must be a pointer to opaque structure");
-  StructType *ImgTy = cast<StructType>(ArgTy->getPointerElementType());
-  assert(ImgTy->isOpaque() && "image type must be an opaque structure");
+  SmallVector<StructType *, 4> ParamTys;
+  getParameterTypes(CI, ParamTys);
+  StructType *ImgTy = ParamTys[0];
+  assert(ImgTy && ImgTy->isOpaque() &&
+         "image type must be an opaque structure");
   StringRef ImgTyName = ImgTy->getName();
   assert(ImgTyName.startswith("opencl.image") && "not an OCL image type");
 
@@ -755,18 +754,20 @@ void SPIRVToOCLBase::visitCallSPIRVImageSampleExplicitLodBuiltIn(CallInst *CI,
                                                                  Op OC) {
   assert(CI->getCalledFunction() && "Unexpected indirect call");
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  CallInst *CallSampledImg = cast<CallInst>(CI->getArgOperand(0));
+  SmallVector<StructType *, 6> ParamTys;
+  getParameterTypes(CallSampledImg, ParamTys);
   StringRef ImageTypeName;
   bool IsDepthImage = false;
-  if (isOCLImageType(
-          (cast<CallInst>(CI->getOperand(0)))->getArgOperand(0)->getType(),
-          &ImageTypeName))
+  if (isOCLImageStructType(ParamTys[0], &ImageTypeName))
     IsDepthImage = ImageTypeName.contains("_depth_");
 
   auto ModifyArguments = [=](CallInst *, std::vector<Value *> &Args,
                              llvm::Type *&RetTy) {
-    CallInst *CallSampledImg = cast<CallInst>(Args[0]);
     auto Img = CallSampledImg->getArgOperand(0);
-    assert(isOCLImageType(Img->getType()));
+    if (!Img->getType()->isOpaquePointerTy())
+      assert(isOCLImageStructType(
+          Img->getType()->getNonOpaquePointerElementType()));
     auto Sampler = CallSampledImg->getArgOperand(1);
     Args[0] = Img;
     Args.insert(Args.begin() + 1, Sampler);
@@ -1247,27 +1248,53 @@ void SPIRVToOCLBase::translateOpaqueTypes() {
     if (!IsSPIRVOpaque)
       continue;
 
-    SmallVector<std::string, 8> Postfixes;
-    std::string DecodedST = decodeSPIRVTypeName(STName, Postfixes);
-
-    if (!SPIRVOpaqueTypeOpCodeMap::find(DecodedST))
-      continue;
-
-    Op OP = SPIRVOpaqueTypeOpCodeMap::map(DecodedST);
-    std::string OCLOpaqueName;
-    if (OP == OpTypeImage)
-      OCLOpaqueName = getOCLImageOpaqueType(Postfixes);
-    else if (OP == OpTypePipe)
-      OCLOpaqueName = getOCLPipeOpaqueType(Postfixes);
-    else if (isSubgroupAvcINTELTypeOpCode(OP))
-      OCLOpaqueName = OCLSubgroupINTELTypeOpCodeMap::rmap(OP);
-    else if (isOpaqueGenericTypeOpCode(OP))
-      OCLOpaqueName = OCLOpaqueTypeOpCodeMap::rmap(OP);
-    else
-      continue;
-
-    S->setName(OCLOpaqueName);
+    S->setName(translateOpaqueType(STName));
   }
+}
+
+std::string SPIRVToOCLBase::translateOpaqueType(StringRef STName) {
+  if (!STName.startswith(kSPIRVTypeName::PrefixAndDelim))
+    return STName.str();
+
+  SmallVector<std::string, 8> Postfixes;
+  std::string DecodedST = decodeSPIRVTypeName(STName, Postfixes);
+
+  if (!SPIRVOpaqueTypeOpCodeMap::find(DecodedST))
+    return STName.str();
+
+  Op OP = SPIRVOpaqueTypeOpCodeMap::map(DecodedST);
+  std::string OCLOpaqueName;
+  if (OP == OpTypeImage)
+    OCLOpaqueName = getOCLImageOpaqueType(Postfixes);
+  else if (OP == OpTypePipe)
+    OCLOpaqueName = getOCLPipeOpaqueType(Postfixes);
+  else if (isSubgroupAvcINTELTypeOpCode(OP))
+    OCLOpaqueName = OCLSubgroupINTELTypeOpCodeMap::rmap(OP);
+  else if (isOpaqueGenericTypeOpCode(OP))
+    OCLOpaqueName = OCLOpaqueTypeOpCodeMap::rmap(OP);
+  else
+    return STName.str();
+
+  return OCLOpaqueName;
+}
+
+void SPIRVToOCLBase::getParameterTypes(CallInst *CI,
+                                       SmallVectorImpl<StructType *> &Tys) {
+  ::getParameterTypes(CI, Tys);
+  for (auto &Ty : Tys) {
+    if (!Ty)
+      continue;
+    StringRef STName = Ty->getStructName();
+    bool IsSPIRVOpaque =
+        Ty->isOpaque() && STName.startswith(kSPIRVTypeName::PrefixAndDelim);
+
+    if (!IsSPIRVOpaque)
+      continue;
+
+    std::string NewName = translateOpaqueType(STName);
+    if (NewName != STName)
+      Ty = getOrCreateOpaqueStructType(M, NewName);
+  };
 }
 
 void addSPIRVBIsLoweringPass(ModulePassManager &PassMgr,

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -262,7 +262,10 @@ public:
   /// example: spirv.Pipe._0 => opencl.pipe_ro_t
   std::string getOCLPipeOpaqueType(SmallVector<std::string, 8> &Postfixes);
 
+  void getParameterTypes(CallInst *CI, SmallVectorImpl<StructType *> &Tys);
+
   void translateOpaqueTypes();
+  std::string translateOpaqueType(StringRef STName);
 
   Module *M;
   LLVMContext *Ctx;

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -50,6 +50,7 @@
 
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
+#include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Metadata.h"
@@ -206,10 +207,14 @@ std::string mapSPIRVTypeToOCLType(SPIRVType *Ty, bool Signed) {
 
 PointerType *getOrCreateOpaquePtrType(Module *M, const std::string &Name,
                                       unsigned AddrSpace) {
+  return PointerType::get(getOrCreateOpaqueStructType(M, Name), AddrSpace);
+}
+
+StructType *getOrCreateOpaqueStructType(Module *M, StringRef Name) {
   auto OpaqueType = StructType::getTypeByName(M->getContext(), Name);
   if (!OpaqueType)
     OpaqueType = StructType::create(M->getContext(), Name);
-  return PointerType::get(OpaqueType, AddrSpace);
+  return OpaqueType;
 }
 
 PointerType *getSamplerType(Module *M) {
@@ -252,51 +257,37 @@ bool isPointerToOpaqueStructType(llvm::Type *Ty, const std::string &Name) {
   return false;
 }
 
-bool isSPIRVSamplerType(llvm::Type *Ty) {
-  if (auto *PT = dyn_cast<PointerType>(Ty))
-    if (auto *ST = dyn_cast<StructType>(PT->getPointerElementType()))
-      if (ST->isOpaque()) {
-        auto Name = ST->getName();
-        if (Name.startswith(std::string(kSPIRVTypeName::PrefixAndDelim) +
-                            kSPIRVTypeName::Sampler)) {
-          return true;
-        }
+bool isOCLImageStructType(llvm::Type *Ty, StringRef *Name) {
+  if (auto *ST = dyn_cast_or_null<StructType>(Ty))
+    if (ST->isOpaque()) {
+      auto FullName = ST->getName();
+      if (FullName.find(kSPR2TypeName::ImagePrefix) == 0) {
+        if (Name)
+          *Name = FullName.drop_front(strlen(kSPR2TypeName::OCLPrefix));
+        return true;
       }
-  return false;
-}
-
-bool isOCLImageType(llvm::Type *Ty, StringRef *Name) {
-  if (auto PT = dyn_cast<PointerType>(Ty))
-    if (auto *ST = dyn_cast<StructType>(PT->getPointerElementType()))
-      if (ST->isOpaque()) {
-        auto FullName = ST->getName();
-        if (FullName.find(kSPR2TypeName::ImagePrefix) == 0) {
-          if (Name)
-            *Name = FullName.drop_front(strlen(kSPR2TypeName::OCLPrefix));
-          return true;
-        }
-      }
+    }
   return false;
 }
 
 /// \param BaseTyName is the type Name as in spirv.BaseTyName.Postfixes
 /// \param Postfix contains postfixes extracted from the SPIR-V image
 ///   type Name as spirv.BaseTyName.Postfixes.
-bool isSPIRVType(llvm::Type *Ty, StringRef BaseTyName, StringRef *Postfix) {
-  if (auto PT = dyn_cast<PointerType>(Ty))
-    if (auto *ST = dyn_cast<StructType>(PT->getPointerElementType()))
-      if (ST->isOpaque()) {
-        auto FullName = ST->getName();
-        std::string N =
-            std::string(kSPIRVTypeName::PrefixAndDelim) + BaseTyName.str();
-        if (FullName != N)
-          N = N + kSPIRVTypeName::Delimiter;
-        if (FullName.startswith(N)) {
-          if (Postfix)
-            *Postfix = FullName.drop_front(N.size());
-          return true;
-        }
+bool isSPIRVStructType(llvm::Type *Ty, StringRef BaseTyName,
+                       StringRef *Postfix) {
+  if (auto *ST = dyn_cast<StructType>(Ty))
+    if (ST->isOpaque()) {
+      auto FullName = ST->getName();
+      std::string N =
+          std::string(kSPIRVTypeName::PrefixAndDelim) + BaseTyName.str();
+      if (FullName != N)
+        N = N + kSPIRVTypeName::Delimiter;
+      if (FullName.startswith(N)) {
+        if (Postfix)
+          *Postfix = FullName.drop_front(N.size());
+        return true;
       }
+    }
   return false;
 }
 
@@ -655,6 +646,118 @@ bool hasArrayArg(Function *F) {
   return false;
 }
 
+void getParameterTypes(Function *F, SmallVectorImpl<StructType *> &ArgTys) {
+  // Start by filling in a skeleton of information we can get from the LLVM type
+  // itself.
+  ArgTys.clear();
+  auto *FT = F->getFunctionType();
+  ArgTys.reserve(FT->getNumParams());
+  bool HasSret = false;
+  for (Argument &Arg : F->args()) {
+    if (!Arg.getType()->isPointerTy())
+      ArgTys.push_back(nullptr);
+    else if (Type *Ty = Arg.getParamStructRetType()) {
+      assert(!HasSret && &Arg == F->getArg(0) &&
+             "sret parameter should only appear on the first argument");
+      HasSret = true;
+      ArgTys.push_back(dyn_cast<StructType>(Ty));
+    } else {
+      ArgTys.push_back(nullptr);
+    }
+  }
+
+  // If there's no mangled name, we can't do anything. Also, if there's no
+  // parameters, do nothing.
+  StringRef Name = F->getName();
+  if (!Name.startswith("_Z") || ArgTys.empty())
+    return;
+
+  Module *M = F->getParent();
+
+  // Skip the first argument if it's an sret parameter--this would be an
+  // implicit parameter not recognized as part of the function parameters.
+  auto *ArgIter = ArgTys.begin();
+  if (HasSret)
+    ++ArgIter;
+
+  // Demangle the function arguments.
+  ItaniumPartialDemangler Demangler;
+  std::string OwnedStr = F->getName().str();
+  if (Demangler.partialDemangle(OwnedStr.c_str()))
+    return;
+  char *Buf = nullptr;
+  size_t BufLen = 0;
+  Buf = Demangler.getFunctionParameters(Buf, &BufLen);
+  StringRef Args(Buf, BufLen);
+  // Strip parentheses from the result.
+  Args = Args.slice(1, Args.size() - 2);
+
+  if (Args.find_first_of("<(") == StringRef::npos) {
+    // Go through the function arguments using type names where possible.
+    SmallVector<StringRef, 8> ArgParams;
+    Args.split(ArgParams, ", ");
+
+    // Sanity check that the name mangling matches up to the expected number of
+    // arguments.
+    if (ArgParams.size() > (size_t)(ArgTys.end() - ArgIter)) {
+      LLVM_DEBUG(dbgs() << "[getParameterTypes] function " << F->getName()
+                        << " appears to have " << ArgParams.size()
+                        << " arguments but has " << (ArgTys.end() - ArgIter)
+                        << "\n");
+      free(Buf);
+      return;
+    }
+
+    for (StringRef Arg : ArgParams) {
+      StructType *Pointee = nullptr;
+      if (Arg.endswith("*") && !Arg.endswith("**")) {
+        // Strip off address space and other qualifiers.
+        StringRef MangledStructName = Arg.split(' ').first;
+
+        if (MangledStructName.consume_front("__spirv_")) {
+          // This is a pointer to a SPIR-V OpType* opaque struct. In general,
+          // convert __spirv_<Type>[__Suffix] to %spirv.Type[._Suffix]
+          auto NameSuffixPair = MangledStructName.split('_');
+          std::string StructName = "spirv.";
+          StructName += NameSuffixPair.first;
+          if (!NameSuffixPair.second.empty()) {
+            StructName += ".";
+            StructName += NameSuffixPair.second;
+          }
+          Pointee = getOrCreateOpaqueStructType(M, StructName);
+        } else if (MangledStructName.startswith("opencl.")) {
+          Pointee = getOrCreateOpaqueStructType(M, MangledStructName);
+        }
+      } else if (!Arg.contains(' ') && Arg.startswith("ocl_")) {
+        // Bare structure type that starts with ocl_ is a builtin opencl type.
+        // See clang/lib/CodeGen/CGOpenCLRuntime for how these map to LLVM types
+        // and clang/lib/AST/ItaniumMangle for how they are mangled.
+        // In general, ocl_<foo> is mapped to pointer-to-%opencl.<foo>, but
+        // there is some variance around whether or not _t is included in the
+        // mangled name.
+        std::string StructName =
+            StringSwitch<StringRef>(Arg)
+                .Case("ocl_sampler", "opencl.sampler_t")
+                .Case("ocl_event", "opencl.event_t")
+                .Case("ocl_clkevent", "opencl.clk_event_t")
+                .Case("ocl_queue", "opencl.queue_t")
+                .Case("ocl_reserveid", "opencl.reserve_id_t")
+                .Default("")
+                .str();
+        if (StructName.empty()) {
+          StructName = "opencl.";
+          StructName += Arg.substr(4); // Strip off ocl_
+          if (!Arg.endswith("_t"))
+            StructName += "_t";
+        }
+        Pointee = getOrCreateOpaqueStructType(M, StructName);
+      }
+      *ArgIter++ = Pointee;
+    }
+  }
+  free(Buf);
+}
+
 CallInst *mutateCallInst(
     Module *M, CallInst *CI,
     std::function<std::string(CallInst *, std::vector<Value *> &)> ArgMutate,
@@ -911,9 +1014,9 @@ Metadata *getMDOperandOrNull(MDNode *N, unsigned I) {
   return N->getOperand(I);
 }
 
-std::string getMDOperandAsString(MDNode *N, unsigned I) {
+StringRef getMDOperandAsString(MDNode *N, unsigned I) {
   if (auto *Str = dyn_cast_or_null<MDString>(getMDOperandOrNull(N, I)))
-    return Str->getString().str();
+    return Str->getString();
   return "";
 }
 
@@ -939,7 +1042,7 @@ std::set<std::string> getNamedMDAsStringSet(Module *M,
     if (!MD || MD->getNumOperands() == 0)
       continue;
     for (unsigned J = 0, N = MD->getNumOperands(); J != N; ++J)
-      StrSet.insert(getMDOperandAsString(MD, J));
+      StrSet.insert(getMDOperandAsString(MD, J).str());
   }
 
   return StrSet;
@@ -1291,7 +1394,7 @@ bool isSPIRVConstantName(StringRef TyName) {
 Type *getSPIRVTypeByChangeBaseTypeName(Module *M, Type *T, StringRef OldName,
                                        StringRef NewName) {
   StringRef Postfixes;
-  if (isSPIRVType(T, OldName, &Postfixes))
+  if (isSPIRVStructType(T, OldName, &Postfixes))
     return getOrCreateOpaquePtrType(M, getSPIRVTypeName(NewName, Postfixes));
   LLVM_DEBUG(dbgs() << " Invalid SPIR-V type " << *T << '\n');
   llvm_unreachable("Invalid SPIR-V type");
@@ -1556,13 +1659,16 @@ StringRef getAccessQualifierFullName(StringRef TyName) {
 }
 
 /// Translates OpenCL image type names to SPIR-V.
-Type *getSPIRVImageTypeFromOCL(Module *M, Type *ImageTy) {
-  assert(isOCLImageType(ImageTy) && "Unsupported type");
-  auto ImageTypeName = ImageTy->getPointerElementType()->getStructName();
-  StringRef Acc = kAccessQualName::ReadOnly;
-  if (hasAccessQualifiedName(ImageTypeName))
-    Acc = getAccessQualifierFullName(ImageTypeName);
-  return getOrCreateOpaquePtrType(M, mapOCLTypeNameToSPIRV(ImageTypeName, Acc));
+Type *adaptSPIRVImageType(Module *M, Type *PointeeType) {
+  if (isOCLImageStructType(PointeeType)) {
+    auto ImageTypeName = PointeeType->getStructName();
+    StringRef Acc = kAccessQualName::ReadOnly;
+    if (hasAccessQualifiedName(ImageTypeName))
+      Acc = getAccessQualifierFullName(ImageTypeName);
+    return getOrCreateOpaqueStructType(
+        M, mapOCLTypeNameToSPIRV(ImageTypeName, Acc));
+  }
+  return PointeeType;
 }
 
 llvm::PointerType *getOCLClkEventType(Module *M) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -102,7 +102,7 @@ static void foreachKernelArgMD(
         Func) {
   for (unsigned I = 0, E = MD->getNumOperands(); I != E; ++I) {
     SPIRVFunctionParameter *BA = BF->getArgument(I);
-    Func(getMDOperandAsString(MD, I), BA);
+    Func(getMDOperandAsString(MD, I).str(), BA);
   }
 }
 
@@ -359,7 +359,8 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
       }
       if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
         assert(AddrSpc == SPIRAS_Global);
-        auto SPIRVImageTy = getSPIRVImageTypeFromOCL(M, T);
+        auto *SPIRVImageTy =
+            PointerType::get(adaptSPIRVImageType(M, ST), SPIRAS_Global);
         return mapType(T, transType(SPIRVImageTy));
       }
       if (STName == kSPR2TypeName::Sampler)
@@ -390,7 +391,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
         }
       }
 
-      if (isPointerToOpaqueStructType(T)) {
+      if (ST->isOpaque()) {
         return mapType(
             T, BM->addPointerType(SPIRSPIRVAddrSpaceMap::map(
                                       static_cast<SPIRAddressSpace>(AddrSpc)),
@@ -615,17 +616,17 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(Type *T) {
                                     static_cast<spv::AccessQualifier>(Ops[6])));
   } else if (TN == kSPIRVTypeName::SampledImg) {
     return mapType(
-        T, BM->addSampledImageType(static_cast<SPIRVTypeImage *>(
-               transType(getSPIRVTypeByChangeBaseTypeName(
-                   M, T, kSPIRVTypeName::SampledImg, kSPIRVTypeName::Image)))));
+        T,
+        BM->addSampledImageType(static_cast<SPIRVTypeImage *>(
+            transType(getSPIRVTypeByChangeBaseTypeName(
+                M, ST, kSPIRVTypeName::SampledImg, kSPIRVTypeName::Image)))));
   } else if (TN == kSPIRVTypeName::VmeImageINTEL) {
     // This type is the same as SampledImageType, but consumed by Subgroup AVC
     // Intel extension instructions.
-    return mapType(
-        T,
-        BM->addVmeImageINTELType(static_cast<SPIRVTypeImage *>(
-            transType(getSPIRVTypeByChangeBaseTypeName(
-                M, T, kSPIRVTypeName::VmeImageINTEL, kSPIRVTypeName::Image)))));
+    return mapType(T, BM->addVmeImageINTELType(static_cast<SPIRVTypeImage *>(
+                          transType(getSPIRVTypeByChangeBaseTypeName(
+                              M, ST, kSPIRVTypeName::VmeImageINTEL,
+                              kSPIRVTypeName::Image)))));
   } else if (TN == kSPIRVTypeName::Sampler)
     return mapType(T, BM->addSamplerType());
   else if (TN == kSPIRVTypeName::DeviceEvent)
@@ -1234,7 +1235,7 @@ LLVMToSPIRVBase::getLoopControl(const BranchInst *Branch,
 
   for (const MDOperand &MDOp : LoopMD->operands()) {
     if (MDNode *Node = dyn_cast<MDNode>(MDOp)) {
-      std::string S = getMDOperandAsString(Node, 0);
+      StringRef S = getMDOperandAsString(Node, 0);
       // Set the loop control bits. Parameters are set in the order described
       // in 3.23 SPIR-V Spec. rev. 1.4:
       // Bits that are set can indicate whether an additional operand follows,
@@ -2494,9 +2495,13 @@ SPIRVValue *LLVMToSPIRVBase::oclTransSpvcCastSampler(CallInst *CI,
   auto FT = F->getFunctionType();
   auto RT = FT->getReturnType();
   assert(FT->getNumParams() == 1);
-  assert((isSPIRVType(RT, kSPIRVTypeName::Sampler) ||
-          isPointerToOpaqueStructType(RT, kSPR2TypeName::Sampler)) &&
-         FT->getParamType(0)->isIntegerTy() && "Invalid sampler type");
+  if (!RT->isOpaquePointerTy()) {
+    StructType *ST = dyn_cast<StructType>(RT->getNonOpaquePointerElementType());
+    (void)ST;
+    assert(isSPIRVStructType(ST, kSPIRVTypeName::Sampler) ||
+           (ST->isOpaque() && ST->getName() == kSPR2TypeName::Sampler));
+  }
+  assert(FT->getParamType(0)->isIntegerTy() && "Invalid sampler type");
   auto Arg = CI->getArgOperand(0);
 
   auto GetSamplerConstant = [&](uint64_t SamplerValue) {
@@ -4635,9 +4640,9 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     // for this call, because there is no support for type corresponding to
     // OpTypeSampledImage. So, in this case, we create the required type here.
     Value *Image = CI->getArgOperand(0);
-    Type *ImageTy = Image->getType();
-    if (isOCLImageType(ImageTy))
-      ImageTy = getSPIRVImageTypeFromOCL(M, ImageTy);
+    SmallVector<StructType *, 4> ParamTys;
+    getParameterTypes(CI, ParamTys);
+    Type *ImageTy = adaptSPIRVImageType(M, ParamTys[0]);
     Type *SampledImgTy = getSPIRVTypeByChangeBaseTypeName(
         M, ImageTy, kSPIRVTypeName::Image, kSPIRVTypeName::SampledImg);
     Value *Sampler = CI->getArgOperand(1);


### PR DESCRIPTION
The centerpiece of this patch is the addition of getParameterTypes function,
which will parse out the pointee struct types using LLVM's built-in Itanium
demangling interface (which is unfortunately not easy to use). Passing this
information along via llvm StructTypes was chosen to minimize the impact of
this change on caller code; it is likely that a future cleanup patch to use
an enum or similar mechanism to represent possible SPIR-V struct types would
be advisable.

A side effect of this change is that several helper methods that query
pointer element types can be eliminated, which does lead to some cleanup that
got tangled up in the demangler-enabling work.

Extra function calls to getPointerElementType() are temporarily added to
disentangle this patch from work moving OCLTypeToSPIRV to store pointee types
rather than pointer types; this will likely be fixed as part of the effort to
get SPIRVWriter working with opaque pointer types.