### PR TITLE
[Mutator] Migrate OCLBuiltinTransInfo::PostProc to the mutator interface.

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.h
+++ b/lib/SPIRV/OCLToSPIRV.h
@@ -280,6 +280,10 @@ private:
   /// Transform OpenCL vload/vstore function name.
   void transVecLoadStoreName(std::string &DemangledName,
                              const std::string &Stem, bool AlwaysN);
+
+  void processSubgroupBlockReadWriteINTEL(CallInst *CI,
+                                          OCLBuiltinTransInfo &Info,
+                                          const Type *DataTy);
 };
 
 class OCLToSPIRVLegacy : public OCLToSPIRVBase, public llvm::ModulePass {

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -158,12 +158,12 @@ struct OCLBuiltinTransInfo {
   std::string MangledName;
   std::string Postfix; // Postfix to be added
   /// Postprocessor of operands
-  std::function<void(std::vector<Value *> &)> PostProc;
+  std::function<void(BuiltinCallMutator &)> PostProc;
   Type *RetTy;      // Return type of the translated function
   bool IsRetSigned; // When RetTy is int, determines if extensions
                     // on it should be a sext or zet.
   OCLBuiltinTransInfo() : RetTy(nullptr), IsRetSigned(false) {
-    PostProc = [](std::vector<Value *> &) {};
+    PostProc = [](BuiltinCallMutator &) {};
   }
 };
 


### PR DESCRIPTION
This requires changing all of the callers of this method at the same time.