### PR TITLE
Fix 2 STL usage issues

### DIFF
--- a/test/transcoding/SPV_KHR_integer_dot_product-sat.ll
+++ b/test/transcoding/SPV_KHR_integer_dot_product-sat.ll
@@ -291,6 +291,6 @@ attributes #0 = { nounwind }
 !5 = !{i32 0, i32 0}
 !6 = !{!"none", !"none", !"none", !"none", !"none", !"none"}
 !7 = !{!"int", !"int", !"char", !"short", !"int", !"long"}
-!8 = !{!"", !"", !"", !"", !"", !"", !""}
+!8 = !{!"", !"", !"", !"", !"", !""}
 !9 = !{!"char4", !"char4", !"char", !"short", !"int", !"long"}
 !10 = !{!"short2", !"short2", !"char", !"short", !"int", !"long"}

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -484,7 +484,8 @@ static int parseSPVExtOption(
 
   for (unsigned i = 0; i < SPVExt.size(); ++i) {
     const std::string &ExtString = SPVExt[i];
-    if ('+' != ExtString.front() && '-' != ExtString.front()) {
+    if (ExtString.empty() ||
+        ('+' != ExtString.front() && '-' != ExtString.front())) {
       errs() << "Invalid value of --spirv-ext, expected format is:\n"
              << "\t--spirv-ext=+EXT_NAME,-EXT_NAME\n";
       return -1;


### PR DESCRIPTION
Fix two issues related to STL usage reported in https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1433

* Fix excess kernel_arg_type_qual entry in test
    The metadata had 7 entries whereas the function only has 6 parameters,
    causing foreachKernelArgMD to read past the end of an std::vector.

* Fix UB when validating spirv-ext option
    When passing `spirv-ext=,`, SPVExt will contain empty strings.
    Calling `front` on an empty string is undefined behavior, so first
    ensure that the string is not empty.