### PR TITLE
Add -emit-opaque-pointers flag

### DIFF
--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -153,6 +153,11 @@ static cl::opt<bool>
     SPIRVToolsDis("spirv-tools-dis", cl::init(false),
                   cl::desc("Emit textual assembly using SPIRV-Tools"));
 
+static cl::opt<bool> EmitOpaquePointers(
+    "emit-opaque-pointers", cl::init(false),
+    cl::desc(
+        "Emit opaque/typed LLVM pointers for the translation from SPIR-V."));
+
 using SPIRV::ExtensionID;
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
@@ -344,7 +349,7 @@ static bool isFileEmpty(const std::string &FileName) {
 
 static int convertSPIRVToLLVM(const SPIRV::TranslatorOpts &Opts) {
   LLVMContext Context;
-  Context.setOpaquePointers(false);
+  Context.setOpaquePointers(EmitOpaquePointers);
 
   std::ifstream IFS(InputFile, std::ios::binary);
   Module *M;

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -153,10 +153,11 @@ static cl::opt<bool>
     SPIRVToolsDis("spirv-tools-dis", cl::init(false),
                   cl::desc("Emit textual assembly using SPIRV-Tools"));
 
-static cl::opt<bool> EmitOpaquePointers(
-    "emit-opaque-pointers", cl::init(false),
-    cl::desc(
-        "Emit opaque/typed LLVM pointers for the translation from SPIR-V."));
+static cl::opt<bool>
+    EmitOpaquePointers("emit-opaque-pointers", cl::init(false),
+                       cl::desc("Emit opaque instead of typed LLVM pointers "
+                                "for the translation from SPIR-V."),
+                       cl::Hidden);
 
 using SPIRV::ExtensionID;
 


### PR DESCRIPTION
This option is useful for testing opaque pointers support and controled
transition of lit tests.