### PR TITLE
[NFC] Let setMinSPIRVVersion take a VersionNumber

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1380,8 +1380,7 @@ LLVMToSPIRVBase::getLoopControl(const BranchInst *Branch,
       else if (S == "llvm.loop.unroll.count" &&
                !(LoopControl & LoopControlDontUnrollMask)) {
         if (BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
-          BM->setMinSPIRVVersion(
-              static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
+          BM->setMinSPIRVVersion(VersionNumber::SPIRV_1_4);
           size_t I = getMDOperandAsInt(Node, 1);
           ParametersToSort.emplace_back(spv::LoopControlPartialCountMask, I);
           LoopControl |= spv::LoopControlPartialCountMask;
@@ -4213,8 +4212,7 @@ LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF, Function *F) {
       SPIRVWord ModuleVersion = static_cast<SPIRVWord>(BM->getSPIRVVersion());
       if (AS != SPIRAS_Input && AS != SPIRAS_Output &&
           ModuleVersion < static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4))
-        BM->setMinSPIRVVersion(
-            static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
+        BM->setMinSPIRVVersion(VersionNumber::SPIRV_1_4);
       Interface.push_back(ValueMap[&GV]->getId());
     }
   }
@@ -4569,8 +4567,7 @@ bool LLVMToSPIRVBase::transExecutionMode() {
       case spv::ExecutionModeRoundingModeRTE:
       case spv::ExecutionModeRoundingModeRTZ: {
         if (BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
-          BM->setMinSPIRVVersion(
-              static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
+          BM->setMinSPIRVVersion(VersionNumber::SPIRV_1_4);
           AddSingleArgExecutionMode(static_cast<ExecutionMode>(EMode));
         } else if (BM->isAllowedToUseExtension(
                        ExtensionID::SPV_KHR_float_controls)) {
@@ -5255,7 +5252,7 @@ bool runSpirvWriterPasses(Module *M, std::ostream *OS, std::string &ErrMsg,
     if (!BM->getErrorLog().checkError(ModuleVer <= Opts.getMaxVersion(),
                                       SPIRVEC_TripleMaxVersionIncompatible))
       return false;
-    BM->setMinSPIRVVersion(static_cast<SPIRVWord>(ModuleVer));
+    BM->setMinSPIRVVersion(ModuleVer);
   }
 
   ModulePassManager PassMgr;

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -521,7 +521,8 @@ void SPIRVEntry::updateModuleVersion() const {
   if (!Module)
     return;
 
-  Module->setMinSPIRVVersion(getRequiredSPIRVVersion());
+  Module->setMinSPIRVVersion(
+      static_cast<VersionNumber>(getRequiredSPIRVVersion()));
 }
 
 spv_ostream &operator<<(spv_ostream &O, const SPIRVEntry &E) {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -183,7 +183,7 @@ void SPIRVImageInstBase::setOpWords(const std::vector<SPIRVWord> &OpsArg) {
     if (ImgOps & SignZeroExtMasks) {
       SPIRVModule *M = getModule();
       if (M->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
-        M->setMinSPIRVVersion(static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
+        M->setMinSPIRVVersion(VersionNumber::SPIRV_1_4);
       } else {
         // Drop SignExtend/ZeroExtend if we cannot use SPIR-V 1.4.
         Ops[ImgOpsIndex] &= ~SignZeroExtMasks;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -176,8 +176,8 @@ public:
   virtual void setSPIRVVersion(SPIRVWord) = 0;
   virtual void insertEntryNoId(SPIRVEntry *Entry) = 0;
 
-  void setMinSPIRVVersion(SPIRVWord Ver) {
-    setSPIRVVersion(std::max(Ver, getSPIRVVersion()));
+  void setMinSPIRVVersion(VersionNumber Ver) {
+    setSPIRVVersion(std::max(static_cast<SPIRVWord>(Ver), getSPIRVVersion()));
   }
 
   // Object creation functions

--- a/lib/SPIRV/libSPIRV/SPIRVValue.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.cpp
@@ -103,8 +103,7 @@ void SPIRVValue::setNoIntegerDecorationWrap(bool HasNoIntegerWrap) {
       NoIntegerWrapDecoration == DecorationNoSignedWrap ? "nsw" : "nuw";
 #endif // _SPIRVDBG
   if (Module->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
-    Module->setMinSPIRVVersion(
-        static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4));
+    Module->setMinSPIRVVersion(VersionNumber::SPIRV_1_4);
     addDecorate(new SPIRVDecorate(NoIntegerWrapDecoration, this));
     SPIRVDBG(spvdbgs() << "Set " << InstStr << " for obj " << Id << "\n")
   } else if (Module->isAllowedToUseExtension(


### PR DESCRIPTION
This avoids the need for casts at each call site.