### PR TITLE
[CI] Exclude some files from code style checks

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -43,7 +43,12 @@ jobs:
     - name: Gather list of changes
       id: gather-list-of-changes
       run: |
-        git diff -U0 --no-color ${{ github.sha }}^ -- include lib ':(exclude)lib/SPIRV/libSPIRV/spirv.hpp' > diff-to-inspect.txt
+        git diff -U0 --no-color ${{ github.sha }}^ -- include lib \
+            ':(exclude)include/LLVMSPIRVExtensions.inc' \
+            ':(exclude)lib/SPIRV/libSPIRV/SPIRVErrorEnum.h' \
+            ':(exclude)lib/SPIRV/libSPIRV/SPIRVOpCodeEnum.h' \
+            ':(exclude)lib/SPIRV/libSPIRV/SPIRVOpCodeEnumInternal.h' \
+            > diff-to-inspect.txt
         if [ -s diff-to-inspect.txt ]; then
           # Here we set an output of our step, which is used later to either
           # perform or skip further steps, i.e. there is no sense to install


### PR DESCRIPTION
Some files cannot be parsed on their own as they for example require a
macro to be defined.  To avoid spurious failures of clang-tidy,
exclude such files from the code style checks.

Remove `spirv.hpp` from the list as it is no longer in the tree.