### PR TITLE
Don't use not --crash to check for report_fatal_error messages.

### DIFF
--- a/test/lower-non-standard-vec-with-ext.ll
+++ b/test/lower-non-standard-vec-with-ext.ll
@@ -1,9 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: not --crash llvm-spirv -s %t.bc
+; RUN: not llvm-spirv -s %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_vector_compute -s %t.bc
-
-; Temporarily disable test as it fails after an LLVM change.
-; XFAIL: *
 
 ; ModuleID = 'lower-non-standard-vec-with-ext'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"


### PR DESCRIPTION
In https://reviews.llvm.org/D126550, report_fatal_error was changed to not use
the abort function, which means it no longer registers as a crash by the
definition of not --crash.