### PR TITLE
[SPIR-V] Exchange abort() to exit() in llvm-spirv tool by default

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.cpp
@@ -42,5 +42,6 @@
 using namespace SPIRV;
 
 bool SPIRV::SPIRVDbgEnable = false;
-bool SPIRV::SPIRVDbgAbortOnError = true;
+SPIRV::SPIRVDbgErrorHandlingKinds SPIRV::SPIRVDbgError =
+    SPIRVDbgErrorHandlingKinds::Exit;
 bool SPIRV::SPIRVDbgErrorMsgIncludesSourceInfo = true;

--- a/lib/SPIRV/libSPIRV/SPIRVDebug.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDebug.h
@@ -59,8 +59,9 @@ extern bool SPIRVDbgEnable;
 // Include source file and line number in error message.
 extern bool SPIRVDbgErrorMsgIncludesSourceInfo;
 
-// Enable assert on error
-extern bool SPIRVDbgAbortOnError;
+// Enable assert or exit on error
+enum class SPIRVDbgErrorHandlingKinds { Abort, Exit, Ignore };
+extern SPIRVDbgErrorHandlingKinds SPIRVDbgError;
 
 // Output stream for SPIRV debug information.
 inline spv_ostream &spvdbgs() {

--- a/lib/SPIRV/libSPIRV/SPIRVError.h
+++ b/lib/SPIRV/libSPIRV/SPIRVError.h
@@ -113,10 +113,19 @@ inline bool SPIRVErrorLog::checkError(bool Cond, SPIRVErrorCode ErrCode,
   if (SPIRVDbgErrorMsgIncludesSourceInfo && FileName)
     SS << " [Src: " << FileName << ":" << LineNo << " " << CondString << " ]";
   setError(ErrCode, SS.str());
-  if (SPIRVDbgAbortOnError) {
+  switch (SPIRVDbgError) {
+  case SPIRVDbgErrorHandlingKinds::Abort:
     spvdbgs() << SS.str() << '\n';
     spvdbgs().flush();
     abort();
+    break;
+  case SPIRVDbgErrorHandlingKinds::Exit:
+    spvdbgs() << SS.str() << '\n';
+    spvdbgs().flush();
+    std::exit(ErrCode);
+    break;
+  case SPIRVDbgErrorHandlingKinds::Ignore:
+    break;
   }
   return Cond;
 }

--- a/test/negative/invalid-int-bitwidth.ll
+++ b/test/negative/invalid-int-bitwidth.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidBitWidth: Invalid bit width in input: 128
 

--- a/test/negative/llvm-unhandled-intrinsic.ll
+++ b/test/negative/llvm-unhandled-intrinsic.ll
@@ -2,7 +2,7 @@
 ; It either represents intrinsic's semantics with SPIRV instruction(s), or
 ; reports an error.
 ; RUN: llvm-as %s -o %t.bc
-; RUN: not --crash llvm-spirv %t.bc 2>&1 | FileCheck %s
+; RUN: not llvm-spirv %t.bc 2>&1 | FileCheck %s
 
 ; CHECK: InvalidFunctionCall: Unexpected llvm intrinsic:
 

--- a/test/negative/unimplemented.spt
+++ b/test/negative/unimplemented.spt
@@ -20,6 +20,6 @@
 
 ; Test that we gracefully reject an unimplemented opcode such as OpDPdx.
 
-; RUN: not --crash llvm-spirv %s -to-binary -o %t.spv 2>&1 | FileCheck %s
+; RUN: not llvm-spirv %s -to-binary -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: UnimplementedOpCode: Unimplemented opcode 207

--- a/test/negative/unsupported-triple.ll
+++ b/test/negative/unsupported-triple.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidTargetTriple: Expects spir-unknown-unknown or spir64-unknown-unknown. Actual target triple is aarch64
 

--- a/test/negative/zero-length-array.ll
+++ b/test/negative/zero-length-array.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidArraySize: Array size must be at least 1: [0 x i32]
 

--- a/test/spirv-unknown-extensions.spt
+++ b/test/spirv-unknown-extensions.spt
@@ -39,6 +39,6 @@
 
 1 FunctionEnd
 
-; RUN: not --crash llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s
+; RUN: not llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s
 ; CHECK: input SPIR-V module uses unknown extension 'unknown_spirv_extension'
 

--- a/test/spirv-version-controls-negative-1.spt
+++ b/test/spirv-version-controls-negative-1.spt
@@ -27,7 +27,7 @@
 
 1 FunctionEnd
 
-; RUN: not --crash llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: not llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
 ; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (66816)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.4 (66560)
 

--- a/test/spirv-version-controls-negative-2.spt
+++ b/test/spirv-version-controls-negative-2.spt
@@ -27,7 +27,7 @@
 
 1 FunctionEnd
 
-; RUN: not --crash llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: not llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
 ; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (1024)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.4 (66560)
 

--- a/test/spirv-version-controls.spt
+++ b/test/spirv-version-controls.spt
@@ -30,6 +30,6 @@
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv --spirv-max-version=1.1 -o %t
-; RUN: not --crash llvm-spirv -r %t.spv --spirv-max-version=1.0 -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: not llvm-spirv -r %t.spv --spirv-max-version=1.0 -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
 ; CHECK-ERROR: Invalid SPIR-V module: incorrect SPIR-V version number 1.1 (65792) - it conflicts with --spirv-max-version which is set to 1.0 (65536)

--- a/test/transcoding/NoSignedUnsignedWrap.ll
+++ b/test/transcoding/NoSignedUnsignedWrap.ll
@@ -23,7 +23,7 @@
 ;
 ; Check that translator is able to reject SPIR-V if extension is disallowed
 ;
-; RUN: not --crash llvm-spirv -r %t.spv --spirv-ext=-SPV_KHR_no_integer_wrap_decoration -o - 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID-SPIRV
+; RUN: not llvm-spirv -r %t.spv --spirv-ext=-SPV_KHR_no_integer_wrap_decoration -o - 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID-SPIRV
 ;
 ; Check that translator is able to skip nsw/nuw attributes if extension is disabled implicitly or explicitly
 ;

--- a/test/transcoding/SPV_INTEL_variable_length_array/negative.ll
+++ b/test/transcoding/SPV_INTEL_variable_length_array/negative.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as < %s -o %t.bc
-; RUN: not --crash llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-INTRINSIC
-; RUN: not --crash llvm-spirv %t.bc -spirv-allow-unknown-intrinsics -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ALLOCA
+; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-INTRINSIC
+; RUN: not llvm-spirv %t.bc -spirv-allow-unknown-intrinsics -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ALLOCA
 
 ; CHECK-INTRINSIC: InvalidFunctionCall: Unexpected llvm intrinsic:
 ; CHECK-INTRINSIC-NEXT: call i8* @llvm.stacksave()


### PR DESCRIPTION
This backports https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/561

Signed-off-by: haonanya <haonan.yang@intel.com>