### PR TITLE
Restore getArgIndex in OCLTypeToSPIRV

### DIFF
--- a/lib/SPIRV/LLVMSPIRVOpts.cpp
+++ b/lib/SPIRV/LLVMSPIRVOpts.cpp
@@ -50,9 +50,9 @@ using namespace SPIRV;
 
 bool TranslatorOpts::isUnknownIntrinsicAllowed(IntrinsicInst *II) const
     noexcept {
-  if (!SPIRVAllowUnknownIntrinsics.hasValue())
+  if (!SPIRVAllowUnknownIntrinsics.has_value())
     return false;
-  const auto &IntrinsicPrefixList = SPIRVAllowUnknownIntrinsics.getValue();
+  const auto &IntrinsicPrefixList = SPIRVAllowUnknownIntrinsics.value();
   StringRef IntrinsicName = II->getCalledOperand()->getName();
   for (const auto Prefix : IntrinsicPrefixList) {
     if (IntrinsicName.startswith(Prefix)) // Also true if `Prefix` is empty
@@ -62,7 +62,7 @@ bool TranslatorOpts::isUnknownIntrinsicAllowed(IntrinsicInst *II) const
 }
 
 bool TranslatorOpts::isSPIRVAllowUnknownIntrinsicsEnabled() const noexcept {
-  return SPIRVAllowUnknownIntrinsics.hasValue();
+  return SPIRVAllowUnknownIntrinsics.has_value();
 }
 
 void TranslatorOpts::setSPIRVAllowUnknownIntrinsics(

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -532,8 +532,8 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgPointerType(const DIDerivedType *PT) {
   Ops[BaseTypeIdx] = Base->getId();
   Ops[StorageClassIdx] = ~0U; // all ones denote no address space
   Optional<unsigned> AS = PT->getDWARFAddressSpace();
-  if (AS.hasValue()) {
-    SPIRAddressSpace SPIRAS = static_cast<SPIRAddressSpace>(AS.getValue());
+  if (AS.has_value()) {
+    SPIRAddressSpace SPIRAS = static_cast<SPIRAddressSpace>(AS.value());
     Ops[StorageClassIdx] = SPIRSPIRVAddrSpaceMap::map(SPIRAS);
   }
   Ops[FlagsIdx] = transDebugFlags(PT);
@@ -986,7 +986,7 @@ SPIRVExtInst *LLVMToSPIRVDbgTran::getSource(const T *DIEntry) {
   Ops[FileIdx] = BM->getString(FileName)->getId();
   DIFile *F = DIEntry ? DIEntry->getFile() : nullptr;
   if (F && F->getRawChecksum()) {
-    auto CheckSum = F->getChecksum().getValue();
+    auto CheckSum = F->getChecksum().value();
     Ops[TextIdx] = BM->getString("//__" + CheckSum.getKindAsString().str() +
                                  ":" + CheckSum.Value.str())
                        ->getId();

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -184,7 +184,7 @@ void OCLTypeToSPIRVBase::adaptArgumentsBySamplerUse(Module &M) {
       addAdaptedType(SamplerArg, getSamplerStructType(&M), SPIRAS_Constant);
       auto Caller = cast<Argument>(SamplerArg)->getParent();
       addWork(Caller);
-      TraceArg(Caller, Idx);
+      TraceArg(Caller, cast<Argument>(SamplerArg)->getArgNo());
     }
   };
 

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -72,8 +72,8 @@ void SPIRVLowerMemmoveBase::LowerMemMoveInst(MemMoveInst &I) {
   MaybeAlign SrcAlign = I.getSourceAlign();
 
   auto *Alloca = Builder.CreateAlloca(AllocaTy);
-  if (SrcAlign.hasValue())
-    Alloca->setAlignment(SrcAlign.getValue());
+  if (SrcAlign.has_value())
+    Alloca->setAlignment(SrcAlign.value());
 
   // FIXME: Do we need to pass the size of alloca here? From LangRef:
   // > The first argument is a constant integer representing the size of the

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1652,8 +1652,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         LVar->addAttribute(kVCMetadata::VCVolatile);
       auto SEVAttr = translateSEVMetadata(BVar, LVar->getContext());
       if (SEVAttr)
-        LVar->addAttribute(SEVAttr.getValue().getKindAsString(),
-                           SEVAttr.getValue().getValueAsString());
+        LVar->addAttribute(SEVAttr.value().getKindAsString(),
+                           SEVAttr.value().getValueAsString());
     }
 
     return Res;
@@ -4140,7 +4140,7 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
   auto SEVAttr = translateSEVMetadata(BF, F->getContext());
 
   if (SEVAttr)
-    F->addAttributeAtIndex(AttributeList::ReturnIndex, SEVAttr.getValue());
+    F->addAttributeAtIndex(AttributeList::ReturnIndex, SEVAttr.value());
 
   for (Function::arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E;
        ++I) {
@@ -4154,7 +4154,7 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
     }
     SEVAttr = translateSEVMetadata(BA, F->getContext());
     if (SEVAttr)
-      F->addParamAttr(ArgNo, SEVAttr.getValue());
+      F->addParamAttr(ArgNo, SEVAttr.value());
     if (BA->hasDecorate(DecorationMediaBlockIOINTEL)) {
       assert(BA->getType()->isTypeImage() &&
              "MediaBlockIOINTEL decoration is valid only on image parameters");

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1116,7 +1116,7 @@ SPIRVToLLVMDbgTran::ParseChecksum(StringRef Text) {
     auto Checksum = Text.substr(ColonPos).ltrim(':');
     if (auto Kind = DIFile::getChecksumKind(KindStr)) {
       size_t ChecksumEndPos = Checksum.find_if_not(llvm::isHexDigit);
-      CS.emplace(Kind.getValue(), Checksum.substr(0, ChecksumEndPos));
+      CS.emplace(Kind.value(), Checksum.substr(0, ChecksumEndPos));
     }
   }
   return CS;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2700,15 +2700,15 @@ struct IntelLSUControlsInfo {
       ResultVec.emplace_back(DecorationDontStaticallyCoalesceINTEL,
                              std::vector<std::string>());
     // Conditional values
-    if (CacheSizeInfo.hasValue()) {
+    if (CacheSizeInfo.has_value()) {
       ResultVec.emplace_back(
           DecorationCacheSizeINTEL,
-          std::vector<std::string>{std::to_string(CacheSizeInfo.getValue())});
+          std::vector<std::string>{std::to_string(CacheSizeInfo.value())});
     }
-    if (PrefetchInfo.hasValue()) {
+    if (PrefetchInfo.has_value()) {
       ResultVec.emplace_back(
           DecorationPrefetchINTEL,
-          std::vector<std::string>{std::to_string(PrefetchInfo.getValue())});
+          std::vector<std::string>{std::to_string(PrefetchInfo.value())});
     }
     return ResultVec;
   }
@@ -2886,7 +2886,7 @@ AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
         LSUControls.setWithBitMask(ParamsBitMask);
       } else if (Name == "cache-size") {
         ValidDecorationFound = true;
-        if (!LSUControls.CacheSizeInfo.hasValue())
+        if (!LSUControls.CacheSizeInfo.has_value())
           continue;
         unsigned CacheSizeValue = 0;
         bool Failure = ValueStr.getAsInteger(10, CacheSizeValue);

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -597,8 +597,8 @@ void SPIRVModuleImpl::addCapability(SPIRVCapabilityKind Cap) {
     // While we are reading existing SPIR-V we need to read it as-is and don't
     // add required extensions for each entry automatically
     auto Ext = CapObj->getRequiredExtension();
-    if (Ext.hasValue())
-      addExtension(Ext.getValue());
+    if (Ext.has_value())
+      addExtension(Ext.value());
   }
 
   CapMap.insert(std::make_pair(Cap, CapObj));
@@ -722,8 +722,8 @@ SPIRVEntry *SPIRVModuleImpl::addEntry(SPIRVEntry *Entry) {
     // While we are reading existing SPIR-V we need to read it as-is and don't
     // add required extensions for each entry automatically
     auto Ext = Entry->getRequiredExtension();
-    if (Ext.hasValue())
-      addExtension(Ext.getValue());
+    if (Ext.has_value())
+      addExtension(Ext.value());
   }
 
   return Entry;

--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -172,7 +172,7 @@ const SPIRVDecoder &operator>>(const SPIRVDecoder &I, std::vector<T> &V) {
 template <typename T>
 const SPIRVDecoder &operator>>(const SPIRVDecoder &I, llvm::Optional<T> &V) {
   if (V)
-    I >> V.getValue();
+    I >> V.value();
   return I;
 }
 
@@ -206,7 +206,7 @@ template <typename T>
 const SPIRVEncoder &operator<<(const SPIRVEncoder &O,
                                const llvm::Optional<T> &V) {
   if (V)
-    O << V.getValue();
+    O << V.value();
   return O;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -898,10 +898,10 @@ public:
     return {ExtensionID::SPV_INTEL_vector_compute};
   }
 
-  bool hasAccessQualifier() const { return AccessKind.hasValue(); }
+  bool hasAccessQualifier() const { return AccessKind.has_value(); }
   SPIRVAccessQualifierKind getAccessQualifier() const {
     assert(hasAccessQualifier());
-    return AccessKind.getValue();
+    return AccessKind.value();
   }
 
 protected:

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -131,7 +131,7 @@ public:
       return EV;
     EV = Type->getRequiredExtension();
     assert(Module &&
-           (!EV.hasValue() || Module->isAllowedToUseExtension(EV.getValue())));
+           (!EV.has_value() || Module->isAllowedToUseExtension(EV.value())));
     return EV;
   }
 

--- a/test/image-user-sampler-args.ll
+++ b/test/image-user-sampler-args.ll
@@ -1,0 +1,30 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64"
+
+%opencl.image2d_ro_t = type opaque
+%opencl.sampler_t = type opaque
+
+define internal spir_func <4 x float> @user_fn(%opencl.image2d_ro_t addrspace(1)* %I, %opencl.sampler_t addrspace(2)* %S, <2 x float> %Pos) {
+entry:
+  %call = tail call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)* %I, %opencl.sampler_t addrspace(2)* %S, <2 x float> noundef %Pos) #0
+  ret <4 x float> %call
+}
+
+declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(%opencl.image2d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*, <2 x float>) local_unnamed_addr
+
+define hidden spir_kernel void @kernel_fn(float addrspace(1)* %0, %opencl.image2d_ro_t addrspace(1)* %1, %opencl.sampler_t addrspace(2)* %2, i32 %3, i32 %4) local_unnamed_addr {
+entry:
+  %5 = call spir_func <4 x float> @user_fn(%opencl.image2d_ro_t addrspace(1)* %1, %opencl.sampler_t addrspace(2)* %2, <2 x float> undef)
+  %add16 = add nsw i32 undef, undef
+  ret void
+}
+
+attributes #0 = { convergent nounwind readonly willreturn }
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 2, i32 0}


### PR DESCRIPTION
Commit 4a9c78ee ("Prepare SPIRVWriter for type conversion without
opaque pointers. (#1499)", 2022-06-20) removed `getArgIndex` in favor
of passing `Idx`, but this leads to incorrect adaptation of argument
types if sampler arguments are not in the same position between
different functions.

We might be able to drop `adaptArgumentsBySamplerUse` entirely, as we
don't represent samplers as i32 anymore; but for now just fix the
regression.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1562