### PR TITLE
Draft approach for handling transTypeDesc

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -157,7 +157,8 @@ bool regularizeLlvmForSpirv(Module *M, std::string &ErrMsg,
 
 /// \brief Mangle OpenCL builtin function function name.
 void mangleOpenClBuiltin(const std::string &UnmangledName,
-                         ArrayRef<Type *> ArgTypes, std::string &MangledName);
+                         ArrayRef<Type *> ArgTypes, AttributeList &Attrs,
+                         std::string &MangledName);
 
 /// Create a pass for translating LLVM to SPIR-V.
 ModulePass *createLLVMToSPIRVLegacy(SPIRV::SPIRVModule *);

--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -9,6 +9,7 @@ add_llvm_library(LLVMSPIRVLib
   OCLTypeToSPIRV.cpp
   OCLUtil.cpp
   VectorComputeUtil.cpp
+  SPIRVBuiltinHelper.cpp
   SPIRVLowerBitCastToNonStandardType.cpp
   SPIRVLowerBool.cpp
   SPIRVLowerConstExpr.cpp

--- a/lib/SPIRV/OCLToSPIRV.h
+++ b/lib/SPIRV/OCLToSPIRV.h
@@ -41,6 +41,7 @@
 #define SPIRV_OCLTOSPIRV_H
 
 #include "OCLUtil.h"
+#include "SPIRVBuiltinHelper.h"
 
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/PassManager.h"
@@ -50,10 +51,11 @@ namespace SPIRV {
 
 class OCLTypeToSPIRVBase;
 
-class OCLToSPIRVBase : public InstVisitor<OCLToSPIRVBase> {
+class OCLToSPIRVBase : public InstVisitor<OCLToSPIRVBase>, BuiltinCallHelper {
 public:
   OCLToSPIRVBase()
-      : M(nullptr), Ctx(nullptr), CLVer(0), OCLTypeToSPIRVPtr(nullptr) {}
+      : BuiltinCallHelper(ManglingRules::SPIRV), Ctx(nullptr), CLVer(0),
+      OCLTypeToSPIRVPtr(nullptr) {}
   virtual ~OCLToSPIRVBase() {}
   bool runOCLToSPIRV(Module &M);
 
@@ -255,7 +257,6 @@ public:
   OCLTypeToSPIRVBase *getOCLTypeToSPIRV() { return OCLTypeToSPIRVPtr; }
 
 private:
-  Module *M;
   LLVMContext *Ctx;
   unsigned CLVer; /// OpenCL version as major*10+minor
   std::set<Value *> ValuesToDelete;
@@ -270,6 +271,9 @@ private:
   /// Transform OpenCL vload/vstore function name.
   void transVecLoadStoreName(std::string &DemangledName,
                              const std::string &Stem, bool AlwaysN);
+
+  void processSubgroupBlockReadWriteINTEL(CallInst *CI,
+    OCLBuiltinTransInfo &Info, const Type *DataTy);
 };
 
 class OCLToSPIRVLegacy : public OCLToSPIRVBase, public llvm::ModulePass {

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1154,9 +1154,11 @@ public:
     } else if (NameRef.startswith("vstore")) {
       addUnsignedArg(1);
     } else if (NameRef.startswith("ndrange_")) {
-      addUnsignedArg(-1);
+      addUnsignedArgs(0, 2);
       if (NameRef[8] == '2' || NameRef[8] == '3') {
-        setArgAttr(-1, SPIR::ATTR_CONST);
+        setArgAttr(0, SPIR::ATTR_CONST);
+        setArgAttr(1, SPIR::ATTR_CONST);
+        setArgAttr(2, SPIR::ATTR_CONST);
       }
     } else if (NameRef.contains("umax")) {
       addUnsignedArg(-1);
@@ -1602,7 +1604,9 @@ Value *SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
 
 void llvm::mangleOpenClBuiltin(const std::string &UniqName,
                                ArrayRef<Type *> ArgTypes,
+                               AttributeList &Attrs,
                                std::string &MangledName) {
   OCLUtil::OCLBuiltinFuncMangleInfo BtnInfo(ArgTypes);
+  BtnInfo.fillFromAttributeList(Attrs, ArgTypes.size());
   MangledName = SPIRV::mangleBuiltin(UniqName, ArgTypes, &BtnInfo);
 }

--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -1,0 +1,175 @@
+//===- SPIRVBuiltinHelper.cpp - Helpers for managing calls to builtins ----===//
+//
+//                     The LLVM/SPIR-V Translator
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimers.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimers in the documentation
+// and/or other materials provided with the distribution.
+// Neither the names of The Khronos Group, nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// Software without specific prior written permission.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+// THE SOFTWARE.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements helper functions for adding calls to OpenCL or SPIR-V
+// builtin functions, or for rewriting calls to one into calls to the other.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SPIRVBuiltinHelper.h"
+#include "SPIRVInternal.h"
+
+using namespace llvm;
+using namespace SPIRV;
+
+static std::unique_ptr<BuiltinFuncMangleInfo> makeMangler(ManglingRules Rules) {
+  switch (Rules) {
+  case ManglingRules::None:
+    return nullptr;
+  case ManglingRules::SPIRV:
+    return std::make_unique<BuiltinFuncMangleInfo>();
+  case ManglingRules::OpenCL:
+    assert(false && "Not yet implemented");
+    return nullptr;
+  }
+}
+
+BuiltinCallMutator::BuiltinCallMutator(CallInst *CI, std::string FuncName,
+    ManglingRules Rules)
+: CI(CI), FuncName(FuncName), Attrs(CI->getAttributes()),
+  ReturnTy(CI->getType()), Args(CI->args()), Rules(Rules) {
+  // XXX: replace this with real stuff
+  for (Value *Arg : Args) {
+    Type *PET = Arg->getType()->isPointerTy() ? Arg->getType()->getPointerElementType() : nullptr;
+    PointerElementTypes.push_back(PET);
+  }
+}
+
+#if 0
+BuiltinCallMutator::BuiltinCallMutator(BuiltinCallMutator &&Other)
+: CI(Other.CI), FuncName(std::move(Other.FuncName)),
+  MutateRet(std::move(Other.MutateRet)), Attrs(Other.Attrs),
+  ReturnTy(Other.ReturnTy), Args(std::move(Other.Args)),
+  Rules(std::move(Other.Rules)) {
+  // Clear the other's CI instance so that it knows not to construct the actual
+  // call.
+  Other.CI = nullptr;
+}
+#endif
+
+BuiltinCallMutator::~BuiltinCallMutator() {
+  if (!CI)
+    return;
+  IRBuilder<> Builder(CI);
+  auto Mangler = makeMangler(Rules);
+  for (unsigned I = 0; I < Args.size(); I++)
+    Mangler->getTypeMangleInfo(I).PointerElementType = PointerElementTypes[I];
+  CallInst *NewCall = Builder.Insert(
+    addCallInst(CI->getModule(), FuncName, ReturnTy, Args, &Attrs, nullptr,
+      Mangler.get()));
+  Value *Result = MutateRet ? MutateRet(Builder, NewCall) : NewCall;
+  Result->takeName(CI);
+  if (!CI->getType()->isVoidTy())
+    CI->replaceAllUsesWith(Result);
+  CI->eraseFromParent();
+}
+
+BuiltinCallMutator &BuiltinCallMutator::setArgs(ArrayRef<Value *> NewArgs) {
+  // Retain only the function attributes, not any parameter attributes.
+  Attrs = AttributeList::get(CI->getContext(),
+      Attrs.getFnAttrs(), Attrs.getRetAttrs(), {});
+  Args.clear();
+  PointerElementTypes.clear();
+  for (Value *Arg : NewArgs) {
+    //assert(!Arg->getType()->isPointerTy() &&
+    //  "Cannot use this signature with pointer types");
+    Args.push_back(Arg);
+    // XXX
+    Type *PET = Arg->getType()->isPointerTy() ? Arg->getType()->getPointerElementType() : nullptr;
+    PointerElementTypes.push_back(PET);
+  }
+  return *this;
+}
+
+static void moveAttributes(LLVMContext &Ctx, AttributeList &Attrs,
+    unsigned Start, unsigned Len, unsigned Dest) {
+  unsigned CopyFromIndex = Start;
+  unsigned CopyToIndex = Dest;
+  signed Dir = 1;
+  // If we would overwrite the values we need to copy going from low to high,
+  // reverse the dierction.
+  if (Start < Dest && Dest < Start + Len) {
+    Dir = -1;
+    CopyFromIndex += Len - 1;
+    CopyToIndex += Len - 1;
+  }
+  for (unsigned Index = 0; Index < Len; Index++, CopyFromIndex += Dir,
+      CopyToIndex += Dir) {
+    AttributeSet ParamAttrs = Attrs.getParamAttrs(CopyFromIndex);
+    Attrs = Attrs.removeParamAttributes(Ctx, CopyToIndex);
+    Attrs = Attrs.addParamAttributes(Ctx, CopyToIndex,
+        AttrBuilder(Ctx, ParamAttrs));
+  }
+}
+
+BuiltinCallMutator &BuiltinCallMutator::insertArg(unsigned Index,
+    ValueTypePair Arg) {
+  // Move all the param attributes
+  moveAttributes(CI->getContext(), Attrs, Index, Args.size() - Index,
+      Index + 1);
+  Args.insert(Args.begin() + Index, Arg.first);
+  PointerElementTypes.insert(PointerElementTypes.begin() + Index, Arg.second);
+  return *this;
+}
+
+BuiltinCallMutator &BuiltinCallMutator::replaceArg(unsigned Index,
+    ValueTypePair Arg) {
+  Args[Index] = Arg.first;
+  Attrs = Attrs.removeParamAttributes(CI->getContext(), Index);
+  PointerElementTypes[Index] = Arg.second;
+  return *this;
+}
+
+BuiltinCallMutator &BuiltinCallMutator::removeArg(unsigned Index) {
+  moveAttributes(CI->getContext(), Attrs, Index + 1, Args.size() - Index - 1,
+    Index);
+  Args.erase(Args.begin() + Index);
+  PointerElementTypes.erase(PointerElementTypes.begin() + Index);
+  return *this;
+}
+
+BuiltinCallMutator &BuiltinCallMutator::changeReturnType(Type *NewReturnTy,
+    MutateRetFuncTy MutateFunc) {
+  ReturnTy = NewReturnTy;
+  MutateRet = std::move(MutateFunc);
+  return *this;
+}
+
+BuiltinCallMutator BuiltinCallHelper::mutateCallInst(CallInst *CI, spv::Op Opcode) {
+  return mutateCallInst(CI, getSPIRVFuncName(Opcode));
+}
+
+BuiltinCallMutator BuiltinCallHelper::mutateCallInst(CallInst *CI, std::string FuncName) {
+  return BuiltinCallMutator(CI, std::move(FuncName), Rules);
+}

--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -1,0 +1,170 @@
+//===- SPIRVBuiltinHelper.h - Helpers for managing calls to builtins ------===//
+//
+//                     The LLVM/SPIR-V Translator
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// Copyright (c) 2022 The Khronos Group Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimers.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimers in the documentation
+// and/or other materials provided with the distribution.
+// Neither the names of The Khronos Group, nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// Software without specific prior written permission.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+// THE SOFTWARE.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements helper functions for adding calls to OpenCL or SPIR-V
+// builtin functions, or for rewriting calls to one into calls to the other.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SPIRVBUILTINHELPER_H
+#define SPIRVBUILTINHELPER_H
+
+#include "libSPIRV/SPIRVOpCode.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/IRBuilder.h"
+
+namespace SPIRV {
+enum class ManglingRules {
+  None,
+  OpenCL,
+  SPIRV
+};
+
+class BuiltinCallMutator {
+  llvm::CallInst *CI;
+  std::string FuncName;
+  std::function<llvm::Value *(llvm::IRBuilder<> &, llvm::CallInst *)> MutateRet;
+  typedef decltype(MutateRet) MutateRetFuncTy;
+  llvm::AttributeList Attrs;
+  llvm::Type *ReturnTy;
+  llvm::SmallVector<llvm::Value *, 8> Args;
+  llvm::SmallVector<llvm::Type *, 8> PointerElementTypes;
+  ManglingRules Rules;
+
+  friend class BuiltinCallHelper;
+  BuiltinCallMutator(llvm::CallInst *CI, std::string FuncName,
+      ManglingRules Rules);
+
+  void setElementType(unsigned Index, llvm::Type *ElementType);
+
+public:
+  ~BuiltinCallMutator();
+  BuiltinCallMutator(const BuiltinCallMutator &) = delete;
+  BuiltinCallMutator &operator=(const BuiltinCallMutator &) = delete;
+  BuiltinCallMutator &operator=(BuiltinCallMutator &&) = delete;
+
+  // The move constructor shouldn't be called ever, but there's no way to return
+  // a non-movable, non-copyable type in C++14 without a valid move constructor,
+  // even if the move constructor would never be called. By not providing a move
+  // constructor, we'll guarantee that any move that isn't elided produces an
+  // error of some kind (even if it is a link error). In C++17 mode, however,
+  // we'll have a fully-deleted constructor to make it a compiler error instead.
+#ifndef __cpp_guaranteed_copy_elision
+  BuiltinCallMutator(BuiltinCallMutator &&);
+#else
+  BuiltinCallMutator(BuiltinCallMutator &&) = delete;
+#endif
+
+  llvm::Value *getArg(unsigned Index) const { return Args[Index]; }
+
+  struct ValueTypePair : public std::pair<llvm::Value *, llvm::Type *> {
+    ValueTypePair(llvm::Value *V) : pair(V, nullptr) {
+      assert(!V->getType()->isPointerTy() &&
+          "Must specify a pointer element type if value is a pointer.");
+    }
+    ValueTypePair(std::pair<llvm::Value *, llvm::Type *> P) : pair(P) {}
+    ValueTypePair(llvm::Value *V, llvm::Type * T) : pair(V, T) {}
+  };
+
+
+  /// Use the following arguments as the arguments of the new call, replacing
+  /// any previous arguments. This version may not be used if any argument is of
+  /// pointer type.
+  BuiltinCallMutator &setArgs(llvm::ArrayRef<llvm::Value *> Args);
+
+  BuiltinCallMutator &changeReturnType(llvm::Type *ReturnTy,
+      MutateRetFuncTy MutateFunc);
+
+  /// Insert an argument before the given index. This version may not be used if
+  /// the argument is of pointer type.
+  BuiltinCallMutator &insertArg(unsigned Index, ValueTypePair Arg);
+
+  /// Add an argument to the end of the argument list.
+  BuiltinCallMutator &appendArg(llvm::Value *Arg) {
+    return insertArg(Args.size(), Arg);
+  }
+
+  BuiltinCallMutator &replaceArg(unsigned Index, ValueTypePair Arg);
+
+  BuiltinCallMutator &removeArg(unsigned Index);
+
+  BuiltinCallMutator &moveArg(unsigned FromIndex, unsigned ToIndex) {
+    if (FromIndex == ToIndex)
+      return *this;
+    ValueTypePair Pair(Args[FromIndex], PointerElementTypes[FromIndex]);
+    removeArg(FromIndex);
+    insertArg(ToIndex, Pair);
+    return *this;
+  }
+
+  template <typename FnType>
+  BuiltinCallMutator &mapArg(unsigned Index, FnType Func,
+      std::enable_if_t<llvm::is_invocable<FnType, llvm::Value*>::value>* = nullptr) {
+    replaceArg(Index, Func(Args[Index]));
+    return *this;
+  }
+
+  template <typename FnType>
+  BuiltinCallMutator &mapArg(unsigned Index, FnType Func,
+      std::enable_if_t<llvm::is_invocable<FnType, llvm::Value*, llvm::Type*>::value>* = nullptr) {
+    replaceArg(Index, Func(Args[Index], PointerElementTypes[Index]));
+    return *this;
+  }
+
+  template <typename FnType>
+  BuiltinCallMutator &mapArgs(FnType Func) {
+    for (unsigned I = 0, E = Args.size(); I < E; I++)
+      mapArg(I, Func);
+    return *this;
+  }
+};
+
+class BuiltinCallHelper {
+  ManglingRules Rules;
+
+protected:
+  llvm::Module *M = nullptr;
+
+public:
+  explicit BuiltinCallHelper(ManglingRules Rules) : Rules(Rules) {}
+  void initialize(llvm::Module &M) { this->M = &M; }
+
+  BuiltinCallMutator mutateCallInst(llvm::CallInst *CI, spv::Op Opcode);
+  BuiltinCallMutator mutateCallInst(llvm::CallInst *CI, std::string FuncName);
+};
+
+} // namespace SPIRV
+
+#endif // SPIRVBUILTINHELPER_H

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -709,20 +709,6 @@ Instruction *mutateCallInst(
     BuiltinFuncMangleInfo *Mangle = nullptr, AttributeList *Attrs = nullptr,
     bool TakeName = false);
 
-/// Mutate call instruction to call SPIR-V builtin function.
-CallInst *mutateCallInstSPIRV(
-    Module *M, CallInst *CI,
-    std::function<std::string(CallInst *, std::vector<Value *> &)> ArgMutate,
-    AttributeList *Attrs = nullptr);
-
-/// Mutate call instruction to call SPIR-V builtin function.
-Instruction *mutateCallInstSPIRV(
-    Module *M, CallInst *CI,
-    std::function<std::string(CallInst *, std::vector<Value *> &, Type *&RetTy)>
-        ArgMutate,
-    std::function<Instruction *(CallInst *)> RetMutate,
-    AttributeList *Attrs = nullptr);
-
 /// Mutate function by change the arguments.
 /// \param ArgMutate mutates the function arguments.
 /// \param TakeName Take the original function's name if a new function with
@@ -886,11 +872,6 @@ std::string getSPIRVTypeName(StringRef BaseTyName, StringRef Postfixes = "");
 
 /// Checks if given type name is either ConstantSampler or ConsantPipeStorage.
 bool isSPIRVConstantName(StringRef TyName);
-
-/// Get SPIR-V type by changing the type name from spirv.OldName.Postfixes
-/// to spirv.NewName.Postfixes.
-Type *getSPIRVTypeByChangeBaseTypeName(Module *M, Type *T, StringRef OldName,
-                                       StringRef NewName);
 
 /// Get SPIR-V type by changing the type name from spirv.OldName.Postfixes
 /// to spirv.NewName.Postfixes.

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -45,6 +45,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
 
 namespace llvm {
@@ -82,6 +83,7 @@ public:
   Type *transType(SPIRVType *BT, bool IsClassMember = false);
   std::string transTypeToOCLTypeName(SPIRVType *BT, bool IsSigned = true);
   std::vector<Type *> transTypeVector(const std::vector<SPIRVType *> &);
+  llvm::AttributeList transTypeAttributes(llvm::ArrayRef<SPIRVType *> Tys);
   bool translate();
   bool transAddressingModel();
 

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -591,11 +591,13 @@ bool SPIRVRegularizeLLVMBase::regularize() {
           Value *Val = Cmpxchg->getNewValOperand();
           Value *Comparator = Cmpxchg->getCompareOperand();
 
+          Type *MemType = Cmpxchg->getCompareOperand()->getType();
+
           llvm::Value *Args[] = {Ptr,        MemoryScope, EqualSem,
                                  UnequalSem, Val,         Comparator};
           auto *Res = addCallInstSPIRV(M, "__spirv_AtomicCompareExchange",
-                                       Cmpxchg->getCompareOperand()->getType(),
-                                       Args, nullptr, &II, "cmpxchg.res");
+                                       MemType, Args, nullptr, {MemType},
+                                       &II, "cmpxchg.res");
           IRBuilder<> Builder(Cmpxchg);
           auto *Cmp = Builder.CreateICmpEQ(Res, Comparator, "cmpxchg.success");
           auto *V1 = Builder.CreateInsertValue(

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -276,6 +276,8 @@ void SPIRVToOCLBase::visitCallSPRIVImageQuerySize(CallInst *CI) {
   }
 
   AttributeList Attributes = CI->getCalledFunction()->getAttributes();
+  Attributes = Attributes.addParamAttributes(*Ctx, 0,
+      AttrBuilder(*Ctx).addTypeAttr(Attribute::ElementType, ImgTy));
   BuiltinFuncMangleInfo Mangle;
   Type *Int32Ty = Type::getInt32Ty(*Ctx);
   Instruction *GetImageSize = nullptr;

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -870,8 +870,8 @@ CallInst *addCallInstSPIRV(Module *M, StringRef FuncName, Type *RetTy,
   BuiltinFuncMangleInfo BtnInfo;
   for (unsigned I = 0; I < PointerElementTypes.size(); I++) {
     BtnInfo.getTypeMangleInfo(I).PointerElementType = PointerElementTypes[I];
-    if (Args[I]->getType()->isPointerTy())
-      assert(Args[I]->getType()->getPointerElementType() == PointerElementTypes[I]);
+    if (Args[I]->getType()->isPointerTy() && !Args[I]->getType()->isOpaquePointerTy())
+      assert(Args[I]->getType()->getNonOpaquePointerElementType() == PointerElementTypes[I]);
   }
   return addCallInst(M, FuncName, RetTy, Args, Attrs, Pos, &BtnInfo, InstName);
 }

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -849,23 +849,6 @@ void mutateFunction(
     F->eraseFromParent();
 }
 
-CallInst *mutateCallInstSPIRV(
-    Module *M, CallInst *CI,
-    std::function<std::string(CallInst *, std::vector<Value *> &)> ArgMutate,
-    AttributeList *Attrs) {
-  BuiltinFuncMangleInfo BtnInfo;
-  return mutateCallInst(M, CI, ArgMutate, &BtnInfo, Attrs);
-}
-
-Instruction *mutateCallInstSPIRV(
-    Module *M, CallInst *CI,
-    std::function<std::string(CallInst *, std::vector<Value *> &, Type *&RetTy)>
-        ArgMutate,
-    std::function<Instruction *(CallInst *)> RetMutate, AttributeList *Attrs) {
-  BuiltinFuncMangleInfo BtnInfo;
-  return mutateCallInst(M, CI, ArgMutate, RetMutate, &BtnInfo, Attrs);
-}
-
 CallInst *addCallInst(Module *M, StringRef FuncName, Type *RetTy,
                       ArrayRef<Value *> Args, AttributeList *Attrs,
                       Instruction *Pos, BuiltinFuncMangleInfo *Mangle,
@@ -1423,13 +1406,6 @@ bool isSPIRVConstantName(StringRef TyName) {
     return true;
 
   return false;
-}
-
-Type *getSPIRVTypeByChangeBaseTypeName(Module *M, Type *T, StringRef OldName,
-                                       StringRef NewName) {
-  return PointerType::get(
-      getSPIRVStructTypeByChangeBaseTypeName(M, T, OldName, NewName),
-      SPIRAS_Global);
 }
 
 Type *getSPIRVStructTypeByChangeBaseTypeName(Module *M, Type *T,


### PR DESCRIPTION
This patch is nowhere near ready enough for full review, but I wanted to solicit some feedback on the approach before I delve too much further into implementation:

The basic underlying goal is to have everyone who generates mangled function names identify what the pointer element types of their parameters should be. (This is basically the inverse of the `getParameterTypes` function I added earlier in #1477). As far as getting this information into the guts of the mangler, I've settled on stuffing it in `BuiltinArgTypeMangleInfo` (and this comes with some concomitant changes to `BuiltinTypeMangleInfo` to make doing this easier). But there's a few different ways of getting the type information to that point, and I'm somewhat less certain as to how to do that.

One option is to use `elementtype` attributes and then port the information from attribute lists to the mangling info structs. Except it turns out that actually repeatedly specifying `elementtype` attributes in code isn't very ergonomic, and the code has to follow up by stripping `elementtype` from the attribute lists because it's not (presently) legal in LLVM IR.

The other main option I've considered is to add in an extra `ArrayRef<Type *> PointerElementTypes` argument. This is easier to work with when you're doing something like `addCallInstSPIRV`, but it doesn't quite handle the case where we have a `ocl_event *` parameter, which needs an extra level of indirection. (The indirection in general is somewhat hackily specified, but it does work well enough for now.)

Whatever method is done, all of the `mutateCallInst` calls become more painful. Now you have to either make sure that the attribute sets are moved properly when you add or delete arguments, or you have to concomitantly modify a second array of pointer element types. I've basically decided to give up on keeping the current interface of `mutateCallInst` call and instead resort to a new way of specifying it that makes the modifications generally more obvious:

```c++
mutateCallInst(CI, NewFuncName)
  .addArg(SomeValue)
  .removeArg(3)
  .moveArg(5, 2)
  .mapArg(3, [](Value *V) { return Builder.CreateSplat(10, V); });
```

I've replaced all of the calls to `mutateCallInstSPIRV` to get a feeling for how sufficient or not sufficient this interface is. There's still a lot of cleanup that would need to be done before I'd consider this ready for full review (in particular, `Info.PostProc` needs to operate on a mutator object, and not the `std::vector<Value*> Args` that it does now), and there's even more scope for replacing more code with `IRBuilder` calls. Documentation of the new interface is of course woefully lacking. But I'd like to get some feedback from @svenvh, @YetAnotherCompilerEngineer, and possibly others on if this interface is a desirable approach, or if I should pursue some other way of handling all of the `mutateCallInst` transformations.