### PR TITLE
Suppress some clang-tidy errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,21 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
-WarningsAsErrors: 'llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
+Checks: |
+  -*,
+  clang-diagnostic-*,
+  llvm-*,
+  -llvm-header-guard,
+  misc-*,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  readability-identifier-naming
+WarningsAsErrors: |
+  llvm-*,
+  -llvm-header-guard,
+  misc-*,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  readability-identifier-naming
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -178,7 +178,7 @@ constexpr ExecutionMode ExecutionModeFastCompositeKernelINTEL =
 constexpr ExecutionMode ExecutionModeStreamingInterfaceINTEL =
     static_cast<ExecutionMode>(IExecModeStreamingInterfaceINTEL);
 
-constexpr LoopControlMask LoopControlLoopCountINTELMask =
+static const LoopControlMask LoopControlLoopCountINTELMask =
     static_cast<LoopControlMask>(ILoopControlLoopCountINTELMask);
 
 } // namespace internal


### PR DESCRIPTION
Split the .clang-tidy check lists out over multiple lines to improve
readability.

Suppress `misc-non-private-member-variables-in-classes` as the code
currently contains many instances that fail this check.

Drop `constexpr` from `LoopControlLoopCountINTELMask` after clang
started diagnosing this with b36453530418 ("[Clang] Diagnose
ill-formed constant expression when setting ...", 2022-07-28).
Removing `constexpr` is just a workaround, the long term fix would be
to upstream the new enum value to `spirv.hpp`.