### PR TITLE
Fix parsing of --spec-const option

### DIFF
--- a/test/transcoding/spec_const.ll
+++ b/test/transcoding/spec_const.ll
@@ -4,7 +4,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv -r -emit-opaque-pointers -spec-const "0:i1:1 1:i8:11 2:i16:22 3:i32:33 4:i64:44 5:f16:5.5 6:f32:6.6 7:f64:7.7" %t.spv -o %t.rev.spec.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers -spec-const "0:i1:1 1:i8:11 2:i16:22 3:i32:33 4:i64:4609589727908835759 5:f16:5.5 6:f32:6.6 7:f64:7.7" %t.spv -o %t.rev.spec.bc
 ; RUN: llvm-dis < %t.rev.spec.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPEC
 
 ; CHECK-SPIRV-NOT: Capability Matrix
@@ -56,7 +56,7 @@ entry:
   store i32 %3, i32 addrspace(1)* %i, align 4
 
   ; CHECK-LLVM: store i64 3, ptr addrspace(1) %l, align 8
-  ; CHECK-LLVM-SPEC: store i64 44, ptr addrspace(1) %l, align 8
+  ; CHECK-LLVM-SPEC: store i64 4609589727908835759, ptr addrspace(1) %l, align 8
   %4 = call i64 @_Z20__spirv_SpecConstantix(i32 4, i64 3)
   store i64 %4, i64 addrspace(1)* %l, align 8
 

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -581,7 +581,7 @@ bool parseSpecConstOpt(llvm::StringRef SpecConstStr,
       }
       APInt Value;
       bool Err = Params[2].getAsInteger(10, Value);
-      if (Err || Value.getNumWords() > 1 ||
+      if (Err || Value.getActiveWords() > 1 ||
           (Width < 64 && Value.getZExtValue() >> Width)) {
         errs() << "Error: Invalid value for '-" << SpecConst.ArgStr
                << "' option! In \"" << Option << "\": can't convert \""


### PR DESCRIPTION
While running OpenCL-CTS SPIR-V subtests, i found that launching llvm-spirv with arguments:

`-r --spec-const=101:i64:4609589727908835759`

results in error message:

`Error: Invalid value for '-spec-const' option! In "101:i64:4609589727908835759": can't convert "4609589727908835759" to 64-bit integer number`

However, 4609589727908835759 fits into 64bits (0x3ff88d6f544bb1af). The problem seems to be that getNumWords() returns 2 so i changed it to use getActiveBits(), but i'm not 100% sure this is the proper fix.