### PR TITLE
[CI] Reinstate deprecated-declarations warning as error

### DIFF
--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -76,7 +76,7 @@ jobs:
           mkdir build && cd build
           cmake ${{ github.workspace }}/SPIRV-LLVM-Translator \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_CXX_FLAGS="-Werror -Wno-error=deprecated-declarations" \
+            -DCMAKE_CXX_FLAGS="-Werror" \
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_EXTERNAL_LIT="/usr/lib/llvm-${{ env.LLVM_VERSION }}/build/utils/lit/lit.py" \
             -DLLVM_EXTERNAL_PROJECTS="SPIRV-Headers" \


### PR DESCRIPTION
This reverts commit 55d1de820841e6d9d1c6ca0cd534323d69a1cbf1.

Now that the last use of the deprecated `getPointerElementType` has
been removed, treat uses of deprecated functions as errors again.