### PR TITLE
[CMake] Enable LLVM_BUILD_TOOLS for out-of-tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ if (NOT DEFINED LLVM_SPIRV_BUILD_EXTERNAL)
   endif(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif (NOT DEFINED LLVM_SPIRV_BUILD_EXTERNAL)
 
+if(LLVM_SPIRV_BUILD_EXTERNAL)
+  # Make sure llvm-spirv gets built when building outside the llvm tree.
+  set(LLVM_BUILD_TOOLS ON)
+endif(LLVM_SPIRV_BUILD_EXTERNAL)
+
 # Download spirv.hpp from the official SPIRV-Headers repository.
 # One can skip this step by manually setting
 # LLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR path.


### PR DESCRIPTION
This ensures the llvm-spirv tool is added to the "all" target, so that
it is included when installing the project.