### PR TITLE
[Mutator] Migrate atomics builtins to the mutator interface.

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -485,28 +485,23 @@ void OCLToSPIRVBase::visitCallAsyncWorkGroupCopy(CallInst *CI,
 }
 
 CallInst *OCLToSPIRVBase::visitCallAtomicCmpXchg(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  Value *Expected = nullptr;
   CallInst *NewCI = nullptr;
-  mutateCallInstOCL(
-      M, CI,
-      [&](CallInst *CI, std::vector<Value *> &Args, Type *&RetTy) {
-        Expected = Args[1]; // temporary save second argument.
-        RetTy = Args[2]->getType();
-        Args[1] = new LoadInst(RetTy, Args[1], "exp", false, CI);
-        assert(Args[1]->getType()->isIntegerTy() &&
-               Args[2]->getType()->isIntegerTy() &&
-               "In SPIR-V 1.0 arguments of OpAtomicCompareExchange must be "
-               "an integer type scalars");
-        return kOCLBuiltinName::AtomicCmpXchgStrong;
-      },
-      [&](CallInst *NCI) -> Instruction * {
-        NewCI = NCI;
-        Instruction *Store = new StoreInst(NCI, Expected, NCI->getNextNode());
-        return new ICmpInst(Store->getNextNode(), CmpInst::ICMP_EQ, NCI,
-                            NCI->getArgOperand(1));
-      },
-      &Attrs);
+  {
+    auto Mutator = mutateCallInst(CI, kOCLBuiltinName::AtomicCmpXchgStrong);
+    Value *Expected = Mutator.getArg(1);
+    Type *MemTy = Mutator.getArg(2)->getType();
+    assert(MemTy->isIntegerTy() &&
+           "In SPIR-V 1.0 arguments of OpAtomicCompareExchange must be "
+           "an integer type scalars");
+    Mutator.mapArg(1, [=](IRBuilder<> &Builder, Value *V) {
+      return Builder.CreateLoad(MemTy, V, "exp");
+    });
+    Mutator.changeReturnType(MemTy, [&](IRBuilder<> &Builder, CallInst *NCI) {
+      NewCI = NCI;
+      Builder.CreateStore(NCI, Expected);
+      return Builder.CreateICmpEQ(NCI, NCI->getArgOperand(1));
+    });
+  }
   return NewCI;
 }
 
@@ -570,17 +565,10 @@ void OCLToSPIRVBase::visitCallMemFence(CallInst *CI, StringRef DemangledName) {
 void OCLToSPIRVBase::transMemoryBarrier(CallInst *CI,
                                         AtomicWorkItemFenceLiterals Lit) {
   assert(CI->getCalledFunction() && "Unexpected indirect call");
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstSPIRV(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Args.resize(2);
-        Args[0] = addInt32(map<Scope>(std::get<2>(Lit)));
-        Args[1] = addInt32(
-            mapOCLMemSemanticToSPIRV(std::get<0>(Lit), std::get<1>(Lit)));
-        return getSPIRVFuncName(OpMemoryBarrier);
-      },
-      &Attrs);
+  mutateCallInst(CI, OpMemoryBarrier)
+      .setArgs({addInt32(map<Scope>(std::get<2>(Lit))),
+                addInt32(mapOCLMemSemanticToSPIRV(std::get<0>(Lit),
+                                                  std::get<1>(Lit)))});
 }
 
 void OCLToSPIRVBase::visitCallAtomicLegacy(CallInst *CI, StringRef MangledName,
@@ -747,25 +735,18 @@ void OCLToSPIRVBase::transAtomicBuiltin(CallInst *CI,
 
 void OCLToSPIRVBase::visitCallBarrier(CallInst *CI) {
   auto Lit = getBarrierLiterals(CI);
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstSPIRV(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Args.resize(3);
-        // Execution scope
-        Args[0] = addInt32(map<Scope>(std::get<2>(Lit)));
-        // Memory scope
-        Args[1] = addInt32(map<Scope>(std::get<1>(Lit)));
-        // Use sequential consistent memory order by default.
-        // But if the flags argument is set to 0, we use
-        // None(Relaxed) memory order.
-        unsigned MemFenceFlag = std::get<0>(Lit);
-        OCLMemOrderKind MemOrder = MemFenceFlag ? OCLMO_seq_cst : OCLMO_relaxed;
-        Args[2] = addInt32(mapOCLMemSemanticToSPIRV(
-            MemFenceFlag, MemOrder)); // Memory semantics
-        return getSPIRVFuncName(OpControlBarrier);
-      },
-      &Attrs);
+  // Use sequential consistent memory order by default.
+  // But if the flags argument is set to 0, we use
+  // None(Relaxed) memory order.
+  unsigned MemFenceFlag = std::get<0>(Lit);
+  OCLMemOrderKind MemOrder = MemFenceFlag ? OCLMO_seq_cst : OCLMO_relaxed;
+  mutateCallInst(CI, OpControlBarrier)
+      .setArgs({// Execution scope
+                addInt32(map<Scope>(std::get<2>(Lit))),
+                // Memory scope
+                addInt32(map<Scope>(std::get<1>(Lit))),
+                // Memory semantics
+                addInt32(mapOCLMemSemanticToSPIRV(MemFenceFlag, MemOrder))});
 }
 
 void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
@@ -1300,19 +1281,12 @@ void OCLToSPIRVBase::visitCallVecLoadStore(CallInst *CI, StringRef MangledName,
 }
 
 void OCLToSPIRVBase::visitCallGetFence(CallInst *CI, StringRef DemangledName) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   Op OC = OpNop;
   OCLSPIRVBuiltinMap::find(DemangledName.str(), &OC);
-  std::string SPIRVName = getSPIRVFuncName(OC);
-  mutateCallInstSPIRV(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args, Type *&Ret) {
-        return SPIRVName;
-      },
-      [=](CallInst *NewCI) -> Instruction * {
-        return BinaryOperator::CreateLShr(NewCI, getInt32(M, 8), "", CI);
-      },
-      &Attrs);
+  mutateCallInst(CI, OC).changeReturnType(
+      CI->getType(), [](IRBuilder<> &Builder, CallInst *NewCI) {
+        return Builder.CreateLShr(NewCI, Builder.getInt32(8));
+      });
 }
 
 void OCLToSPIRVBase::visitCallDot(CallInst *CI) {
@@ -1877,32 +1851,26 @@ void OCLToSPIRVBase::visitSubgroupAVCBuiltinCallWithSampler(
 void OCLToSPIRVBase::visitCallSplitBarrierINTEL(CallInst *CI,
                                                 StringRef DemangledName) {
   auto Lit = getBarrierLiterals(CI);
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   Op OpCode =
       StringSwitch<Op>(DemangledName)
           .Case("intel_work_group_barrier_arrive", OpControlBarrierArriveINTEL)
           .Case("intel_work_group_barrier_wait", OpControlBarrierWaitINTEL)
           .Default(OpNop);
 
-  mutateCallInstSPIRV(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Args.resize(3);
-        // Execution scope
-        Args[0] = addInt32(map<Scope>(std::get<2>(Lit)));
-        // Memory scope
-        Args[1] = addInt32(map<Scope>(std::get<1>(Lit)));
-        // Memory semantics
-        // OpControlBarrierArriveINTEL -> Release,
-        // OpControlBarrierWaitINTEL -> Acquire
-        unsigned MemFenceFlag = std::get<0>(Lit);
-        OCLMemOrderKind MemOrder = OpCode == OpControlBarrierArriveINTEL
-                                       ? OCLMO_release
-                                       : OCLMO_acquire;
-        Args[2] = addInt32(mapOCLMemSemanticToSPIRV(MemFenceFlag, MemOrder));
-        return getSPIRVFuncName(OpCode);
-      },
-      &Attrs);
+  // Map memory semantics as follows:
+  // OpControlBarrierArriveINTEL -> Release,
+  // OpControlBarrierWaitINTEL -> Acquire
+  unsigned MemFenceFlag = std::get<0>(Lit);
+  OCLMemOrderKind MemOrder =
+      OpCode == OpControlBarrierArriveINTEL ? OCLMO_release : OCLMO_acquire;
+  mutateCallInst(CI, OpCode)
+      .removeArgs(0, CI->arg_size())
+      // Execution scope
+      .appendArg(addInt32(map<Scope>(std::get<2>(Lit))))
+      // Memory scope
+      .appendArg(addInt32(map<Scope>(std::get<1>(Lit))))
+      // Memory semantics
+      .appendArg(addInt32(mapOCLMemSemanticToSPIRV(MemFenceFlag, MemOrder)));
 }
 
 void OCLToSPIRVBase::visitCallLdexp(CallInst *CI, StringRef MangledName,

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -550,7 +550,8 @@ void move(std::vector<T> &V, size_t Begin, size_t End, size_t Target) {
 }
 
 /// Find position of first pointer type value in a vector.
-inline size_t findFirstPtr(const std::vector<Value *> &Args) {
+template <typename Container>
+inline unsigned findFirstPtr(const Container &Args) {
   auto PtArg = std::find_if(Args.begin(), Args.end(), [](Value *V) {
     return V->getType()->isPointerTy();
   });

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -203,17 +203,17 @@ public:
 
   /// Transform __spirv_OpAtomicCompareExchange and
   /// __spirv_OpAtomicCompareExchangeWeak
-  virtual Instruction *visitCallSPIRVAtomicCmpExchg(CallInst *CI) = 0;
+  virtual void visitCallSPIRVAtomicCmpExchg(CallInst *CI) = 0;
 
   /// Transform __spirv_OpAtomicIIncrement/OpAtomicIDecrement to:
   /// - OCL2.0: atomic_fetch_add_explicit/atomic_fetch_sub_explicit
   /// - OCL1.2: atomic_inc/atomic_dec
-  virtual Instruction *visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) = 0;
+  virtual void visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) = 0;
 
   /// Transform __spirv_Atomic* to atomic_*.
   ///   __spirv_Atomic*(atomic_op, scope, sema, ops, ...) =>
   ///      atomic_*(atomic_op, ops, ..., order(sema), map(scope))
-  virtual Instruction *visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) = 0;
+  virtual void visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) = 0;
 
   /// Transform __spirv_MemoryBarrier to:
   /// - OCL2.0: atomic_work_item_fence.__spirv_MemoryBarrier(scope, sema) =>
@@ -246,7 +246,7 @@ public:
 
   /// Transform __spirv_Opcode to ocl-version specific builtin name
   /// using separate maps for OpenCL 1.2 and OpenCL 2.0
-  virtual Instruction *mutateAtomicName(CallInst *CI, Op OC) = 0;
+  virtual void mutateAtomicName(CallInst *CI, Op OC) = 0;
 
   // Transform FP atomic opcode to corresponding OpenCL function name
   virtual std::string mapFPAtomicName(Op OC) = 0;
@@ -324,35 +324,35 @@ public:
 
   /// Transform __spirv_OpAtomic functions. It firstly conduct generic
   /// mutations for all builtins and then mutate some of them seperately
-  Instruction *visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) override;
+  void visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) override;
 
   /// Transform __spirv_OpAtomicIIncrement / OpAtomicIDecrement to
   /// atomic_inc / atomic_dec
-  Instruction *visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) override;
+  void visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) override;
 
   /// Transform __spirv_OpAtomicUMin/SMin/UMax/SMax into
   /// atomic_min/atomic_max, as there is no distinction in OpenCL 1.2
   /// between signed and unsigned version of those functions
-  Instruction *visitCallSPIRVAtomicUMinUMax(CallInst *CI, Op OC);
+  void visitCallSPIRVAtomicUMinUMax(CallInst *CI, Op OC);
 
   /// Transform __spirv_OpAtomicLoad to atomic_add(*ptr, 0)
-  Instruction *visitCallSPIRVAtomicLoad(CallInst *CI);
+  void visitCallSPIRVAtomicLoad(CallInst *CI);
 
   /// Transform __spirv_OpAtomicStore to atomic_xchg(*ptr, value)
-  Instruction *visitCallSPIRVAtomicStore(CallInst *CI);
+  void visitCallSPIRVAtomicStore(CallInst *CI);
 
   /// Transform __spirv_OpAtomicFlagClear to atomic_xchg(*ptr, 0)
   /// with ignoring the result
-  Instruction *visitCallSPIRVAtomicFlagClear(CallInst *CI);
+  void visitCallSPIRVAtomicFlagClear(CallInst *CI);
 
   /// Transform __spirv_OpAtomicFlagTestAndTest to
   /// (bool)atomic_xchg(*ptr, 1)
-  Instruction *visitCallSPIRVAtomicFlagTestAndSet(CallInst *CI);
+  void visitCallSPIRVAtomicFlagTestAndSet(CallInst *CI);
 
   /// Transform __spirv_OpAtomicCompareExchange/Weak into atomic_cmpxchg
   /// OpAtomicCompareExchangeWeak is not "weak" at all, but instead has
   /// the same semantics as OpAtomicCompareExchange.
-  Instruction *visitCallSPIRVAtomicCmpExchg(CallInst *CI) override;
+  void visitCallSPIRVAtomicCmpExchg(CallInst *CI) override;
 
   /// Trigger assert, since OpenCL 1.2 doesn't support enqueue_kernel
   void visitCallSPIRVEnqueueKernel(CallInst *CI, Op OC) override;
@@ -361,7 +361,7 @@ public:
   CallInst *mutateCommonAtomicArguments(CallInst *CI, Op OC) override;
 
   /// Transform atomic builtin name into correct ocl-dependent name
-  Instruction *mutateAtomicName(CallInst *CI, Op OC) override;
+  void mutateAtomicName(CallInst *CI, Op OC) override;
 
   // Transform FP atomic opcode to corresponding OpenCL function name
   std::string mapFPAtomicName(Op OC) override;
@@ -419,11 +419,11 @@ public:
   /// Transform __spirv_Atomic* to atomic_*.
   ///   __spirv_Atomic*(atomic_op, scope, sema, ops, ...) =>
   ///      atomic_*(generic atomic_op, ops, ..., order(sema), map(scope))
-  Instruction *visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) override;
+  void visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) override;
 
   /// Transform __spirv_OpAtomicIIncrement / OpAtomicIDecrement to
   /// atomic_fetch_add_explicit / atomic_fetch_sub_explicit
-  Instruction *visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) override;
+  void visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) override;
 
   /// Transform __spirv_EnqueueKernel to __enqueue_kernel
   void visitCallSPIRVEnqueueKernel(CallInst *CI, Op OC) override;
@@ -432,7 +432,7 @@ public:
   CallInst *mutateCommonAtomicArguments(CallInst *CI, Op OC) override;
 
   /// Transform atomic builtin name into correct ocl-dependent name
-  Instruction *mutateAtomicName(CallInst *CI, Op OC) override;
+  void mutateAtomicName(CallInst *CI, Op OC) override;
 
   // Transform FP atomic opcode to corresponding OpenCL function name
   std::string mapFPAtomicName(Op OC) override;
@@ -441,7 +441,7 @@ public:
   /// atomic_compare_exchange_strong_explicit
   /// OpAtomicCompareExchangeWeak is not "weak" at all, but instead has
   /// the same semantics as OpAtomicCompareExchange.
-  Instruction *visitCallSPIRVAtomicCmpExchg(CallInst *CI) override;
+  void visitCallSPIRVAtomicCmpExchg(CallInst *CI) override;
 };
 
 class SPIRVToOCL20Pass : public llvm::PassInfoMixin<SPIRVToOCL20Pass>,

--- a/lib/SPIRV/SPIRVToOCL12.cpp
+++ b/lib/SPIRV/SPIRVToOCL12.cpp
@@ -75,197 +75,132 @@ bool SPIRVToOCL12Base::runSPIRVToOCL(Module &Module) {
 }
 
 void SPIRVToOCL12Base::visitCallSPIRVMemoryBarrier(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Value *MemFenceFlags =
-            transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Args[1], CI);
-        Args.assign(1, MemFenceFlags);
-        return kOCLBuiltinName::MemFence;
-      },
-      &Attrs);
+  mutateCallInst(CI, kOCLBuiltinName::MemFence)
+      .mapArg(1,
+              [=](Value *V) {
+                return transSPIRVMemorySemanticsIntoOCLMemFenceFlags(V, CI);
+              })
+      .removeArg(0);
 }
 
 void SPIRVToOCL12Base::visitCallSPIRVControlBarrier(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        auto *MemFenceFlags =
-            transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Args[2], CI);
-        Args.assign(1, MemFenceFlags);
-        return kOCLBuiltinName::Barrier;
-      },
-      &Attrs);
+  mutateCallInst(CI, kOCLBuiltinName::Barrier)
+      .mapArg(2,
+              [=](Value *V) {
+                return transSPIRVMemorySemanticsIntoOCLMemFenceFlags(V, CI);
+              })
+      .removeArg(1)
+      .removeArg(0);
 }
 
 void SPIRVToOCL12Base::visitCallSPIRVSplitBarrierINTEL(CallInst *CI, Op OC) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Value *MemFenceFlags =
-            SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Args[2], CI);
-        Args.assign(1, MemFenceFlags);
-        return OCLSPIRVBuiltinMap::rmap(OC);
-      },
-      &Attrs);
+  mutateCallInst(CI, OCLSPIRVBuiltinMap::rmap(OC))
+      .mapArg(2,
+              [=](Value *V) {
+                return transSPIRVMemorySemanticsIntoOCLMemFenceFlags(V, CI);
+              })
+      .removeArg(1)
+      .removeArg(0);
 }
 
-Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Args.resize(1);
-        return mapAtomicName(OC, CI->getType());
-      },
-      &Attrs);
+void SPIRVToOCL12Base::visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) {
+  mutateCallInst(CI, mapAtomicName(OC, CI->getType()))
+      .removeArg(2)
+      .removeArg(1);
 }
 
 CallInst *SPIRVToOCL12Base::mutateCommonAtomicArguments(CallInst *CI, Op OC) {
-  assert(CI->getCalledFunction() && "Unexpected indirect call");
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  auto Ptr = findFirstPtr(CI->args());
+  auto NumOrder = getSPIRVAtomicBuiltinNumMemoryOrderArgs(OC);
+  auto ArgsToRemove = NumOrder + 1; // OpenCL1.2 builtins does not use
+                                    // scope and memory order arguments
 
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        auto Ptr = findFirstPtr(Args);
-        auto NumOrder = getSPIRVAtomicBuiltinNumMemoryOrderArgs(OC);
-        auto ArgsToRemove = NumOrder + 1; // OpenCL1.2 builtins does not use
-                                          // scope and memory order arguments
-        auto StartIdx = Ptr + 1;
-        auto StopIdx = StartIdx + ArgsToRemove;
-        Args.erase(Args.begin() + StartIdx, Args.begin() + StopIdx);
-        return mapAtomicName(OC, CI->getType());
-      },
-      &Attrs);
+  auto Mutator = mutateCallInst(CI, mapAtomicName(OC, CI->getType()));
+  Mutator.removeArgs(Ptr + 1, ArgsToRemove);
+  return cast<CallInst>(Mutator.getMutated());
 }
 
-Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicUMinUMax(CallInst *CI,
-                                                            Op OC) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        std::swap(Args[1], Args[3]);
-        Args.resize(2);
-        return mapAtomicName(OC, CI->getType());
-      },
-      &Attrs);
+void SPIRVToOCL12Base::visitCallSPIRVAtomicUMinUMax(CallInst *CI, Op OC) {
+  mutateCallInst(CI, mapAtomicName(OC, CI->getType()))
+      .moveArg(3, 1)
+      .removeArg(3)
+      .removeArg(2);
 }
 
-Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicLoad(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Args.resize(1);
-        // There is no atomic_load in OpenCL 1.2 spec.
-        // Emit this builtin via call of atomic_add(*p, 0).
-        Type *PtrElemTy = CI->getType();
-        Args.push_back(Constant::getNullValue(PtrElemTy));
-        return mapAtomicName(OpAtomicIAdd, PtrElemTy);
-      },
-      &Attrs);
+void SPIRVToOCL12Base::visitCallSPIRVAtomicLoad(CallInst *CI) {
+  // There is no atomic_load in OpenCL 1.2 spec.
+  // Emit this builtin via call of atomic_add(*p, 0).
+  Type *PtrElemTy = CI->getType();
+  mutateCallInst(CI, mapAtomicName(OpAtomicIAdd, PtrElemTy))
+      .removeArg(2)
+      .removeArg(1)
+      .appendArg(Constant::getNullValue(PtrElemTy));
 }
 
-Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicStore(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args, Type *&RetTy) {
-        std::swap(Args[1], Args[3]);
-        Args.resize(2);
-        // The type of the value pointed to by Pointer (1st argument), or the
-        // value being exchanged (2nd argument) must be the same as Result Type.
-        RetTy = Args[1]->getType();
-        return mapAtomicName(OpAtomicExchange, RetTy);
-      },
-      [=](CallInst *CI) -> Instruction * { return CI; }, &Attrs);
+void SPIRVToOCL12Base::visitCallSPIRVAtomicStore(CallInst *CI) {
+  Type *RetTy = CI->getArgOperand(3)->getType();
+  mutateCallInst(CI, mapAtomicName(OpAtomicExchange, RetTy))
+      .removeArg(2)
+      .removeArg(1)
+      .changeReturnType(RetTy, nullptr);
 }
 
-Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicFlagClear(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args, Type *&RetTy) {
-        Args.resize(1);
-        Args.push_back(getInt32(M, 0));
-        RetTy = Type::getInt32Ty(M->getContext());
-        return mapAtomicName(OpAtomicExchange, RetTy);
-      },
-      [=](CallInst *CI) -> Instruction * { return CI; }, &Attrs);
+void SPIRVToOCL12Base::visitCallSPIRVAtomicFlagClear(CallInst *CI) {
+  Type *RetTy = Type::getInt32Ty(M->getContext());
+  mutateCallInst(CI, mapAtomicName(OpAtomicExchange, RetTy))
+      .removeArg(2)
+      .removeArg(1)
+      .appendArg(getInt32(M, 0))
+      .changeReturnType(RetTy, nullptr);
 }
 
-Instruction *
-SPIRVToOCL12Base::visitCallSPIRVAtomicFlagTestAndSet(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args, Type *&RetTy) {
-        Args.resize(1);
-        Args.push_back(getInt32(M, 1));
-        RetTy = Type::getInt32Ty(M->getContext());
-        return mapAtomicName(OpAtomicExchange, RetTy);
-      },
-      [=](CallInst *CI) -> Instruction * {
-        return BitCastInst::Create(Instruction::Trunc, CI,
-                                   Type::getInt1Ty(CI->getContext()), "",
-                                   CI->getNextNode());
-      },
-      &Attrs);
+void SPIRVToOCL12Base::visitCallSPIRVAtomicFlagTestAndSet(CallInst *CI) {
+  Type *RetTy = Type::getInt32Ty(M->getContext());
+  mutateCallInst(CI, mapAtomicName(OpAtomicExchange, RetTy))
+      .removeArg(2)
+      .removeArg(1)
+      .appendArg(getInt32(M, 1))
+      .changeReturnType(RetTy, [](IRBuilder<> &Builder, CallInst *NewCI) {
+        return Builder.CreateTrunc(NewCI, Builder.getInt1Ty());
+      });
 }
 
-Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Args.erase(Args.begin() + 1, Args.begin() + 4);
-        // SPIRV OpAtomicCompareExchange and
-        // OpAtomicCompareExchangeWeak has Value and
-        // Comparator in different order than ocl functions
-        // both of them are translated into atomic_cmpxchg
-        std::swap(Args[1], Args[2]);
-        // Type of return value, pointee of the pointer
-        // operand, other operands, all match, and should
-        // be integer scalar types.
-        return mapAtomicName(OpAtomicCompareExchange, CI->getType());
-      },
-      &Attrs);
+void SPIRVToOCL12Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
+  mutateCallInst(CI, mapAtomicName(OpAtomicCompareExchange, CI->getType()))
+      .removeArg(3)
+      .removeArg(2)
+      .removeArg(1)
+      // SPIRV OpAtomicCompareExchange and OpAtomicCompareExchangeWeak has Value
+      // and Comparator in different order than ocl functions both of them are
+      // translated into atomic_cmpxchg
+      .moveArg(2, 1);
 }
 
-Instruction *SPIRVToOCL12Base::visitCallSPIRVAtomicBuiltin(CallInst *CI,
-                                                           Op OC) {
-  Instruction *NewCI = nullptr;
+void SPIRVToOCL12Base::visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) {
   switch (OC) {
   case OpAtomicLoad:
-    NewCI = visitCallSPIRVAtomicLoad(CI);
+    visitCallSPIRVAtomicLoad(CI);
     break;
   case OpAtomicStore:
-    NewCI = visitCallSPIRVAtomicStore(CI);
+    visitCallSPIRVAtomicStore(CI);
     break;
   case OpAtomicFlagClear:
-    NewCI = visitCallSPIRVAtomicFlagClear(CI);
+    visitCallSPIRVAtomicFlagClear(CI);
     break;
   case OpAtomicFlagTestAndSet:
-    NewCI = visitCallSPIRVAtomicFlagTestAndSet(CI);
+    visitCallSPIRVAtomicFlagTestAndSet(CI);
     break;
   case OpAtomicUMin:
   case OpAtomicUMax:
-    NewCI = visitCallSPIRVAtomicUMinUMax(CI, OC);
+    visitCallSPIRVAtomicUMinUMax(CI, OC);
     break;
   case OpAtomicCompareExchange:
   case OpAtomicCompareExchangeWeak:
-    NewCI = visitCallSPIRVAtomicCmpExchg(CI);
+    visitCallSPIRVAtomicCmpExchg(CI);
     break;
   default:
-    NewCI = mutateCommonAtomicArguments(CI, OC);
+    mutateCommonAtomicArguments(CI, OC);
   }
-
-  return NewCI;
 }
 
 void SPIRVToOCL12Base::visitCallSPIRVEnqueueKernel(CallInst *CI, Op OC) {
@@ -287,14 +222,8 @@ std::string SPIRVToOCL12Base::mapFPAtomicName(Op OC) {
   }
 }
 
-Instruction *SPIRVToOCL12Base::mutateAtomicName(CallInst *CI, Op OC) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        return OCL12SPIRVBuiltinMap::rmap(OC);
-      },
-      &Attrs);
+void SPIRVToOCL12Base::mutateAtomicName(CallInst *CI, Op OC) {
+  mutateCallInst(CI, OCL12SPIRVBuiltinMap::rmap(OC));
 }
 
 std::string SPIRVToOCL12Base::mapAtomicName(Op OC, Type *Ty) {

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -74,75 +74,41 @@ bool SPIRVToOCL20Base::runSPIRVToOCL(Module &Module) {
 }
 
 void SPIRVToOCL20Base::visitCallSPIRVMemoryBarrier(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        Value *MemScope =
-            SPIRV::transSPIRVMemoryScopeIntoOCLMemoryScope(Args[0], CI);
-        Value *MemFenceFlags =
-            SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Args[1], CI);
-        Value *MemOrder =
-            SPIRV::transSPIRVMemorySemanticsIntoOCLMemoryOrder(Args[1], CI);
-
-        Args.resize(3);
-        Args[0] = MemFenceFlags;
-        Args[1] = MemOrder;
-        Args[2] = MemScope;
-
-        return kOCLBuiltinName::AtomicWorkItemFence;
-      },
-      &Attrs);
+  Value *MemScope =
+      SPIRV::transSPIRVMemoryScopeIntoOCLMemoryScope(CI->getArgOperand(0), CI);
+  Value *MemFenceFlags = SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
+      CI->getArgOperand(1), CI);
+  Value *MemOrder = SPIRV::transSPIRVMemorySemanticsIntoOCLMemoryOrder(
+      CI->getArgOperand(1), CI);
+  mutateCallInst(CI, kOCLBuiltinName::AtomicWorkItemFence)
+      .setArgs({MemFenceFlags, MemOrder, MemScope});
 }
 
 void SPIRVToOCL20Base::visitCallSPIRVControlBarrier(CallInst *CI) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  SmallVector<AttributeSet, 2> ArgAttrs = {Attrs.getParamAttrs(1),
-                                           Attrs.getParamAttrs(2)};
-  AttributeList NewAttrs = AttributeList::get(*Ctx, Attrs.getFnAttrs(),
-                                              Attrs.getRetAttrs(), ArgAttrs);
-  mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        auto GetArg = [=](unsigned I) {
-          return cast<ConstantInt>(Args[I])->getZExtValue();
-        };
-        auto ExecScope = static_cast<Scope>(GetArg(0));
-        Value *MemScope =
-            getInt32(M, rmap<OCLScopeKind>(static_cast<Scope>(GetArg(1))));
-        Value *MemFenceFlags =
-            SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Args[2], CI);
-
-        Args.resize(2);
-        Args[0] = MemFenceFlags;
-        Args[1] = MemScope;
-
-        return (ExecScope == ScopeWorkgroup) ? kOCLBuiltinName::WorkGroupBarrier
-                                             : kOCLBuiltinName::SubGroupBarrier;
-      },
-      &NewAttrs);
+  auto GetArg = [=](unsigned I) {
+    return cast<ConstantInt>(CI->getArgOperand(I))->getZExtValue();
+  };
+  auto ExecScope = static_cast<Scope>(GetArg(0));
+  Value *MemScope =
+      getInt32(M, rmap<OCLScopeKind>(static_cast<Scope>(GetArg(1))));
+  Value *MemFenceFlags = SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
+      CI->getArgOperand(2), CI);
+  mutateCallInst(CI, ExecScope == ScopeWorkgroup
+                         ? kOCLBuiltinName::WorkGroupBarrier
+                         : kOCLBuiltinName::SubGroupBarrier)
+      .setArgs({MemFenceFlags, MemScope});
 }
 
 void SPIRVToOCL20Base::visitCallSPIRVSplitBarrierINTEL(CallInst *CI, Op OC) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        auto GetArg = [=](unsigned I) {
-          return cast<ConstantInt>(Args[I])->getZExtValue();
-        };
-        Value *MemScope =
-            getInt32(M, rmap<OCLScopeKind>(static_cast<Scope>(GetArg(1))));
-        Value *MemFenceFlags =
-            SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(Args[2], CI);
-
-        Args.resize(2);
-        Args[0] = MemFenceFlags;
-        Args[1] = MemScope;
-
-        return OCLSPIRVBuiltinMap::rmap(OC);
-      },
-      &Attrs);
+  auto GetArg = [=](unsigned I) {
+    return cast<ConstantInt>(CI->getArgOperand(I))->getZExtValue();
+  };
+  Value *MemScope =
+      getInt32(M, rmap<OCLScopeKind>(static_cast<Scope>(GetArg(1))));
+  Value *MemFenceFlags = SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
+      CI->getArgOperand(2), CI);
+  mutateCallInst(CI, OCLSPIRVBuiltinMap::rmap(OC))
+      .setArgs({MemFenceFlags, MemScope});
 }
 
 std::string SPIRVToOCL20Base::mapFPAtomicName(Op OC) {
@@ -160,147 +126,116 @@ std::string SPIRVToOCL20Base::mapFPAtomicName(Op OC) {
   }
 }
 
-Instruction *SPIRVToOCL20Base::mutateAtomicName(CallInst *CI, Op OC) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        // Map fp atomic instructions to regular OpenCL built-ins.
-        if (isFPAtomicOpCode(OC))
-          return mapFPAtomicName(OC);
-        return OCLSPIRVBuiltinMap::rmap(OC);
-      },
-      &Attrs);
+void SPIRVToOCL20Base::mutateAtomicName(CallInst *CI, Op OC) {
+  // Map fp atomic instructions to regular OpenCL built-ins.
+  mutateCallInst(CI, isFPAtomicOpCode(OC) ? mapFPAtomicName(OC)
+                                          : OCLSPIRVBuiltinMap::rmap(OC));
 }
 
-Instruction *SPIRVToOCL20Base::visitCallSPIRVAtomicBuiltin(CallInst *CI,
-                                                           Op OC) {
+void SPIRVToOCL20Base::visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) {
   CallInst *CIG = mutateCommonAtomicArguments(CI, OC);
 
-  Instruction *NewCI = nullptr;
   switch (OC) {
   case OpAtomicIIncrement:
   case OpAtomicIDecrement:
-    NewCI = visitCallSPIRVAtomicIncDec(CIG, OC);
+    visitCallSPIRVAtomicIncDec(CIG, OC);
     break;
   case OpAtomicCompareExchange:
   case OpAtomicCompareExchangeWeak:
-    NewCI = visitCallSPIRVAtomicCmpExchg(CIG);
+    visitCallSPIRVAtomicCmpExchg(CIG);
     break;
   default:
-    NewCI = mutateAtomicName(CIG, OC);
+    mutateAtomicName(CIG, OC);
   }
-
-  return NewCI;
 }
 
-Instruction *SPIRVToOCL20Base::visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) {
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        // Since OpenCL 2.0 doesn't have atomic_inc and atomic_dec builtins,
-        // we translate these instructions to atomic_fetch_add_explicit and
-        // atomic_fetch_sub_explicit OpenCL 2.0 builtins with "operand" argument
-        // = 1.
-        auto Name = OCLSPIRVBuiltinMap::rmap(
-            OC == OpAtomicIIncrement ? OpAtomicIAdd : OpAtomicISub);
-        Type *ValueTy = CI->getType();
-        assert(ValueTy->isIntegerTy());
-        Args.insert(Args.begin() + 1, llvm::ConstantInt::get(ValueTy, 1));
-        return Name;
-      },
-      &Attrs);
+void SPIRVToOCL20Base::visitCallSPIRVAtomicIncDec(CallInst *CI, Op OC) {
+  // Since OpenCL 2.0 doesn't have atomic_inc and atomic_dec builtins, we
+  // translate these instructions to atomic_fetch_add_explicit and
+  // atomic_fetch_sub_explicit OpenCL 2.0 builtins with "operand" argument = 1.
+  auto Name = OCLSPIRVBuiltinMap::rmap(OC == OpAtomicIIncrement ? OpAtomicIAdd
+                                                                : OpAtomicISub);
+  Type *ValueTy = CI->getType();
+  assert(ValueTy->isIntegerTy());
+  mutateCallInst(CI, Name).insertArg(1, ConstantInt::get(ValueTy, 1));
 }
 
 CallInst *SPIRVToOCL20Base::mutateCommonAtomicArguments(CallInst *CI, Op OC) {
-  assert(CI->getCalledFunction() && "Unexpected indirect call");
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
+  std::string Name;
+  // Map fp atomic instructions to regular OpenCL built-ins.
+  if (isFPAtomicOpCode(OC))
+    Name = mapFPAtomicName(OC);
+  else
+    Name = OCLSPIRVBuiltinMap::rmap(OC);
 
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args) {
-        for (size_t I = 0; I < Args.size(); ++I) {
-          Value *PtrArg = Args[I];
-          Type *PtrArgTy = PtrArg->getType();
-          if (PtrArgTy->isPointerTy()) {
-            if (PtrArgTy->getPointerAddressSpace() != SPIRAS_Generic) {
-              Type *FixedPtr = PointerType::getWithSamePointeeType(
-                  cast<PointerType>(PtrArgTy), SPIRAS_Generic);
-              Args[I] = CastInst::CreatePointerBitCastOrAddrSpaceCast(
-                  PtrArg, FixedPtr, PtrArg->getName() + ".as", CI);
-            }
-          }
-        }
-        auto Ptr = findFirstPtr(Args);
-        std::string Name;
-        // Map fp atomic instructions to regular OpenCL built-ins.
-        if (isFPAtomicOpCode(OC))
-          Name = mapFPAtomicName(OC);
-        else
-          Name = OCLSPIRVBuiltinMap::rmap(OC);
-        auto NumOrder = getSPIRVAtomicBuiltinNumMemoryOrderArgs(OC);
-        auto ScopeIdx = Ptr + 1;
-        auto OrderIdx = Ptr + 2;
+  auto Ptr = findFirstPtr(CI->args());
+  auto NumOrder = getSPIRVAtomicBuiltinNumMemoryOrderArgs(OC);
+  auto ScopeIdx = Ptr + 1;
+  auto OrderIdx = Ptr + 2;
+  auto Mutator = mutateCallInst(CI, Name);
 
-        Args[ScopeIdx] =
-            SPIRV::transSPIRVMemoryScopeIntoOCLMemoryScope(Args[ScopeIdx], CI);
-        for (size_t I = 0; I < NumOrder; ++I) {
-          Args[OrderIdx + I] =
-              SPIRV::transSPIRVMemorySemanticsIntoOCLMemoryOrder(
-                  Args[OrderIdx + I], CI);
-        }
-        std::swap(Args[ScopeIdx], Args.back());
-        return Name;
-      },
-      &Attrs);
+  Mutator.mapArgs([=](Value *PtrArg, Type *PtrElemTy) {
+    Type *PtrArgTy = PtrArg->getType();
+    if (PtrArgTy->isPointerTy()) {
+      if (PtrArgTy->getPointerAddressSpace() != SPIRAS_Generic) {
+        Type *FixedPtr = PointerType::getWithSamePointeeType(
+            cast<PointerType>(PtrArgTy), SPIRAS_Generic);
+        PtrArg = CastInst::CreatePointerBitCastOrAddrSpaceCast(
+            PtrArg, FixedPtr, PtrArg->getName() + ".as", CI);
+      }
+    }
+    return std::make_pair(PtrArg, PtrElemTy);
+  });
+  Mutator.mapArg(ScopeIdx, [=](Value *Arg) {
+    return SPIRV::transSPIRVMemoryScopeIntoOCLMemoryScope(Arg, CI);
+  });
+  for (size_t I = 0; I < NumOrder; ++I) {
+    Mutator.mapArg(OrderIdx + I, [=](Value *Arg) {
+      return SPIRV::transSPIRVMemorySemanticsIntoOCLMemoryOrder(Arg, CI);
+    });
+  }
+  Mutator.moveArg(Mutator.arg_size() - 1, ScopeIdx + 1);
+  Mutator.moveArg(ScopeIdx, Mutator.arg_size() - 1);
+
+  return cast<CallInst>(Mutator.getMutated());
 }
 
-Instruction *SPIRVToOCL20Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
-  assert(CI->getCalledFunction() && "Unexpected indirect call");
-  AttributeList Attrs = CI->getCalledFunction()->getAttributes();
-  Instruction *PInsertBefore = CI;
-
+void SPIRVToOCL20Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
   Type *MemTy = CI->getType();
 
-  return mutateCallInstOCL(
-      M, CI,
-      [=](CallInst *, std::vector<Value *> &Args, Type *&RetTy) {
-        // OpAtomicCompareExchange[Weak] semantics is different from
-        // atomic_compare_exchange_strong semantics as well as
-        // arguments order.
-        // OCL built-ins returns boolean value and stores a new/original
-        // value by pointer passed as 2nd argument (aka expected) while SPIR-V
-        // instructions returns this new/original value as a resulting value.
-        AllocaInst *PExpected = new AllocaInst(MemTy, 0, "expected",
-                                               &(*PInsertBefore->getParent()
-                                                      ->getParent()
-                                                      ->getEntryBlock()
-                                                      .getFirstInsertionPt()));
-        PExpected->setAlignment(Align(MemTy->getScalarSizeInBits() / 8));
-        new StoreInst(Args[1], PExpected, PInsertBefore);
-        unsigned AddrSpc = SPIRAS_Generic;
-        Type *PtrTyAS = PointerType::getWithSamePointeeType(
-            cast<PointerType>(PExpected->getType()), AddrSpc);
-        Args[1] = CastInst::CreatePointerBitCastOrAddrSpaceCast(
-            PExpected, PtrTyAS, PExpected->getName() + ".as", PInsertBefore);
-        std::swap(Args[3], Args[4]);
-        std::swap(Args[2], Args[3]);
-        RetTy = Type::getInt1Ty(*Ctx);
-        // OpAtomicCompareExchangeWeak is not "weak" at all, but instead has
-        // the same semantics as OpAtomicCompareExchange.
-        return "atomic_compare_exchange_strong_explicit";
-      },
-      [=](CallInst *CI) -> Instruction * {
+  // OpAtomicCompareExchange[Weak] semantics is different from
+  // atomic_compare_exchange_strong semantics as well as arguments order.
+  // OCL built-ins returns boolean value and stores a new/original
+  // value by pointer passed as 2nd argument (aka expected) while SPIR-V
+  // instructions returns this new/original value as a resulting value.
+  AllocaInst *PExpected = new AllocaInst(
+      MemTy, 0, "expected",
+      &*CI->getParent()->getParent()->getEntryBlock().getFirstInsertionPt());
+  PExpected->setAlignment(Align(MemTy->getScalarSizeInBits() / 8));
+
+  // OpAtomicCompareExchangeWeak is not "weak" at all, but instead has the same
+  // semantics as OpAtomicCompareExchange.
+  mutateCallInst(CI, "atomic_compare_exchange_strong_explicit")
+      .mapArg(1,
+              [=](IRBuilder<> &Builder, Value *Expected) {
+                Builder.CreateStore(Expected, PExpected);
+                unsigned AddrSpc = SPIRAS_Generic;
+                Type *PtrTyAS = PointerType::getWithSamePointeeType(
+                    cast<PointerType>(PExpected->getType()), AddrSpc);
+                Value *V = Builder.CreateAddrSpaceCast(
+                    PExpected, PtrTyAS, PExpected->getName() + ".as");
+                return std::make_pair(V, MemTy);
+              })
+      .moveArg(4, 2)
+      .changeReturnType(Type::getInt1Ty(*Ctx), [=](IRBuilder<> &Builder,
+                                                   CallInst *NewCI) {
         // OCL built-ins atomic_compare_exchange_[strong|weak] return boolean
         // value. So, to obtain the same value as SPIR-V instruction is
         // returning it has to be loaded from the memory where 'expected'
         // value is stored. This memory must contain the needed value after a
         // call to OCL built-in is completed.
-        return new LoadInst(MemTy, CI->getArgOperand(1), "original",
-                            PInsertBefore);
-      },
-      &Attrs);
+        return Builder.CreateLoad(MemTy, NewCI->getArgOperand(1), "original");
+      });
 }
 
 void SPIRVToOCL20Base::visitCallSPIRVEnqueueKernel(CallInst *CI, Op OC) {

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
@@ -45,7 +45,7 @@ __kernel void testAtomicCompareExchangeExplicit_cl20(
 //CHECK-SPIRV: AtomicCompareExchangeWeak {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
 //CHECK-SPIRV: AtomicCompareExchangeWeak {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
 
-//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected1.as, i32 %desired, i32 3, i32 0, i32 2)
-//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected3.as, i32 %desired, i32 4, i32 0, i32 1)
 //CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected5.as, i32 %desired, i32 3, i32 0, i32 2)
-//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected7.as, i32 %desired, i32 4, i32 0, i32 1)
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected8.as, i32 %desired, i32 4, i32 0, i32 1)
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected11.as, i32 %desired, i32 3, i32 0, i32 2)
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected14.as, i32 %desired, i32 4, i32 0, i32 1)

--- a/test/transcoding/memory_access.ll
+++ b/test/transcoding/memory_access.ll
@@ -27,9 +27,9 @@
 ; CHECK-LLVM: load i32, i32 addrspace(4)* %1, align 4
 ; CHECK-LLVM: load volatile i32 addrspace(4)*, i32 addrspace(4)** %ptr, align 8
 ; CHECK-LLVM: load volatile i32 addrspace(4)*, i32 addrspace(4)** %ptr
-; CHECK-LLVM: load volatile i32 addrspace(4)*, i32 addrspace(4)** %ptr, align 8, !nontemporal ![[NTMetadata:[0-9]+]]
+; CHECK-LLVM: %6 = load volatile i32 addrspace(4)*, i32 addrspace(4)** %ptr, align 8, !nontemporal ![[NTMetadata:[0-9]+]]
 ; CHECK-LLVM: store i32 %call, i32 addrspace(4)* %arrayidx, align 4, !nontemporal ![[NTMetadata:[0-9]+]]
-; CHECK-LLVM: store i32 addrspace(4)* %5, i32 addrspace(4)** %ptr
+; CHECK-LLVM: store i32 addrspace(4)* %6, i32 addrspace(4)** %ptr
 ; CHECK-LLVM: ![[NTMetadata:[0-9]+]] = !{i32 1}
 
 ; ModuleID = 'test.bc'

--- a/test/transcoding/memory_access.ll
+++ b/test/transcoding/memory_access.ll
@@ -27,9 +27,9 @@
 ; CHECK-LLVM: load i32, i32 addrspace(4)* %1, align 4
 ; CHECK-LLVM: load volatile i32 addrspace(4)*, i32 addrspace(4)** %ptr, align 8
 ; CHECK-LLVM: load volatile i32 addrspace(4)*, i32 addrspace(4)** %ptr
-; CHECK-LLVM: %6 = load volatile i32 addrspace(4)*, i32 addrspace(4)** %ptr, align 8, !nontemporal ![[NTMetadata:[0-9]+]]
+; CHECK-LLVM: %[[VOLATILELOAD:[0-9]+]] = load volatile i32 addrspace(4)*, i32 addrspace(4)** %ptr, align 8, !nontemporal ![[NTMetadata:[0-9]+]]
 ; CHECK-LLVM: store i32 %call, i32 addrspace(4)* %arrayidx, align 4, !nontemporal ![[NTMetadata:[0-9]+]]
-; CHECK-LLVM: store i32 addrspace(4)* %6, i32 addrspace(4)** %ptr
+; CHECK-LLVM: store i32 addrspace(4)* %[[VOLATILELOAD]], i32 addrspace(4)** %ptr
 ; CHECK-LLVM: ![[NTMetadata:[0-9]+]] = !{i32 1}
 
 ; ModuleID = 'test.bc'


### PR DESCRIPTION
The old mutateCallInst* functions and the new mutator doesn't quite get some of the value names correct, which necessitated some test changes that were looking for particular value names.