### PR TITLE
Fix build by reverting a ValueMap back to std::map

### DIFF
--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -46,7 +46,6 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/PassManager.h"
-#include "llvm/IR/ValueMap.h"
 #include "llvm/Pass.h"
 
 #include <map>
@@ -71,7 +70,7 @@ private:
   llvm::Module *M;
   llvm::LLVMContext *Ctx;
   // Map of argument/Function -> {pointee type, address space}
-  llvm::ValueMap<llvm::Value *, std::pair<llvm::Type *, unsigned>> AdaptedTy;
+  std::map<llvm::Value *, std::pair<llvm::Type *, unsigned>> AdaptedTy;
   std::set<llvm::Function *> WorkSet; // Functions to be adapted
 
   void adaptFunctionArguments(llvm::Function *F);


### PR DESCRIPTION
Commit 4a9c78ee ("Prepare SPIRVWriter for type conversion without
opaque pointers. (#1499)", 2022-06-20) changed
`OCLTypeToSPIRVBase::AdaptedTy` to a `ValueMap`, but that made
`OCLTypeToSPIRVBase` non-movable and non-copyable.  Landing eb8e9adc
("Migrate SPIRVWriter to new PassManager", 2022-06-20) on top caused a
build breakage as it requires `OCLTypeToSPIRVPass` to be copyable.

cc: @jcranmer-intel 