### PR TITLE
[NFC] Remove ExecutionModeNamedBarrierCountINTEL from spirv_internal

### DIFF
--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -356,7 +356,7 @@ void PreprocessMetadataBase::preprocessVectorComputeMetadata(Module *M,
           .getAsInteger(0, NBarrierCnt);
       EM.addOp()
           .add(&F)
-          .add(spv::internal::ExecutionModeNamedBarrierCountINTEL)
+          .add(spv::ExecutionModeNamedBarrierCountINTEL)
           .add(NBarrierCnt)
           .done();
     }

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4215,8 +4215,7 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
     F->addFnAttr(Attr);
   }
 
-  if (auto *EM =
-          BF->getExecutionMode(ExecutionModeNamedBarrierCountINTEL)) {
+  if (auto *EM = BF->getExecutionMode(ExecutionModeNamedBarrierCountINTEL)) {
     unsigned int NBarrierCnt = EM->getLiterals()[0];
     Attribute Attr = Attribute::get(*Context, kVCMetadata::VCNamedBarrierCount,
                                     std::to_string(NBarrierCnt));

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4216,7 +4216,7 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
   }
 
   if (auto *EM =
-          BF->getExecutionMode(internal::ExecutionModeNamedBarrierCountINTEL)) {
+          BF->getExecutionMode(ExecutionModeNamedBarrierCountINTEL)) {
     unsigned int NBarrierCnt = EM->getLiterals()[0];
     Attribute Attr = Attribute::get(*Context, kVCMetadata::VCNamedBarrierCount,
                                     std::to_string(NBarrierCnt));

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4560,7 +4560,7 @@ bool LLVMToSPIRVBase::transExecutionMode() {
           break;
         AddSingleArgExecutionMode(static_cast<ExecutionMode>(EMode));
       } break;
-      case spv::internal::ExecutionModeNamedBarrierCountINTEL: {
+      case spv::ExecutionModeNamedBarrierCountINTEL: {
         if (!BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
           break;
         unsigned NBarrierCnt = 0;

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -582,7 +582,7 @@ void SPIRVExecutionMode::decode(std::istream &I) {
   case ExecutionModeFloatingPointModeALTINTEL:
   case ExecutionModeFloatingPointModeIEEEINTEL:
   case ExecutionModeSharedLocalMemorySizeINTEL:
-  case internal::ExecutionModeNamedBarrierCountINTEL:
+  case ExecutionModeNamedBarrierCountINTEL:
   case ExecutionModeSubgroupSize:
   case ExecutionModeMaxWorkDimINTEL:
   case ExecutionModeNumSIMDWorkitemsINTEL:

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -263,7 +263,7 @@ template <> inline void SPIRVMap<SPIRVExecutionModeKind, SPIRVCapVec>::init() {
                {internal::CapabilityFastCompositeINTEL});
   ADD_VEC_INIT(internal::ExecutionModeStreamingInterfaceINTEL,
                {CapabilityFPGAKernelAttributesINTEL});
-  ADD_VEC_INIT(internal::ExecutionModeNamedBarrierCountINTEL,
+  ADD_VEC_INIT(ExecutionModeNamedBarrierCountINTEL,
                {CapabilityVectorComputeINTEL});
 }
 

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -83,8 +83,7 @@ enum InternalFunctionControlMask { IFunctionControlOptNoneINTELMask = 0x10000 };
 
 enum InternalExecutionMode {
   IExecModeFastCompositeKernelINTEL = 6088,
-  IExecModeStreamingInterfaceINTEL = 6154,
-  IExecModeNamedBarrierCountINTEL = 6417
+  IExecModeStreamingInterfaceINTEL = 6154
 };
 
 enum InternalLoopControlMask { ILoopControlLoopCountINTELMask = 0x1000000 };
@@ -178,9 +177,6 @@ constexpr ExecutionMode ExecutionModeFastCompositeKernelINTEL =
     static_cast<ExecutionMode>(IExecModeFastCompositeKernelINTEL);
 constexpr ExecutionMode ExecutionModeStreamingInterfaceINTEL =
     static_cast<ExecutionMode>(IExecModeStreamingInterfaceINTEL);
-
-constexpr ExecutionMode ExecutionModeNamedBarrierCountINTEL =
-    static_cast<ExecutionMode>(IExecModeNamedBarrierCountINTEL);
 
 static const LoopControlMask LoopControlLoopCountINTELMask =
     static_cast<LoopControlMask>(ILoopControlLoopCountINTELMask);


### PR DESCRIPTION
It was actually upstreamed to SPIR-V Headers already.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>