### PR TITLE
[Backport to 14] Fix out of bounds access in SPIRVToOCLBase::mutateArgsForImageOperands

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -785,8 +785,8 @@ void SPIRVToOCLBase::mutateArgsForImageOperands(std::vector<Value *> &Args,
       if (ImOpValue & ImageOperandsMask::ImageOperandsZeroExtendMask)
         IsSigned = false;
       ImOpValue &= ~SignZeroExtMasks;
-      Args[3] = getInt32(M, ImOpValue);
-      ImOp = cast<ConstantInt>(Args[3]);
+      Args[ImOpArgIndex] = getInt32(M, ImOpValue);
+      ImOp = cast<ConstantInt>(Args[ImOpArgIndex]);
     }
     // Drop "Image Operands" argument.
     Args.erase(Args.begin() + ImOpArgIndex);


### PR DESCRIPTION
When called from visitCallSPIRVImageReadBuiltIn, Args only has three
elements and ImOpArgIndex is 2. This has been causing this function to
"update" an argument past the end of the vector, which caused a crash
when running transcoding/image_signedness.ll on Windows because the
debug build in Windows has bounds checking on std::vector.

With this change, it should update the correct (and not past the end)
argument instead and satisfy the Windows bounds checks.

(cherry picked from commit 6904b388c1a115dbb634b9a194091af84e191a39)