### PR TITLE
Update DebugInfo test after llvm change

### DIFF
--- a/test/DebugInfo/X86/live-debug-variables.ll
+++ b/test/DebugInfo/X86/live-debug-variables.ll
@@ -34,7 +34,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK: DW_TAG_formal_parameter
 ; Check concrete entry has a single location.
 ; CHECK:      DW_TAG_formal_parameter
-; CHECK-NEXT:   DW_AT_location (DW_OP_reg3 RBX)
+; CHECK-NEXT:   DW_AT_location (DW_OP_reg6 RBP)
 ; CHECK-NEXT:   DW_AT_abstract_origin
 ; CHECK-NOT:  DW_TAG_formal_parameter
 


### PR DESCRIPTION
Update a check pattern after LLVM commit 189900eb149b ("X86: Stop assigning register costs for longer encodings.", 2022-09-30).