### PR TITLE
Translate function pointer from global variable as pointer, not as declaration

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1683,7 +1683,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
           }
         }
       }
-      BVarInit = transValue(Init, nullptr);
+      BVarInit = transValue(Init, nullptr, CreateForward, FuncTrans);
     }
 
     SPIRVStorageClassKind StorageClass;
@@ -4159,7 +4159,11 @@ bool LLVMToSPIRVBase::transGlobalVariables() {
       continue;
     } else if (MDNode *IO = ((*I).getMetadata("io_pipe_id")))
       transGlobalIOPipeStorage(&(*I), IO);
-    else if (!transValue(&(*I), nullptr))
+    // As global variables define a pointer to their "content" type, we should
+    // translate here only pointer without declaration even it is a function
+    // pointer.
+    else if (!transValue(&(*I), nullptr, true /*CreateForward - default value*/,
+                         FuncTransMode::Pointer))
       return false;
   }
   return true;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1683,7 +1683,10 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
           }
         }
       }
-      BVarInit = transValue(Init, nullptr, CreateForward, FuncTrans);
+      // As global variables define a pointer to their "content" type, we should
+      // translate here only pointer without declaration even if it is a
+      // function pointer.
+      BVarInit = transValue(Init, nullptr, true, FuncTransMode::Pointer);
     }
 
     SPIRVStorageClassKind StorageClass;
@@ -4159,11 +4162,7 @@ bool LLVMToSPIRVBase::transGlobalVariables() {
       continue;
     } else if (MDNode *IO = ((*I).getMetadata("io_pipe_id")))
       transGlobalIOPipeStorage(&(*I), IO);
-    // As global variables define a pointer to their "content" type, we should
-    // translate here only pointer without declaration even it is a function
-    // pointer.
-    else if (!transValue(&(*I), nullptr, true /*CreateForward - default value*/,
-                         FuncTransMode::Pointer))
+    else if (!transValue(&(*I), nullptr))
       return false;
   }
   return true;

--- a/test/transcoding/SPV_INTEL_function_pointers/global-function-pointer.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/global-function-pointer.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as < %s | llvm-spirv -spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
-; RUN: llvm-as < %s | llvm-spirv -spirv-ext=+SPV_INTEL_function_pointers -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -spirv-ext=+SPV_INTEL_function_pointers -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/test/transcoding/SPV_INTEL_function_pointers/global-function-pointer.ll
+++ b/test/transcoding/SPV_INTEL_function_pointers/global-function-pointer.ll
@@ -1,0 +1,25 @@
+; RUN: llvm-as < %s | llvm-spirv -spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
+; RUN: llvm-as < %s | llvm-spirv -spirv-ext=+SPV_INTEL_function_pointers -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64"
+
+
+; CHECK-SPIRV: Capability FunctionPointersINTEL
+; CHECK-SPIRV: Extension "SPV_INTEL_function_pointers"
+; CHECK-SPIRV: TypeFunction [[#FOO_TY:]] [[#]] [[#]]
+; CHECK-SPIRV: TypePointer [[#FOO_TY_PTR:]] [[#]] [[#FOO_TY]]
+; CHECK-SPIRV: ConstantFunctionPointerINTEL [[#FOO_TY_PTR]] [[#FOO_PTR:]] [[#FOO:]]
+; CHECK-SPIRV: Function [[#]] [[#]] [[#]] [[#FOO_TY]]
+
+; CHECK-LLVM: @two = internal addrspace(1) global i32 (i32, i32)* @_Z4barrii
+; CHECK-LLVM: define spir_func i32 @_Z4barrii(i32 %[[#]], i32 %[[#]])
+
+@two = internal addrspace(1) global i32 (i32, i32)* @_Z4barrii, align 8
+
+; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn writeonly
+define protected spir_func noundef i32 @_Z4barrii(i32 %0, i32 %1) {
+entry:
+  ret i32 1
+}


### PR DESCRIPTION
This patch helps to avoid invalid SPV generation.

When global variable contains a pointer to a function, translator tries to translate it as declaration. Then it translates this function the second time when going through the function list. This leads to double translation of the same function and to the usage of the same IDs in SPIR-V file.