### PR TITLE
Prepare SPIRVWriter for type conversion without opaque pointers.

### DIFF
--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -70,8 +70,8 @@ bool OCLTypeToSPIRVLegacy::runOnModule(Module &M) {
   return runOCLTypeToSPIRV(M);
 }
 
-OCLTypeToSPIRVBase OCLTypeToSPIRVPass::run(llvm::Module &M,
-                                           llvm::ModuleAnalysisManager &MAM) {
+OCLTypeToSPIRVBase &OCLTypeToSPIRVPass::run(llvm::Module &M,
+                                            llvm::ModuleAnalysisManager &MAM) {
   runOCLTypeToSPIRV(M);
   return *this;
 }
@@ -104,45 +104,18 @@ bool OCLTypeToSPIRVBase::runOCLTypeToSPIRV(Module &Module) {
   return false;
 }
 
-void OCLTypeToSPIRVBase::addAdaptedType(Value *V, Type *T) {
+void OCLTypeToSPIRVBase::addAdaptedType(Value *V, Type *Ty,
+                                        unsigned AddrSpace) {
   LLVM_DEBUG(dbgs() << "[add adapted type] ";
              V->printAsOperand(dbgs(), true, M);
-             dbgs() << " => " << *T << '\n');
-  AdaptedTy[V] = T;
+             dbgs() << " => " << *Ty << '\n');
+  AdaptedTy[V] = {Ty, AddrSpace};
 }
 
 void OCLTypeToSPIRVBase::addWork(Function *F) {
   LLVM_DEBUG(dbgs() << "[add work] "; F->printAsOperand(dbgs(), true, M);
              dbgs() << '\n');
   WorkSet.insert(F);
-}
-
-/// Find index of \param V as argument of function call \param CI.
-static unsigned getArgIndex(CallInst *CI, Value *V) {
-  for (unsigned AI = 0, AE = CI->arg_size(); AI != AE; ++AI) {
-    if (CI->getArgOperand(AI) == V)
-      return AI;
-  }
-  llvm_unreachable("Not argument of function call");
-  return ~0U;
-}
-
-/// Find index of \param V as argument of function call \param CI.
-static unsigned getArgIndex(Function *F, Value *V) {
-  auto A = F->arg_begin(), E = F->arg_end();
-  for (unsigned I = 0; A != E; ++I, ++A) {
-    if (&(*A) == V)
-      return I;
-  }
-  llvm_unreachable("Not argument of function");
-  return ~0U;
-}
-
-/// Get i-th argument of a function.
-static Argument *getArg(Function *F, unsigned I) {
-  auto AI = F->arg_begin();
-  std::advance(AI, I);
-  return &(*AI);
 }
 
 /// Create a new function type if \param F has arguments in AdaptedTy, and
@@ -158,15 +131,17 @@ void OCLTypeToSPIRVBase::adaptFunction(Function *F) {
     auto Loc = AdaptedTy.find(&I);
     auto Found = (Loc != AdaptedTy.end());
     Changed |= Found;
-    ArgTys.push_back(Found ? Loc->second : I.getType());
+    ArgTys.push_back(Found ? Loc->second.first : I.getType());
 
     if (Found) {
-      for (auto U : I.users()) {
-        if (auto CI = dyn_cast<CallInst>(U)) {
-          auto ArgIndex = getArgIndex(CI, &I);
+      auto *Ty = Loc->second.first;
+      unsigned AddrSpace = Loc->second.second;
+      for (auto &U : I.uses()) {
+        if (auto *CI = dyn_cast<CallInst>(U.getUser())) {
+          auto ArgIndex = CI->getArgOperandNo(&U);
           auto CF = CI->getCalledFunction();
           if (AdaptedTy.count(CF) == 0) {
-            addAdaptedType(getArg(CF, ArgIndex), Loc->second);
+            addAdaptedType(CF->getArg(ArgIndex), Ty, AddrSpace);
             addWork(CF);
           }
         }
@@ -179,7 +154,7 @@ void OCLTypeToSPIRVBase::adaptFunction(Function *F) {
 
   auto FT = F->getFunctionType();
   FT = FunctionType::get(FT->getReturnType(), ArgTys, FT->isVarArg());
-  addAdaptedType(F, FT);
+  addAdaptedType(F, FT, 0);
 }
 
 // Handle functions with sampler arguments that don't get called by
@@ -204,15 +179,10 @@ void OCLTypeToSPIRVBase::adaptArgumentsBySamplerUse(Module &M) {
           AdaptedTy.count(SamplerArg) != 0) // Already traced this, move on.
         continue;
 
-      if (SamplerArg->getType()->isPointerTy() &&
-          isSPIRVStructType(SamplerArg->getType()->getPointerElementType(),
-                            kSPIRVTypeName::Sampler))
-        return;
-
-      addAdaptedType(SamplerArg, getSamplerType(&M));
+      addAdaptedType(SamplerArg, getSamplerStructType(&M), SPIRAS_Constant);
       auto Caller = cast<Argument>(SamplerArg)->getParent();
       addWork(Caller);
-      TraceArg(Caller, getArgIndex(Caller, SamplerArg));
+      TraceArg(Caller, Idx);
     }
   };
 
@@ -235,20 +205,28 @@ void OCLTypeToSPIRVBase::adaptFunctionArguments(Function *F) {
   if (TypeMD)
     return;
   bool Changed = false;
-  auto FT = F->getFunctionType();
-  auto PI = FT->param_begin();
   auto Arg = F->arg_begin();
-  for (unsigned I = 0; I < F->arg_size(); ++I, ++PI, ++Arg) {
-    auto NewTy = *PI;
-    if (isPointerToOpaqueStructType(NewTy)) {
-      auto STName = NewTy->getPointerElementType()->getStructName();
+  SmallVector<StructType *, 4> ParamTys;
+  getParameterTypes(F, ParamTys);
+
+  // If we couldn't get any information from demangling, there is nothing that
+  // can be done.
+  if (ParamTys.empty())
+    return;
+
+  for (unsigned I = 0; I < F->arg_size(); ++I, ++Arg) {
+    StructType *NewTy = ParamTys[I];
+    if (NewTy && NewTy->isOpaque()) {
+      auto STName = NewTy->getStructName();
       if (!hasAccessQualifiedName(STName))
         continue;
       if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
         auto Ty = STName.str();
         auto AccStr = getAccessQualifierFullName(Ty);
-        addAdaptedType(&*Arg, getOrCreateOpaquePtrType(
-                                  M, mapOCLTypeNameToSPIRV(Ty, AccStr)));
+        addAdaptedType(
+            &*Arg,
+            getOrCreateOpaqueStructType(M, mapOCLTypeNameToSPIRV(Ty, AccStr)),
+            SPIRAS_Global);
         Changed = true;
       }
     }
@@ -269,7 +247,7 @@ void OCLTypeToSPIRVBase::adaptArgumentsByMetadata(Function *F) {
   for (unsigned I = 0, E = TypeMD->getNumOperands(); I != E; ++I, ++Arg) {
     auto OCLTyStr = getMDOperandAsString(TypeMD, I);
     if (OCLTyStr == OCL_TYPE_NAME_SAMPLER_T) {
-      addAdaptedType(&(*Arg), getSamplerType(M));
+      addAdaptedType(&(*Arg), getSamplerStructType(M), SPIRAS_Constant);
       Changed = true;
     } else if (OCLTyStr.startswith("image") && OCLTyStr.endswith("_t")) {
       auto Ty = (Twine("opencl.") + OCLTyStr).str();
@@ -277,8 +255,10 @@ void OCLTypeToSPIRVBase::adaptArgumentsByMetadata(Function *F) {
         auto AccMD = F->getMetadata(SPIR_MD_KERNEL_ARG_ACCESS_QUAL);
         assert(AccMD && "Invalid access qualifier metadata");
         auto AccStr = getMDOperandAsString(AccMD, I);
-        addAdaptedType(&(*Arg), getOrCreateOpaquePtrType(
-                                    M, mapOCLTypeNameToSPIRV(Ty, AccStr)));
+        addAdaptedType(
+            &(*Arg),
+            getOrCreateOpaqueStructType(M, mapOCLTypeNameToSPIRV(Ty, AccStr)),
+            SPIRAS_Global);
         Changed = true;
       }
     }
@@ -315,14 +295,15 @@ void OCLTypeToSPIRVBase::adaptArgumentsByMetadata(Function *F) {
 // opencl data type x and access qualifier y, and use opencl.image_x.y to
 // represent image_x type with access qualifier y.
 //
-Type *OCLTypeToSPIRVBase::getAdaptedType(Value *V) {
-  auto Loc = AdaptedTy.find(V);
-  if (Loc != AdaptedTy.end())
-    return Loc->second;
-
-  if (auto F = dyn_cast<Function>(V))
-    return F->getFunctionType();
-  return V->getType();
+std::pair<Type *, Type *>
+OCLTypeToSPIRVBase::getAdaptedArgumentType(Function *F, unsigned ArgNo) {
+  Value *Arg = F->getArg(ArgNo);
+  auto Loc = AdaptedTy.find(Arg);
+  if (Loc == AdaptedTy.end())
+    return {nullptr, nullptr};
+  Type *PointeeTy = Loc->second.first;
+  Type *PointerTy = PointerType::get(PointeeTy, Loc->second.second);
+  return {PointerTy, PointeeTy};
 }
 
 } // namespace SPIRV

--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -46,6 +46,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/PassManager.h"
+#include "llvm/IR/ValueMap.h"
 #include "llvm/Pass.h"
 
 #include <map>
@@ -58,23 +59,26 @@ public:
   OCLTypeToSPIRVBase();
 
   bool runOCLTypeToSPIRV(llvm::Module &M);
-  /// \return Adapted type based on kernel argument metadata. If \p V is
-  ///   a function, returns function type.
-  /// E.g. for a function with argument of read only opencl.image_2d_t* type
-  /// returns a function with argument of type opencl.image2d_t.read_only*.
-  llvm::Type *getAdaptedType(llvm::Value *V);
+
+  /// Returns the adapted type of the corresponding argument for a function.
+  /// The first value of the returned pair is the LLVM type of the argument.
+  /// The second value of the returned pair is the pointer element type of the
+  /// argument, if the type is a pointer.
+  std::pair<llvm::Type *, llvm::Type *>
+  getAdaptedArgumentType(llvm::Function *F, unsigned ArgNo);
 
 private:
   llvm::Module *M;
   llvm::LLVMContext *Ctx;
-  std::map<llvm::Value *, llvm::Type *> AdaptedTy; // Adapted types for values
-  std::set<llvm::Function *> WorkSet;              // Functions to be adapted
+  // Map of argument/Function -> {pointee type, address space}
+  llvm::ValueMap<llvm::Value *, std::pair<llvm::Type *, unsigned>> AdaptedTy;
+  std::set<llvm::Function *> WorkSet; // Functions to be adapted
 
   void adaptFunctionArguments(llvm::Function *F);
   void adaptArgumentsByMetadata(llvm::Function *F);
   void adaptArgumentsBySamplerUse(llvm::Module &M);
   void adaptFunction(llvm::Function *F);
-  void addAdaptedType(llvm::Value *V, llvm::Type *T);
+  void addAdaptedType(llvm::Value *V, llvm::Type *PointeeTy, unsigned AS);
   void addWork(llvm::Function *F);
 };
 
@@ -92,7 +96,7 @@ class OCLTypeToSPIRVPass : public OCLTypeToSPIRVBase,
 public:
   using Result = OCLTypeToSPIRVBase;
   static llvm::AnalysisKey Key;
-  OCLTypeToSPIRVBase run(llvm::Module &F, llvm::ModuleAnalysisManager &MAM);
+  OCLTypeToSPIRVBase &run(llvm::Module &F, llvm::ModuleAnalysisManager &MAM);
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1326,47 +1326,30 @@ Instruction *mutateCallInstOCL(
                         TakeFuncName);
 }
 
-static std::pair<StringRef, StringRef>
-getSrcAndDstElememntTypeName(BitCastInst *BIC) {
-  if (!BIC)
-    return std::pair<StringRef, StringRef>("", "");
-
-  Type *SrcTy = BIC->getSrcTy();
-  Type *DstTy = BIC->getDestTy();
-  if (SrcTy->isPointerTy())
-    SrcTy = SrcTy->getPointerElementType();
-  if (DstTy->isPointerTy())
-    DstTy = DstTy->getPointerElementType();
-  auto SrcST = dyn_cast<StructType>(SrcTy);
-  auto DstST = dyn_cast<StructType>(DstTy);
-  if (!DstST || !DstST->hasName() || !SrcST || !SrcST->hasName())
-    return std::pair<StringRef, StringRef>("", "");
-
-  return std::make_pair(SrcST->getName(), DstST->getName());
+static StringRef getStructName(Type *Ty) {
+  if (auto *STy = dyn_cast<StructType>(Ty))
+    return STy->isLiteral() ? "" : Ty->getStructName();
+  return "";
 }
 
-bool isSamplerInitializer(Instruction *Inst) {
-  BitCastInst *BIC = dyn_cast<BitCastInst>(Inst);
-  auto Names = getSrcAndDstElememntTypeName(BIC);
-  if (Names.second == getSPIRVTypeName(kSPIRVTypeName::Sampler) &&
-      Names.first == getSPIRVTypeName(kSPIRVTypeName::ConstantSampler))
-    return true;
-
-  return false;
-}
-
-bool isPipeStorageInitializer(Instruction *Inst) {
-  BitCastInst *BIC = dyn_cast<BitCastInst>(Inst);
-  auto Names = getSrcAndDstElememntTypeName(BIC);
-  if (Names.second == getSPIRVTypeName(kSPIRVTypeName::PipeStorage) &&
-      Names.first == getSPIRVTypeName(kSPIRVTypeName::ConstantPipeStorage))
-    return true;
-
-  return false;
-}
-
-bool isSpecialTypeInitializer(Instruction *Inst) {
-  return isSamplerInitializer(Inst) || isPipeStorageInitializer(Inst);
+Value *unwrapSpecialTypeInitializer(Value *V) {
+  if (auto *BC = dyn_cast<BitCastOperator>(V)) {
+    Type *DestTy = BC->getDestTy();
+    Type *SrcTy = BC->getSrcTy();
+    if (SrcTy->isPointerTy() && !SrcTy->isOpaquePointerTy()) {
+      StringRef SrcName =
+          getStructName(SrcTy->getNonOpaquePointerElementType());
+      StringRef DestName =
+          getStructName(DestTy->getNonOpaquePointerElementType());
+      if (DestName == getSPIRVTypeName(kSPIRVTypeName::PipeStorage) &&
+          SrcName == getSPIRVTypeName(kSPIRVTypeName::ConstantPipeStorage))
+        return BC->getOperand(0);
+      if (DestName == getSPIRVTypeName(kSPIRVTypeName::Sampler) &&
+          SrcName == getSPIRVTypeName(kSPIRVTypeName::ConstantSampler))
+        return BC->getOperand(0);
+    }
+  }
+  return nullptr;
 }
 
 bool isSamplerStructTy(StructType *STy) {

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -495,15 +495,10 @@ Instruction *mutateCallInstOCL(
     std::function<Instruction *(CallInst *)> RetMutate,
     AttributeList *Attrs = nullptr, bool TakeFuncName = false);
 
-/// Check if instruction is bitcast from spirv.ConstantSampler to spirv.Sampler
-bool isSamplerInitializer(Instruction *Inst);
-
-/// Check if instruction is bitcast from spirv.ConstantPipeStorage
-/// to spirv.PipeStorage
-bool isPipeStorageInitializer(Instruction *Inst);
-
-/// Check (isSamplerInitializer || isPipeStorageInitializer)
-bool isSpecialTypeInitializer(Instruction *Inst);
+/// If the value is a special type initializer (something that bitcasts from
+/// spirv.ConstantSampler to spirv.Sampler or likewise for PipeStorage), get the
+/// original type initializer, unwrap the bitcast. Otherwise, return nullptr.
+Value *unwrapSpecialTypeInitializer(Value *V);
 
 bool isPipeOrAddressSpaceCastBI(const StringRef MangledName);
 bool isEnqueueKernelBI(const StringRef MangledName);

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -610,7 +610,7 @@ PointerType *getOrCreateOpaquePtrType(Module *M, const std::string &Name,
                                       unsigned AddrSpace = SPIRAS_Global);
 StructType *getOrCreateOpaqueStructType(Module *M, StringRef Name);
 PointerType *getSamplerType(Module *M);
-PointerType *getPipeStorageType(Module *M);
+Type *getSamplerStructType(Module *M);
 PointerType *getSPIRVOpaquePtrType(Module *M, Op OC);
 void getFunctionTypeParameterTypes(llvm::FunctionType *FT,
                                    std::vector<Type *> &ArgTys);
@@ -648,8 +648,8 @@ Scope getArgAsScope(CallInst *CI, unsigned I);
 /// \param I argument index.
 Decoration getArgAsDecoration(CallInst *CI, unsigned I);
 
-bool isPointerToOpaqueStructType(llvm::Type *Ty);
-bool isPointerToOpaqueStructType(llvm::Type *Ty, const std::string &Name);
+/// Check if a type is SPIRV sampler type.
+bool isSPIRVSamplerType(llvm::Type *Ty);
 
 /// Check if a type is OCL image type (if pointed to).
 /// \return type name without "opencl." prefix.
@@ -712,9 +712,6 @@ bool oclIsBuiltin(StringRef Name, StringRef &DemangledName, bool IsCpp = false);
 
 /// Check if a function returns void
 bool isVoidFuncTy(FunctionType *FT);
-
-/// \returns true if \p T is a function pointer type.
-bool isFunctionPointerType(Type *T);
 
 /// \returns true if function \p F has array type argument.
 bool hasArrayArg(Function *F);
@@ -922,6 +919,12 @@ bool isSPIRVConstantName(StringRef TyName);
 /// to spirv.NewName.Postfixes.
 Type *getSPIRVTypeByChangeBaseTypeName(Module *M, Type *T, StringRef OldName,
                                        StringRef NewName);
+
+/// Get SPIR-V type by changing the type name from spirv.OldName.Postfixes
+/// to spirv.NewName.Postfixes.
+Type *getSPIRVStructTypeByChangeBaseTypeName(Module *M, Type *T,
+                                             StringRef OldName,
+                                             StringRef NewName);
 
 /// Get the postfixes of SPIR-V image type name as in spirv.Image.postfixes.
 std::string getSPIRVImageTypePostfixes(StringRef SampledType,

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -222,9 +222,9 @@ PointerType *getSamplerType(Module *M) {
                                   SPIRAS_Constant);
 }
 
-PointerType *getPipeStorageType(Module *M) {
-  return getOrCreateOpaquePtrType(
-      M, getSPIRVTypeName(kSPIRVTypeName::PipeStorage), SPIRAS_Constant);
+Type *getSamplerStructType(Module *M) {
+  return getOrCreateOpaqueStructType(M,
+                                     getSPIRVTypeName(kSPIRVTypeName::Sampler));
 }
 
 PointerType *getSPIRVOpaquePtrType(Module *M, Op OC) {
@@ -240,22 +240,6 @@ void getFunctionTypeParameterTypes(llvm::FunctionType *FT,
 }
 
 bool isVoidFuncTy(FunctionType *FT) { return FT->getReturnType()->isVoidTy(); }
-
-bool isPointerToOpaqueStructType(llvm::Type *Ty) {
-  if (auto PT = dyn_cast<PointerType>(Ty))
-    if (auto *ST = dyn_cast<StructType>(PT->getPointerElementType()))
-      if (ST->isOpaque())
-        return true;
-  return false;
-}
-
-bool isPointerToOpaqueStructType(llvm::Type *Ty, const std::string &Name) {
-  if (auto PT = dyn_cast<PointerType>(Ty))
-    if (auto *ST = dyn_cast<StructType>(PT->getPointerElementType()))
-      if (ST->isOpaque() && ST->getName() == Name)
-        return true;
-  return false;
-}
 
 bool isOCLImageStructType(llvm::Type *Ty, StringRef *Name) {
   if (auto *ST = dyn_cast_or_null<StructType>(Ty))
@@ -624,13 +608,6 @@ bool containsUnsignedAtomicType(StringRef Name) {
     return false;
   return isMangledTypeUnsigned(
       Name[Loc + strlen(kMangledName::AtomicPrefixIncoming)]);
-}
-
-bool isFunctionPointerType(Type *T) {
-  if (isa<PointerType>(T) && isa<FunctionType>(T->getPointerElementType())) {
-    return true;
-  }
-  return false;
 }
 
 Constant *castToVoidFuncPtr(Function *F) {
@@ -1408,9 +1385,17 @@ bool isSPIRVConstantName(StringRef TyName) {
 
 Type *getSPIRVTypeByChangeBaseTypeName(Module *M, Type *T, StringRef OldName,
                                        StringRef NewName) {
+  return PointerType::get(
+      getSPIRVStructTypeByChangeBaseTypeName(M, T, OldName, NewName),
+      SPIRAS_Global);
+}
+
+Type *getSPIRVStructTypeByChangeBaseTypeName(Module *M, Type *T,
+                                             StringRef OldName,
+                                             StringRef NewName) {
   StringRef Postfixes;
   if (isSPIRVStructType(T, OldName, &Postfixes))
-    return getOrCreateOpaquePtrType(M, getSPIRVTypeName(NewName, Postfixes));
+    return getOrCreateOpaqueStructType(M, getSPIRVTypeName(NewName, Postfixes));
   LLVM_DEBUG(dbgs() << " Invalid SPIR-V type " << *T << '\n');
   llvm_unreachable("Invalid SPIR-V type");
   return nullptr;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -324,107 +324,8 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
   // (non-pointer) image or pipe type.
   if (T->isPointerTy()) {
     auto ET = T->getPointerElementType();
-    if (ET->isFunctionTy() &&
-        !BM->checkExtension(ExtensionID::SPV_INTEL_function_pointers,
-                            SPIRVEC_FunctionPointers, toString(T)))
-      return nullptr;
-    auto ST = dyn_cast<StructType>(ET);
     auto AddrSpc = T->getPointerAddressSpace();
-    // Lower global_device and global_host address spaces that were added in
-    // SYCL as part of SYCL_INTEL_usm_address_spaces extension to just global
-    // address space if device doesn't support SPV_INTEL_usm_storage_classes
-    // extension
-    if (!BM->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_usm_storage_classes) &&
-        ((AddrSpc == SPIRAS_GlobalDevice) || (AddrSpc == SPIRAS_GlobalHost))) {
-      auto *NewType = PointerType::getWithSamePointeeType(cast<PointerType>(T),
-                                                          SPIRAS_Global);
-      return mapType(T, transType(NewType));
-    }
-    if (ST && !ST->isSized()) {
-      Op OpCode;
-      StringRef STName = ST->getName();
-      // Workaround for non-conformant SPIR binary
-      if (STName == "struct._event_t") {
-        STName = kSPR2TypeName::Event;
-        ST->setName(STName);
-      }
-      if (STName.startswith(kSPR2TypeName::PipeRO) ||
-          STName.startswith(kSPR2TypeName::PipeWO)) {
-        auto PipeT = BM->addPipeType();
-        PipeT->setPipeAcessQualifier(STName.startswith(kSPR2TypeName::PipeRO)
-                                         ? AccessQualifierReadOnly
-                                         : AccessQualifierWriteOnly);
-        return mapType(T, PipeT);
-      }
-      if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
-        assert(AddrSpc == SPIRAS_Global);
-        auto *SPIRVImageTy =
-            PointerType::get(adaptSPIRVImageType(M, ST), SPIRAS_Global);
-        return mapType(T, transType(SPIRVImageTy));
-      }
-      if (STName == kSPR2TypeName::Sampler)
-        return mapType(T, transType(getSamplerType(M)));
-      if (STName.startswith(kSPIRVTypeName::PrefixAndDelim))
-        return transSPIRVOpaqueType(T);
-
-      if (STName.startswith(kOCLSubgroupsAVCIntel::TypePrefix))
-        return mapType(
-            T, BM->addSubgroupAvcINTELType(
-                   OCLSubgroupINTELTypeOpCodeMap::map(ST->getName().str())));
-
-      if (OCLOpaqueTypeOpCodeMap::find(STName.str(), &OpCode)) {
-        switch (OpCode) {
-        default:
-          return mapType(T, BM->addOpaqueGenericType(OpCode));
-        case OpTypeDeviceEvent:
-          return mapType(T, BM->addDeviceEventType());
-        case OpTypeQueue:
-          return mapType(T, BM->addQueueType());
-        }
-      }
-      if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute)) {
-        if (STName.startswith(kVCType::VCBufferSurface)) {
-          // VCBufferSurface always have Access Qualifier
-          auto Access = getAccessQualifier(STName);
-          return mapType(T, BM->addBufferSurfaceINTELType(Access));
-        }
-      }
-
-      if (ST->isOpaque()) {
-        return mapType(
-            T, BM->addPointerType(SPIRSPIRVAddrSpaceMap::map(
-                                      static_cast<SPIRAddressSpace>(AddrSpc)),
-                                  transType(ET)));
-      }
-    } else {
-      // JointMatrixINTEL type is not necessarily an opaque type, it can be
-      // represented as a structure with pointer to a multidimensional array
-      // member.
-      if (ST && ST->hasName()) {
-        StringRef STName = ST->getName();
-        if (STName.startswith(kSPIRVTypeName::PrefixAndDelim)) {
-          SmallVector<std::string, 8> Postfixes;
-          auto TN = decodeSPIRVTypeName(STName, Postfixes);
-          if (TN == kSPIRVTypeName::JointMatrixINTEL) {
-            return transSPIRVJointMatrixINTELType(T, Postfixes);
-          }
-        }
-      }
-      SPIRVType *ElementType = transType(ET);
-      // ET, as a recursive type, may contain exactly the same pointer T, so it
-      // may happen that after translation of ET we already have translated T,
-      // added the translated pointer to the SPIR-V module and mapped T to this
-      // pointer. Now we have to check TypeMap again.
-      LLVMToSPIRVTypeMap::iterator Loc = TypeMap.find(T);
-      if (Loc != TypeMap.end()) {
-        return Loc->second;
-      }
-      return mapType(
-          T, BM->addPointerType(SPIRSPIRVAddrSpaceMap::map(
-                                    static_cast<SPIRAddressSpace>(AddrSpc)),
-                                ElementType));
-    }
+    return transPointerType(ET, AddrSpc);
   }
 
   if (auto *VecTy = dyn_cast<FixedVectorType>(T))
@@ -465,9 +366,11 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
       Name = ST->getName();
 
     if (Name == getSPIRVTypeName(kSPIRVTypeName::ConstantSampler))
-      return transType(getSamplerType(M));
+      return transSPIRVOpaqueType(getSPIRVTypeName(kSPIRVTypeName::Sampler),
+                                  SPIRAS_Constant);
     if (Name == getSPIRVTypeName(kSPIRVTypeName::ConstantPipeStorage))
-      return transType(getPipeStorageType(M));
+      return transSPIRVOpaqueType(getSPIRVTypeName(kSPIRVTypeName::PipeStorage),
+                                  SPIRAS_Constant);
 
     constexpr size_t MaxNumElements = MaxWordCount - SPIRVTypeStruct::FixedWC;
     const size_t NumElements = ST->getNumElements();
@@ -528,11 +431,136 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
                                       E = FT->param_end();
          I != E; ++I)
       PT.push_back(transType(*I));
-    return mapType(T, BM->addFunctionType(RT, PT));
+    return mapType(T, getSPIRVFunctionType(RT, PT));
   }
 
   llvm_unreachable("Not implemented!");
   return 0;
+}
+
+SPIRVType *LLVMToSPIRVBase::transPointerType(Type *ET, unsigned AddrSpc) {
+  Type *T = PointerType::get(ET, AddrSpc);
+  if (ET->isFunctionTy() &&
+      !BM->checkExtension(ExtensionID::SPV_INTEL_function_pointers,
+                          SPIRVEC_FunctionPointers, toString(T)))
+    return nullptr;
+
+  std::string TypeKey = (Twine((uintptr_t)ET) + Twine(AddrSpc)).str();
+  auto Loc = PointeeTypeMap.find(TypeKey);
+  if (Loc != PointeeTypeMap.end())
+    return Loc->second;
+
+  // A pointer to image or pipe type in LLVM is translated to a SPIRV
+  // (non-pointer) image or pipe type.
+  auto *ST = dyn_cast<StructType>(ET);
+  // Lower global_device and global_host address spaces that were added in
+  // SYCL as part of SYCL_INTEL_usm_address_spaces extension to just global
+  // address space if device doesn't support SPV_INTEL_usm_storage_classes
+  // extension
+  if (!BM->isAllowedToUseExtension(
+          ExtensionID::SPV_INTEL_usm_storage_classes) &&
+      ((AddrSpc == SPIRAS_GlobalDevice) || (AddrSpc == SPIRAS_GlobalHost))) {
+    return transPointerType(ET, SPIRAS_Global);
+  }
+  if (ST && !ST->isSized()) {
+    Op OpCode;
+    StringRef STName = ST->getName();
+    // Workaround for non-conformant SPIR binary
+    if (STName == "struct._event_t") {
+      STName = kSPR2TypeName::Event;
+      ST->setName(STName);
+    }
+
+    std::pair<StringRef, unsigned> Key = {STName, AddrSpc};
+    if (auto *MappedTy = OpaqueStructMap.lookup(Key))
+      return MappedTy;
+
+    auto SaveType = [&](SPIRVType *MappedTy) {
+      OpaqueStructMap[Key] = MappedTy;
+      PointeeTypeMap[TypeKey] = MappedTy;
+      return MappedTy;
+    };
+
+    if (STName.startswith(kSPR2TypeName::PipeRO) ||
+        STName.startswith(kSPR2TypeName::PipeWO)) {
+      auto *PipeT = BM->addPipeType();
+      PipeT->setPipeAcessQualifier(STName.startswith(kSPR2TypeName::PipeRO)
+                                       ? AccessQualifierReadOnly
+                                       : AccessQualifierWriteOnly);
+      return SaveType(PipeT);
+    }
+    if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
+      assert(AddrSpc == SPIRAS_Global);
+      Type *ImageTy = adaptSPIRVImageType(M, ST);
+      return SaveType(transPointerType(ImageTy, SPIRAS_Global));
+    }
+    if (STName == kSPR2TypeName::Sampler)
+      return SaveType(transSPIRVOpaqueType(
+          getSPIRVTypeName(kSPIRVTypeName::Sampler), SPIRAS_Constant));
+    if (STName.startswith(kSPIRVTypeName::PrefixAndDelim))
+      return transSPIRVOpaqueType(STName, AddrSpc);
+
+    if (STName.startswith(kOCLSubgroupsAVCIntel::TypePrefix))
+      return SaveType(BM->addSubgroupAvcINTELType(
+          OCLSubgroupINTELTypeOpCodeMap::map(ST->getName().str())));
+
+    if (OCLOpaqueTypeOpCodeMap::find(STName.str(), &OpCode)) {
+      switch (OpCode) {
+      default:
+        return SaveType(BM->addOpaqueGenericType(OpCode));
+      case OpTypeDeviceEvent:
+        return SaveType(BM->addDeviceEventType());
+      case OpTypeQueue:
+        return SaveType(BM->addQueueType());
+      }
+    }
+    if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute)) {
+      if (STName.startswith(kVCType::VCBufferSurface)) {
+        // VCBufferSurface always have Access Qualifier
+        auto Access = getAccessQualifier(STName);
+        return SaveType(BM->addBufferSurfaceINTELType(Access));
+      }
+    }
+
+    if (ST->isOpaque()) {
+      return SaveType(BM->addPointerType(
+          SPIRSPIRVAddrSpaceMap::map(static_cast<SPIRAddressSpace>(AddrSpc)),
+          transType(ET)));
+    }
+  } else {
+    // JointMatrixINTEL type is not necessarily an opaque type, it can be
+    // represented as a structure with pointer to a multidimensional array
+    // member.
+    if (ST && ST->hasName()) {
+      StringRef STName = ST->getName();
+      if (STName.startswith(kSPIRVTypeName::PrefixAndDelim)) {
+        SmallVector<std::string, 8> Postfixes;
+        auto TN = decodeSPIRVTypeName(STName, Postfixes);
+        if (TN == kSPIRVTypeName::JointMatrixINTEL) {
+          SPIRVType *TranslatedTy = transSPIRVJointMatrixINTELType(Postfixes);
+          PointeeTypeMap[TypeKey] = TranslatedTy;
+          return TranslatedTy;
+        }
+      }
+    }
+    SPIRVType *ElementType = transType(ET);
+    // ET, as a recursive type, may contain exactly the same pointer T, so it
+    // may happen that after translation of ET we already have translated T,
+    // added the translated pointer to the SPIR-V module and mapped T to this
+    // pointer. Now we have to check PointeeTypeMap again.
+    auto Loc = PointeeTypeMap.find(TypeKey);
+    if (Loc != PointeeTypeMap.end()) {
+      return Loc->second;
+    }
+    SPIRVType *TranslatedTy = BM->addPointerType(
+        SPIRSPIRVAddrSpaceMap::map(static_cast<SPIRAddressSpace>(AddrSpc)),
+        ElementType);
+    PointeeTypeMap[TypeKey] = TranslatedTy;
+    return TranslatedTy;
+  }
+
+  llvm_unreachable("Not implemented!");
+  return nullptr;
 }
 
 // Representation in LLVM IR before the translator is a pointer array wrapped
@@ -552,7 +580,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
 // of OpCompositeConstruct instruction is always the joint matrix type, it's
 // simply not true.
 SPIRVType *LLVMToSPIRVBase::transSPIRVJointMatrixINTELType(
-    Type *T, SmallVector<std::string, 8> Postfixes) {
+    SmallVector<std::string, 8> Postfixes) {
   Type *ElemTy = nullptr;
   StringRef Ty{Postfixes[0]};
   auto NumBits = llvm::StringSwitch<unsigned>(Ty)
@@ -582,26 +610,34 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVJointMatrixINTELType(
   std::vector<SPIRVValue *> Args;
   for (size_t I = 1; I != Postfixes.size(); ++I)
     Args.emplace_back(transConstant(ParseInteger(Postfixes[I])));
-  return mapType(T, BM->addJointMatrixINTELType(transType(ElemTy), Args));
+  return BM->addJointMatrixINTELType(transType(ElemTy), Args);
 }
 
-SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(Type *T) {
-  auto ET = T->getPointerElementType();
-  auto ST = cast<StructType>(ET);
-  auto STName = ST->getStructName();
+SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(StringRef STName,
+                                                 unsigned AddrSpace) {
+  std::pair<StringRef, unsigned> Key = {STName, AddrSpace};
+  if (auto *MappedTy = OpaqueStructMap.lookup(Key))
+    return MappedTy;
+
+  auto SaveType = [&](SPIRVType *MappedTy) {
+    OpaqueStructMap[Key] = MappedTy;
+    return MappedTy;
+  };
+  StructType *ST = StructType::getTypeByName(M->getContext(), STName);
+
   assert(STName.startswith(kSPIRVTypeName::PrefixAndDelim) &&
          "Invalid SPIR-V opaque type name");
   SmallVector<std::string, 8> Postfixes;
   auto TN = decodeSPIRVTypeName(STName, Postfixes);
   if (TN == kSPIRVTypeName::Pipe) {
-    assert(T->getPointerAddressSpace() == SPIRAS_Global);
+    assert(AddrSpace == SPIRAS_Global);
     assert(Postfixes.size() == 1 && "Invalid pipe type ops");
     auto PipeT = BM->addPipeType();
     PipeT->setPipeAcessQualifier(
         static_cast<spv::AccessQualifier>(atoi(Postfixes[0].c_str())));
-    return mapType(T, PipeT);
+    return SaveType(PipeT);
   } else if (TN == kSPIRVTypeName::Image) {
-    assert(T->getPointerAddressSpace() == SPIRAS_Global);
+    assert(AddrSpace == SPIRAS_Global);
     // The sampled type needs to be translated through LLVM type to guarantee
     // uniqueness.
     auto SampledT = transType(
@@ -611,35 +647,88 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(Type *T) {
       Ops.push_back(atoi(Postfixes[I].c_str()));
     SPIRVTypeImageDescriptor Desc(static_cast<SPIRVImageDimKind>(Ops[0]),
                                   Ops[1], Ops[2], Ops[3], Ops[4], Ops[5]);
-    return mapType(T,
-                   BM->addImageType(SampledT, Desc,
-                                    static_cast<spv::AccessQualifier>(Ops[6])));
+    return SaveType(BM->addImageType(
+        SampledT, Desc, static_cast<spv::AccessQualifier>(Ops[6])));
   } else if (TN == kSPIRVTypeName::SampledImg) {
-    return mapType(
-        T,
-        BM->addSampledImageType(static_cast<SPIRVTypeImage *>(
-            transType(getSPIRVTypeByChangeBaseTypeName(
-                M, ST, kSPIRVTypeName::SampledImg, kSPIRVTypeName::Image)))));
+    return SaveType(
+        BM->addSampledImageType(static_cast<SPIRVTypeImage *>(transPointerType(
+            getSPIRVStructTypeByChangeBaseTypeName(
+                M, ST, kSPIRVTypeName::SampledImg, kSPIRVTypeName::Image),
+            SPIRAS_Global))));
   } else if (TN == kSPIRVTypeName::VmeImageINTEL) {
     // This type is the same as SampledImageType, but consumed by Subgroup AVC
     // Intel extension instructions.
-    return mapType(T, BM->addVmeImageINTELType(static_cast<SPIRVTypeImage *>(
-                          transType(getSPIRVTypeByChangeBaseTypeName(
-                              M, ST, kSPIRVTypeName::VmeImageINTEL,
-                              kSPIRVTypeName::Image)))));
+    return SaveType(
+        BM->addVmeImageINTELType(static_cast<SPIRVTypeImage *>(transPointerType(
+            getSPIRVStructTypeByChangeBaseTypeName(
+                M, ST, kSPIRVTypeName::VmeImageINTEL, kSPIRVTypeName::Image),
+            SPIRAS_Global))));
   } else if (TN == kSPIRVTypeName::Sampler)
-    return mapType(T, BM->addSamplerType());
+    return SaveType(BM->addSamplerType());
   else if (TN == kSPIRVTypeName::DeviceEvent)
-    return mapType(T, BM->addDeviceEventType());
+    return SaveType(BM->addDeviceEventType());
   else if (TN == kSPIRVTypeName::Queue)
-    return mapType(T, BM->addQueueType());
+    return SaveType(BM->addQueueType());
   else if (TN == kSPIRVTypeName::PipeStorage)
-    return mapType(T, BM->addPipeStorageType());
+    return SaveType(BM->addPipeStorageType());
   else if (TN == kSPIRVTypeName::JointMatrixINTEL) {
-    return transSPIRVJointMatrixINTELType(T, Postfixes);
+    return SaveType(transSPIRVJointMatrixINTELType(Postfixes));
   } else
-    return mapType(T,
-                   BM->addOpaqueGenericType(SPIRVOpaqueTypeOpCodeMap::map(TN)));
+    return SaveType(
+        BM->addOpaqueGenericType(SPIRVOpaqueTypeOpCodeMap::map(TN)));
+}
+
+SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
+  Type *Ty = V->getType();
+  if (!Ty->isPointerTy())
+    return transType(Ty);
+
+  if (auto *F = dyn_cast<Function>(V)) {
+    SPIRVType *RT = transType(F->getReturnType());
+    std::vector<SPIRVType *> PT;
+    for (Argument &Arg : F->args()) {
+      auto TypePair =
+          OCLTypeToSPIRVPtr->getAdaptedArgumentType(F, Arg.getArgNo());
+      Type *Ty = TypePair.first;
+      Type *PointeeTy = TypePair.second;
+      if (!Ty) {
+        Ty = Arg.getType();
+        if (Ty->isPointerTy())
+          PointeeTy = Ty->getNonOpaquePointerElementType();
+      }
+      SPIRVType *TransTy = nullptr;
+      if (Ty->isPointerTy())
+        TransTy = transPointerType(PointeeTy, Ty->getPointerAddressSpace());
+      else
+        TransTy = transType(Ty);
+      PT.push_back(TransTy);
+    }
+
+    return getSPIRVFunctionType(RT, PT);
+  }
+  return transPointerType(Ty->getNonOpaquePointerElementType(),
+                          Ty->getPointerAddressSpace());
+}
+
+SPIRVType *
+LLVMToSPIRVBase::getSPIRVFunctionType(SPIRVType *RT,
+                                      const std::vector<SPIRVType *> &Args) {
+  // Come up with a unique string identifier for the arguments. This is a hacky
+  // way of doing so, but it works.
+  std::string TypeKey;
+  llvm::raw_string_ostream TKS(TypeKey);
+  TKS << (uintptr_t)RT << ",";
+  for (SPIRVType *ArgTy : Args) {
+    TKS << (uintptr_t)ArgTy << ",";
+  }
+
+  // Create a SPIRVType for the function type. Since SPIRVModule doesn't do
+  // any type uniquing for SPIRVType, we have to do it ourself.
+  TKS.flush();
+  auto It = PointeeTypeMap.find(TypeKey);
+  if (It == PointeeTypeMap.end())
+    It = PointeeTypeMap.insert({TypeKey, BM->addFunctionType(RT, Args)}).first;
+  return It->second;
 }
 
 SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
@@ -655,8 +744,8 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
     return nullptr;
   }
 
-  SPIRVTypeFunction *BFT = static_cast<SPIRVTypeFunction *>(
-      transType(OCLTypeToSPIRVPtr->getAdaptedType(F)));
+  SPIRVTypeFunction *BFT =
+      static_cast<SPIRVTypeFunction *>(transScavengedType(F));
   SPIRVFunction *BF =
       static_cast<SPIRVFunction *>(mapValue(F, BM->addFunction(BFT)));
   BF->setFunctionControlMask(transFunctionControlMask(F));
@@ -1488,12 +1577,12 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                             SPIRVEC_FunctionPointers, toString(V)))
       return nullptr;
     return BM->addConstantFunctionPointerINTEL(
-        transType(F->getType()),
+        transPointerType(F->getFunctionType(), F->getAddressSpace()),
         static_cast<SPIRVFunction *>(transValue(F, nullptr)));
   }
 
   if (auto GV = dyn_cast<GlobalVariable>(V)) {
-    llvm::PointerType *Ty = GV->getType();
+    llvm::Type *Ty = GV->getValueType();
     // Though variables with common linkage type are initialized by 0,
     // they can be represented in SPIR-V as uninitialized variables with
     // 'Export' linkage type, just as tentative definitions look in C
@@ -1507,13 +1596,11 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       assert(BV);
       return mapValue(V, BV);
     } else if (ConstantExpr *ConstUE = dyn_cast_or_null<ConstantExpr>(Init)) {
-      Instruction *Inst = ConstUE->getAsInstruction();
-      if (isSpecialTypeInitializer(Inst)) {
-        Init = Inst->getOperand(0);
-        Ty = static_cast<PointerType *>(Init->getType());
+      Value *SpecialInit = unwrapSpecialTypeInitializer(ConstUE);
+      if (auto *SpecialGV = dyn_cast_or_null<GlobalValue>(SpecialInit)) {
+        Init = SpecialGV;
+        Ty = SpecialGV->getValueType();
       }
-      Inst->dropAllReferences();
-      UnboundInst.push_back(Inst);
       BVarInit = transValue(Init, nullptr);
     } else if (ST && isa<UndefValue>(Init)) {
       // Undef initializer for LLVM structure be can translated to
@@ -1552,7 +1639,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     }
 
     SPIRVStorageClassKind StorageClass;
-    auto AddressSpace = static_cast<SPIRAddressSpace>(Ty->getAddressSpace());
+    auto AddressSpace = static_cast<SPIRAddressSpace>(GV->getAddressSpace());
     bool IsVectorCompute =
         BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute) &&
         GV->hasAttribute(kVCMetadata::VCGlobalVariable);
@@ -1572,8 +1659,9 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       StorageClass = SPIRSPIRVAddrSpaceMap::map(AddressSpace);
     }
 
+    SPIRVType *TranslatedTy = transPointerType(Ty, GV->getAddressSpace());
     auto BVar = static_cast<SPIRVVariable *>(
-        BM->addVariable(transType(Ty), GV->isConstant(), transLinkageType(GV),
+        BM->addVariable(TranslatedTy, GV->isConstant(), transLinkageType(GV),
                         BVarInit, GV->getName().str(), StorageClass, nullptr));
 
     if (IsVectorCompute) {
@@ -1717,6 +1805,8 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
             BB));
 
   if (AllocaInst *Alc = dyn_cast<AllocaInst>(V)) {
+    SPIRVType *TranslatedTy =
+        transPointerType(Alc->getAllocatedType(), Alc->getAddressSpace());
     if (Alc->isArrayAllocation()) {
       if (!BM->checkExtension(ExtensionID::SPV_INTEL_variable_length_array,
                               SPIRVEC_InvalidInstruction,
@@ -1727,11 +1817,11 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
 
       SPIRVValue *Length = transValue(Alc->getArraySize(), BB);
       assert(Length && "Couldn't translate array size!");
-      return mapValue(V, BM->addInstTemplate(OpVariableLengthArrayINTEL,
-                                             {Length->getId()}, BB,
-                                             transType(Alc->getType())));
+      return mapValue(V,
+                      BM->addInstTemplate(OpVariableLengthArrayINTEL,
+                                          {Length->getId()}, BB, TranslatedTy));
     }
-    return mapValue(V, BM->addVariable(transType(Alc->getType()), false,
+    return mapValue(V, BM->addVariable(TranslatedTy, false,
                                        spv::internal::LinkageTypeInternal,
                                        nullptr, Alc->getName().str(),
                                        StorageClassFunction, BB));
@@ -1864,8 +1954,8 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
   }
 
   if (UnaryInstruction *U = dyn_cast<UnaryInstruction>(V)) {
-    if (isSpecialTypeInitializer(U))
-      return mapValue(V, transValue(U->getOperand(0), BB));
+    if (auto *Init = unwrapSpecialTypeInitializer(U))
+      return mapValue(V, transValue(Init, BB));
     auto UI = transUnaryInst(U, BB);
     return mapValue(V, UI ? UI : transValue(U->getOperand(0), BB));
   }
@@ -1908,9 +1998,11 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       }
     }
 
-    return mapValue(V, BM->addPtrAccessChainInst(transType(GEP->getType()),
-                                                 TransPointerOperand, Indices,
-                                                 BB, GEP->isInBounds()));
+    SPIRVType *TranslatedTy = transPointerType(
+        GEP->getResultElementType(), GEP->getType()->getPointerAddressSpace());
+    return mapValue(V,
+                    BM->addPtrAccessChainInst(TranslatedTy, TransPointerOperand,
+                                              Indices, BB, GEP->isInBounds()));
   }
 
   if (auto Ext = dyn_cast<ExtractElementInst>(V)) {
@@ -2013,6 +2105,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
 }
 
 SPIRVType *LLVMToSPIRVBase::mapType(Type *T, SPIRVType *BT) {
+  assert(!T->isPointerTy() && "Pointer types cannot be stored in the type map");
   auto EmplaceStatus = TypeMap.try_emplace(T, BT);
   // TODO: Uncomment the assertion, once the type mapping issue is resolved
   // assert(EmplaceStatus.second && "The type was already added to the map");
@@ -2504,11 +2597,15 @@ SPIRVValue *LLVMToSPIRVBase::oclTransSpvcCastSampler(CallInst *CI,
   assert(FT->getParamType(0)->isIntegerTy() && "Invalid sampler type");
   auto Arg = CI->getArgOperand(0);
 
+  auto *TransRT =
+      transPointerType(getOrCreateOpaqueStructType(M, kSPR2TypeName::Sampler),
+                       RT->getPointerAddressSpace());
+
   auto GetSamplerConstant = [&](uint64_t SamplerValue) {
     auto AddrMode = (SamplerValue & 0xE) >> 1;
     auto Param = SamplerValue & 0x1;
     auto Filter = SamplerValue ? ((SamplerValue & 0x30) >> 4) - 1 : 0;
-    auto BV = BM->addSamplerConstant(transType(RT), AddrMode, Param, Filter);
+    auto *BV = BM->addSamplerConstant(TransRT, AddrMode, Param, Filter);
     return BV;
   };
 
@@ -2529,7 +2626,7 @@ SPIRVValue *LLVMToSPIRVBase::oclTransSpvcCastSampler(CallInst *CI,
   }
   // Sampler is a function argument
   auto BV = transValue(Arg, BB);
-  assert(BV && BV->getType() == transType(RT));
+  assert(BV && BV->getType() == TransRT);
   return BV;
 }
 
@@ -3475,12 +3572,12 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       std::vector<SPIRVValue *> Elts(TNumElts, transValue(Val, BB));
       Init = BM->addCompositeConstant(CompositeTy, Elts);
     }
-    SPIRVType *VarTy = transType(PointerType::get(AT, SPIRV::SPIRAS_Constant));
+    SPIRVType *VarTy = transPointerType(AT, SPIRV::SPIRAS_Constant);
     SPIRVValue *Var = BM->addVariable(VarTy, /*isConstant*/ true,
                                       spv::internal::LinkageTypeInternal, Init,
                                       "", StorageClassUniformConstant, nullptr);
     SPIRVType *SourceTy =
-        transType(PointerType::get(Val->getType(), SPIRV::SPIRAS_Constant));
+        transPointerType(Val->getType(), SPIRV::SPIRAS_Constant);
     SPIRVValue *Source = BM->addUnaryInst(OpBitcast, SourceTy, Var, BB);
     SPIRVValue *Target = transValue(MSI->getRawDest(), BB);
     return BM->addCopyMemorySizedInst(Target, Source, CompositeTy->getLength(),
@@ -3632,7 +3729,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
   case Intrinsic::stacksave: {
     if (BM->isAllowedToUseExtension(
             ExtensionID::SPV_INTEL_variable_length_array)) {
-      auto *Ty = transType(II->getType());
+      auto *Ty = transPointerType(Type::getInt8Ty(M->getContext()), 0);
       return BM->addInstTemplate(OpSaveMemoryINTEL, BB, Ty);
     }
     BM->getErrorLog().checkError(
@@ -4643,12 +4740,12 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     SmallVector<StructType *, 4> ParamTys;
     getParameterTypes(CI, ParamTys);
     Type *ImageTy = adaptSPIRVImageType(M, ParamTys[0]);
-    Type *SampledImgTy = getSPIRVTypeByChangeBaseTypeName(
+    Type *SampledImgTy = getSPIRVStructTypeByChangeBaseTypeName(
         M, ImageTy, kSPIRVTypeName::Image, kSPIRVTypeName::SampledImg);
     Value *Sampler = CI->getArgOperand(1);
-    return BM->addSampledImageInst(transType(SampledImgTy),
-                                   transValue(Image, BB),
-                                   transValue(Sampler, BB), BB);
+    return BM->addSampledImageInst(
+        transPointerType(SampledImgTy, SPIRAS_Global), transValue(Image, BB),
+        transValue(Sampler, BB), BB);
   }
   case OpFixedSqrtINTEL:
   case OpFixedRecipINTEL:
@@ -4961,9 +5058,12 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       auto *SPI = SPIRVInstTemplateBase::create(OC);
       std::vector<SPIRVWord> SPArgs;
       for (size_t I = 0, E = Args.size(); I != E; ++I) {
-        assert((!isFunctionPointerType(Args[I]->getType()) ||
-                isa<Function>(Args[I])) &&
-               "Invalid function pointer argument");
+        if (Args[I]->getType()->isPointerTy()) {
+          Value *Pointee = Args[I]->stripPointerCasts();
+          (void)Pointee;
+          assert((Pointee == Args[I] || !isa<Function>(Pointee)) &&
+                 "Illegal use of a function pointer type");
+        }
         SPArgs.push_back(SPI->isOperandLiteral(I)
                              ? cast<ConstantInt>(Args[I])->getZExtValue()
                              : transValue(Args[I], BB)->getId());

--- a/test/lshr-constexpr.ll
+++ b/test/lshr-constexpr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as -opaque-pointers=1 %s -o %t.bc
+; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/lshr-constexpr.ll
+++ b/test/lshr-constexpr.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=1 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM


### PR DESCRIPTION
This changeset is, by itself, not yet enough to get most SPIR-V files to be
emitted when the input module is in opaque pointer mode. However, this does
remove all of the calls to `getPointerElementType` that SPIRVWriter makes
(directly or indirectly), except for the ones that directly correspond to
translating a pointer type.

A later changeset will add a type scavenger that will be used to find the
pointee type of a pointer. All calls to `getPointerElementType` that remain
after this one will be instead shifted to query the type scavenger instead. To
facilitate this change, several methods are added to avoid querying pointer
element types, and they have been added in several places where their need is
known.

The most basic of basic kernels, those that do not use pointer types (other than
declaring global values and functions) will work in opaque pointer mode with
this changeset.