### PR TITLE
[NFC] Avoid excess runs of OCLTypeToSPIRV

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5036,7 +5036,6 @@ void addPassesForSPIRV(legacy::PassManager &PassMgr,
   if (Opts.isSPIRVMemToRegEnabled())
     PassMgr.add(createPromoteMemoryToRegisterPass());
   PassMgr.add(createPreprocessMetadataLegacy());
-  PassMgr.add(createOCLTypeToSPIRVLegacy());
   PassMgr.add(createSPIRVLowerOCLBlocksLegacy());
   PassMgr.add(createOCLToSPIRVLegacy());
   PassMgr.add(createSPIRVRegularizeLLVMLegacy());


### PR DESCRIPTION
OCLTypeToSPIRV is an analysis required by other passes, so we don't
need to run it explicitly.