### PR TITLE
XFAIL constantexpr test after LLVM float binop removal

### DIFF
--- a/test/vector-metadata-constexpr.ll
+++ b/test/vector-metadata-constexpr.ll
@@ -2,6 +2,9 @@
 ; RUN: llvm-spirv -s %t.bc -o - | llvm-dis -o - | FileCheck %s
 ; RUN: llvm-spirv %t.bc
 
+; TODO: update or remove test following deprecation of float binop constant expressions.
+; XFAIL: *
+
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir64-unknown-unknown"
 


### PR DESCRIPTION
LLVM commit 4bb7b6fae3be ("[IR] Remove support for float binop
constant expressions", 2022-07-12) caused this test to fail.