### PR TITLE
Drop the JointMatrixINTEL struct-renaming pass when opaque pointers are enabled.

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -375,7 +375,7 @@ void SPIRVRegularizeLLVMBase::adaptStructTypes(StructType *ST) {
   // register by OpCompositeConstruct. And we can't claim, that the Result type
   // of OpCompositeConstruct instruction is always the joint matrix type, it's
   // simply not true.
-  if (MangledName == "__spirv_JointMatrixINTEL" && !PtrTy->isOpaque()) {
+  if (MangledName == "__spirv_JointMatrixINTEL" && !ST->isOpaquePointerTy()) {
     auto *PtrTy = dyn_cast<PointerType>(ST->getElementType(0));
     assert(PtrTy &&
            "Expected a pointer to an array to represent joint matrix type");

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -377,7 +377,7 @@ void SPIRVRegularizeLLVMBase::adaptStructTypes(StructType *ST) {
   // simply not true.
   if (MangledName == "__spirv_JointMatrixINTEL" && !PtrTy->isOpaque()) {
     auto *PtrTy = dyn_cast<PointerType>(ST->getElementType(0));
-    assert(PtrTy && !PtrTy->isOpaque() &&
+    assert(PtrTy &&
            "Expected a pointer to an array to represent joint matrix type");
     std::vector<size_t> TypeLayout;
     ArrayType *ArrayTy =

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -375,7 +375,7 @@ void SPIRVRegularizeLLVMBase::adaptStructTypes(StructType *ST) {
   // register by OpCompositeConstruct. And we can't claim, that the Result type
   // of OpCompositeConstruct instruction is always the joint matrix type, it's
   // simply not true.
-  if (MangledName == "__spirv_JointMatrixINTEL") {
+  if (MangledName == "__spirv_JointMatrixINTEL" && !PtrTy->isOpaque()) {
     auto *PtrTy = dyn_cast<PointerType>(ST->getElementType(0));
     assert(PtrTy && !PtrTy->isOpaque() &&
            "Expected a pointer to an array to represent joint matrix type");


### PR DESCRIPTION
The frontend is being changed to lower the struct name to the correct LLVM name
directly, obviating the need for this check. See
https://github.com/intel/llvm/pull/6535 for this change.

This marks the removal of the final call to the deprecated method
Type::getPointerElementType, although there remains some code that is not fully
working with opaque pointers enabled.