### PR TITLE
[Backport to 10] Fix wrong DICompositeType size (#1452)

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -204,7 +204,7 @@ SPIRVToLLVMDbgTran::transTypeArray(const SPIRVExtInst *DebugInst) {
     SPIRVConstant *C = BM->get<SPIRVConstant>(Ops[I]);
     int64_t Count = static_cast<int64_t>(C->getZExtIntValue());
     Subscripts.push_back(Builder.getOrCreateSubrange(0, Count));
-    TotalCount *= static_cast<uint64_t>(Count);
+    TotalCount *= Count > 0 ? static_cast<size_t>(Count) : 0;
   }
   DINodeArray SubscriptArray = Builder.getOrCreateArray(Subscripts);
   size_t Size = getDerivedSizeInBits(BaseTy) * TotalCount;


### PR DESCRIPTION
If count = -1 we shouldln't cast it to unsigned