### PR TITLE
Fix tests after LLVM defaults to opaque pointers

### DIFF
--- a/test/AtomicBuiltinsFloat.ll
+++ b/test/AtomicBuiltinsFloat.ll
@@ -1,7 +1,7 @@
 ; Check that translator generates atomic instructions for atomic builtins
 ; FP-typed atomic_fetch_sub and atomic_fetch_sub_explicit should be translated
 ; to FunctionCall
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/AtomicCompareExchange.ll
+++ b/test/AtomicCompareExchange.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: spirv-val %t.spv

--- a/test/AtomicCompareExchange_cl20.ll
+++ b/test/AtomicCompareExchange_cl20.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/CheckCapKernelWithoutKernel.ll
+++ b/test/CheckCapKernelWithoutKernel.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/ContractionON.ll
+++ b/test/ContractionON.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-fp-contract=on
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
 ; RUN: spirv-val %t.spv

--- a/test/ContractionOff.ll
+++ b/test/ContractionOff.ll
@@ -17,22 +17,22 @@
 ; clang -cc1 -x cl -emit-llvm -O2 -disable-llvm-passes -triple spir64 1.cl -o 1.ll
 ; opt -mem2reg 1.ll -S -o 1.o.ll
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv.default
 ; RUN: llvm-spirv %t.spv.default -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-ON
 ; RUN: spirv-val %t.spv.default
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv.off --spirv-fp-contract=off
 ; RUN: llvm-spirv %t.spv.off -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-OFF
 ; RUN: spirv-val %t.spv.off
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv.fast --spirv-fp-contract=fast
 ; RUN: llvm-spirv %t.spv.fast -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-FAST
 ; RUN: spirv-val %t.spv.fast
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv.on --spirv-fp-contract=on
 ; RUN: llvm-spirv %t.spv.on -to-text -o - | FileCheck %s --check-prefixes CHECK,CHECK-ON
 ; RUN: spirv-val %t.spv.on

--- a/test/DebugInfo/COFF/global-dllimport.ll
+++ b/test/DebugInfo/COFF/global-dllimport.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/COFF/no-cus.ll
+++ b/test/DebugInfo/COFF/no-cus.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/DebugControlFlow.cl
+++ b/test/DebugInfo/DebugControlFlow.cl
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -cl-std=CL2.0 -O0 -debug-info-kind=standalone -gno-column-info -emit-llvm %s -o %t.ll -no-opaque-pointers
-// RUN: llvm-as %t.ll -o %t.bc
+// RUN: llvm-as -opaque-pointers=0 %t.ll -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/DebugInfo/DebugInfoChecksum.ll
+++ b/test/DebugInfo/DebugInfoChecksum.ll
@@ -10,7 +10,7 @@
 ; Command line:
 ; ./clang -cc1 -debug-info-kind=standalone -S -emit-llvm -triple spir -gcodeview -gcodeview-ghash main.cpp
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/DebugInfo/DebugInfoChecksumCompileUnit.ll
+++ b/test/DebugInfo/DebugInfoChecksumCompileUnit.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/DebugInfo/DebugInfoLLVMArg.ll
+++ b/test/DebugInfo/DebugInfoLLVMArg.ll
@@ -1,6 +1,6 @@
 ; This test checks that DW_OP_LLVM_arg operation goes through round trip translation correctly.
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/DebugInfo/DebugInfoLexicalBlockDependency.ll
+++ b/test/DebugInfo/DebugInfoLexicalBlockDependency.ll
@@ -3,7 +3,7 @@
 ;   - The parent scope of the local variable VAL is the lexical block LB
 ;   - The parent scope of the lexical block LB is the subprogram.
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll

--- a/test/DebugInfo/DebugInfoNoneEntity.ll
+++ b/test/DebugInfo/DebugInfoNoneEntity.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; Translation shouldn't crash:
 ; RUN: llvm-spirv %t.bc -spirv-text
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/DebugInfo/DebugInfoProducer.ll
+++ b/test/DebugInfo/DebugInfoProducer.ll
@@ -10,7 +10,7 @@
 ; Command line:
 ; ./clang -cc1 -debug-info-kind=standalone -v s.cpp -S -emit-llvm -triple spir
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/DebugInfo/DebugInfoSubrange.ll
+++ b/test/DebugInfo/DebugInfoSubrange.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o %t.spt
 ; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV
 

--- a/test/DebugInfo/DebugInfoWithUnknownIntrinsics.ll
+++ b/test/DebugInfo/DebugInfoWithUnknownIntrinsics.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+all --spirv-allow-unknown-intrinsics
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis %t.bc -o %t.ll

--- a/test/DebugInfo/DebugUnstructuredControlFlow.cl
+++ b/test/DebugInfo/DebugUnstructuredControlFlow.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown -cl-std=CL2.0 -O0 -debug-info-kind=standalone -gno-column-info -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -cl-std=CL2.0 -O0 -debug-info-kind=standalone -gno-column-info -emit-llvm-bc %s -o %t.bc -no-opaque-pointers
 // RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_unstructured_loop_controls -o %t.spv
 // RUN: llvm-spirv %t.spv --to-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/DebugInfo/Generic/2009-11-05-DeadGlobalVariable.ll
+++ b/test/DebugInfo/Generic/2009-11-05-DeadGlobalVariable.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/2009-11-06-NamelessGlobalVariable.ll
+++ b/test/DebugInfo/Generic/2009-11-06-NamelessGlobalVariable.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/2009-11-10-CurrentFn.ll
+++ b/test/DebugInfo/Generic/2009-11-10-CurrentFn.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/2010-01-05-DbgScope.ll
+++ b/test/DebugInfo/Generic/2010-01-05-DbgScope.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/2010-03-12-llc-crash.ll
+++ b/test/DebugInfo/Generic/2010-03-12-llc-crash.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/2010-03-24-MemberFn.ll
+++ b/test/DebugInfo/Generic/2010-03-24-MemberFn.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/2010-04-19-FramePtr.ll
+++ b/test/DebugInfo/Generic/2010-04-19-FramePtr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/2010-06-29-InlinedFnLocalVar.ll
+++ b/test/DebugInfo/Generic/2010-06-29-InlinedFnLocalVar.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/2010-10-01-crash.ll
+++ b/test/DebugInfo/Generic/2010-10-01-crash.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/PR20038.ll
+++ b/test/DebugInfo/Generic/PR20038.ll
@@ -3,7 +3,7 @@
 ; For some reason, the output when targetting sparc is not quite as expected.
 ; XFAIL: sparc
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/bug_null_debuginfo.ll
+++ b/test/DebugInfo/Generic/bug_null_debuginfo.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/constant-pointers.ll
+++ b/test/DebugInfo/Generic/constant-pointers.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/dead-argument-order.ll
+++ b/test/DebugInfo/Generic/dead-argument-order.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/debug-info-eis-option.ll
+++ b/test/DebugInfo/Generic/debug-info-eis-option.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=legacy
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/def-line.ll
+++ b/test/DebugInfo/Generic/def-line.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/discriminator.ll
+++ b/test/DebugInfo/Generic/discriminator.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/dwarf-public-names.ll
+++ b/test/DebugInfo/Generic/dwarf-public-names.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/enum.ll
+++ b/test/DebugInfo/Generic/enum.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/func-using-decl.ll
+++ b/test/DebugInfo/Generic/func-using-decl.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/global.ll
+++ b/test/DebugInfo/Generic/global.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/gmlt_profiling.ll
+++ b/test/DebugInfo/Generic/gmlt_profiling.ll
@@ -1,5 +1,5 @@
 ; REQUIRES: object-emission
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/imported-name-inlined.ll
+++ b/test/DebugInfo/Generic/imported-name-inlined.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/incorrect-variable-debugloc1.ll
+++ b/test/DebugInfo/Generic/incorrect-variable-debugloc1.ll
@@ -4,7 +4,7 @@
 ; for powerpc, until PR21881 is fixed.
 ; XFAIL: powerpc64
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/inline-scopes.ll
+++ b/test/DebugInfo/Generic/inline-scopes.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/inlined-arguments.ll
+++ b/test/DebugInfo/Generic/inlined-arguments.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/inlined-locations.ll
+++ b/test/DebugInfo/Generic/inlined-locations.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s
 

--- a/test/DebugInfo/Generic/inlined-vars.ll
+++ b/test/DebugInfo/Generic/inlined-vars.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/linear-dbg-value.ll
+++ b/test/DebugInfo/Generic/linear-dbg-value.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/linkage-name-abstract.ll
+++ b/test/DebugInfo/Generic/linkage-name-abstract.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/member-order.ll
+++ b/test/DebugInfo/Generic/member-order.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/missing-abstract-variable.ll
+++ b/test/DebugInfo/Generic/missing-abstract-variable.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/multiline.ll
+++ b/test/DebugInfo/Generic/multiline.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/namespace_function_definition.ll
+++ b/test/DebugInfo/Generic/namespace_function_definition.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/namespace_inline_function_definition.ll
+++ b/test/DebugInfo/Generic/namespace_inline_function_definition.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/noscopes.ll
+++ b/test/DebugInfo/Generic/noscopes.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/pass-by-value.ll
+++ b/test/DebugInfo/Generic/pass-by-value.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 ;
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 ;

--- a/test/DebugInfo/Generic/ptrsize.ll
+++ b/test/DebugInfo/Generic/ptrsize.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/restrict.ll
+++ b/test/DebugInfo/Generic/restrict.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/templ-func-decl.ll
+++ b/test/DebugInfo/Generic/templ-func-decl.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/template-recursive-void.ll
+++ b/test/DebugInfo/Generic/template-recursive-void.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/tu-member-pointer.ll
+++ b/test/DebugInfo/Generic/tu-member-pointer.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/two-cus-from-same-file.ll
+++ b/test/DebugInfo/Generic/two-cus-from-same-file.ll
@@ -5,7 +5,7 @@
 
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/typedef-arr-size.ll
+++ b/test/DebugInfo/Generic/typedef-arr-size.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s
 

--- a/test/DebugInfo/Generic/typedef.ll
+++ b/test/DebugInfo/Generic/typedef.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/undef-func-call.ll
+++ b/test/DebugInfo/Generic/undef-func-call.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv
 

--- a/test/DebugInfo/Generic/varargs.ll
+++ b/test/DebugInfo/Generic/varargs.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 ;
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/Generic/version.ll
+++ b/test/DebugInfo/Generic/version.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 ; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM

--- a/test/DebugInfo/LocalAddressSpace.ll
+++ b/test/DebugInfo/LocalAddressSpace.ll
@@ -4,7 +4,7 @@
 ;}
 ; clang -cc1 -triple spir -disable-llvm-passes -triple spir /work/tmp/tmp.cl -O0 -debug-info-kind=standalone -emit-llvm -o /work/llvm/projects/llvm-spirv/test/DebugInfo/LocalAddressSpace.ll
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/RecursiveDebugInfo.ll
+++ b/test/DebugInfo/RecursiveDebugInfo.ll
@@ -36,7 +36,7 @@
 ;    return 0;
 ;  }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s

--- a/test/DebugInfo/SourceLanguageLLVMToSPIRV.ll
+++ b/test/DebugInfo/SourceLanguageLLVMToSPIRV.ll
@@ -6,16 +6,16 @@
 ; checks DW_LANG_C_plus_plus_17 is mapped to C++ for OpenCL should be
 ; added once this is defined.
 
-; RUN: sed -e 's/INPUT_LANGUAGE/DW_LANG_C99/' %s | llvm-as - -o %t.bc
+; RUN: sed -e 's/INPUT_LANGUAGE/DW_LANG_C99/' %s | llvm-as -opaque-pointers=0 - -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-OPENCLC
 
-; RUN: sed -e 's/INPUT_LANGUAGE/DW_LANG_OpenCL/' %s | llvm-as - -o %t.bc
+; RUN: sed -e 's/INPUT_LANGUAGE/DW_LANG_OpenCL/' %s | llvm-as -opaque-pointers=0 - -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-OPENCLC
 
-; RUN: sed -e 's/INPUT_LANGUAGE/DW_LANG_C_plus_plus/' %s | llvm-as - -o %t.bc
+; RUN: sed -e 's/INPUT_LANGUAGE/DW_LANG_C_plus_plus/' %s | llvm-as -opaque-pointers=0 - -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-CPP4OPENCL
 
-; RUN: sed -e 's/INPUT_LANGUAGE/DW_LANG_C_plus_plus_14/' %s | llvm-as - -o %t.bc
+; RUN: sed -e 's/INPUT_LANGUAGE/DW_LANG_C_plus_plus_14/' %s | llvm-as -opaque-pointers=0 - -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-CPP4OPENCL
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/DebugInfo/TransTypeCompositeCaseClass_.ll
+++ b/test/DebugInfo/TransTypeCompositeCaseClass_.ll
@@ -8,7 +8,7 @@
 ;   return 0;
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/DebugInfo/UnknownBaseType.ll
+++ b/test/DebugInfo/UnknownBaseType.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/2010-04-13-PubType.ll
+++ b/test/DebugInfo/X86/2010-04-13-PubType.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/2011-09-26-GlobalVarContext.ll
+++ b/test/DebugInfo/X86/2011-09-26-GlobalVarContext.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/2011-12-16-BadStructRef.ll
+++ b/test/DebugInfo/X86/2011-12-16-BadStructRef.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/DIModule.ll
+++ b/test/DebugInfo/X86/DIModule.ll
@@ -1,5 +1,5 @@
 ; ModuleID = '/Volumes/Data/apple-internal/llvm/tools/clang/test/Modules/debug-info-moduleimport.m'
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/DIModuleContext.ll
+++ b/test/DebugInfo/X86/DIModuleContext.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/DW_AT_byte_size.ll
+++ b/test/DebugInfo/X86/DW_AT_byte_size.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/DW_AT_linkage_name.ll
+++ b/test/DebugInfo/X86/DW_AT_linkage_name.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/DW_AT_specification.ll
+++ b/test/DebugInfo/X86/DW_AT_specification.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/DW_AT_stmt_list_sec_offset.ll
+++ b/test/DebugInfo/X86/DW_AT_stmt_list_sec_offset.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/Fortran-DIModule.ll
+++ b/test/DebugInfo/X86/Fortran-DIModule.ll
@@ -1,5 +1,5 @@
 ; This test checks attributes of a Fortran module.
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/InlinedFnLocalVar.ll
+++ b/test/DebugInfo/X86/InlinedFnLocalVar.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/abstract_origin.ll
+++ b/test/DebugInfo/X86/abstract_origin.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/aligned_stack_var.ll
+++ b/test/DebugInfo/X86/aligned_stack_var.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/arguments.ll
+++ b/test/DebugInfo/X86/arguments.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/coff_debug_info_type.ll
+++ b/test/DebugInfo/X86/coff_debug_info_type.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/coff_relative_names.ll
+++ b/test/DebugInfo/X86/coff_relative_names.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/constant-aggregate.ll
+++ b/test/DebugInfo/X86/constant-aggregate.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/constant-loclist.ll
+++ b/test/DebugInfo/X86/constant-loclist.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/convert-debugloc.ll
+++ b/test/DebugInfo/X86/convert-debugloc.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/cu-ranges.ll
+++ b/test/DebugInfo/X86/cu-ranges.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/data_member_location.ll
+++ b/test/DebugInfo/X86/data_member_location.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-byval-parameter.ll
+++ b/test/DebugInfo/X86/dbg-byval-parameter.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-declare-alloca.ll
+++ b/test/DebugInfo/X86/dbg-declare-alloca.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-declare-arg.ll
+++ b/test/DebugInfo/X86/dbg-declare-arg.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-declare.ll
+++ b/test/DebugInfo/X86/dbg-declare.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_variable_length_array
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-file-name.ll
+++ b/test/DebugInfo/X86/dbg-file-name.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-prolog-end.ll
+++ b/test/DebugInfo/X86/dbg-prolog-end.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-value-const-byref.ll
+++ b/test/DebugInfo/X86/dbg-value-const-byref.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-value-frame-index.ll
+++ b/test/DebugInfo/X86/dbg-value-frame-index.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-value-isel.ll
+++ b/test/DebugInfo/X86/dbg-value-isel.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-value-location.ll
+++ b/test/DebugInfo/X86/dbg-value-location.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dbg-value-range.ll
+++ b/test/DebugInfo/X86/dbg-value-range.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/debug-dead-local-var.ll
+++ b/test/DebugInfo/X86/debug-dead-local-var.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/debug-info-access.ll
+++ b/test/DebugInfo/X86/debug-info-access.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/debug_frame.ll
+++ b/test/DebugInfo/X86/debug_frame.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/default-subrange-array.ll
+++ b/test/DebugInfo/X86/default-subrange-array.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dimodule-external-fortran.ll
+++ b/test/DebugInfo/X86/dimodule-external-fortran.ll
@@ -20,7 +20,7 @@
 ;
 ; The test would be in em.ll.
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 ; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj  %t.ll -o - | llvm-dwarfdump - | FileCheck %s

--- a/test/DebugInfo/X86/discriminator2.ll
+++ b/test/DebugInfo/X86/discriminator2.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/discriminator3.ll
+++ b/test/DebugInfo/X86/discriminator3.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/double-declare.ll
+++ b/test/DebugInfo/X86/double-declare.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dw_op_minus_direct.ll
+++ b/test/DebugInfo/X86/dw_op_minus_direct.ll
@@ -1,5 +1,5 @@
 ; Test dwarf codegen of DW_OP_minus.
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dwarf-aranges-no-dwarf-labels.ll
+++ b/test/DebugInfo/X86/dwarf-aranges-no-dwarf-labels.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dwarf-linkage-names.ll
+++ b/test/DebugInfo/X86/dwarf-linkage-names.ll
@@ -1,7 +1,7 @@
 ; DWARF linkage name attributes are optional; verify they are missing for
 ; PS4 triple or when tuning for SCE.
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dwarf-public-names.ll
+++ b/test/DebugInfo/X86/dwarf-public-names.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/dwarf-pubnames-split.ll
+++ b/test/DebugInfo/X86/dwarf-pubnames-split.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/earlydup-crash.ll
+++ b/test/DebugInfo/X86/earlydup-crash.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/ending-run.ll
+++ b/test/DebugInfo/X86/ending-run.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/enum-class.ll
+++ b/test/DebugInfo/X86/enum-class.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/enum-fwd-decl.ll
+++ b/test/DebugInfo/X86/enum-fwd-decl.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/fi-expr.ll
+++ b/test/DebugInfo/X86/fi-expr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/float_const.ll
+++ b/test/DebugInfo/X86/float_const.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/frame-register.ll
+++ b/test/DebugInfo/X86/frame-register.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/ghost-sdnode-dbgvalues.ll
+++ b/test/DebugInfo/X86/ghost-sdnode-dbgvalues.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/header.ll
+++ b/test/DebugInfo/X86/header.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/inline-member-function.ll
+++ b/test/DebugInfo/X86/inline-member-function.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/inline-seldag-test.ll
+++ b/test/DebugInfo/X86/inline-seldag-test.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/inlined-formal-parameter.ll
+++ b/test/DebugInfo/X86/inlined-formal-parameter.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/isel-cse-line.ll
+++ b/test/DebugInfo/X86/isel-cse-line.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/lexical-block-file-inline.ll
+++ b/test/DebugInfo/X86/lexical-block-file-inline.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/lexical_block.ll
+++ b/test/DebugInfo/X86/lexical_block.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/linkage-name.ll
+++ b/test/DebugInfo/X86/linkage-name.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/live-debug-variables.ll
+++ b/test/DebugInfo/X86/live-debug-variables.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/low-pc-cu.ll
+++ b/test/DebugInfo/X86/low-pc-cu.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/mi-print.ll
+++ b/test/DebugInfo/X86/mi-print.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/missing-file-line.ll
+++ b/test/DebugInfo/X86/missing-file-line.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/mixed-nodebug-cu.ll
+++ b/test/DebugInfo/X86/mixed-nodebug-cu.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/nophysreg.ll
+++ b/test/DebugInfo/X86/nophysreg.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/partial-constant.ll
+++ b/test/DebugInfo/X86/partial-constant.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/pr13303.ll
+++ b/test/DebugInfo/X86/pr13303.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/processes-relocations.ll
+++ b/test/DebugInfo/X86/processes-relocations.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/reference-argument.ll
+++ b/test/DebugInfo/X86/reference-argument.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/rematerialize.ll
+++ b/test/DebugInfo/X86/rematerialize.ll
@@ -1,5 +1,5 @@
 ; REQUIRES: object-emission
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/single-dbg_value.ll
+++ b/test/DebugInfo/X86/single-dbg_value.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/single-fi.ll
+++ b/test/DebugInfo/X86/single-fi.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/split-dwarf-multiple-cu-hash.ll
+++ b/test/DebugInfo/X86/split-dwarf-multiple-cu-hash.ll
@@ -1,5 +1,5 @@
 ; RUN: rm -rf %t && mkdir -p %t
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/split-dwarf-omit-empty.ll
+++ b/test/DebugInfo/X86/split-dwarf-omit-empty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/static_member_array.ll
+++ b/test/DebugInfo/X86/static_member_array.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/stmt-list.ll
+++ b/test/DebugInfo/X86/stmt-list.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/subrange-type.ll
+++ b/test/DebugInfo/X86/subrange-type.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/sycl-vec-3.ll
+++ b/test/DebugInfo/X86/sycl-vec-3.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s

--- a/test/DebugInfo/X86/tail-merge.ll
+++ b/test/DebugInfo/X86/tail-merge.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/this-stack_value.ll
+++ b/test/DebugInfo/X86/this-stack_value.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/type_units_with_addresses.ll
+++ b/test/DebugInfo/X86/type_units_with_addresses.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: object-emission
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/unattached-global.ll
+++ b/test/DebugInfo/X86/unattached-global.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/union-const.ll
+++ b/test/DebugInfo/X86/union-const.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/union-template.ll
+++ b/test/DebugInfo/X86/union-template.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/X86/vector.ll
+++ b/test/DebugInfo/X86/vector.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/builtin-get-global-id.ll
+++ b/test/DebugInfo/builtin-get-global-id.ll
@@ -9,7 +9,7 @@
 ; Command line:
 ; ./clang -cc1 1.cl -triple spir64 -cl-std=cl2.0 -emit-llvm -finclude-default-header -debug-info-kind=line-tables-only -O0
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s

--- a/test/DebugInfo/expr-opcode.ll
+++ b/test/DebugInfo/expr-opcode.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll

--- a/test/DebugInfo/omit-empty.ll
+++ b/test/DebugInfo/omit-empty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
 

--- a/test/DebugInfo/translate_sampler_initializer.ll
+++ b/test/DebugInfo/translate_sampler_initializer.ll
@@ -14,7 +14,7 @@
 ; Command line:
 ; clang -cc1 -triple spir constant_sampler.cl -cl-std=cl2.0 -emit-llvm -o llvm-spirv/test/DebugInfo/translate_sampler_initializer.ll -finclude-default-header -debug-info-kind=standalone
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 
 ; CHECK: TypeSampler [[#SamplerTy:]]

--- a/test/EnqueueEmptyKernel.ll
+++ b/test/EnqueueEmptyKernel.ll
@@ -12,7 +12,7 @@
 ;;                  0, NULL, NULL,
 ;;                  ^(){});
 ;; }
-; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s > %t.bc
 ; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/ExecutionMode.ll
+++ b/test/ExecutionMode.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 
 ; CHECK-DAG: TypeVoid [[VOID:[0-9]+]]

--- a/test/ExtendBitBoolArg.ll
+++ b/test/ExtendBitBoolArg.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -s %t.bc -o %t.regulzarized.bc
 ; RUN: llvm-dis %t.regulzarized.bc -o %t.regulzarized.ll
 ; RUN: FileCheck < %t.regulzarized.ll %s

--- a/test/FOrdGreaterThanEqual_bool.ll
+++ b/test/FOrdGreaterThanEqual_bool.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/FOrdGreaterThanEqual_int.ll
+++ b/test/FOrdGreaterThanEqual_int.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/FortranArray.ll
+++ b/test/FortranArray.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; Translation shouldn't crash:
 ; RUN: llvm-spirv %t.bc -spirv-text
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/LinkOnceODR.ll
+++ b/test/LinkOnceODR.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_KHR_linkonce_odr %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/OpVectorInsertDynamic.ll
+++ b/test/OpVectorInsertDynamic.ll
@@ -3,7 +3,7 @@
 ;  return c;
 ;}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/RelativeSrcPath.ll
+++ b/test/RelativeSrcPath.ll
@@ -8,7 +8,7 @@
 
 ; Directory: /tmp
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 
 ; ModuleID = 'RelativeSrcPath.cl'

--- a/test/SPIRVVersionAutodetect_1_0.ll
+++ b/test/SPIRVVersionAutodetect_1_0.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/SPIRVVersionAutodetect_1_1.ll
+++ b/test/SPIRVVersionAutodetect_1_1.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/SampledImageRetType.ll
+++ b/test/SampledImageRetType.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s
 

--- a/test/SamplerArgNonKernel.ll
+++ b/test/SamplerArgNonKernel.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/SingleOpLine.ll
+++ b/test/SingleOpLine.ll
@@ -4,7 +4,7 @@
 ; Command:
 ; clang -cc1 -triple spir -O0 -debug-info-kind=line-tables-only -emit-llvm -o /tmp/SingleOpLine.ll /tmp/SingleOpLine.cl
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 
 ; ModuleID = '/tmp/SingleOpLine.cl'

--- a/test/SpecConstants/bool-spirv-specconstant.ll
+++ b/test/SpecConstants/bool-spirv-specconstant.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 
 ; CHECK: Decorate [[#BOOL_CONST:]] SpecId [[#]]

--- a/test/TruncToBool.ll
+++ b/test/TruncToBool.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/appending-linkage-type.ll
+++ b/test/appending-linkage-type.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv -spirv-ext=+SPV_INTEL_vector_compute,+SPV_INTEL_usm_storage_classes
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll

--- a/test/atomic-load-store.ll
+++ b/test/atomic-load-store.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s

--- a/test/atomicrmw.ll
+++ b/test/atomicrmw.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s

--- a/test/builtin-vars-gep.ll
+++ b/test/builtin-vars-gep.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r -o %t.rev.bc

--- a/test/builtin_vars-decorate.ll
+++ b/test/builtin_vars-decorate.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/callable-attribute-decoration.ll
+++ b/test/callable-attribute-decoration.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_fast_composite
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/capability-Int64Atomics-store.ll
+++ b/test/capability-Int64Atomics-store.ll
@@ -6,7 +6,7 @@
 ;   atomic_store(object, desired);
 ;}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/capability-Int64Atomics.ll
+++ b/test/capability-Int64Atomics.ll
@@ -6,7 +6,7 @@
 ;   atomic_fetch_xor(object, desired);
 ;}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/capability-arbitrary-precision-integers.ll
+++ b/test/capability-arbitrary-precision-integers.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_arbitrary_precision_integers -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/capability-integers.ll
+++ b/test/capability-integers.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/capbility-kernel.ll
+++ b/test/capbility-kernel.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/complex-constexpr-vector.ll
+++ b/test/complex-constexpr-vector.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/complex-constexpr.ll
+++ b/test/complex-constexpr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/constexpr_phi.ll
+++ b/test/constexpr_phi.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/constexpr_vector.ll
+++ b/test/constexpr_vector.ll
@@ -1,5 +1,5 @@
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_function_pointers
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/create-placeholders-for-phi-operands.ll
+++ b/test/create-placeholders-for-phi-operands.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv -spirv-ext=+SPV_INTEL_variable_length_array
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll

--- a/test/custom_class.ll
+++ b/test/custom_class.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc
 
 ; --- Source code ---

--- a/test/customized_func_with_underscore.ll
+++ b/test/customized_func_with_underscore.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o - | llvm-spirv -o %t.spv
+; RUN: llvm-as -opaque-pointers=0 %s -o - | llvm-spirv -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/debug-label-skip.ll
+++ b/test/debug-label-skip.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 
 source_filename = "debug-label-bitcode.c"

--- a/test/empty-module.ll
+++ b/test/empty-module.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/empty.ll
+++ b/test/empty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/entry-point-interfaces.ll
+++ b/test/entry-point-interfaces.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val --target-env spv1.4 %t.spv

--- a/test/entry_point_func.ll
+++ b/test/entry_point_func.ll
@@ -1,6 +1,6 @@
 ;; Test to check that an LLVM spir_kernel gets translated into an
 ;; Entrypoint wrapper and Function with LinkageAttributes
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/exec_mode_float_control_intel.ll
+++ b/test/exec_mode_float_control_intel.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_float_controls2
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV

--- a/test/exec_mode_float_control_khr.ll
+++ b/test/exec_mode_float_control_khr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-max-version=1.1 --spirv-ext=+SPV_KHR_float_controls
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: FileCheck %s --input-file %t.spt -check-prefixes=SPV,SPVEXT

--- a/test/fast-composit-entry.ll
+++ b/test/fast-composit-entry.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_fast_composite
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/float-controls-decorations.ll
+++ b/test/float-controls-decorations.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute,+SPV_INTEL_float_controls2
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/half_extension.ll
+++ b/test/half_extension.ll
@@ -7,7 +7,7 @@
 ;   return y;
 ;}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/half_no_extension.ll
+++ b/test/half_no_extension.ll
@@ -5,7 +5,7 @@
 ;   vstorea_half4_rtp( data, 0, f );
 ;}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/image.ll
+++ b/test/image.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/image_decl_func_arg.ll
+++ b/test/image_decl_func_arg.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/image_dim.ll
+++ b/test/image_dim.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/image_store.ll
+++ b/test/image_store.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/layout.ll
+++ b/test/layout.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/link-attribute.ll
+++ b/test/link-attribute.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/linkage-types.ll
+++ b/test/linkage-types.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s > %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/linked-list.ll
+++ b/test/linked-list.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/literal-struct.ll
+++ b/test/literal-struct.ll
@@ -11,7 +11,7 @@
 ;   myBlock();
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/llvm-intrinsics/abs.ll
+++ b/test/llvm-intrinsics/abs.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/assume.ll
+++ b/test/llvm-intrinsics/assume.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_expect_assume -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/llvm-intrinsics/bswap.ll
+++ b/test/llvm-intrinsics/bswap.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -to-binary %t.spt -o %t.spv

--- a/test/llvm-intrinsics/ceil.ll
+++ b/test/llvm-intrinsics/ceil.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/constrained-arithmetic.ll
+++ b/test/llvm-intrinsics/constrained-arithmetic.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/constrained-comparison.ll
+++ b/test/llvm-intrinsics/constrained-comparison.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/constrained-convert.ll
+++ b/test/llvm-intrinsics/constrained-convert.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/ctlz.ll
+++ b/test/llvm-intrinsics/ctlz.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/ctpop.ll
+++ b/test/llvm-intrinsics/ctpop.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/cttz.ll
+++ b/test/llvm-intrinsics/cttz.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/dynamic-memmove.ll
+++ b/test/llvm-intrinsics/dynamic-memmove.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/llvm-intrinsics/expect.ll
+++ b/test/llvm-intrinsics/expect.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_expect_assume -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/llvm-intrinsics/experimental.noalias.scope.decl.ll
+++ b/test/llvm-intrinsics/experimental.noalias.scope.decl.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s

--- a/test/llvm-intrinsics/fabs.ll
+++ b/test/llvm-intrinsics/fabs.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/fmuladd.ll
+++ b/test/llvm-intrinsics/fmuladd.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t-default.spv
 ; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=true -o %t-replace.spv
 ; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=false -o %t-break.spv

--- a/test/llvm-intrinsics/fp-intrinsics.ll
+++ b/test/llvm-intrinsics/fp-intrinsics.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/fshl.ll
+++ b/test/llvm-intrinsics/fshl.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/fshr.ll
+++ b/test/llvm-intrinsics/fshr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/instrprof.ll
+++ b/test/llvm-intrinsics/instrprof.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/llvm-intrinsics/invariant.ll
+++ b/test/llvm-intrinsics/invariant.ll
@@ -1,5 +1,5 @@
 ; Make sure the translator doesn't crash if the input LLVM IR contains llvm.invariant.* intrinsics
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s

--- a/test/llvm-intrinsics/lifetime.ll
+++ b/test/llvm-intrinsics/lifetime.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt

--- a/test/llvm-intrinsics/maxnum.ll
+++ b/test/llvm-intrinsics/maxnum.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/memcpy.align.ll
+++ b/test/llvm-intrinsics/memcpy.align.ll
@@ -24,7 +24,7 @@
 ;}
 ; clang -cc1 -triple spir -disable-llvm-passes t.cl -emit-llvm -o t.ll
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/llvm-intrinsics/memmove.ll
+++ b/test/llvm-intrinsics/memmove.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/llvm-intrinsics/memset.ll
+++ b/test/llvm-intrinsics/memset.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/llvm-intrinsics/nearbyint.ll
+++ b/test/llvm-intrinsics/nearbyint.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/sadd.with.overflow.ll
+++ b/test/llvm-intrinsics/sadd.with.overflow.ll
@@ -11,7 +11,7 @@
 ; With the following options:
 ; -emit-llvm -fno-discard-value-names -O2 -g0 -ftrapv -target spir
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
 
 ; CHECK: call { i32, i1 } @llvm_sadd_with_overflow_i32

--- a/test/llvm-intrinsics/sqrt.ll
+++ b/test/llvm-intrinsics/sqrt.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
 ; RUN: spirv-val %t.spv

--- a/test/llvm-intrinsics/trap.ll
+++ b/test/llvm-intrinsics/trap.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/llvm-intrinsics/umul.with.overflow.ll
+++ b/test/llvm-intrinsics/umul.with.overflow.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/llvm-intrinsics/usub.sat.ll
+++ b/test/llvm-intrinsics/usub.sat.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/llvm.is.constant.ll
+++ b/test/llvm.is.constant.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t_recover.bc
 ; RUN: llvm-dis %t_recover.bc -o - | FileCheck %s

--- a/test/long-constant-array.ll
+++ b/test/long-constant-array.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; Check that everything is fine if SPV_INTEL_long_constant_composite is enabled

--- a/test/long-type-struct.ll
+++ b/test/long-type-struct.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_constant_composite %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/lower-non-standard-types.ll
+++ b/test/lower-non-standard-types.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s --implicit-check-not="<6 x i32>"
 
 ; CHECK: [[ASCastInst:%.*]] = addrspacecast <3 x i64> addrspace(1)* @Id to <3 x i64> addrspace(4)*

--- a/test/lower-non-standard-vec-with-ext.ll
+++ b/test/lower-non-standard-vec-with-ext.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv -s %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_vector_compute -s %t.bc
 

--- a/test/lshr-constexpr.ll
+++ b/test/lshr-constexpr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/mangled_function.ll
+++ b/test/mangled_function.ll
@@ -9,7 +9,7 @@
 ; }
 ; clang -cc1 /work/tmp/tmp.cl -cl-std=CL2.0 -triple spir-unknown-unknown  -finclude-default-header -emit-llvm -o test/mangled_function.ll
 
-; RUN: llvm-as < %s | llvm-spirv -o %t.spv
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -o - -to-text | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.spv -o - -r | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/memory_model_md.ll
+++ b/test/memory_model_md.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/multi_md.ll
+++ b/test/multi_md.ll
@@ -1,7 +1,7 @@
 ; Check duplicate operands in opencl.ocl.version metadata is accepted without
 ; assertion.
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/negative/SPV_INTEL_bfloat16_conversion/bf16tof_inval_input_ty.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/bf16tof_inval_input_ty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_bfloat16_conversion 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
 

--- a/test/negative/SPV_INTEL_bfloat16_conversion/bf16tof_inval_output_ty.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/bf16tof_inval_output_ty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_bfloat16_conversion 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
 

--- a/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertAsBFloat16Float_inval_scalar_signature.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertAsBFloat16Float_inval_scalar_signature.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK-ERROR: OpConvertAsBFloat16Float must be of float and take i16

--- a/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertAsBFloat16Float_inval_vec_elem_ty.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertAsBFloat16Float_inval_vec_elem_ty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK-ERROR: OpConvertAsBFloat16NFloatN must be of <N x float> and take <N x i16>

--- a/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertAsBFloat16Float_inval_vec_size.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertAsBFloat16Float_inval_vec_size.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK-ERROR: ConvertAsBFloat162Float2 must be of <2 x float> and take <2 x i16>

--- a/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertBFloat16AsUshort_inval_scalar_signature.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertBFloat16AsUshort_inval_scalar_signature.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK-ERROR: OpConvertBFloat16AsUShort must be of i16 and take float

--- a/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertBFloat16AsUshort_inval_vec_elem_ty.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertBFloat16AsUshort_inval_vec_elem_ty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK-ERROR: OpConvertBFloat16NAsUShortN must be of <N x i16> and take <N x float>

--- a/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertBFloat16AsUshort_inval_vec_size.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension/ConvertBFloat16AsUshort_inval_vec_size.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK-ERROR: ConvertBFloat162AsUShort2 must be of <2 x i16> and take <2 x float>

--- a/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_input_ty.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_input_ty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_bfloat16_conversion 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
 

--- a/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_output_ty_1.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_output_ty_1.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_bfloat16_conversion 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
 

--- a/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_output_ty_2.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_output_ty_2.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_bfloat16_conversion 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
 

--- a/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_params.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_params.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_bfloat16_conversion 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
 

--- a/test/negative/atomicrmw-unsupported-operation.ll
+++ b/test/negative/atomicrmw-unsupported-operation.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidInstruction: Can't translate llvm instruction:

--- a/test/negative/feature_requires_extension.ll
+++ b/test/negative/feature_requires_extension.ll
@@ -1,7 +1,7 @@
 ; Check whether the translator reports an error for a module with token type
 ; if SPV_INTEL_token_type extension is not used.
 
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc 2>&1 --spirv-allow-unknown-intrinsics | FileCheck %s
 
 ; CHECK: RequiresExtension: Feature requires the following SPIR-V extension:

--- a/test/negative/invalid-constant-generic-cast.ll
+++ b/test/negative/invalid-constant-generic-cast.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidModule: Invalid SPIR-V module: Casts from generic address space to constant are illegal

--- a/test/negative/invalid-device-local-cast.ll
+++ b/test/negative/invalid-device-local-cast.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidModule: Invalid SPIR-V module: Casts from global_device/global_host only allowed to global/generic 

--- a/test/negative/invalid-int-bitwidth.ll
+++ b/test/negative/invalid-int-bitwidth.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidBitWidth: Invalid bit width in input: 128

--- a/test/negative/invalid-private-global-cast.ll
+++ b/test/negative/invalid-private-global-cast.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidModule: Invalid SPIR-V module: Casts from private/local/global address space are allowed only to generic

--- a/test/negative/llvm-unhandled-intrinsic.ll
+++ b/test/negative/llvm-unhandled-intrinsic.ll
@@ -1,7 +1,7 @@
 ; Translator should not translate llvm intrinsic calls straight forward.
 ; It either represents intrinsic's semantics with SPIRV instruction(s), or
 ; reports an error.
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc 2>&1 | FileCheck %s
 
 ; CHECK: InvalidFunctionCall: Unexpected llvm intrinsic:

--- a/test/negative/unsup_invoke_instr.ll
+++ b/test/negative/unsup_invoke_instr.ll
@@ -1,6 +1,6 @@
 ;Translator does not parse some llvm instructions
 ;and emit errror message in that case.
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc 2>&1 | FileCheck %s
 
 ; CHECK: InvalidInstruction: Can't translate llvm instruction:

--- a/test/negative/unsupported-triple.ll
+++ b/test/negative/unsupported-triple.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidTargetTriple: Expects spir-unknown-unknown or spir64-unknown-unknown. Actual target triple is aarch64

--- a/test/negative/zero-length-array.ll
+++ b/test/negative/zero-length-array.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidArraySize: Array size must be at least 1: [0 x i32]

--- a/test/no_capability_shader.ll
+++ b/test/no_capability_shader.ll
@@ -1,6 +1,6 @@
 ;__kernel void sample_test(read_only image2d_t src, read_only image1d_buffer_t buff){}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/nullptr-metadata-test.ll
+++ b/test/nullptr-metadata-test.ll
@@ -1,5 +1,5 @@
 ; This test ensures that the translator does not crash
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 
 ; ModuleID = 'test.bc'

--- a/test/opencl.queue_t.ll
+++ b/test/opencl.queue_t.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/optnone.ll
+++ b/test/optnone.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_optnone -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_optnone %t.bc -o %t.spv

--- a/test/pointer_type_mapping.ll
+++ b/test/pointer_type_mapping.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+all -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 

--- a/test/preprocess-metadata.ll
+++ b/test/preprocess-metadata.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/relationals.ll
+++ b/test/relationals.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/select.ll
+++ b/test/select.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/simple.ll
+++ b/test/simple.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o %t
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"

--- a/test/sitofp-with-bool.ll
+++ b/test/sitofp-with-bool.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/spec_const_decoration.ll
+++ b/test/spec_const_decoration.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 
 ; CHECK: Decorate [[#SpecConst:]] SpecId 0

--- a/test/spirv-extensions-control.ll
+++ b/test/spirv-extensions-control.ll
@@ -9,7 +9,7 @@
 ; RUN: not llvm-spirv --spirv-ext= 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID-FORMAT
 ;
 ; Bunch of positive tests:
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+all -o - 2>&1 | FileCheck %s --check-prefix=CHECK-VALID
 ; RUN: llvm-spirv %t.bc --spirv-ext=-all -o - 2>&1 | FileCheck %s --check-prefix=CHECK-VALID
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_subgroups -o - 2>&1 | FileCheck %s --check-prefix=CHECK-VALID

--- a/test/spirv-load-store.ll
+++ b/test/spirv-load-store.ll
@@ -1,5 +1,5 @@
 ; Translate SPIR-V friendly OpLoad and OpStore calls
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/spirv-tools-dis.ll
+++ b/test/spirv-tools-dis.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-tools-dis -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc --spirv-tools-dis -o - | spirv-as
 

--- a/test/spirv-triple.ll
+++ b/test/spirv-triple.ll
@@ -1,3 +1,3 @@
-; RUN: llvm-as < %s | llvm-spirv -o %t
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -o %t
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"

--- a/test/spirv.Queue.ll
+++ b/test/spirv.Queue.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/spirv_global_variable_decoration.ll
+++ b/test/spirv_global_variable_decoration.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc

--- a/test/spirv_param_decorations.ll
+++ b/test/spirv_param_decorations.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc

--- a/test/spirv_param_decorations_quals.ll
+++ b/test/spirv_param_decorations_quals.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc

--- a/test/store.ll
+++ b/test/store.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
 ; RUN: FileCheck < %t %s
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/AllowIntrinsics.ll
+++ b/test/transcoding/AllowIntrinsics.ll
@@ -1,6 +1,6 @@
 ; The test checks command-line option for the translator which allows to represent
 ; unknown intrinsics as external function calls in SPIR-V.
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-allow-unknown-intrinsics %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/AtomicCompareExchange_cl20.ll
+++ b/test/transcoding/AtomicCompareExchange_cl20.ll
@@ -2,7 +2,7 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s

--- a/test/transcoding/AtomicFAddEXT.ll
+++ b/test/transcoding/AtomicFAddEXT.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_add -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt

--- a/test/transcoding/AtomicFAddEXTForOCL.ll
+++ b/test/transcoding/AtomicFAddEXTForOCL.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_add -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt

--- a/test/transcoding/AtomicFMaxEXT.ll
+++ b/test/transcoding/AtomicFMaxEXT.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_min_max -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt

--- a/test/transcoding/AtomicFMaxEXTForOCL.ll
+++ b/test/transcoding/AtomicFMaxEXTForOCL.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_min_max -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt

--- a/test/transcoding/AtomicFMinEXT.ll
+++ b/test/transcoding/AtomicFMinEXT.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_min_max -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt

--- a/test/transcoding/AtomicFMinEXTForOCL.ll
+++ b/test/transcoding/AtomicFMinEXTForOCL.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_EXT_shader_atomic_float_min_max -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt

--- a/test/transcoding/BitReversePref.ll
+++ b/test/transcoding/BitReversePref.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 
 ;CHECK:  Decorate [[#FUNC_NAME:]] LinkageAttributes "_Z10BitReversei"

--- a/test/transcoding/BuildNDRange.ll
+++ b/test/transcoding/BuildNDRange.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/BuildNDRange_2.ll
+++ b/test/transcoding/BuildNDRange_2.ll
@@ -18,7 +18,7 @@
 ;; }
 ;; bash$ $PATH_TO_GEN/bin/clang -cc1 -x cl -cl-std=CL2.0 -triple spir64-unknown-unknown -emit-llvm  -include opencl-20.h  BuildNDRange_2.cl -o BuildNDRange_2.ll
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/CreatePipeFromPipeStorage.ll
+++ b/test/transcoding/CreatePipeFromPipeStorage.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/DecorationAlignment.ll
+++ b/test/transcoding/DecorationAlignment.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/DecorationMaxByteOffset.ll
+++ b/test/transcoding/DecorationMaxByteOffset.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/ExecutionMode_SPIR_to_SPIRV.ll
+++ b/test/transcoding/ExecutionMode_SPIR_to_SPIRV.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/FPGABufferLocation.ll
+++ b/test/transcoding/FPGABufferLocation.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_buffer_location -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/FPGAUnstructuredLoopAttr.ll
+++ b/test/transcoding/FPGAUnstructuredLoopAttr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s > %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_unstructured_loop_controls --spirv-ext=+SPV_INTEL_fpga_loop_controls -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_unstructured_loop_controls --spirv-ext=+SPV_INTEL_fpga_loop_controls -o %t.spv

--- a/test/transcoding/ForwardPtr.ll
+++ b/test/transcoding/ForwardPtr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-ext=+all -o %t.spv
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -spirv-ext=+all -o %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/GlobalFunAnnotate.ll
+++ b/test/transcoding/GlobalFunAnnotate.ll
@@ -1,4 +1,4 @@
-;RUN: llvm-as %s -o %t.bc
+;RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ;RUN: llvm-spirv %t.bc -o %t.spv
 ;RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ;RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/InfiniteLoopMetadataPlacement.ll
+++ b/test/transcoding/InfiniteLoopMetadataPlacement.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_unstructured_loop_controls %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPV
 

--- a/test/transcoding/IntelFPGAMemoryAccesses.ll
+++ b/test/transcoding/IntelFPGAMemoryAccesses.ll
@@ -41,7 +41,7 @@
 ;   return 0;
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_accesses -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 

--- a/test/transcoding/IntelFPGAMemoryAttributes.ll
+++ b/test/transcoding/IntelFPGAMemoryAttributes.ll
@@ -205,7 +205,7 @@
 ; LLVM IR compilation command:
 ; clang -cc1 -triple spir -disable-llvm-passes -fsycl-is-device -emit-llvm intel-fpga-local-var.cpp
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -o %t.spv
 ; RUN: llvm-spirv %t.spv --spirv-ext=+SPV_INTEL_fpga_memory_attributes -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/IntelFPGAMemoryAttributesForStaticVar.ll
+++ b/test/transcoding/IntelFPGAMemoryAttributesForStaticVar.ll
@@ -39,7 +39,7 @@
 ; LLVM IR compilation command:
 ; clang -cc1 -triple spir -disable-llvm-passes -fsycl-is-device -emit-llvm intel-fpga-local-var.cpp
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 

--- a/test/transcoding/IntelFPGAMemoryAttributesForStruct.ll
+++ b/test/transcoding/IntelFPGAMemoryAttributesForStruct.ll
@@ -181,7 +181,7 @@
 ; LLVM IR compilation command:
 ; clang -cc1 -triple spir -disable-llvm-passes -fsycl-is-device -emit-llvm intel-fpga-local-var.cpp
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -o %t.spv
 ; RUN: llvm-spirv %t.spv --spirv-ext=+SPV_INTEL_fpga_memory_attributes -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/IntelFPGAReg.ll
+++ b/test/transcoding/IntelFPGAReg.ll
@@ -54,7 +54,7 @@
 ;   A ca(213);
 ;   A cb = __builtin_intel_fpga_reg(ca);
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; FIXME: add more negative test cases
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_reg -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt

--- a/test/transcoding/KernelArgTypeInOpString.ll
+++ b/test/transcoding/KernelArgTypeInOpString.ll
@@ -20,7 +20,7 @@
 ; As a workaround we store original names in OpString instruction:
 ; OpString "kernel_arg_type.%kernel_name%.typename0,typename1,..."
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -preserve-ocl-kernel-arg-type-metadata-through-string %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV-WORKAROUND
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt

--- a/test/transcoding/KernelArgTypeInOpString2.ll
+++ b/test/transcoding/KernelArgTypeInOpString2.ll
@@ -22,7 +22,7 @@
 ; As a workaround we store original names in OpString instruction:
 ; OpString "kernel_arg_type.%kernel_name%.typename0,typename1,..."
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -preserve-ocl-kernel-arg-type-metadata-through-string %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV-WORKAROUND
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt

--- a/test/transcoding/LoopUnroll.ll
+++ b/test/transcoding/LoopUnroll.ll
@@ -36,7 +36,7 @@
 ; Command:
 ; clang -cc1 -triple spir64 -O0 LoopUnroll.cl -emit-llvm -o /test/SPIRV/transcoding/LoopUnroll.ll
 
-; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s > %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/NoSignedUnsignedWrap.ll
+++ b/test/transcoding/NoSignedUnsignedWrap.ll
@@ -7,7 +7,7 @@
 ;
 ; Positive tests:
 ;
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-max-version=1.1 --spirv-ext=+SPV_KHR_no_integer_wrap_decoration -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-EXT
 ; RUN: llvm-spirv %t.bc --spirv-max-version=1.1 --spirv-ext=+SPV_KHR_no_integer_wrap_decoration -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/OpAllAny.ll
+++ b/test/transcoding/OpAllAny.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpBitReverse_i32.ll
+++ b/test/transcoding/OpBitReverse_i32.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/OpBitReverse_v2i16.ll
+++ b/test/transcoding/OpBitReverse_v2i16.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/OpConstantBool.ll
+++ b/test/transcoding/OpConstantBool.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpConstantSampler.ll
+++ b/test/transcoding/OpConstantSampler.ll
@@ -10,7 +10,7 @@
 ;   read_imagef(src, sampler2, 0, 0);
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpDot.ll
+++ b/test/transcoding/OpDot.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpGenericPtrMemSemantics.ll
+++ b/test/transcoding/OpGenericPtrMemSemantics.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpGroupAllAny.ll
+++ b/test/transcoding/OpGroupAllAny.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpGroupAsyncCopy.ll
+++ b/test/transcoding/OpGroupAsyncCopy.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpImageQuerySize.ll
+++ b/test/transcoding/OpImageQuerySize.ll
@@ -2,7 +2,7 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpImageReadMS.ll
+++ b/test/transcoding/OpImageReadMS.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpImageSampleExplicitLod.ll
+++ b/test/transcoding/OpImageSampleExplicitLod.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpLine.ll
+++ b/test/transcoding/OpLine.ll
@@ -12,8 +12,8 @@
 ;    }
 ;    return b;
 ;}
-; RUN: llvm-as < %s | llvm-spirv -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: llvm-as < %s | llvm-spirv -o %t.spv
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o -| FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/OpMin.ll
+++ b/test/transcoding/OpMin.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpPhi_ArgumentsPlaceholders.ll
+++ b/test/transcoding/OpPhi_ArgumentsPlaceholders.ll
@@ -12,7 +12,7 @@
 ;;    }
 ;;}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpSwitch32.ll
+++ b/test/transcoding/OpSwitch32.ll
@@ -14,7 +14,7 @@
 ;}
 ; bash$ clang -cc1 -triple spir64-unknown-unknown -x cl -cl-std=CL2.0 -O0 -include opencl.h -emit-llvm OpSwitch.cl -o test_32.ll
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpSwitch64.ll
+++ b/test/transcoding/OpSwitch64.ll
@@ -17,7 +17,7 @@
 ;}
 ; bash$ clang -cc1 -triple spir64-unknown-unknown -x cl -cl-std=CL2.0 -O0 -include opencl.h -emit-llvm OpSwitch.cl -o test_64.ll
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpSwitchChar.ll
+++ b/test/transcoding/OpSwitchChar.ll
@@ -14,7 +14,7 @@
 ;  }
 ;}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpSwitchEmpty.ll
+++ b/test/transcoding/OpSwitchEmpty.ll
@@ -8,7 +8,7 @@
 ; Command:
 ; clang -cc1 -triple spir -emit-llvm -o test/SPIRV/OpSwitchEmpty.ll OpSwitchEmpty.cl -disable-llvm-passes
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s  --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/OpVariable_Initializer.ll
+++ b/test/transcoding/OpVariable_Initializer.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpVectorExtractDynamic.ll
+++ b/test/transcoding/OpVectorExtractDynamic.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpenCL/atomic_work_item_fence.cl
+++ b/test/transcoding/OpenCL/atomic_work_item_fence.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc -no-opaque-pointers
 //
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/OpenCL/barrier.cl
+++ b/test/transcoding/OpenCL/barrier.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc -no-opaque-pointers
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/OpenCL/mem_fence.cl
+++ b/test/transcoding/OpenCL/mem_fence.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc -no-opaque-pointers
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/OpenCL/sub_group_barrier.cl
+++ b/test/transcoding/OpenCL/sub_group_barrier.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc -no-opaque-pointers
 //
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/OpenCL/work_group_barrier.cl
+++ b/test/transcoding/OpenCL/work_group_barrier.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc -no-opaque-pointers
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/PipeBlocking.ll
+++ b/test/transcoding/PipeBlocking.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_blocking_pipes,+SPV_INTEL_arbitrary_precision_integers -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; FIXME: add more negative test cases

--- a/test/transcoding/PipeStorage.ll
+++ b/test/transcoding/PipeStorage.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/PipeStorageIOINTEL.ll
+++ b/test/transcoding/PipeStorageIOINTEL.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_io_pipes -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/RecursiveType.ll
+++ b/test/transcoding/RecursiveType.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/RelationalOperatorsFOrd.ll
+++ b/test/transcoding/RelationalOperatorsFOrd.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/RelationalOperatorsFUnord.ll
+++ b/test/transcoding/RelationalOperatorsFUnord.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/ReqdSubgroupSize.ll
+++ b/test/transcoding/ReqdSubgroupSize.ll
@@ -3,7 +3,7 @@
 ; kernel __attribute__((intel_reqd_sub_group_size(8)))
 ; void foo() {}
 
-; RUN: llvm-as %s -o - | llvm-spirv -o %t.spv
+; RUN: llvm-as -opaque-pointers=0 %s -o - | llvm-spirv -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.spv -r -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/SPV_INTEL_arithmetic_fence/arithmetic_fence.ll
+++ b/test/transcoding/SPV_INTEL_arithmetic_fence/arithmetic_fence.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_arithmetic_fence -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension.ll
+++ b/test/transcoding/SPV_INTEL_bfloat16_conversion/cl_bfloat16_conversions_extension.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 
 ; RUN: not llvm-spirv %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-WO-EXT
 

--- a/test/transcoding/SPV_INTEL_bfloat16_conversion/convert_bfloat16_generic.ll
+++ b/test/transcoding/SPV_INTEL_bfloat16_conversion/convert_bfloat16_generic.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_bfloat16_conversion
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_complex_float_mul_div/complex-operations.ll
+++ b/test/transcoding/SPV_INTEL_complex_float_mul_div/complex-operations.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_complex_float_mul_div
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_not_builtin.ll
+++ b/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_not_builtin.ll
@@ -4,7 +4,7 @@
 ;   intel_sub_group_avc_mce_ime_boo();
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s
 
 ; Checks that a function with a name started from 'intel_sub_group_avc_' prefix,

--- a/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_types.ll
+++ b/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_types.ll
@@ -19,7 +19,7 @@
 ;   intel_sub_group_avc_ime_dual_reference_streamin_t dstreamin = 0x0;
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_device_side_avc_motion_estimation -o - -spirv-text | FileCheck %s
 
 ; CHECK: Capability Groups

--- a/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_wrappers.ll
+++ b/test/transcoding/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_wrappers.ll
@@ -26,7 +26,7 @@
 ;   intel_sub_group_avc_sic_get_inter_distortions(sic_result);
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_device_side_avc_motion_estimation -o - -spirv-text | FileCheck %s
 
 ; The test checks that 'cl_intel_device_side_avc_motion_estimation' wrapper built-ins correctly

--- a/test/transcoding/SPV_INTEL_fpga_dsp_control/prefer_dsp.ll
+++ b/test/transcoding/SPV_INTEL_fpga_dsp_control/prefer_dsp.ll
@@ -14,7 +14,7 @@
 ; return 0;
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_dsp_control -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_fpga_dsp_control/prefer_dsp_propagate.ll
+++ b/test/transcoding/SPV_INTEL_fpga_dsp_control/prefer_dsp_propagate.ll
@@ -15,7 +15,7 @@
 ; return 0;
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_dsp_control -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGAIVDepLoopAttr.ll
+++ b/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGAIVDepLoopAttr.ll
@@ -67,7 +67,7 @@
 ;   return 0;
 ; }
 
-; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s > %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_loop_controls -o %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGAIVDepLoopAttrOnClosure.ll
+++ b/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGAIVDepLoopAttrOnClosure.ll
@@ -36,7 +36,7 @@
 ;   return 0;
 ; }
 
-; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s > %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_loop_controls -o %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGALoopAttr.ll
+++ b/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGALoopAttr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s > %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_loop_controls -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_loop_controls -o %t.spv

--- a/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGALoopMergeInst.ll
+++ b/test/transcoding/SPV_INTEL_fpga_loop_controls/FPGALoopMergeInst.ll
@@ -98,7 +98,7 @@
 ; (!"llvm.loop.ivdep.*" <-> LoopControlDependency*Mask)
 ; into a separate test file
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-ext=+all -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_fpga_loop_controls/intel_multiple_fpga_loop_attrs.ll
+++ b/test/transcoding/SPV_INTEL_fpga_loop_controls/intel_multiple_fpga_loop_attrs.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s > %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s > %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_loop_controls -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_loop_controls -o %t.spv

--- a/test/transcoding/SPV_INTEL_function_pointers/bitcast.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/bitcast.ll
@@ -6,7 +6,7 @@
 ;    int (*fun_ptr)(int) = &foo;
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_function_pointers/const-function-pointer.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/const-function-pointer.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.r.bc

--- a/test/transcoding/SPV_INTEL_function_pointers/decor-func-ptr-arg-attr.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/decor-func-ptr-arg-attr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spt -spirv-text -spirv-ext=+SPV_INTEL_function_pointers
 ; RUN: FileCheck < %t.spt %s --check-prefix CHECK-SPIRV
 

--- a/test/transcoding/SPV_INTEL_function_pointers/fp-from-host.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/fp-from-host.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_INTEL_function_pointers -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv

--- a/test/transcoding/SPV_INTEL_function_pointers/fp-in-recusive-type.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/fp-in-recusive-type.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ;

--- a/test/transcoding/SPV_INTEL_function_pointers/function-pointer-as-function-arg.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/function-pointer-as-function-arg.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_INTEL_function_pointers -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv

--- a/test/transcoding/SPV_INTEL_function_pointers/function-pointer.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/function-pointer.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_INTEL_function_pointers -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv

--- a/test/transcoding/SPV_INTEL_function_pointers/global_ctor_dtor.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/global_ctor_dtor.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
 ; RUN: llvm-spirv -r %t.spv

--- a/test/transcoding/SPV_INTEL_function_pointers/gv-func-ptr.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/gv-func-ptr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.r.bc
 ; RUN: llvm-dis %t.r.bc -o %t.r.ll

--- a/test/transcoding/SPV_INTEL_function_pointers/non-uniform-function-pointer.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/non-uniform-function-pointer.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_INTEL_function_pointers -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv

--- a/test/transcoding/SPV_INTEL_function_pointers/referenced-indirectly.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/referenced-indirectly.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_INTEL_function_pointers -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv

--- a/test/transcoding/SPV_INTEL_function_pointers/select.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/select.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_function_pointers/vector_elem.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/vector_elem.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text --spirv-ext=+SPV_INTEL_function_pointers | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -spirv-text --spirv-ext=+SPV_INTEL_function_pointers | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; CHECK-SPIRV-DAG: 6 Name [[F1:[0-9+]]] "_Z2f1u2CMvb32_j"
 ; CHECK-SPIRV-DAG: 6 Name [[F2:[0-9+]]] "_Z2f2u2CMvb32_j"

--- a/test/transcoding/SPV_INTEL_global_variable_decorations/global_var_decorations.ll
+++ b/test/transcoding/SPV_INTEL_global_variable_decorations/global_var_decorations.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_global_variable_decorations -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_hw_thread_queries/intel_hw_thread_queries_function_call.ll
+++ b/test/transcoding/SPV_INTEL_hw_thread_queries/intel_hw_thread_queries_function_call.ll
@@ -1,6 +1,6 @@
 ; Test for SPV_INTEL_hw_thread_queries feature
 ; SPIR-V friendly LLVM IR to SPIR-V translation and vice versa
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_hw_thread_queries -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_hw_thread_queries/intel_hw_thread_queries_load_from_global.ll
+++ b/test/transcoding/SPV_INTEL_hw_thread_queries/intel_hw_thread_queries_load_from_global.ll
@@ -1,6 +1,6 @@
 ; Test for SPV_INTEL_hw_thread_queries feature
 ; SPIR-V friendly LLVM IR to SPIR-V translation and vice versa
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_hw_thread_queries -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_hw_thread_queries/negative_intel_hw_thread_queries.ll
+++ b/test/transcoding/SPV_INTEL_hw_thread_queries/negative_intel_hw_thread_queries.ll
@@ -1,7 +1,7 @@
 ; Negative test for SPV_INTEL_hw_thread_queries feature
 ; Check for errors in case if the extension is not enabled, but the appropriate
 ; SPV-IR patter is found
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidModule: Invalid SPIR-V module: Intel HW thread queries must be enabled by SPV_INTEL_hw_thread_queries extension.

--- a/test/transcoding/SPV_INTEL_inline_assembly/inline_asm_basic.cl
+++ b/test/transcoding/SPV_INTEL_inline_assembly/inline_asm_basic.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown -x cl -cl-std=CL2.0 -O0 -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -x cl -cl-std=CL2.0 -O0 -emit-llvm-bc %s -o %t.bc -no-opaque-pointers
 // RUN: llvm-spirv -spirv-ext=+SPV_INTEL_inline_assembly %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix.ll
+++ b/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -s -o %t.pre.bc
 ; RUN: llvm-dis %t.pre.bc -o - | FileCheck %s --check-prefix=CHECK-PRE
 ; RUN: llvm-spirv %t.bc -spirv-ext=+SPV_INTEL_joint_matrix -o %t.spv

--- a/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_bfloat16.ll
+++ b/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_bfloat16.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 
 ; RUN: llvm-spirv -s %t.bc -o %t.regularized.bc
 ; RUN: llvm-dis %t.regularized.bc -o %t.regularized.ll

--- a/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_element.ll
+++ b/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_element.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-ext=+all -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 

--- a/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_extract_insert_element_of_sycl_half.ll
+++ b/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_extract_insert_element_of_sycl_half.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 
 ; RUN: llvm-spirv -s %t.bc -o %t.regularized.bc
 ; RUN: llvm-dis %t.regularized.bc -o %t.regularized.ll

--- a/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_half.ll
+++ b/test/transcoding/SPV_INTEL_joint_matrix/joint_matrix_half.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -s -o %t.pre.bc
 ; RUN: llvm-dis %t.pre.bc -o - | FileCheck %s --check-prefix=CHECK-PRE
 ; RUN: llvm-spirv %t.bc -spirv-ext=+SPV_INTEL_joint_matrix -o %t.spv

--- a/test/transcoding/SPV_INTEL_kernel_attributes/intel_fpga_function_attributes.ll
+++ b/test/transcoding/SPV_INTEL_kernel_attributes/intel_fpga_function_attributes.ll
@@ -24,7 +24,7 @@
 ;;   kernel<class kernel_name2>([]() [[intel::no_global_work_offset(0)]]{});
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_kernel_attributes,+SPV_INTEL_fpga_cluster_attributes,+SPV_INTEL_loop_fuse,+SPV_INTEL_fpga_invocation_pipelining_attributes -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_kernel_attributes/streaming_interface_attribute.ll
+++ b/test/transcoding/SPV_INTEL_kernel_attributes/streaming_interface_attribute.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_kernel_attributes -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-barrier.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-barrier.ll
@@ -1,6 +1,6 @@
 ; The test checks if the translator won't crash
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_memory_access_aliasing -o %t.spv
 
 ; ModuleID = 'main'

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-empty-md.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-empty-md.ll
@@ -1,7 +1,7 @@
 ; Check that the translator doesn't fail on a translation of empty aliasing
 ; metadata
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_memory_access_aliasing -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-lifetime.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-lifetime.ll
@@ -2,7 +2,7 @@
 ; TODO need to figure out how to translate the alias.scope/noalias metadata
 ; in a case when it attached to a call to lifetime intrinsic. Now just skip it.
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_memory_access_aliasing -o %t.spv
 
 ; ModuleID = 'main'

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-load-store.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-load-store.ll
@@ -24,7 +24,7 @@
 ;; using https://github.com/intel/llvm.git bb5a2fece7c3315d7c72d8495c34a8a6eabc92d8
 ;; with an exception of !16 noalias medata - it doesn't make any sence.
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_memory_access_aliasing -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-masked-load-store.ll
+++ b/test/transcoding/SPV_INTEL_memory_access_aliasing/intel-alias-masked-load-store.ll
@@ -25,7 +25,7 @@
 ;; where generated loads and stores where replaced with calls to @wrappedload
 ;; and @wrappedstore functions
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_memory_access_aliasing -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_non_constant_addrspace_printf/non-constant-printf.ll
+++ b/test/transcoding/SPV_INTEL_non_constant_addrspace_printf/non-constant-printf.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-WO-EXT
 
 ; RUN: llvm-spirv -spirv-text %t.bc -o %t.spt --spirv-ext=+SPV_INTEL_non_constant_addrspace_printf

--- a/test/transcoding/SPV_INTEL_runtime_aligned/RuntimeAligned.ll
+++ b/test/transcoding/SPV_INTEL_runtime_aligned/RuntimeAligned.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_runtime_aligned -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_INTEL_token_type/token_type_intel.ll
+++ b/test/transcoding/SPV_INTEL_token_type/token_type_intel.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-unknown-intrinsics --spirv-ext=+SPV_INTEL_token_type
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/SPV_INTEL_variable_length_array/basic.ll
+++ b/test/transcoding/SPV_INTEL_variable_length_array/basic.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_variable_length_array
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/SPV_INTEL_variable_length_array/complex-cfg.ll
+++ b/test/transcoding/SPV_INTEL_variable_length_array/complex-cfg.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_variable_length_array
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/SPV_INTEL_variable_length_array/negative.ll
+++ b/test/transcoding/SPV_INTEL_variable_length_array/negative.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-INTRINSIC
 ; RUN: not llvm-spirv %t.bc -spirv-allow-unknown-intrinsics -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ALLOCA
 

--- a/test/transcoding/SPV_INTEL_variable_length_array/vla_spec_const.ll
+++ b/test/transcoding/SPV_INTEL_variable_length_array/vla_spec_const.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_variable_length_array
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv  --spec-const=0:i64:28 -o %t.rev.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/buffer_surface_intel.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/buffer_surface_intel.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute --spirv-allow-unknown-intrinsics
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/decoration_byte_offset.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/decoration_byte_offset.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute --spirv-allow-unknown-intrinsics=llvm.genx
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/decoration_media_block_io.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/decoration_media_block_io.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute --spirv-allow-unknown-intrinsics=llvm.genx
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/decoration_simt_call.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/decoration_simt_call.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute --spirv-allow-unknown-intrinsics=llvm.genx
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/decoration_single_element_vector.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/decoration_single_element_vector.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute --spirv-allow-unknown-intrinsics=llvm.genx
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/decoration_volatile.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/decoration_volatile.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute --spirv-allow-unknown-intrinsics=llvm.genx
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/exec_mode_argument_io_kind.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/exec_mode_argument_io_kind.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/exec_mode_float_control.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/exec_mode_float_control.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-max-version=1.1 --spirv-ext=+SPV_INTEL_vector_compute,+SPV_KHR_float_controls,+SPV_INTEL_float_controls2
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/exec_mode_shared_local_memory_size.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/exec_mode_shared_local_memory_size.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/extension_spirv_intel_vector_compute.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/extension_spirv_intel_vector_compute.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute,+SPV_KHR_float_controls,+SPV_INTEL_float_controls2
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/SPV_INTEL_vector_compute/extension_vector_compute_stability.ll
+++ b/test/transcoding/SPV_INTEL_vector_compute/extension_vector_compute_stability.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute,+SPV_KHR_float_controls,+SPV_INTEL_float_controls2 --spirv-allow-unknown-intrinsics=llvm.genx
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute,+SPV_KHR_float_controls,+SPV_INTEL_float_controls2 --spirv-allow-unknown-intrinsics

--- a/test/transcoding/SPV_KHR_integer_dot_product-nonsat.ll
+++ b/test/transcoding/SPV_KHR_integer_dot_product-nonsat.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -spirv-text -o %t.txt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_KHR_integer_dot_product -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_KHR_integer_dot_product-sat.ll
+++ b/test/transcoding/SPV_KHR_integer_dot_product-sat.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -spirv-text -o %t.txt 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_KHR_integer_dot_product -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/SPV_KHR_uniform_group_instructions/group-instructions.ll
+++ b/test/transcoding/SPV_KHR_uniform_group_instructions/group-instructions.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-WO-EXT
 

--- a/test/transcoding/SpecConstantComposite.ll
+++ b/test/transcoding/SpecConstantComposite.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/annotate_attribute.ll
+++ b/test/transcoding/annotate_attribute.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv %t.bc -o %t.spv
@@ -7,7 +7,7 @@
 
 ; Check that even when FPGA memory extensions are enabled - yet we have
 ; UserSemantic decoration be generated
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_accesses,+SPV_INTEL_fpga_memory_attributes -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; Check SPIR-V versions in a format magic number + version

--- a/test/transcoding/annotation_dbg_info_drop.ll
+++ b/test/transcoding/annotation_dbg_info_drop.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK,CHECK-SPV

--- a/test/transcoding/annotation_generic_decoration.ll
+++ b/test/transcoding/annotation_generic_decoration.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_attributes -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/atomic_load_store.ll
+++ b/test/transcoding/atomic_load_store.ll
@@ -2,7 +2,7 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/atomics_1.2.ll
+++ b/test/transcoding/atomics_1.2.ll
@@ -1,7 +1,7 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/bitcast.ll
+++ b/test/transcoding/bitcast.ll
@@ -2,7 +2,7 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/builtin_calls.ll
+++ b/test/transcoding/builtin_calls.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/builtin_function_readnone_attr.ll
+++ b/test/transcoding/builtin_function_readnone_attr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/builtin_vars.ll
+++ b/test/transcoding/builtin_vars.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/builtin_vars_arithmetics.ll
+++ b/test/transcoding/builtin_vars_arithmetics.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/builtin_vars_opt.ll
+++ b/test/transcoding/builtin_vars_opt.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/capability-arbitrary-precision-fixed-point-numbers.ll
+++ b/test/transcoding/capability-arbitrary-precision-fixed-point-numbers.ll
@@ -92,7 +92,7 @@
 ;   return 0;
 ; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_arbitrary_precision_fixed_point -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 

--- a/test/transcoding/capability-arbitrary-precision-floating-point.ll
+++ b/test/transcoding/capability-arbitrary-precision-floating-point.ll
@@ -405,7 +405,7 @@
 ; LLVM IR compilation command:
 ; clang -I llvm/include/sycl -S -emit-llvm -fno-sycl-early-optimizations -fsycl-device-only capability-arbitrary-precision-floating-point.cpp
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_arbitrary_precision_floating_point -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 

--- a/test/transcoding/check_ro_qualifier.ll
+++ b/test/transcoding/check_ro_qualifier.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/check_wo_qualifier.ll
+++ b/test/transcoding/check_wo_qualifier.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/cl-types.ll
+++ b/test/transcoding/cl-types.ll
@@ -18,7 +18,7 @@
 ;; ){
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/cl_intel_sub_groups.ll
+++ b/test/transcoding/cl_intel_sub_groups.ll
@@ -33,7 +33,7 @@
 ;    intel_sub_group_block_write_ul2(lp, ul2);
 ;}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o - -spirv-text --spirv-ext=+SPV_INTEL_subgroups | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_subgroups
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/dbginfo-bug-on-bool-converts.ll
+++ b/test/transcoding/dbginfo-bug-on-bool-converts.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s

--- a/test/transcoding/exec_mode_float_control_empty.ll
+++ b/test/transcoding/exec_mode_float_control_empty.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv --spirv-ext=+SPV_KHR_float_controls,+SPV_INTEL_float_controls2 %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/transcoding/extract_insert_value.ll
+++ b/test/transcoding/extract_insert_value.ll
@@ -2,7 +2,7 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/fadd.ll
+++ b/test/transcoding/fadd.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/fclamp.ll
+++ b/test/transcoding/fclamp.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/fcmp.ll
+++ b/test/transcoding/fcmp.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/fdiv.ll
+++ b/test/transcoding/fdiv.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/fence_inst.ll
+++ b/test/transcoding/fence_inst.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_runtime_aligned -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/fmod.ll
+++ b/test/transcoding/fmod.ll
@@ -1,7 +1,7 @@
 ; __kernel void fmod_kernel( float out, float in1, float in2 )
 ; { out = fmod( in1, in2 ); }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/fmul.ll
+++ b/test/transcoding/fmul.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/fneg.ll
+++ b/test/transcoding/fneg.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/fp_contract_reassoc_fast_mode.ll
+++ b/test/transcoding/fp_contract_reassoc_fast_mode.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV-OFF
 ; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_fp_fast_math_mode -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV-ON
 ; RUN: llvm-spirv  --spirv-ext=+SPV_INTEL_fp_fast_math_mode %t.bc -o %t.spv

--- a/test/transcoding/frem.ll
+++ b/test/transcoding/frem.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/fsub.ll
+++ b/test/transcoding/fsub.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/get_image_num_mip_levels.ll
+++ b/test/transcoding/get_image_num_mip_levels.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/global-constant-expression.ll
+++ b/test/transcoding/global-constant-expression.ll
@@ -1,5 +1,5 @@
-; RUN: llvm-as < %s | llvm-spirv -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: llvm-as < %s | llvm-spirv -o %t.spv
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/transcoding/image_builtins.ll
+++ b/test/transcoding/image_builtins.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/image_channel.ll
+++ b/test/transcoding/image_channel.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/image_get_size_with_access_qualifiers.ll
+++ b/test/transcoding/image_get_size_with_access_qualifiers.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/image_signedness.ll
+++ b/test/transcoding/image_signedness.ll
@@ -3,7 +3,7 @@
 ; TODO: Translator does not handle signedness for read_image/write_image yet.
 ; XFAIL: *
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/image_with_access_qualifiers.ll
+++ b/test/transcoding/image_with_access_qualifiers.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/image_with_suffix.ll
+++ b/test/transcoding/image_with_suffix.ll
@@ -1,7 +1,7 @@
 ; Test that an image type name suffixed with .<n> does not crash the
 ; translator.
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/intel_fpga_lsu_optimized.ll
+++ b/test/transcoding/intel_fpga_lsu_optimized.ll
@@ -49,7 +49,7 @@
 ; }
 
 ; Check that translation of optimized IR doesn't crash:
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_accesses -o %t.spv
 
 ; Check that reverse translation restore ptr.annotations correctly:

--- a/test/transcoding/intel_usm_addrspaces.ll
+++ b/test/transcoding/intel_usm_addrspaces.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_usm_storage_classes -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-EXT
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/transcoding/intrinsic_result_store.ll
+++ b/test/transcoding/intrinsic_result_store.ll
@@ -1,7 +1,7 @@
 ; Regression test for intrinsic calls' translation edge cases
 ; with subsequent store instructions.
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/transcoding/isequal.ll
+++ b/test/transcoding/isequal.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/kernel_arg_name.ll
+++ b/test/transcoding/kernel_arg_name.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o - | llvm-spirv -o %t.spv
+; RUN: llvm-as -opaque-pointers=0 %s -o - | llvm-spirv -o %t.spv
 ; RUN: llvm-spirv %t.spv -spirv-gen-kernel-arg-name-md -r -o - | llvm-dis -o - | FileCheck %s
 
 ; CHECK: spir_kernel void @named_arg(float %f) {{.*}} !kernel_arg_name ![[MD_named:[0-9]+]]

--- a/test/transcoding/kernel_arg_type_qual.ll
+++ b/test/transcoding/kernel_arg_type_qual.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -preserve-ocl-kernel-arg-type-metadata-through-string %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV-NEGATIVE
 ; RUN: llvm-spirv -preserve-ocl-kernel-arg-type-metadata-through-string %t.bc -o %t.spv

--- a/test/transcoding/kernel_query.ll
+++ b/test/transcoding/kernel_query.ll
@@ -15,7 +15,7 @@
 ; Compilation command:
 ; clang -cc1 -triple spir-unknown-unknown -O0 -cl-std=CL2.0 -emit-llvm kernel_query.cl
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/linked-program.ll
+++ b/test/transcoding/linked-program.ll
@@ -1,6 +1,6 @@
 ; REQUIRES: spirv-link
 ;
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: spirv-link %t.spv -o %t.linked.spv

--- a/test/transcoding/memory_access.ll
+++ b/test/transcoding/memory_access.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/optional-core-features-multiple.ll
+++ b/test/transcoding/optional-core-features-multiple.ll
@@ -4,7 +4,7 @@
 ; kernel void test(read_only image2d_t img) {}
 ; -----------------------------------------------
 ;
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/readonly.ll
+++ b/test/transcoding/readonly.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/relationals_double.ll
+++ b/test/transcoding/relationals_double.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/relationals_float.ll
+++ b/test/transcoding/relationals_float.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/relationals_half.ll
+++ b/test/transcoding/relationals_half.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/spec_const.ll
+++ b/test/transcoding/spec_const.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/spirv-private-array-initialization.ll
+++ b/test/transcoding/spirv-private-array-initialization.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as <%s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 <%s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t_4mspirv.bc

--- a/test/transcoding/spirv-types.ll
+++ b/test/transcoding/spirv-types.ll
@@ -1,6 +1,6 @@
 ;; Test SPIR-V opaque types
 ;;
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.from-llvm.spv

--- a/test/transcoding/sub_group_ballot.ll
+++ b/test/transcoding/sub_group_ballot.ll
@@ -155,7 +155,7 @@
 ;;     dst[4] = get_sub_group_lt_mask();
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt

--- a/test/transcoding/sub_group_clustered_reduce.ll
+++ b/test/transcoding/sub_group_clustered_reduce.ll
@@ -173,7 +173,7 @@
 ;;     dst[2] = sub_group_clustered_reduce_logical_xor(v, 2);
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/sub_group_extended_types.ll
+++ b/test/transcoding/sub_group_extended_types.ll
@@ -179,7 +179,7 @@
 ;;     dst[8] = sub_group_scan_exclusive_max(v);
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/sub_group_non_uniform_arithmetic.ll
+++ b/test/transcoding/sub_group_non_uniform_arithmetic.ll
@@ -308,7 +308,7 @@
 ;;     dst[8] = sub_group_non_uniform_scan_exclusive_logical_xor(v);
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/sub_group_non_uniform_vote.ll
+++ b/test/transcoding/sub_group_non_uniform_vote.ll
@@ -61,7 +61,7 @@
 ;;     }
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/sub_group_shuffle.ll
+++ b/test/transcoding/sub_group_shuffle.ll
@@ -79,7 +79,7 @@
 ;;     dst[1] = sub_group_shuffle_xor( v, 0 );
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/sub_group_shuffle_relative.ll
+++ b/test/transcoding/sub_group_shuffle_relative.ll
@@ -79,7 +79,7 @@
 ;;     dst[1] = sub_group_shuffle_down( v, 0 );
 ;; }
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/suminmaxIntr.ll
+++ b/test/transcoding/suminmaxIntr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/sycl_array_zero_init.ll
+++ b/test/transcoding/sycl_array_zero_init.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s

--- a/test/transcoding/undef_initializer.ll
+++ b/test/transcoding/undef_initializer.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/unreachable.ll
+++ b/test/transcoding/unreachable.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/vec8.ll
+++ b/test/transcoding/vec8.ll
@@ -4,7 +4,7 @@
 ;Source:
 ;__kernel void test( int8 v ) {}
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv

--- a/test/transcoding/vec_type_hint.cl
+++ b/test/transcoding/vec_type_hint.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown -x cl -cl-std=CL2.0 -O0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -x cl -cl-std=CL2.0 -O0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc -no-opaque-pointers
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/vector_casts.ll
+++ b/test/transcoding/vector_casts.ll
@@ -2,7 +2,7 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/uitofp-with-bool.ll
+++ b/test/uitofp-with-bool.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r -spirv-target-env="SPV-IR" %t.spv -o %t.bc

--- a/test/vector-metadata-constexpr.ll
+++ b/test/vector-metadata-constexpr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc
 

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -344,6 +344,8 @@ static bool isFileEmpty(const std::string &FileName) {
 
 static int convertSPIRVToLLVM(const SPIRV::TranslatorOpts &Opts) {
   LLVMContext Context;
+  Context.setOpaquePointers(false);
+
   std::ifstream IFS(InputFile, std::ios::binary);
   Module *M;
   std::string Err;


### PR DESCRIPTION
Update for LLVM commit `41d5033eb162 ("[IR] Enable opaque pointers by default", 2022-06-02)`.