### PR TITLE
[OpaquePtr] Pass pointer type information into mangleBuiltin.

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -106,6 +106,10 @@ std::unique_ptr<SPIRVModule> readSpirvModule(std::istream &IS,
                                              const SPIRV::TranslatorOpts &Opts,
                                              std::string &ErrMsg);
 
+/// This contains a pair of the pointer element type and an indirection
+/// parameter (to capture cases where an array of OpenCL types is used).
+typedef llvm::PointerIntPair<llvm::Type *, 1, bool> PointerIndirectPair;
+
 } // End namespace SPIRV
 
 namespace llvm {
@@ -157,7 +161,9 @@ bool regularizeLlvmForSpirv(Module *M, std::string &ErrMsg,
 
 /// \brief Mangle OpenCL builtin function function name.
 void mangleOpenClBuiltin(const std::string &UnmangledName,
-                         ArrayRef<Type *> ArgTypes, std::string &MangledName);
+                         ArrayRef<Type *> ArgTypes,
+                         ArrayRef<SPIRV::PointerIndirectPair> ArgPointerTypes,
+                         std::string &MangledName);
 
 /// Create a pass for translating LLVM to SPIR-V.
 ModulePass *createLLVMToSPIRVLegacy(SPIRV::SPIRVModule *);

--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -160,6 +160,9 @@ bool regularizeLlvmForSpirv(Module *M, std::string &ErrMsg,
                             const SPIRV::TranslatorOpts &Opts);
 
 /// \brief Mangle OpenCL builtin function function name.
+/// If any type in ArgTypes is a pointer type, the corresponding entry in
+/// ArgPointerTypes should contain the type should point to. If there are no
+/// pointer-typed arguments in ArgTypes, then ArgPointerTypes may be empty.
 void mangleOpenClBuiltin(const std::string &UnmangledName,
                          ArrayRef<Type *> ArgTypes,
                          ArrayRef<SPIRV::PointerIndirectPair> ArgPointerTypes,

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1604,9 +1604,9 @@ Value *SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
 
 void llvm::mangleOpenClBuiltin(const std::string &UniqName,
                                ArrayRef<Type *> ArgTypes,
-                               ArrayRef<PointerIndirectPair> PETs,
+                               ArrayRef<PointerIndirectPair> PointerElementTys,
                                std::string &MangledName) {
   OCLUtil::OCLBuiltinFuncMangleInfo BtnInfo(ArgTypes);
-  BtnInfo.fillPointerElementTypes(PETs);
+  BtnInfo.fillPointerElementTypes(PointerElementTys);
   MangledName = SPIRV::mangleBuiltin(UniqName, ArgTypes, &BtnInfo);
 }

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1154,9 +1154,11 @@ public:
     } else if (NameRef.startswith("vstore")) {
       addUnsignedArg(1);
     } else if (NameRef.startswith("ndrange_")) {
-      addUnsignedArg(-1);
+      addUnsignedArgs(0, 2);
       if (NameRef[8] == '2' || NameRef[8] == '3') {
-        setArgAttr(-1, SPIR::ATTR_CONST);
+        setArgAttr(0, SPIR::ATTR_CONST);
+        setArgAttr(1, SPIR::ATTR_CONST);
+        setArgAttr(2, SPIR::ATTR_CONST);
       }
     } else if (NameRef.contains("umax")) {
       addUnsignedArg(-1);
@@ -1602,7 +1604,9 @@ Value *SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
 
 void llvm::mangleOpenClBuiltin(const std::string &UniqName,
                                ArrayRef<Type *> ArgTypes,
+                               ArrayRef<PointerIndirectPair> PETs,
                                std::string &MangledName) {
   OCLUtil::OCLBuiltinFuncMangleInfo BtnInfo(ArgTypes);
+  BtnInfo.fillPointerElementTypes(PETs);
   MangledName = SPIRV::mangleBuiltin(UniqName, ArgTypes, &BtnInfo);
 }

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -447,6 +447,10 @@ enum Spir2SamplerKind {
   CLK_FILTER_LINEAR = 0x0020,
 };
 
+/// This contains a pair of the pointer element type and an indirection
+/// parameter (to capture cases where an array of OpenCL types is used).
+typedef llvm::PointerIntPair<llvm::Type *, 1, bool> PointerIndirectPair;
+
 /// Additional information for mangling a function argument type.
 struct BuiltinArgTypeMangleInfo {
   bool IsSigned;
@@ -457,10 +461,11 @@ struct BuiltinArgTypeMangleInfo {
   bool IsLocalArgBlock;
   SPIR::TypePrimitiveEnum Enum;
   unsigned Attr;
+  PointerIndirectPair PointerElementType;
   BuiltinArgTypeMangleInfo()
       : IsSigned(true), IsVoidPtr(false), IsEnum(false), IsSampler(false),
         IsAtomic(false), IsLocalArgBlock(false), Enum(SPIR::PRIMITIVE_NONE),
-        Attr(0) {}
+        Attr(0), PointerElementType(nullptr, false) {}
 };
 
 /// Information for mangling builtin function.
@@ -469,92 +474,61 @@ public:
   /// Translate builtin function name and set
   /// argument attributes and unsigned args.
   BuiltinFuncMangleInfo(const std::string &UniqName = "")
-      : LocalArgBlockIdx(-1), VarArgIdx(-1), DontMangle(false) {
+      : VarArgIdx(-1), DontMangle(false) {
     if (!UniqName.empty())
       init(UniqName);
   }
   virtual ~BuiltinFuncMangleInfo() {}
   const std::string &getUnmangledName() const { return UnmangledName; }
-  void addUnsignedArg(int Ndx) { UnsignedArgs.insert(Ndx); }
+  void addUnsignedArg(int Ndx) {
+    if (Ndx == -1)
+      return addUnsignedArgs(0, 10); // 10 is enough for everybody, right?
+    getTypeMangleInfo(Ndx).IsSigned = false;
+  }
   void addUnsignedArgs(int StartNdx, int StopNdx) {
     assert(StartNdx < StopNdx && "wrong parameters");
     for (int I = StartNdx; I <= StopNdx; ++I)
       addUnsignedArg(I);
   }
-  void addVoidPtrArg(int Ndx) { VoidPtrArgs.insert(Ndx); }
-  void addSamplerArg(int Ndx) { SamplerArgs.insert(Ndx); }
-  void addAtomicArg(int Ndx) { AtomicArgs.insert(Ndx); }
-  void setLocalArgBlock(int Ndx) {
-    assert(0 <= Ndx && "it is not allowed to set less than zero index");
-    LocalArgBlockIdx = Ndx;
+  void addVoidPtrArg(unsigned Ndx) { getTypeMangleInfo(Ndx).IsVoidPtr = true; }
+  void addSamplerArg(unsigned Ndx) { getTypeMangleInfo(Ndx).IsSampler = true; }
+  void addAtomicArg(unsigned Ndx) { getTypeMangleInfo(Ndx).IsAtomic = true; }
+  void setLocalArgBlock(unsigned Ndx) {
+    getTypeMangleInfo(Ndx).IsLocalArgBlock = true;
   }
-  void setEnumArg(int Ndx, SPIR::TypePrimitiveEnum Enum) {
-    EnumArgs[Ndx] = Enum;
+  void setEnumArg(unsigned Ndx, SPIR::TypePrimitiveEnum Enum) {
+    auto &Info = getTypeMangleInfo(Ndx);
+    Info.IsEnum = true;
+    Info.Enum = Enum;
   }
-  void setArgAttr(int Ndx, unsigned Attr) { Attrs[Ndx] = Attr; }
+  void setArgAttr(unsigned Ndx, unsigned Attr) {
+    getTypeMangleInfo(Ndx).Attr = Attr;
+  }
   void setVarArg(int Ndx) {
     assert(0 <= Ndx && "it is not allowed to set less than zero index");
     VarArgIdx = Ndx;
   }
   void setAsDontMangle() { DontMangle = true; }
-  bool isArgUnsigned(int Ndx) {
-    return UnsignedArgs.count(-1) || UnsignedArgs.count(Ndx);
-  }
-  bool isArgVoidPtr(int Ndx) {
-    return VoidPtrArgs.count(-1) || VoidPtrArgs.count(Ndx);
-  }
-  bool isArgSampler(int Ndx) { return SamplerArgs.count(Ndx); }
-  bool isArgAtomic(int Ndx) { return AtomicArgs.count(Ndx); }
-  bool isLocalArgBlock(int Ndx) { return LocalArgBlockIdx == Ndx; }
-  bool isArgEnum(int Ndx, SPIR::TypePrimitiveEnum *Enum = nullptr) {
-    auto Loc = EnumArgs.find(Ndx);
-    if (Loc == EnumArgs.end())
-      Loc = EnumArgs.find(-1);
-    if (Loc == EnumArgs.end())
-      return false;
-    if (Enum)
-      *Enum = Loc->second;
-    return true;
-  }
   bool avoidMangling() { return DontMangle; }
-  unsigned getArgAttr(int Ndx) {
-    auto Loc = Attrs.find(Ndx);
-    if (Loc == Attrs.end())
-      Loc = Attrs.find(-1);
-    if (Loc == Attrs.end())
-      return 0;
-    return Loc->second;
-  }
   // get ellipsis index, single ellipsis at the end of the function is possible
   // only return value < 0 if none
   int getVarArg() const { return VarArgIdx; }
-  BuiltinArgTypeMangleInfo getTypeMangleInfo(int Ndx) {
-    BuiltinArgTypeMangleInfo Info;
-    Info.IsSigned = !isArgUnsigned(Ndx);
-    Info.IsVoidPtr = isArgVoidPtr(Ndx);
-    Info.IsEnum = isArgEnum(Ndx, &Info.Enum);
-    Info.IsSampler = isArgSampler(Ndx);
-    Info.IsAtomic = isArgAtomic(Ndx);
-    Info.IsLocalArgBlock = isLocalArgBlock(Ndx);
-    Info.Attr = getArgAttr(Ndx);
+  BuiltinArgTypeMangleInfo &getTypeMangleInfo(unsigned Ndx) {
+    while (Ndx >= ArgInfo.size())
+      ArgInfo.emplace_back();
+    BuiltinArgTypeMangleInfo &Info = ArgInfo[Ndx];
     return Info;
   }
   virtual void init(StringRef UniqUnmangledName) {
     UnmangledName = UniqUnmangledName.str();
   }
 
+  void fillPointerElementTypes(ArrayRef<PointerIndirectPair> PETs);
+
 protected:
   std::string UnmangledName;
-  std::set<int> UnsignedArgs; // unsigned arguments, or -1 if all are unsigned
-  std::set<int> VoidPtrArgs;  // void pointer arguments, or -1 if all are void
-                              // pointer
-  std::set<int> SamplerArgs;  // sampler arguments
-  std::set<int> AtomicArgs;   // atomic arguments
-  std::map<int, SPIR::TypePrimitiveEnum> EnumArgs; // enum arguments
-  std::map<int, unsigned> Attrs;                   // argument attributes
-  int LocalArgBlockIdx; // index of a block with local arguments, idx < 0 if
-                        // none
-  int VarArgIdx;        // index of ellipsis argument, idx < 0 if none
+  std::vector<BuiltinArgTypeMangleInfo> ArgInfo;
+  int VarArgIdx; // index of ellipsis argument, idx < 0 if none
 private:
   bool DontMangle; // clang doesn't apply mangling for some builtin functions
                    // (i.e. enqueue_kernel)
@@ -598,7 +572,8 @@ void removeFnAttr(CallInst *Call, Attribute::AttrKind Attr);
 void addFnAttr(CallInst *Call, Attribute::AttrKind Attr);
 void saveLLVMModule(Module *M, const std::string &OutputFile);
 std::string mapSPIRVTypeToOCLType(SPIRVType *Ty, bool Signed);
-std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed);
+std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed,
+                                 Type *PointerElementType = nullptr);
 SPIRVDecorate *mapPostfixToDecorate(StringRef Postfix, SPIRVEntry *Target);
 
 /// Add decorations to a SPIR-V entry.
@@ -682,7 +657,8 @@ StringRef dePrefixSPIRVName(StringRef R, SmallVectorImpl<StringRef> &Postfix);
 /// Get a canonical function name for a SPIR-V op code.
 std::string getSPIRVFuncName(Op OC, StringRef PostFix = "");
 
-std::string getSPIRVFuncName(Op OC, const Type *PRetTy, bool IsSigned = false);
+std::string getSPIRVFuncName(Op OC, const Type *PRetTy, bool IsSigned = false,
+                             Type *PointerElementType = nullptr);
 
 std::string getSPIRVFuncName(SPIRVBuiltinVariableKind BVKind);
 
@@ -785,6 +761,7 @@ CallInst *addCallInst(Module *M, StringRef FuncName, Type *RetTy,
 /// Add a call instruction for SPIR-V builtin function.
 CallInst *addCallInstSPIRV(Module *M, StringRef FuncName, Type *RetTy,
                            ArrayRef<Value *> Args, AttributeList *Attrs,
+                           ArrayRef<Type *> PointerElementTypes,
                            Instruction *Pos, StringRef InstName);
 
 /// Add a call of spir_block_bind function.
@@ -889,7 +866,8 @@ std::string getPostfix(Decoration Dec, unsigned Value = 0);
 /// Get postfix _R{ReturnType} for return type
 /// The returned postfix does not includ "_" at the beginning
 std::string getPostfixForReturnType(CallInst *CI, bool IsSigned = false);
-std::string getPostfixForReturnType(const Type *PRetTy, bool IsSigned = false);
+std::string getPostfixForReturnType(const Type *PRetTy, bool IsSigned = false,
+                                    Type *PointerElementType = nullptr);
 
 Constant *getScalarOrVectorConstantInt(Type *T, uint64_t V,
                                        bool IsSigned = false);
@@ -1013,6 +991,7 @@ inline void getParameterTypes(CallInst *CI,
 /// manner
 std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
                                            ArrayRef<Type *> ArgTys,
+                                           ArrayRef<PointerIndirectPair> PETs,
                                            Type *RetTy = nullptr);
 
 /// Mangle a function in SPIR-V friendly IR manner
@@ -1024,7 +1003,8 @@ std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
 /// \param Types of arguments of SPIR-V built-in function
 /// \return IA64 mangled name.
 std::string getSPIRVFriendlyIRFunctionName(const std::string &UniqName,
-                                           spv::Op OC, ArrayRef<Type *> ArgTys);
+                                           spv::Op OC, ArrayRef<Type *> ArgTys,
+                                           ArrayRef<PointerIndirectPair> PETs);
 
 /// Cast a function to a void(void) funtion pointer.
 Constant *castToVoidFuncPtr(Function *F);

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -447,10 +447,6 @@ enum Spir2SamplerKind {
   CLK_FILTER_LINEAR = 0x0020,
 };
 
-/// This contains a pair of the pointer element type and an indirection
-/// parameter (to capture cases where an array of OpenCL types is used).
-typedef llvm::PointerIntPair<llvm::Type *, 1, bool> PointerIndirectPair;
-
 /// Additional information for mangling a function argument type.
 struct BuiltinArgTypeMangleInfo {
   bool IsSigned;
@@ -523,7 +519,7 @@ public:
     UnmangledName = UniqUnmangledName.str();
   }
 
-  void fillPointerElementTypes(ArrayRef<PointerIndirectPair> PETs);
+  void fillPointerElementTypes(ArrayRef<PointerIndirectPair>);
 
 protected:
   std::string UnmangledName;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -582,6 +582,98 @@ std::string SPIRVToLLVM::transTypeToOCLTypeName(SPIRVType *T, bool IsSigned) {
   }
 }
 
+std::vector<PointerIndirectPair>
+SPIRVToLLVM::getPointerElementTypes(ArrayRef<SPIRVType *> Tys) {
+  std::vector<PointerIndirectPair> PETs;
+  for (SPIRVType *T : Tys) {
+    PointerIndirectPair PtrElemTy;
+    switch (static_cast<SPIRVWord>(T->getOpCode())) {
+    case OpTypePointer: {
+      SPIRVType *UntransTy = T->getPointerElementType();
+      PtrElemTy.setPointer(transType(UntransTy));
+      if (PtrElemTy.getPointer()->isPointerTy()) {
+        PtrElemTy = getPointerElementTypes(UntransTy)[0];
+        PtrElemTy.setInt(true);
+      }
+      break;
+    }
+    case OpTypeImage: {
+      auto *ST = static_cast<SPIRVTypeImage *>(T);
+      if (ST->isOCLImage())
+        PtrElemTy.setPointer(
+            getOrCreateOpaqueStructType(M, transOCLImageTypeName(ST)));
+      break;
+    }
+    case OpTypeSampledImage: {
+      auto *ST = static_cast<SPIRVTypeSampledImage *>(T);
+      PtrElemTy.setPointer(
+          getOrCreateOpaqueStructType(M, transOCLSampledImageTypeName(ST)));
+      break;
+    }
+    case OpTypePipe: {
+      auto *PT = static_cast<SPIRVTypePipe *>(T);
+      PtrElemTy.setPointer(
+          getOrCreateOpaqueStructType(M, transPipeTypeName(PT)));
+      break;
+    }
+    case OpTypePipeStorage: {
+      auto *PST = static_cast<SPIRVTypePipeStorage *>(T);
+      PtrElemTy.setPointer(
+          getOrCreateOpaqueStructType(M, transOCLPipeStorageTypeName(PST)));
+      break;
+    }
+    case OpTypeVmeImageINTEL: {
+      auto *VT = static_cast<SPIRVTypeVmeImageINTEL *>(T);
+      PtrElemTy.setPointer(
+          getOrCreateOpaqueStructType(M, transVMEImageTypeName(VT)));
+      break;
+    }
+    case OpTypeBufferSurfaceINTEL: {
+      auto *PST = static_cast<SPIRVTypeBufferSurfaceINTEL *>(T);
+      PtrElemTy.setPointer(
+          getOrCreateOpaqueStructType(M, transVCTypeName(PST)));
+      break;
+    }
+    case internal::OpTypeJointMatrixINTEL: {
+      auto *MT = static_cast<SPIRVTypeJointMatrixINTEL *>(T);
+      auto R = static_cast<SPIRVConstant *>(MT->getRows())->getZExtIntValue();
+      auto C =
+          static_cast<SPIRVConstant *>(MT->getColumns())->getZExtIntValue();
+      std::stringstream SS;
+      SS << kSPIRVTypeName::PostfixDelim;
+      SS << transTypeToOCLTypeName(MT->getCompType());
+      auto L = static_cast<SPIRVConstant *>(MT->getLayout())->getZExtIntValue();
+      auto S = static_cast<SPIRVConstant *>(MT->getScope())->getZExtIntValue();
+      SS << kSPIRVTypeName::PostfixDelim << R << kSPIRVTypeName::PostfixDelim
+         << C << kSPIRVTypeName::PostfixDelim << L
+         << kSPIRVTypeName::PostfixDelim << S;
+      if (auto *Use = MT->getUse())
+        SS << kSPIRVTypeName::PostfixDelim
+           << static_cast<SPIRVConstant *>(Use)->getZExtIntValue();
+      std::string Name =
+          getSPIRVTypeName(kSPIRVTypeName::JointMatrixINTEL, SS.str());
+      PtrElemTy.setPointer(getOrCreateOpaqueStructType(M, Name));
+      break;
+    }
+    case OpTypeFunction: {
+      // A function parameter will get converted into a function pointer later,
+      // so make sure elementtype() attribute reflects the actual function type.
+      PtrElemTy.setPointer(transType(T));
+      break;
+    }
+    default: {
+      auto OC = T->getOpCode();
+      if (isOpaqueGenericTypeOpCode(OC) || isSubgroupAvcINTELTypeOpCode(OC))
+        PtrElemTy.setPointer(getOrCreateOpaqueStructType(
+            M, getSPIRVTypeName(SPIRVOpaqueTypeOpCodeMap::rmap(OC))));
+    }
+    }
+
+    PETs.push_back(PtrElemTy);
+  }
+  return PETs;
+}
+
 std::vector<Type *>
 SPIRVToLLVM::transTypeVector(const std::vector<SPIRVType *> &BT) {
   std::vector<Type *> T;
@@ -3024,11 +3116,13 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
     }
   }
 
+  std::vector<PointerIndirectPair> PETs =
+      getPointerElementTypes(SPIRVInstruction::getOperandTypes(Ops));
   if (BM->getDesiredBIsRepresentation() != BIsRepresentation::SPIRVFriendlyIR)
-    mangleOpenClBuiltin(FuncName, ArgTys, MangledName);
+    mangleOpenClBuiltin(FuncName, ArgTys, PETs, MangledName);
   else
     MangledName =
-        getSPIRVFriendlyIRFunctionName(FuncName, BI->getOpCode(), ArgTys);
+        getSPIRVFriendlyIRFunctionName(FuncName, BI->getOpCode(), ArgTys, PETs);
 
   Function *Func = M->getFunction(MangledName);
   FunctionType *FT = FunctionType::get(RetTy, ArgTys, false);
@@ -3177,7 +3271,10 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   if (AddRetTypePostfix) {
     const Type *RetTy =
         BI->hasType() ? transType(BI->getType()) : Type::getVoidTy(*Context);
-    return transBuiltinFromInst(getSPIRVFuncName(OC, RetTy, IsRetSigned) +
+    Type *PET = RetTy->isPointerTy()
+                    ? getPointerElementTypes(BI->getType())[0].getPointer()
+                    : nullptr;
+    return transBuiltinFromInst(getSPIRVFuncName(OC, RetTy, IsRetSigned, PET) +
                                     getSPIRVFuncSuffix(BI),
                                 BI, BB);
   }
@@ -4256,9 +4353,11 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC,
          "Not OpenCL extended instruction");
 
   std::vector<Type *> ArgTypes = transTypeVector(BC->getArgTypes());
+  std::vector<PointerIndirectPair> PETs =
+      getPointerElementTypes(BC->getArgTypes());
   Type *RetTy = transType(BC->getType());
   std::string MangledName =
-      getSPIRVFriendlyIRFunctionName(ExtOp, ArgTypes, RetTy);
+      getSPIRVFriendlyIRFunctionName(ExtOp, ArgTypes, PETs, RetTy);
 
   SPIRVDBG(spvdbgs() << "[transOCLBuiltinFromExtInst] UnmangledName: "
                      << UnmangledName << " MangledName: " << MangledName

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -46,7 +46,6 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSet.h"
-#include "llvm/IR/Attributes.h"
 #include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
 
 namespace llvm {

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -41,10 +41,12 @@
 #ifndef SPIRVREADER_H
 #define SPIRVREADER_H
 
+#include "SPIRVInternal.h"
 #include "SPIRVModule.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/IR/Attributes.h"
 #include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
 
 namespace llvm {
@@ -82,6 +84,8 @@ public:
   Type *transType(SPIRVType *BT, bool IsClassMember = false);
   std::string transTypeToOCLTypeName(SPIRVType *BT, bool IsSigned = true);
   std::vector<Type *> transTypeVector(const std::vector<SPIRVType *> &);
+  std::vector<PointerIndirectPair>
+  getPointerElementTypes(llvm::ArrayRef<SPIRVType *> Tys);
   bool translate();
   bool transAddressingModel();
 

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -591,11 +591,13 @@ bool SPIRVRegularizeLLVMBase::regularize() {
           Value *Val = Cmpxchg->getNewValOperand();
           Value *Comparator = Cmpxchg->getCompareOperand();
 
+          Type *MemType = Cmpxchg->getCompareOperand()->getType();
+
           llvm::Value *Args[] = {Ptr,        MemoryScope, EqualSem,
                                  UnequalSem, Val,         Comparator};
-          auto *Res = addCallInstSPIRV(M, "__spirv_AtomicCompareExchange",
-                                       Cmpxchg->getCompareOperand()->getType(),
-                                       Args, nullptr, &II, "cmpxchg.res");
+          auto *Res =
+              addCallInstSPIRV(M, "__spirv_AtomicCompareExchange", MemType,
+                               Args, nullptr, {MemType}, &II, "cmpxchg.res");
           IRBuilder<> Builder(Cmpxchg);
           auto *Cmp = Builder.CreateICmpEQ(Res, Comparator, "cmpxchg.success");
           auto *V1 = Builder.CreateInsertValue(

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -277,6 +277,7 @@ void SPIRVToOCLBase::visitCallSPRIVImageQuerySize(CallInst *CI) {
 
   AttributeList Attributes = CI->getCalledFunction()->getAttributes();
   BuiltinFuncMangleInfo Mangle;
+  Mangle.getTypeMangleInfo(0).PointerElementType.setPointer(ImgTy);
   Type *Int32Ty = Type::getInt32Ty(*Ctx);
   Instruction *GetImageSize = nullptr;
 

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2390,26 +2390,26 @@ private:
 
 namespace SPIRV {
 void BuiltinFuncMangleInfo::fillPointerElementTypes(
-    ArrayRef<PointerIndirectPair> PETs) {
-  for (unsigned I = 0; I < PETs.size(); I++) {
-    getTypeMangleInfo(I).PointerElementType = PETs[I];
+    ArrayRef<PointerIndirectPair> PointerElementTys) {
+  for (unsigned I = 0; I < PointerElementTys.size(); I++) {
+    getTypeMangleInfo(I).PointerElementType = PointerElementTys[I];
   }
 }
 
-std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
-                                           ArrayRef<Type *> ArgTys,
-                                           ArrayRef<PointerIndirectPair> PETs,
-                                           Type *RetTy) {
+std::string
+getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId, ArrayRef<Type *> ArgTys,
+                               ArrayRef<PointerIndirectPair> PointerElementTys,
+                               Type *RetTy) {
   OpenCLStdToSPIRVFriendlyIRMangleInfo MangleInfo(ExtOpId, ArgTys, RetTy);
-  MangleInfo.fillPointerElementTypes(PETs);
+  MangleInfo.fillPointerElementTypes(PointerElementTys);
   return mangleBuiltin(MangleInfo.getUnmangledName(), ArgTys, &MangleInfo);
 }
 
-std::string getSPIRVFriendlyIRFunctionName(const std::string &UniqName,
-                                           spv::Op OC, ArrayRef<Type *> ArgTys,
-                                           ArrayRef<PointerIndirectPair> PETs) {
+std::string getSPIRVFriendlyIRFunctionName(
+    const std::string &UniqName, spv::Op OC, ArrayRef<Type *> ArgTys,
+    ArrayRef<PointerIndirectPair> PointerElementTys) {
   SPIRVFriendlyIRMangleInfo MangleInfo(OC, ArgTys);
-  MangleInfo.fillPointerElementTypes(PETs);
+  MangleInfo.fillPointerElementTypes(PointerElementTys);
   return mangleBuiltin(UniqName, ArgTys, &MangleInfo);
 }
 

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -102,7 +102,7 @@ void saveLLVMModule(Module *M, const std::string &OutputFile) {
   Out.keep();
 }
 
-std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed) {
+std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed, Type *PET) {
   if (Ty->isHalfTy())
     return "half";
   if (Ty->isFloatTy())
@@ -147,6 +147,11 @@ std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed) {
   // value of some SPIR-V instructions may be represented as pointer to a struct
   // in LLVM IR) we can mangle the type.
   BuiltinFuncMangleInfo MangleInfo;
+  if (Ty->isPointerTy()) {
+    assert(cast<PointerType>(const_cast<Type *>(Ty))
+               ->isOpaqueOrPointeeTypeMatches(PET));
+    MangleInfo.getTypeMangleInfo(0).PointerElementType.setPointer(PET);
+  }
   std::string MangledName =
       mangleBuiltin("", const_cast<Type *>(Ty), &MangleInfo);
   // Remove "_Z0"(3 characters) from the front of the name
@@ -403,9 +408,10 @@ std::string getSPIRVFuncName(Op OC, StringRef PostFix) {
   return prefixSPIRVName(getName(OC) + PostFix.str());
 }
 
-std::string getSPIRVFuncName(Op OC, const Type *PRetTy, bool IsSigned) {
+std::string getSPIRVFuncName(Op OC, const Type *PRetTy, bool IsSigned,
+                             Type *PET) {
   return prefixSPIRVName(getName(OC) + kSPIRVPostfix::Divider +
-                         getPostfixForReturnType(PRetTy, IsSigned));
+                         getPostfixForReturnType(PRetTy, IsSigned, PET));
 }
 
 std::string getSPIRVFuncName(SPIRVBuiltinVariableKind BVKind) {
@@ -463,9 +469,10 @@ std::string getPostfixForReturnType(CallInst *CI, bool IsSigned) {
   return getPostfixForReturnType(CI->getType(), IsSigned);
 }
 
-std::string getPostfixForReturnType(const Type *PRetTy, bool IsSigned) {
+std::string getPostfixForReturnType(const Type *PRetTy, bool IsSigned,
+                                    Type *PET) {
   return std::string(kSPIRVPostfix::Return) +
-         mapLLVMTypeToOCLType(PRetTy, IsSigned);
+         mapLLVMTypeToOCLType(PRetTy, IsSigned, PET);
 }
 
 // Enqueue kernel, kernel query, pipe and address space cast built-ins
@@ -750,6 +757,24 @@ void getParameterTypes(Function *F, SmallVectorImpl<StructType *> &ArgTys) {
   free(Buf);
 }
 
+// This is a transitional helper function to fill in mangling information for
+// mangleBuiltin while all the calls to mutateCallInst are being transitioned.
+static void typeMangle(BuiltinFuncMangleInfo *Mangle, ArrayRef<Value *> Args) {
+  if (!Mangle)
+    return;
+  for (unsigned I = 0; I < Args.size(); I++)
+    if (Args[I]->getType()->isPointerTy()) {
+      auto &PointeeTy = Mangle->getTypeMangleInfo(I).PointerElementType;
+      PointeeTy.setPointer(
+          Args[I]->getType()->getNonOpaquePointerElementType());
+      if (PointeeTy.getPointer()->isPointerTy()) {
+        PointeeTy.setPointer(
+            PointeeTy.getPointer()->getNonOpaquePointerElementType());
+        PointeeTy.setInt(true);
+      }
+    }
+}
+
 CallInst *mutateCallInst(
     Module *M, CallInst *CI,
     std::function<std::string(CallInst *, std::vector<Value *> &)> ArgMutate,
@@ -763,6 +788,7 @@ CallInst *mutateCallInst(
     InstName = CI->getName().str();
     CI->setName(InstName + ".old");
   }
+  typeMangle(Mangle, Args);
   auto NewCI = addCallInst(M, NewName, CI->getType(), Args, Attrs, CI, Mangle,
                            InstName, TakeFuncName);
   NewCI->setDebugLoc(CI->getDebugLoc());
@@ -784,6 +810,7 @@ Instruction *mutateCallInst(
   Type *RetTy = CI->getType();
   auto NewName = ArgMutate(CI, Args, RetTy);
   StringRef InstName = CI->getName();
+  typeMangle(Mangle, Args);
   auto NewCI = addCallInst(M, NewName, RetTy, Args, Attrs, CI, Mangle, InstName,
                            TakeFuncName);
   auto NewI = RetMutate(NewCI);
@@ -857,8 +884,16 @@ CallInst *addCallInst(Module *M, StringRef FuncName, Type *RetTy,
 
 CallInst *addCallInstSPIRV(Module *M, StringRef FuncName, Type *RetTy,
                            ArrayRef<Value *> Args, AttributeList *Attrs,
+                           ArrayRef<Type *> PointerElementTypes,
                            Instruction *Pos, StringRef InstName) {
   BuiltinFuncMangleInfo BtnInfo;
+  for (unsigned I = 0; I < PointerElementTypes.size(); I++) {
+    BtnInfo.getTypeMangleInfo(I).PointerElementType.setPointer(
+        PointerElementTypes[I]);
+    if (Args[I]->getType()->isPointerTy())
+      assert(cast<PointerType>(Args[I]->getType())
+                 ->isOpaqueOrPointeeTypeMatches(PointerElementTypes[I]));
+  }
   return addCallInst(M, FuncName, RetTy, Args, Attrs, Pos, &BtnInfo, InstName);
 }
 
@@ -1203,7 +1238,9 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
         transTypeDesc(VecTy->getElementType(), Info), VecTy->getNumElements()));
   }
   if (Ty->isArrayTy()) {
-    return transTypeDesc(PointerType::get(Ty->getArrayElementType(), 0), Info);
+    BuiltinArgTypeMangleInfo DTInfo = Info;
+    DTInfo.PointerElementType.setPointer(Ty->getArrayElementType());
+    return transTypeDesc(Ty->getArrayElementType()->getPointerTo(0), DTInfo);
   }
   if (Ty->isStructTy()) {
     auto Name = Ty->getStructName();
@@ -1231,7 +1268,16 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
   }
 
   if (Ty->isPointerTy()) {
-    auto ET = Ty->getPointerElementType();
+    auto *ET = Info.PointerElementType.getPointer();
+    if (!ET)
+      ET = Type::getInt8Ty(Ty->getContext());
+    BuiltinArgTypeMangleInfo DTInfo = Info;
+    if (Info.PointerElementType.getInt()) {
+      ET = DTInfo.PointerElementType.getPointer()->getPointerTo(0);
+      DTInfo.PointerElementType.setInt(false);
+    } else {
+      DTInfo.PointerElementType.setPointer(Type::getInt8Ty(Ty->getContext()));
+    }
     SPIR::ParamType *EPT = nullptr;
     if (isa<FunctionType>(ET)) {
       assert(isVoidFuncTy(cast<FunctionType>(ET)) && "Not supported");
@@ -1285,7 +1331,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
 
     if (VoidPtr && ET->isIntegerTy(8))
       ET = Type::getVoidTy(ET->getContext());
-    auto PT = new SPIR::PointerType(transTypeDesc(ET, Info));
+    auto *PT = new SPIR::PointerType(transTypeDesc(ET, DTInfo));
     PT->setAddressSpace(static_cast<SPIR::TypeAttributeEnum>(
         Ty->getPointerAddressSpace() + (unsigned)SPIR::ATTR_ADDR_SPACE_FIRST));
     for (unsigned I = SPIR::ATTR_QUALIFIER_FIRST, E = SPIR::ATTR_QUALIFIER_LAST;
@@ -1891,7 +1937,7 @@ bool lowerBuiltinVariableToCall(GlobalVariable *GV,
   if (HasIndexArg)
     ArgTy.push_back(Type::getInt32Ty(C));
   std::string MangledName;
-  mangleOpenClBuiltin(FuncName, ArgTy, MangledName);
+  mangleOpenClBuiltin(FuncName, ArgTy, {}, MangledName);
   Function *Func = M->getFunction(MangledName);
   if (!Func) {
     FunctionType *FT = FunctionType::get(ReturnTy, ArgTy, false);
@@ -2343,17 +2389,27 @@ private:
 } // namespace
 
 namespace SPIRV {
+void BuiltinFuncMangleInfo::fillPointerElementTypes(
+    ArrayRef<PointerIndirectPair> PETs) {
+  for (unsigned I = 0; I < PETs.size(); I++) {
+    getTypeMangleInfo(I).PointerElementType = PETs[I];
+  }
+}
+
 std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
                                            ArrayRef<Type *> ArgTys,
+                                           ArrayRef<PointerIndirectPair> PETs,
                                            Type *RetTy) {
   OpenCLStdToSPIRVFriendlyIRMangleInfo MangleInfo(ExtOpId, ArgTys, RetTy);
+  MangleInfo.fillPointerElementTypes(PETs);
   return mangleBuiltin(MangleInfo.getUnmangledName(), ArgTys, &MangleInfo);
 }
 
 std::string getSPIRVFriendlyIRFunctionName(const std::string &UniqName,
-                                           spv::Op OC,
-                                           ArrayRef<Type *> ArgTys) {
+                                           spv::Op OC, ArrayRef<Type *> ArgTys,
+                                           ArrayRef<PointerIndirectPair> PETs) {
   SPIRVFriendlyIRMangleInfo MangleInfo(OC, ArgTys);
+  MangleInfo.fillPointerElementTypes(PETs);
   return mangleBuiltin(UniqName, ArgTys, &MangleInfo);
 }
 


### PR DESCRIPTION
This includes a rejigging of the BuiltinFuncMangleInfo to actually act as the
source of information to pass this information into.

Only some of the call sites of mangleBuiltin have been properly updated to pass
in the pointer type element information. The various mutateCallInst* callers
have yet to be updated, so those methods are temporarily relying on querying
getPointerElementType() to generate this information.