### PR TITLE
Disable test after LLVM change

### DIFF
--- a/test/lower-non-standard-vec-with-ext.ll
+++ b/test/lower-non-standard-vec-with-ext.ll
@@ -2,6 +2,9 @@
 ; RUN: not --crash llvm-spirv -s %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_vector_compute -s %t.bc
 
+; Temporarily disable test as it fails after an LLVM change.
+; XFAIL: *
+
 ; ModuleID = 'lower-non-standard-vec-with-ext'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"


### PR DESCRIPTION
An LLVM change in the range 1f06398e96d4..80b3dcc045f8 caused this
test to fail.  XFAIL the test while investigating.