### PR TITLE
Remove 'using namespace llvm' from some headers

### DIFF
--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -51,40 +51,39 @@
 #include <map>
 #include <set>
 
-using namespace llvm;
-
 namespace SPIRV {
 
 class OCLTypeToSPIRVBase {
 public:
   OCLTypeToSPIRVBase();
 
-  bool runOCLTypeToSPIRV(Module &M);
+  bool runOCLTypeToSPIRV(llvm::Module &M);
   /// \return Adapted type based on kernel argument metadata. If \p V is
   ///   a function, returns function type.
   /// E.g. for a function with argument of read only opencl.image_2d_t* type
   /// returns a function with argument of type opencl.image2d_t.read_only*.
-  Type *getAdaptedType(Value *V);
+  llvm::Type *getAdaptedType(llvm::Value *V);
 
 private:
-  Module *M;
-  LLVMContext *Ctx;
-  std::map<Value *, Type *> AdaptedTy; // Adapted types for values
-  std::set<Function *> WorkSet;        // Functions to be adapted
+  llvm::Module *M;
+  llvm::LLVMContext *Ctx;
+  std::map<llvm::Value *, llvm::Type *> AdaptedTy; // Adapted types for values
+  std::set<llvm::Function *> WorkSet;              // Functions to be adapted
 
-  void adaptFunctionArguments(Function *F);
-  void adaptArgumentsByMetadata(Function *F);
-  void adaptArgumentsBySamplerUse(Module &M);
-  void adaptFunction(Function *F);
-  void addAdaptedType(Value *V, Type *T);
-  void addWork(Function *F);
+  void adaptFunctionArguments(llvm::Function *F);
+  void adaptArgumentsByMetadata(llvm::Function *F);
+  void adaptArgumentsBySamplerUse(llvm::Module &M);
+  void adaptFunction(llvm::Function *F);
+  void addAdaptedType(llvm::Value *V, llvm::Type *T);
+  void addWork(llvm::Function *F);
 };
 
-class OCLTypeToSPIRVLegacy : public OCLTypeToSPIRVBase, public ModulePass {
+class OCLTypeToSPIRVLegacy : public OCLTypeToSPIRVBase,
+                             public llvm::ModulePass {
 public:
   OCLTypeToSPIRVLegacy();
-  void getAnalysisUsage(AnalysisUsage &AU) const override;
-  bool runOnModule(Module &M) override;
+  void getAnalysisUsage(llvm::AnalysisUsage &AU) const override;
+  bool runOnModule(llvm::Module &M) override;
   static char ID;
 };
 

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.h
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.h
@@ -40,8 +40,6 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 
-using namespace llvm;
-
 namespace SPIRV {
 
 class SPIRVLowerBitCastToNonStandardTypePass
@@ -50,13 +48,14 @@ public:
   SPIRVLowerBitCastToNonStandardTypePass(const SPIRV::TranslatorOpts &Opts)
       : Opts(Opts) {}
 
-  PreservedAnalyses run(Function &F, FunctionAnalysisManager &FAM);
+  llvm::PreservedAnalyses run(llvm::Function &F,
+                              llvm::FunctionAnalysisManager &FAM);
 
 private:
   SPIRV::TranslatorOpts Opts;
 };
 
-class SPIRVLowerBitCastToNonStandardTypeLegacy : public FunctionPass {
+class SPIRVLowerBitCastToNonStandardTypeLegacy : public llvm::FunctionPass {
 public:
   static char ID;
   SPIRVLowerBitCastToNonStandardTypeLegacy(const SPIRV::TranslatorOpts &Opts)
@@ -64,11 +63,11 @@ public:
 
   SPIRVLowerBitCastToNonStandardTypeLegacy() : FunctionPass(ID) {}
 
-  bool runOnFunction(Function &F) override;
+  bool runOnFunction(llvm::Function &F) override;
 
-  bool doFinalization(Module &M) override;
+  bool doFinalization(llvm::Module &M) override;
 
-  StringRef getPassName() const override;
+  llvm::StringRef getPassName() const override;
 
 private:
   SPIRV::TranslatorOpts Opts;

--- a/lib/SPIRV/SPIRVLowerBool.h
+++ b/lib/SPIRV/SPIRVLowerBool.h
@@ -44,27 +44,25 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 
-using namespace llvm;
-
 namespace SPIRV {
 
-class SPIRVLowerBoolBase : public InstVisitor<SPIRVLowerBoolBase> {
+class SPIRVLowerBoolBase : public llvm::InstVisitor<SPIRVLowerBoolBase> {
 public:
   SPIRVLowerBoolBase() : Context(nullptr) {}
   virtual ~SPIRVLowerBoolBase() {}
-  void replace(Instruction *I, Instruction *NewI);
-  bool isBoolType(Type *Ty);
-  virtual void visitTruncInst(TruncInst &I);
-  void handleExtInstructions(Instruction &I);
-  void handleCastInstructions(Instruction &I);
-  virtual void visitZExtInst(ZExtInst &I);
-  virtual void visitSExtInst(SExtInst &I);
-  virtual void visitUIToFPInst(UIToFPInst &I);
-  virtual void visitSIToFPInst(SIToFPInst &I);
-  bool runLowerBool(Module &M);
+  void replace(llvm::Instruction *I, llvm::Instruction *NewI);
+  bool isBoolType(llvm::Type *Ty);
+  virtual void visitTruncInst(llvm::TruncInst &I);
+  void handleExtInstructions(llvm::Instruction &I);
+  void handleCastInstructions(llvm::Instruction &I);
+  virtual void visitZExtInst(llvm::ZExtInst &I);
+  virtual void visitSExtInst(llvm::SExtInst &I);
+  virtual void visitUIToFPInst(llvm::UIToFPInst &I);
+  virtual void visitSIToFPInst(llvm::SIToFPInst &I);
+  bool runLowerBool(llvm::Module &M);
 
 private:
-  LLVMContext *Context;
+  llvm::LLVMContext *Context;
 };
 
 class SPIRVLowerBoolPass : public llvm::PassInfoMixin<SPIRVLowerBoolPass>,
@@ -74,10 +72,11 @@ public:
                               llvm::ModuleAnalysisManager &MAM);
 };
 
-class SPIRVLowerBoolLegacy : public ModulePass, public SPIRVLowerBoolBase {
+class SPIRVLowerBoolLegacy : public llvm::ModulePass,
+                             public SPIRVLowerBoolBase {
 public:
   SPIRVLowerBoolLegacy();
-  bool runOnModule(Module &M) override;
+  bool runOnModule(llvm::Module &M) override;
 
   static char ID;
 };

--- a/lib/SPIRV/SPIRVLowerMemmove.h
+++ b/lib/SPIRV/SPIRVLowerMemmove.h
@@ -44,20 +44,18 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 
-using namespace llvm;
-
 namespace SPIRV {
 
 class SPIRVLowerMemmoveBase {
 public:
   SPIRVLowerMemmoveBase() : Context(nullptr) {}
 
-  void LowerMemMoveInst(MemMoveInst &I);
-  bool expandMemMoveIntrinsicUses(Function &F);
-  bool runLowerMemmove(Module &M);
+  void LowerMemMoveInst(llvm::MemMoveInst &I);
+  bool expandMemMoveIntrinsicUses(llvm::Function &F);
+  bool runLowerMemmove(llvm::Module &M);
 
 private:
-  LLVMContext *Context;
+  llvm::LLVMContext *Context;
 };
 
 class SPIRVLowerMemmovePass : public llvm::PassInfoMixin<SPIRVLowerMemmovePass>,
@@ -67,11 +65,11 @@ public:
                               llvm::ModuleAnalysisManager &MAM);
 };
 
-class SPIRVLowerMemmoveLegacy : public ModulePass,
+class SPIRVLowerMemmoveLegacy : public llvm::ModulePass,
                                 public SPIRVLowerMemmoveBase {
 public:
   SPIRVLowerMemmoveLegacy();
-  bool runOnModule(Module &M) override;
+  bool runOnModule(llvm::Module &M) override;
 
   static char ID;
 };

--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.h
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.h
@@ -39,22 +39,20 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 
-using namespace llvm;
-
 namespace SPIRV {
 
 class SPIRVLowerSaddWithOverflowBase
-    : public InstVisitor<SPIRVLowerSaddWithOverflowBase> {
+    : public llvm::InstVisitor<SPIRVLowerSaddWithOverflowBase> {
 public:
   SPIRVLowerSaddWithOverflowBase() : Context(nullptr) {}
   virtual ~SPIRVLowerSaddWithOverflowBase() {}
-  virtual void visitIntrinsicInst(CallInst &I);
+  virtual void visitIntrinsicInst(llvm::CallInst &I);
 
-  bool runLowerSaddWithOverflow(Module &M);
+  bool runLowerSaddWithOverflow(llvm::Module &M);
 
 private:
-  LLVMContext *Context;
-  Module *Mod;
+  llvm::LLVMContext *Context;
+  llvm::Module *Mod;
   bool TheModuleIsModified = false;
 };
 
@@ -66,12 +64,12 @@ public:
                               llvm::ModuleAnalysisManager &MAM);
 };
 
-class SPIRVLowerSaddWithOverflowLegacy : public ModulePass,
+class SPIRVLowerSaddWithOverflowLegacy : public llvm::ModulePass,
                                          public SPIRVLowerSaddWithOverflowBase {
 public:
   SPIRVLowerSaddWithOverflowLegacy();
 
-  bool runOnModule(Module &M) override;
+  bool runOnModule(llvm::Module &M) override;
 
   static char ID;
 };

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -41,28 +41,26 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 
-using namespace llvm;
-
 namespace SPIRV {
 
 class SPIRVRegularizeLLVMBase {
 public:
   SPIRVRegularizeLLVMBase() : M(nullptr), Ctx(nullptr) {}
 
-  bool runRegularizeLLVM(Module &M);
+  bool runRegularizeLLVM(llvm::Module &M);
   // Lower functions
   bool regularize();
 
   // SPIR-V disallows functions being entrypoints and called
   // LLVM doesn't. This adds a wrapper around the entry point
   // that later SPIR-V writer renames.
-  void addKernelEntryPoint(Module *M);
+  void addKernelEntryPoint(llvm::Module *M);
 
   /// Some LLVM intrinsics that have no SPIR-V counterpart may be wrapped in
   /// @spirv.llvm_intrinsic_* function. During reverse translation from SPIR-V
   /// to LLVM IR we can detect this @spirv.llvm_intrinsic_* function and
   /// replace it with @llvm.intrinsic.* back.
-  void lowerIntrinsicToFunction(IntrinsicInst *Intrinsic);
+  void lowerIntrinsicToFunction(llvm::IntrinsicInst *Intrinsic);
 
   /// No SPIR-V counterpart for @llvm.fshl.*(@llvm.fshr.*) intrinsic. It will be
   /// lowered to a newly generated @spirv.llvm_fshl_*(@spirv.llvm_fshr_*)
@@ -79,10 +77,10 @@ public:
   ///
   /// The actual implementation algorithm will be slightly different for
   /// simplification purposes.
-  void lowerFunnelShift(IntrinsicInst *FSHIntrinsic);
+  void lowerFunnelShift(llvm::IntrinsicInst *FSHIntrinsic);
 
-  void lowerUMulWithOverflow(IntrinsicInst *UMulIntrinsic);
-  void buildUMulWithOverflowFunc(Function *UMulFunc);
+  void lowerUMulWithOverflow(llvm::IntrinsicInst *UMulIntrinsic);
+  void buildUMulWithOverflowFunc(llvm::Function *UMulFunc);
 
   // For some cases Clang emits VectorExtractDynamic as:
   // void @_Z28__spirv_VectorExtractDynamic(<Ty>* sret(<Ty>), jointMatrix, idx);
@@ -94,9 +92,9 @@ public:
   // @_Z27__spirv_VectorInsertDynamic(jointMatrix, <Ty>, idx)
   // Need to add additional GEP, store and load instructions and mutate called
   // function to avoid translation failures
-  void expandSYCLTypeUsing(Module *M);
-  void expandVEDWithSYCLTypeSRetArg(Function *F);
-  void expandVIDWithSYCLTypeByValComp(Function *F);
+  void expandSYCLTypeUsing(llvm::Module *M);
+  void expandVEDWithSYCLTypeSRetArg(llvm::Function *F);
+  void expandVIDWithSYCLTypeByValComp(llvm::Function *F);
 
   // According to the specification, the operands of a shift instruction must be
   // a scalar/vector of integer. When LLVM-IR contains a shift instruction with
@@ -104,15 +102,15 @@ public:
   // comply with the specification. For example: "%shift = lshr i1 0, 1";
   // The bit instruction should be changed to the extended version
   // "%shift = lshr i32 0, 1" so the args are treated as int operands.
-  Value *extendBitInstBoolArg(Instruction *OldInst);
+  Value *extendBitInstBoolArg(llvm::Instruction *OldInst);
 
-  static std::string lowerLLVMIntrinsicName(IntrinsicInst *II);
-  void adaptStructTypes(StructType *ST);
+  static std::string lowerLLVMIntrinsicName(llvm::IntrinsicInst *II);
+  void adaptStructTypes(llvm::StructType *ST);
   static char ID;
 
 private:
-  Module *M;
-  LLVMContext *Ctx;
+  llvm::Module *M;
+  llvm::LLVMContext *Ctx;
 };
 
 class SPIRVRegularizeLLVMPass
@@ -126,14 +124,14 @@ public:
   }
 };
 
-class SPIRVRegularizeLLVMLegacy : public ModulePass,
+class SPIRVRegularizeLLVMLegacy : public llvm::ModulePass,
                                   public SPIRVRegularizeLLVMBase {
 public:
   SPIRVRegularizeLLVMLegacy() : ModulePass(ID) {
     initializeSPIRVRegularizeLLVMLegacyPass(*PassRegistry::getPassRegistry());
   }
 
-  bool runOnModule(Module &M) override;
+  bool runOnModule(llvm::Module &M) override;
 
   static char ID;
 };


### PR DESCRIPTION
Avoid namespace pollution for any files that include these headers.  This is a followup from #1483.