### PR TITLE
Rework the demangler to support recovering more pointer element types.

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -1010,7 +1010,7 @@ void OCLToSPIRVBase::visitCallReadImageWithSampler(CallInst *CI,
   Function *Func = CI->getCalledFunction();
   AttributeList Attrs = Func->getAttributes();
   bool IsRetScalar = !CI->getType()->isVectorTy();
-  SmallVector<StructType *, 3> ArgStructTys;
+  SmallVector<Type *, 3> ArgStructTys;
   getParameterTypes(CI, ArgStructTys);
   mutateCallInstSPIRV(
       M, CI,
@@ -1073,7 +1073,7 @@ void OCLToSPIRVBase::visitCallGetImageSize(CallInst *CI,
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   StringRef TyName;
   SmallVector<StringRef, 4> SubStrs;
-  SmallVector<StructType *, 4> ParamTys;
+  SmallVector<Type *, 4> ParamTys;
   getParameterTypes(CI, ParamTys);
   auto IsImg = isOCLImageStructType(ParamTys[0], &TyName);
   (void)IsImg;
@@ -1632,7 +1632,7 @@ static void processSubgroupBlockReadWriteINTEL(CallInst *CI,
 // reads and vector block reads.
 void OCLToSPIRVBase::visitSubgroupBlockReadINTEL(CallInst *CI) {
   OCLBuiltinTransInfo Info;
-  SmallVector<StructType *, 2> ParamTys;
+  SmallVector<Type *, 2> ParamTys;
   getParameterTypes(CI, ParamTys);
   if (isOCLImageStructType(ParamTys[0]))
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupImageBlockReadINTEL);
@@ -1647,7 +1647,7 @@ void OCLToSPIRVBase::visitSubgroupBlockReadINTEL(CallInst *CI) {
 // instructions.
 void OCLToSPIRVBase::visitSubgroupBlockWriteINTEL(CallInst *CI) {
   OCLBuiltinTransInfo Info;
-  SmallVector<StructType *, 3> ParamTys;
+  SmallVector<Type *, 3> ParamTys;
   getParameterTypes(CI, ParamTys);
   if (isOCLImageStructType(ParamTys[0]))
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupImageBlockWriteINTEL);
@@ -1768,7 +1768,7 @@ void OCLToSPIRVBase::visitSubgroupAVCWrapperBuiltinCall(
   OCLSPIRVSubgroupAVCIntelBuiltinMap::find(ToMCEFName, &ToMCEOC);
   assert(ToMCEOC != OpNop && "Invalid Subgroup AVC Intel built-in call");
 
-  SmallVector<StructType *, 2> ParamTys;
+  SmallVector<Type *, 2> ParamTys;
   getParameterTypes(CI, ParamTys);
 
   if (std::strcmp(TyKind, "payload") == 0) {
@@ -1837,7 +1837,7 @@ void OCLToSPIRVBase::visitSubgroupAVCBuiltinCallWithSampler(
   mutateCallInstSPIRV(
       M, CI,
       [=](CallInst *, std::vector<Value *> &Args) {
-        SmallVector<StructType *, 4> ParamTys;
+        SmallVector<Type *, 4> ParamTys;
         getParameterTypes(CI, ParamTys);
         auto *TyIt =
             std::find_if(ParamTys.begin(), ParamTys.end(), isSamplerStructTy);

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -208,7 +208,7 @@ void OCLTypeToSPIRVBase::adaptFunctionArguments(Function *F) {
     return;
   bool Changed = false;
   auto Arg = F->arg_begin();
-  SmallVector<StructType *, 4> ParamTys;
+  SmallVector<Type *, 4> ParamTys;
   getParameterTypes(F, ParamTys);
 
   // If we couldn't get any information from demangling, there is nothing that
@@ -217,7 +217,7 @@ void OCLTypeToSPIRVBase::adaptFunctionArguments(Function *F) {
     return;
 
   for (unsigned I = 0; I < F->arg_size(); ++I, ++Arg) {
-    StructType *NewTy = ParamTys[I];
+    StructType *NewTy = dyn_cast_or_null<StructType>(ParamTys[I]);
     if (NewTy && NewTy->isOpaque()) {
       auto STName = NewTy->getStructName();
       if (!hasAccessQualifiedName(STName))

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1364,7 +1364,8 @@ Value *unwrapSpecialTypeInitializer(Value *V) {
   return nullptr;
 }
 
-bool isSamplerStructTy(StructType *STy) {
+bool isSamplerStructTy(Type *Ty) {
+  auto *STy = dyn_cast_or_null<StructType>(Ty);
   return STy && STy->hasName() && STy->getName() == kSPR2TypeName::Sampler;
 }
 

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -507,7 +507,7 @@ bool isEnqueueKernelBI(const StringRef MangledName);
 bool isKernelQueryBI(const StringRef MangledName);
 
 /// Check that the type is the sampler_t
-bool isSamplerStructTy(StructType *Ty);
+bool isSamplerStructTy(Type *Ty);
 
 // Checks if the binary operator is an unfused fmul + fadd instruction.
 bool isUnfusedMulAdd(BinaryOperator *B);

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -50,6 +50,7 @@
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/TypedPointerType.h"
 
 #include <functional>
 #include <utility>
@@ -970,11 +971,15 @@ std::string mangleBuiltin(StringRef UniqName, ArrayRef<Type *> ArgTypes,
 /// Extract the pointee types of arguments from a mangled function name. If the
 /// corresponding type is not a pointer to a struct type, its value will be a
 /// nullptr instead.
-void getParameterTypes(Function *F, SmallVectorImpl<StructType *> &ArgTys);
-inline void getParameterTypes(CallInst *CI,
-                              SmallVectorImpl<StructType *> &ArgTys) {
+void getParameterTypes(
+    Function *F, SmallVectorImpl<Type *> &ArgTys,
+    std::function<std::string(StringRef)> StructNameMapFn = nullptr);
+inline void getParameterTypes(CallInst *CI, SmallVectorImpl<Type *> &ArgTys) {
   return getParameterTypes(CI->getCalledFunction(), ArgTys);
 }
+void getParameterTypes(
+    Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
+    std::function<std::string(StringRef)> StructNameMapFn = nullptr);
 
 /// Mangle a function from OpenCL extended instruction set in SPIR-V friendly IR
 /// manner

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -269,14 +269,16 @@ private:
   std::string groupOCToOCLBuiltinName(CallInst *CI, Op OC);
   /// Transform SPV-IR image opaque type into OpenCL representation,
   /// example: spirv.Image._void_1_0_0_0_0_0_1 => opencl.image2d_wo_t
-  std::string getOCLImageOpaqueType(SmallVector<std::string, 8> &Postfixes);
+  static std::string
+  getOCLImageOpaqueType(SmallVector<std::string, 8> &Postfixes);
   /// Transform SPV-IR pipe opaque type into OpenCL representation,
   /// example: spirv.Pipe._0 => opencl.pipe_ro_t
-  std::string getOCLPipeOpaqueType(SmallVector<std::string, 8> &Postfixes);
+  static std::string
+  getOCLPipeOpaqueType(SmallVector<std::string, 8> &Postfixes);
 
-  void getParameterTypes(CallInst *CI, SmallVectorImpl<StructType *> &Tys);
+  void getParameterTypes(CallInst *CI, SmallVectorImpl<Type *> &Tys);
 
-  std::string translateOpaqueType(StringRef STName);
+  static std::string translateOpaqueType(StringRef STName);
 
   /// Mutate the argument list based on (optional) image operands at position
   /// ImOpArgIndex.  Set IsSigned according to any SignExtend/ZeroExtend Image

--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -229,7 +229,7 @@ void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
   // If the function is a mangled name, try to recover types from the Itanium
   // name mangling.
   if (F.getName().startswith("_Z")) {
-    SmallVector<StructType *, 8> ParameterTypes;
+    SmallVector<Type *, 8> ParameterTypes;
     getParameterTypes(&F, ParameterTypes);
     for (Argument *Arg : PointerArgs) {
       if (auto *Ty = ParameterTypes[Arg->getArgNo()]) {

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -38,6 +38,10 @@
 ///
 //===----------------------------------------------------------------------===//
 
+// This file needs to be included before anything that declares
+// llvm::PointerType to avoid a compilation bug on MSVC.
+#include "llvm/Demangle/ItaniumDemangle.h"
+
 #include "FunctionDescriptor.h"
 #include "ManglingUtils.h"
 #include "NameMangleAPI.h"
@@ -50,7 +54,6 @@
 
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
-#include "llvm/Demangle/ItaniumDemangle.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Metadata.h"

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -50,7 +50,7 @@
 
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
-#include "llvm/Demangle/Demangle.h"
+#include "llvm/Demangle/ItaniumDemangle.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Metadata.h"
@@ -661,12 +661,191 @@ static std::string demangleBuiltinOpenCLTypeName(StringRef MangledStructName) {
   return LlvmStructName;
 }
 
-void getParameterTypes(Function *F, SmallVectorImpl<StructType *> &ArgTys) {
+/// Convert a C/C++ type name into an LLVM type, if it's a basic integer or
+/// floating point type.
+static Type *parsePrimitiveType(LLVMContext &Ctx, StringRef Name) {
+  return StringSwitch<Type *>(Name)
+      .Cases("char", "signed char", "unsigned char", Type::getInt8Ty(Ctx))
+      .Cases("short", "unsigned short", Type::getInt16Ty(Ctx))
+      .Cases("int", "unsigned int", Type::getInt32Ty(Ctx))
+      .Cases("long", "unsigned long", Type::getInt64Ty(Ctx))
+      .Cases("long long", "unsigned long long", Type::getInt64Ty(Ctx))
+      .Case("half", Type::getHalfTy(Ctx))
+      .Case("float", Type::getFloatTy(Ctx))
+      .Case("double", Type::getDoubleTy(Ctx))
+      .Case("void", Type::getInt8Ty(Ctx))
+      .Default(nullptr);
+}
+
+} // namespace SPIRV
+
+// The demangler node hierarchy doesn't use LLVM's RTTI helper functions (as it
+// also needs to live in libcxxabi). By specializing this implementation here,
+// we can add support for these functions.
+#define NODE(X)                                                                \
+  template <typename From> struct llvm::isa_impl<itanium_demangle::X, From> {  \
+    static inline bool doit(const From &Val) {                                 \
+      return Val.getKind() == itanium_demangle::Node::K##X;                    \
+    }                                                                          \
+  };
+#include "llvm/Demangle/ItaniumNodes.def"
+
+namespace SPIRV {
+
+namespace {
+// An allocator to use with the demangler API.
+class DefaultAllocator {
+  BumpPtrAllocator Alloc;
+
+public:
+  void reset() { Alloc.Reset(); }
+
+  template <typename T, typename... Args> T *makeNode(Args &&...ArgList) {
+    return new (Alloc.Allocate(sizeof(T), alignof(T)))
+        T(std::forward<Args>(ArgList)...);
+  }
+
+  void *allocateNodeArray(size_t Sz) {
+    using namespace llvm::itanium_demangle;
+    return Alloc.Allocate(sizeof(Node *) * Sz, alignof(Node *));
+  }
+};
+} // unnamed namespace
+
+static StringRef stringify(const itanium_demangle::NameType *Node) {
+  const itanium_demangle::StringView Str = Node->getName();
+  return StringRef(Str.begin(), Str.size());
+}
+
+void getParameterTypes(Function *F, SmallVectorImpl<Type *> &ArgTys,
+                       std::function<std::string(StringRef)> NameMapFn) {
+  SmallVector<TypedPointerType *, 10> PIPs;
+  getParameterTypes(F, PIPs, std::move(NameMapFn));
+  for (auto *Pair : PIPs) {
+    ArgTys.push_back(Pair ? Pair->getElementType() : nullptr);
+  }
+}
+
+template <typename FnType>
+static TypedPointerType *
+parseNode(Module *M, const llvm::itanium_demangle::Node *ParamType,
+          FnType GetStructType) {
+  using namespace llvm::itanium_demangle;
+  Type *PointeeTy = nullptr;
+  unsigned AS = 0;
+
+  if (auto *Name = dyn_cast<NameType>(ParamType)) {
+    // This corresponds to a simple class name. Since we only care about
+    // pointer element types, the only relevant names are those corresponding
+    // to the OpenCL special types (which all begin with "ocl_").
+    StringRef Arg(stringify(Name));
+    if (Arg.startswith("ocl_")) {
+      const std::string StructName = demangleBuiltinOpenCLTypeName(Arg);
+      PointeeTy = GetStructType(StructName);
+    } else if (Arg.consume_front("__spirv_")) {
+      // This is a pointer to a SPIR-V OpType* opaque struct. In general,
+      // convert __spirv_<Type>[__Suffix] to %spirv.Type[._Suffix]
+      auto NameSuffixPair = Arg.split('_');
+      std::string StructName = "spirv.";
+      StructName += NameSuffixPair.first;
+      if (!NameSuffixPair.second.empty()) {
+        StructName += ".";
+        StructName += NameSuffixPair.second;
+      }
+      PointeeTy = GetStructType(StructName);
+    } else if (Arg == "ndrange_t") {
+      PointeeTy = GetStructType(Arg);
+    }
+  } else if (auto *P = dyn_cast<itanium_demangle::PointerType>(ParamType)) {
+    const Node *Pointee = P->getPointee();
+
+    // Strip through all of the qualifiers on the pointee type.
+    while (true) {
+      if (auto *VendorTy = dyn_cast<VendorExtQualType>(Pointee)) {
+        Pointee = VendorTy->getTy();
+        StringRef Qualifier(VendorTy->getExt().begin(),
+                            VendorTy->getExt().size());
+        if (Qualifier.consume_front("AS")) {
+          Qualifier.getAsInteger(10, AS);
+        }
+      } else if (auto *Qual = dyn_cast<QualType>(Pointee)) {
+        Pointee = Qual->getChild();
+      } else {
+        break;
+      }
+    }
+
+    if (auto *Name = dyn_cast<NameType>(Pointee)) {
+      StringRef MangledStructName(stringify(Name));
+      if (MangledStructName.consume_front("__spirv_")) {
+        // This is a pointer to a SPIR-V OpType* opaque struct. In general,
+        // convert __spirv_<Type>[__Suffix] to %spirv.Type[._Suffix]
+        auto NameSuffixPair = MangledStructName.split('_');
+        std::string StructName = "spirv.";
+        StructName += NameSuffixPair.first;
+        if (!NameSuffixPair.second.empty()) {
+          StructName += ".";
+          StructName += NameSuffixPair.second;
+        }
+        PointeeTy = GetStructType(StructName);
+      } else if (MangledStructName.startswith("opencl.")) {
+        PointeeTy = GetStructType(MangledStructName);
+      } else if (MangledStructName.startswith("ocl_")) {
+        const std::string StructName =
+            demangleBuiltinOpenCLTypeName(MangledStructName);
+        PointeeTy = TypedPointerType::get(GetStructType(StructName), 0);
+      } else {
+        PointeeTy = parsePrimitiveType(M->getContext(), MangledStructName);
+      }
+    } else if (auto *BitInt = dyn_cast<BitIntType>(Pointee)) {
+      unsigned BitWidth = 0;
+      BitInt->match([&](const Node *NodeSize, bool) {
+        const StringRef SizeStr(stringify(cast<NameType>(NodeSize)));
+        SizeStr.getAsInteger(10, BitWidth);
+      });
+      PointeeTy = Type::getIntNTy(M->getContext(), BitWidth);
+    } else if (auto *Vec = dyn_cast<itanium_demangle::VectorType>(Pointee)) {
+      unsigned ElemCount = 0;
+      const StringRef ElemCountStr(
+          stringify(cast<NameType>(Vec->getDimension())));
+      ElemCountStr.getAsInteger(10, ElemCount);
+      if (auto *Name = dyn_cast<NameType>(Vec->getBaseType())) {
+        PointeeTy = parsePrimitiveType(M->getContext(), stringify(Name));
+        PointeeTy = llvm::VectorType::get(PointeeTy, ElemCount, false);
+      }
+    } else if (llvm::isa<itanium_demangle::PointerType>(Pointee)) {
+      PointeeTy = parseNode(M, Pointee, GetStructType);
+    } else {
+      // Other possible pointee types do not correspond to any of the special
+      // struct types were are looking for here.
+    }
+  } else if (auto *VendorTy = dyn_cast<VendorExtQualType>(ParamType)) {
+    // This is a block parameter. Decode the pointee type as if it were a
+    // void (*)(void) function pointer type.
+    if (VendorTy->getExt() == "block_pointer") {
+      PointeeTy =
+          llvm::FunctionType::get(Type::getVoidTy(M->getContext()), false);
+    }
+  } else {
+    // Other parameter types are not likely to be pointer types, so we can
+    // ignore these.
+  }
+  return PointeeTy ? TypedPointerType::get(PointeeTy, AS) : nullptr;
+}
+
+void getParameterTypes(Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
+                       std::function<std::string(StringRef)> NameMapFn) {
+  using namespace llvm::itanium_demangle;
   // If there's no mangled name, we can't do anything. Also, if there's no
   // parameters, do nothing.
   StringRef Name = F->getName();
   if (!Name.startswith("_Z") || F->arg_empty())
     return;
+
+  Module *M = F->getParent();
+  auto GetStructType = [&](StringRef Name) {
+    return getOrCreateOpaqueStructType(M, NameMapFn ? NameMapFn(Name) : Name);
+  };
 
   // Start by filling in a skeleton of information we can get from the LLVM type
   // itself.
@@ -681,13 +860,15 @@ void getParameterTypes(Function *F, SmallVectorImpl<StructType *> &ArgTys) {
       assert(!HasSret && &Arg == F->getArg(0) &&
              "sret parameter should only appear on the first argument");
       HasSret = true;
-      ArgTys.push_back(dyn_cast<StructType>(Ty));
+      if (auto *STy = dyn_cast<StructType>(Ty))
+        ArgTys.push_back(
+            TypedPointerType::get(GetStructType(STy->getName()), 0));
+      else
+        ArgTys.push_back(TypedPointerType::get(Ty, 0));
     } else {
       ArgTys.push_back(nullptr);
     }
   }
-
-  Module *M = F->getParent();
 
   // Skip the first argument if it's an sret parameter--this would be an
   // implicit parameter not recognized as part of the function parameters.
@@ -701,61 +882,37 @@ void getParameterTypes(Function *F, SmallVectorImpl<StructType *> &ArgTys) {
   // "(ocl_image1d_array_wo, int __vector(2), int, int __vector(4))" (in other
   // words, the stuff between the parentheses if you ran C++ filt, including
   // the parentheses itself).
-  ItaniumPartialDemangler Demangler;
-  std::string MangledName = F->getName().str();
-  if (Demangler.partialDemangle(MangledName.c_str()))
+  const StringRef MangledName(F->getName());
+  ManglingParser<DefaultAllocator> Demangler(MangledName.begin(),
+                                             MangledName.end());
+  // We expect to see only function name encodings here. If it's not a function
+  // name encoding, bail out.
+  auto *RootNode = dyn_cast_or_null<FunctionEncoding>(Demangler.parse());
+  if (!RootNode)
     return;
-  char *Buf = nullptr;
-  size_t BufLen = 0;
-  Buf = Demangler.getFunctionParameters(Buf, &BufLen);
-  StringRef Args(Buf, BufLen);
-  // Strip parentheses from the result.
-  Args = Args.slice(1, Args.size() - 2);
 
-  if (Args.find_first_of("<(") == StringRef::npos) {
-    // Go through the function arguments using type names where possible.
-    SmallVector<StringRef, 8> ArgParams;
-    Args.split(ArgParams, ", ");
-
-    // Sanity check that the name mangling matches up to the expected number of
-    // arguments.
-    if (ArgParams.size() > (size_t)(ArgTys.end() - ArgIter)) {
-      LLVM_DEBUG(dbgs() << "[getParameterTypes] function " << F->getName()
-                        << " appears to have " << ArgParams.size()
-                        << " arguments but has " << (ArgTys.end() - ArgIter)
-                        << "\n");
-      free(Buf);
-      return;
-    }
-
-    for (StringRef Arg : ArgParams) {
-      StructType *Pointee = nullptr;
-      if (Arg.endswith("*") && !Arg.endswith("**")) {
-        // Strip off address space and other qualifiers.
-        StringRef MangledStructName = Arg.split(' ').first;
-
-        if (MangledStructName.consume_front("__spirv_")) {
-          // This is a pointer to a SPIR-V OpType* opaque struct. In general,
-          // convert __spirv_<Type>[__Suffix] to %spirv.Type[._Suffix]
-          auto NameSuffixPair = MangledStructName.split('_');
-          std::string StructName = "spirv.";
-          StructName += NameSuffixPair.first;
-          if (!NameSuffixPair.second.empty()) {
-            StructName += ".";
-            StructName += NameSuffixPair.second;
-          }
-          Pointee = getOrCreateOpaqueStructType(M, StructName);
-        } else if (MangledStructName.startswith("opencl.")) {
-          Pointee = getOrCreateOpaqueStructType(M, MangledStructName);
-        }
-      } else if (!Arg.contains(' ') && Arg.startswith("ocl_")) {
-        std::string StructName = demangleBuiltinOpenCLTypeName(Arg);
-        Pointee = getOrCreateOpaqueStructType(M, StructName);
-      }
-      *ArgIter++ = Pointee;
-    }
+  // Sanity check that the name mangling matches up to the expected number of
+  // arguments.
+  if (RootNode->getParams().size() > (size_t)(ArgTys.end() - ArgIter)) {
+    LLVM_DEBUG(dbgs() << "[getParameterTypes] function " << MangledName
+                      << " appears to have " << RootNode->getParams().size()
+                      << " arguments but has " << (ArgTys.end() - ArgIter)
+                      << "\n");
+    return;
   }
-  free(Buf);
+
+  for (auto *ParamType : RootNode->getParams()) {
+    Type *ArgTy = F->getArg(ArgIter - ArgTys.begin())->getType();
+    TypedPointerType *PointeeTy = parseNode(M, ParamType, GetStructType);
+    if (ArgTy->isPointerTy() && PointeeTy == nullptr) {
+      PointeeTy = TypedPointerType::get(Type::getInt8Ty(ArgTy->getContext()),
+                                        ArgTy->getPointerAddressSpace());
+      LLVM_DEBUG(dbgs() << "Failed to recover type of argument "
+                        << (ArgIter - ArgTys.begin()) << " of function "
+                        << F->getName() << "\n");
+    }
+    *ArgIter++ = PointeeTy;
+  }
 }
 
 static Type *toTypedPointerType(Type *T) {

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -893,7 +893,7 @@ void getParameterTypes(Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
 
   // Sanity check that the name mangling matches up to the expected number of
   // arguments.
-  if (RootNode->getParams().size() > (size_t)(ArgTys.end() - ArgIter)) {
+  if (RootNode->getParams().size() != (size_t)(ArgTys.end() - ArgIter)) {
     LLVM_DEBUG(dbgs() << "[getParameterTypes] function " << MangledName
                       << " appears to have " << RootNode->getParams().size()
                       << " arguments but has " << (ArgTys.end() - ArgIter)

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4799,7 +4799,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     // for this call, because there is no support for type corresponding to
     // OpTypeSampledImage. So, in this case, we create the required type here.
     Value *Image = CI->getArgOperand(0);
-    SmallVector<StructType *, 4> ParamTys;
+    SmallVector<Type *, 4> ParamTys;
     getParameterTypes(CI, ParamTys);
     Type *ImageTy = adaptSPIRVImageType(M, ParamTys[0]);
     Type *SampledImgTy = getSPIRVStructTypeByChangeBaseTypeName(

--- a/test/type-scavenger/varargs.ll
+++ b/test/type-scavenger/varargs.ll
@@ -8,11 +8,14 @@ target triple = "spir-unknown-unknown"
 @.str = internal unnamed_addr addrspace(2) constant [11 x i8] c"Value: %p\0A\00", align 1
 
 
-; CHECK: 4 TypeInt [[INT:[0-9]+]] 32 0
-; CHECK: 4 TypePointer [[INTPTR:[0-9]+]] 7 [[INT]]
+; CHECK-DAG: 4 TypeInt [[INT:[0-9]+]] 32 0
+; CHECK-DAG: 4 TypeInt [[CHAR:[0-9]+]] 8 0
+; CHECK-DAG: 4 TypePointer [[INTPTR:[0-9]+]] 7 [[INT]]
+; CHECK-DAG: 4 TypePointer [[CHARPTR:[0-9]+]] 0 [[CHAR]]
 ; CHECK: 5 Variable {{[0-9]+}} [[STR:[0-9]+]] 0
 ; CHECK: 4 Variable [[INTPTR]] [[IPTR:[0-9]+]] 7
-; CHECK: 7 ExtInst [[INT]] {{[0-9]+}} {{[0-9]+}} printf [[STR]] [[IPTR]]
+; CHECK: 4 Bitcast [[CHARPTR]] [[I8STR:[0-9]+]] [[STR]]
+; CHECK: 7 ExtInst [[INT]] {{[0-9]+}} {{[0-9]+}} printf [[I8STR]] [[IPTR]]
 
 ; Function Attrs: nounwind
 define spir_kernel void @foo() {


### PR DESCRIPTION
This branch doesn't quite work yet, because it turns out the demangler changes I relied on were in https://github.com/intel/llvm/pull/4207 and not in LLVM itself, so I have to go upstream that first.