### PR TITLE
[NFC] Factor out mutateArgsForImageOperands

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -766,15 +766,21 @@ static char getTypeSuffix(Type *T) {
 }
 
 void SPIRVToOCLBase::mutateArgsForImageOperands(std::vector<Value *> &Args) {
-  if (Args.size() > 4) {
+  if (Args.size() > 3) {
     ConstantInt *ImOp = dyn_cast<ConstantInt>(Args[3]);
-    ConstantFP *LodVal = dyn_cast<ConstantFP>(Args[4]);
+    uint64_t ImOpValue = 0;
+    if (ImOp)
+      ImOpValue = ImOp->getZExtValue();
     // Drop "Image Operands" argument.
     Args.erase(Args.begin() + 3, Args.begin() + 4);
-    // If the image operand is LOD and its value is zero, drop it too.
-    if (ImOp && LodVal && LodVal->isNullValue() &&
-        ImOp->getZExtValue() == ImageOperandsMask::ImageOperandsLodMask)
-      Args.erase(Args.begin() + 3, Args.end());
+
+    if (Args.size() > 3) {
+      ConstantFP *LodVal = dyn_cast<ConstantFP>(Args[3]);
+      // If the image operand is LOD and its value is zero, drop it too.
+      if (LodVal && LodVal->isNullValue() &&
+          ImOpValue == ImageOperandsMask::ImageOperandsLodMask)
+        Args.erase(Args.begin() + 3, Args.end());
+    }
   }
 }
 

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -272,6 +272,9 @@ private:
 
   std::string translateOpaqueType(StringRef STName);
 
+  /// Mutate the argument list based on (optional) image operands.
+  void mutateArgsForImageOperands(std::vector<Value *> &Args);
+
 protected:
   Module *M;
   LLVMContext *Ctx;

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -241,6 +241,9 @@ public:
   // Transform FP atomic opcode to corresponding OpenCL function name
   virtual std::string mapFPAtomicName(Op OC) = 0;
 
+  void translateOpaqueTypes();
+
+private:
   /// Transform uniform group opcode to corresponding OpenCL function name,
   /// example: GroupIAdd(Reduce) => group_iadd => work_group_reduce_add |
   /// sub_group_reduce_add
@@ -267,9 +270,9 @@ public:
 
   void getParameterTypes(CallInst *CI, SmallVectorImpl<StructType *> &Tys);
 
-  void translateOpaqueTypes();
   std::string translateOpaqueType(StringRef STName);
 
+protected:
   Module *M;
   LLVMContext *Ctx;
 };


### PR DESCRIPTION
Prepare for handling SignExtend/ZeroExtend image operands, by merging some code for handling image operands.

* [NFC] Separate image operand and LoD handling
* [NFC] Factor out mutateArgsForImageOperands
* [NFC] Restrict access to some SPIRVToOCLBase members