### PR TITLE
Use SPIR-V subarch version if present in triple

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5176,6 +5176,24 @@ bool isValidLLVMModule(Module *M, SPIRVErrorLog &ErrorLog) {
 
 namespace {
 
+VersionNumber getVersionFromTriple(const Triple &TT, SPIRVErrorLog &ErrorLog) {
+  switch (TT.getSubArch()) {
+  case Triple::SPIRVSubArch_v10:
+    return VersionNumber::SPIRV_1_0;
+  case Triple::SPIRVSubArch_v11:
+    return VersionNumber::SPIRV_1_1;
+  case Triple::SPIRVSubArch_v12:
+    return VersionNumber::SPIRV_1_2;
+  case Triple::SPIRVSubArch_v13:
+    return VersionNumber::SPIRV_1_3;
+  case Triple::SPIRVSubArch_v14:
+    return VersionNumber::SPIRV_1_4;
+  default:
+    ErrorLog.checkError(false, SPIRVEC_InvalidSubArch, TT.getArchName().str());
+    return VersionNumber::MaximumVersion;
+  }
+}
+
 bool runSpirvWriterPasses(Module *M, std::ostream *OS, std::string &ErrMsg,
                           const SPIRV::TranslatorOpts &Opts) {
   // Perform the conversion and write the resulting SPIR-V if an ostream has
@@ -5185,6 +5203,20 @@ bool runSpirvWriterPasses(Module *M, std::ostream *OS, std::string &ErrMsg,
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule(Opts));
   if (!isValidLLVMModule(M, BM->getErrorLog()))
     return false;
+
+  // If the module carries a SPIR-V triple with a version subarch, target
+  // that SPIR-V version.
+  Triple TargetTriple(M->getTargetTriple());
+  if ((TargetTriple.getArch() == Triple::spirv32 ||
+       TargetTriple.getArch() == Triple::spirv64) &&
+      TargetTriple.getSubArch() != Triple::NoSubArch) {
+    VersionNumber ModuleVer =
+        getVersionFromTriple(TargetTriple, BM->getErrorLog());
+    if (!BM->getErrorLog().checkError(ModuleVer <= Opts.getMaxVersion(),
+                                      SPIRVEC_TripleMaxVersionIncompatible))
+      return false;
+    BM->setMinSPIRVVersion(static_cast<SPIRVWord>(ModuleVer));
+  }
 
   ModulePassManager PassMgr;
   addPassesForSPIRV(PassMgr, Opts);

--- a/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
@@ -2,6 +2,9 @@
 _SPIRV_OP(Success, "")
 _SPIRV_OP(InvalidTargetTriple,
           "Expects spir-unknown-unknown or spir64-unknown-unknown.")
+_SPIRV_OP(InvalidSubArch, "Expecting v1.0-v1.4.")
+_SPIRV_OP(TripleMaxVersionIncompatible,
+          "Triple version and maximum version are incompatible.")
 _SPIRV_OP(InvalidAddressingModel, "Expects 0-2.")
 _SPIRV_OP(InvalidMemoryModel, "Expects 0-3.")
 _SPIRV_OP(InvalidFunctionControlMask, "")

--- a/test/spirv-triple-with-version.ll
+++ b/test/spirv-triple-with-version.ll
@@ -1,0 +1,19 @@
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
+
+; RUN: not llvm-spirv %t.bc -spirv-max-version=1.0 -o - -spirv-text 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID
+; RUN: not llvm-spirv %t.bc -spirv-max-version=1.1 -o - -spirv-text 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID
+
+; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK12
+; RUN: llvm-spirv %t.bc -spirv-max-version=1.2 -o - -spirv-text | FileCheck %s --check-prefix=CHECK12
+; RUN: llvm-spirv %t.bc -spirv-max-version=1.3 -o - -spirv-text | FileCheck %s --check-prefix=CHECK12
+; RUN: llvm-spirv %t.bc -spirv-max-version=1.4 -o - -spirv-text | FileCheck %s --check-prefix=CHECK12
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64v1.2-unknown-unknown"
+
+; This is a module with a SPIR-V subarch.  Ensure that the SPIR-V version specified as the subarch is taken into account by llvm-spirv.
+
+; CHECK-INVALID: TripleMaxVersionIncompatible: Triple version and maximum version are incompatible.
+
+; 66048 = 0x10200, i.e. version 1.2
+; CHECK12: 119734787 66048


### PR DESCRIPTION
~We cannot emit an exact version yet, so at least warn when the user
provides an LLVM module with an exact SPIR-V version specified.~

Ensure that the SPIR-V version specified as the subarch is taken into account by llvm-spirv.