### PR TITLE
Update test after LLVM ConstantExpr change

### DIFF
--- a/test/complex-constexpr-vector.ll
+++ b/test/complex-constexpr-vector.ll
@@ -6,6 +6,9 @@
 ; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
+; TODO: update or remove test following deprecation of float binop constant expressions.
+; XFAIL: *
+
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64"
 


### PR DESCRIPTION
LLVM commit 8edb9c3c56e8 ("[ConstantExpr] Don't create float binop
expressions", 2022-07-08) caused this test to fail.  XFAIL the test to
get CI green again.