### PR TITLE
Fix reverse translation addrspace annotation assert

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3536,7 +3536,8 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
       while (!isStaticMemoryAttribute && BaseInst &&
              (isa<BitCastInst>(BaseInst) || isa<AddrSpaceCastInst>(BaseInst))) {
         BaseInst = dyn_cast<Instruction>(BaseInst->getOperand(0));
-        if (const auto*const BaseAlloca = dyn_cast_or_null<AllocaInst>(BaseInst)) {
+        if (const auto *const BaseAlloca =
+                dyn_cast_or_null<AllocaInst>(BaseInst)) {
 
           // If the alloca has a struct type, the annotation is likely for the
           // first member (even though there's no GEP) and so should still use

--- a/test/transcoding/annotate_attribute.ll
+++ b/test/transcoding/annotate_attribute.ll
@@ -221,8 +221,7 @@ define weak_odr dso_local spir_kernel void @_ZTSZ11TestKernelAvE4MyIP(i32 addrsp
   ; CHECK-LLVM: %[[ALLOCA:.*]] = alloca %struct.MyIP, align 8
   ; CHECK-LLVM: %[[BITCAST:.*]] = bitcast ptr %[[ALLOCA]] to ptr
   ; CHECK-LLVM: %[[ADDRSPACECAST:.*]] = addrspacecast ptr %[[BITCAST]] to ptr addrspace(4)
-  ; CHECK-LLVM: %[[UNADDRSPACECAST:.*]] = addrspacecast ptr addrspace(4) %[[ADDRSPACECAST]] to ptr
-  ; CHECK-LLVM: call void @llvm.var.annotation(ptr %[[UNADDRSPACECAST]], ptr [[STR12]], ptr undef, i32 undef, ptr undef)
+  ; CHECK-LLVM: call ptr addrspace(4) @llvm.ptr.annotation.p4(ptr addrspace(4) %[[ADDRSPACECAST]], ptr [[STR12]], ptr undef, i32 undef, ptr undef)
   %6 = bitcast i8 addrspace(4)* %5 to i32 addrspace(4)* addrspace(4)*
   %7 = addrspacecast i32 addrspace(1)* %0 to i32 addrspace(4)*
   store i32 addrspace(4)* %7, i32 addrspace(4)* addrspace(4)* %6, align 8, !tbaa !17

--- a/test/transcoding/annotate_attribute.ll
+++ b/test/transcoding/annotate_attribute.ll
@@ -24,6 +24,7 @@
 ; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "annotation_with_zerointializer: 0, 0, 0"
 ; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "annotation_with_false: 0"
 ; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "annotation_mixed: 0, 1, 0"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "abc: 1, 2, 3"
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
@@ -33,6 +34,7 @@ target triple = "spir64-unknown-linux"
 %struct.S = type { i32 }
 %struct.S.1 = type { i32 }
 %struct.S.2 = type { i32 }
+%struct.MyIP = type { i32 addrspace(4)* }
 
 ; CHECK-LLVM-DAG:  [[STR:@[0-9_.]+]] = {{.*}}42
 ; CHECK-LLVM-DAG: [[STR2:@[0-9_.]+]] = {{.*}}{FOO}
@@ -45,6 +47,7 @@ target triple = "spir64-unknown-linux"
 ; CHECK-LLVM-DAG: [[STR9:@[0-9_.]+]] = {{.*}}annotation_with_zerointializer: 0, 0, 0
 ; CHECK-LLVM-DAG: [[STR10:@[0-9_.]+]] = {{.*}}annotation_with_false: 0
 ; CHECK-LLVM-DAG: [[STR11:@[0-9_.]+]] = {{.*}}"annotation_mixed: 0, 1, 0
+; CHECK-LLVM-DAG: [[STR12:@[0-9_.]+]] = {{.*}}"abc: 1, 2, 3
 @.str = private unnamed_addr constant [3 x i8] c"42\00", section "llvm.metadata"
 @.str.1 = private unnamed_addr constant [23 x i8] c"annotate_attribute.cpp\00", section "llvm.metadata"
 @.str.2 = private unnamed_addr constant [6 x i8] c"{FOO}\00", section "llvm.metadata"
@@ -61,6 +64,9 @@ target triple = "spir64-unknown-linux"
 @.args.2 = private unnamed_addr constant { i32, i32, i32 } zeroinitializer, section "llvm.metadata"
 @.args.3 = private unnamed_addr constant { i1 } zeroinitializer, section "llvm.metadata"
 @.args.4 = private unnamed_addr constant { i32, i32, i32 } { i32 0, i32 1, i32 0 }, section "llvm.metadata"
+@.str.11 = private unnamed_addr constant [4 x i8] c"abc\00", section "llvm.metadata"
+@.str.1.12 = private unnamed_addr constant [9 x i8] c"test.cpp\00", section "llvm.metadata"
+@.args = private unnamed_addr constant { i32, i32, i32 } { i32 1, i32 2, i32 3 }, section "llvm.metadata"
 
 
 ; Function Attrs: nounwind
@@ -205,6 +211,30 @@ entry:
   ret i32 0
 }
 
+; Function Attrs: mustprogress norecurse
+define weak_odr dso_local spir_kernel void @_ZTSZ11TestKernelAvE4MyIP(i32 addrspace(1)* noundef align 4 %0) local_unnamed_addr #5 !kernel_arg_buffer_location !15 !sycl_kernel_omit_args !16 {
+  %2 = alloca %struct.MyIP, align 8
+  %3 = bitcast %struct.MyIP* %2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 8, i8* nonnull %3) #4
+  %4 = addrspacecast i8* %3 to i8 addrspace(4)*
+  %5 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %4, i8* getelementptr inbounds ([4 x i8], [4 x i8]* @.str.11, i64 0, i64 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.1.12, i64 0, i64 0), i32 13, i8* bitcast ({ i32, i32, i32 }* @.args to i8*))
+  ; CHECK-LLVM: %[[ALLOCA:.*]] = alloca %struct.MyIP, align 8
+  ; CHECK-LLVM: %[[BITCAST:.*]] = bitcast ptr %[[ALLOCA]] to ptr
+  ; CHECK-LLVM: %[[ADDRSPACECAST:.*]] = addrspacecast ptr %[[BITCAST]] to ptr addrspace(4)
+  ; CHECK-LLVM: %[[UNADDRSPACECAST:.*]] = addrspacecast ptr addrspace(4) %[[ADDRSPACECAST]] to ptr
+  ; CHECK-LLVM: call void @llvm.var.annotation(ptr %[[UNADDRSPACECAST]], ptr [[STR12]], ptr undef, i32 undef, ptr undef)
+  %6 = bitcast i8 addrspace(4)* %5 to i32 addrspace(4)* addrspace(4)*
+  %7 = addrspacecast i32 addrspace(1)* %0 to i32 addrspace(4)*
+  store i32 addrspace(4)* %7, i32 addrspace(4)* addrspace(4)* %6, align 8, !tbaa !17
+  %8 = bitcast i8 addrspace(4)* %5 to i32 addrspace(4)* addrspace(4)*
+  %9 = load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %8, align 8, !tbaa !17
+  %10 = load i32, i32 addrspace(4)* %9, align 4, !tbaa !19
+  %11 = shl nsw i32 %10, 1
+  store i32 %11, i32 addrspace(4)* %9, align 4, !tbaa !19
+  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %3) #4
+  ret void
+}
+
 declare dso_local void @_Z3fooi(i32 noundef)
 
 ; Function Attrs: nounwind
@@ -213,11 +243,15 @@ declare i8* @llvm.ptr.annotation.p0i8(i8*, i8*, i8*, i32, i8*) #4
 ; Function Attrs: nounwind
 declare i32* @llvm.ptr.annotation.p0i32(i32*, i8*, i8*, i32, i8*) #4
 
+; Function Attrs: nounwind
+declare i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)*, i8*, i8*, i32, i8*) #4
+
 attributes #0 = { nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { argmemonly nounwind }
 attributes #2 = { inlinehint nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { nounwind optnone noinline "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #4 = { nounwind }
+attributes #5 = { mustprogress norecurse "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="test.cpp" "uniform-work-group-size"="true" }
 
 !llvm.module.flags = !{!0}
 !opencl.spir.version = !{!1}
@@ -239,3 +273,8 @@ attributes #4 = { nounwind }
 !12 = !{!"float", !7, i64 0}
 !13 = !{!10, !7, i64 4}
 !14 = !{!10, !12, i64 8}
+!15 = !{i32 -1}
+!16 = !{i1 false}
+!17 = !{!18, !6, i64 0}
+!18 = !{!"_ZTSZ11TestKernelAvE4MyIP", !6, i64 0}
+!19 = !{!11, !11, i64 0}


### PR DESCRIPTION
When annotating values, SPIRVToLLVM::transIntelFPGADecorations scans the preceding instructions to see if they're based on an alloca. llvm.var.annotation is used to mark that value if there is a base alloca; otherwise, llvm.ptr.annotation is used. In some cases an annotated value based on an alloca has a non-zero address space, which is a problem because llvm.var.annotation (unlike llvm.ptr.annotation) only accepts address space zero pointers. This change is a simple fix to add another addrspacecast to return the pointer to address space zero so it can be annotated.

Some misleading variable names are also updated to more clearly convey the behavior of this code.