### PR TITLE
Reorder SPIR-V blocks to emit dominators first

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4378,10 +4378,102 @@ void LLVMToSPIRVBase::fpContractUpdateRecursive(Function *F, FPContract FPC) {
   }
 }
 
+/// Returns a range that traverses \p F ensuring that dominator blocks are
+/// visited before the blocks they dominate.
+///
+/// Compared to llvm::ReversePostOrderTraversal which also visits dominators
+/// before dominated blocks, this traversal aims to be more stable and will keep
+/// basic blocks in their original order as much as possible, only reordering
+/// them to visit dominators ahead of their dominated blocks when needed. \p DT
+/// is not copied by this function and needs to outlive any iterators created
+/// from this range.
+static auto stablePreDominatorTraversal(Function& F, const DominatorTree& DT) {
+
+  // A local iterator type for traversing a function in the desired order.
+  class StablePreDominatorIterator : public iterator_facade_base<StablePreDominatorIterator, std::forward_iterator_tag, BasicBlock> {
+
+    // The passed DominatorTree; may be unset for end iterators.
+    const DominatorTree* DT;
+
+    // The set of basic blocks already visited in this traversal.
+    DenseSet<const BasicBlock*> VisitedBBs;
+
+    // The next basic block in original function order, or nullptr if the
+    // traversal is over.
+    BasicBlock* NextBB = nullptr;
+
+    // The current basic block in the traversal, or nullptr for end iterators.
+    BasicBlock* CurBB = nullptr;
+
+    // Returns the most immediate dominator of \p BB which does not have an
+    // unvisited dominator and so can be visited in this traversal.
+    BasicBlock* visitableDominator(BasicBlock* BB) const {
+
+      // Find BB's dominator; if there is none, BB can be visited immediately.
+      const auto*const BBNode = DT->getNode(BB);
+      if (!BBNode) return BB;
+      const auto*const DomNode = BBNode->getIDom();
+      if (!DomNode) return BB;
+      BasicBlock*const Dominator = DomNode->getBlock();
+
+      // If the dominator's been visited, BB can now be visited.
+      if (VisitedBBs.count(Dominator))
+        return BB;
+
+      // Otherwise, find the dominator's visitable dominator instead.
+      return visitableDominator(Dominator);
+    }
+
+    // Advances the iterator and returns the next basic block to be visited in
+    // the traversal.
+    BasicBlock* next() {
+
+      // If NextBB is nullptr, the end of the traversal has been reached.
+      if (!NextBB) return nullptr;
+
+      // Check if NextBB has already been visited; if so, advance past it.
+      if (VisitedBBs.count(NextBB)) {
+        NextBB = NextBB->getNextNode();
+        return next();
+      }
+
+      // If NextBB is unvisited, visit its next visitable dominator.
+      BasicBlock*const ToVisit = visitableDominator(NextBB);
+      VisitedBBs.insert(ToVisit);
+      return ToVisit;
+    }
+
+  public:
+
+    // Constructs an end iterator.
+    StablePreDominatorIterator() {}
+
+    // Constructs a begin iterator at the start of \p F.
+    StablePreDominatorIterator(Function& F, const DominatorTree& DT) : DT(&DT), NextBB(&F.getEntryBlock()) {
+      ++*this;
+    }
+
+    // Methods required by iterator_facade_base.
+    bool operator==(const StablePreDominatorIterator& Other) const {
+      return CurBB == Other.CurBB;
+    }
+    BasicBlock& operator*() const { return *CurBB; }
+    StablePreDominatorIterator& operator++() {
+      CurBB = next();
+      return *this;
+    }
+  };
+
+  return make_range(StablePreDominatorIterator(F, DT), StablePreDominatorIterator());
+}
+
 void LLVMToSPIRVBase::transFunction(Function *I) {
   SPIRVFunction *BF = transFunctionDecl(I);
-  // Creating all basic blocks before creating any instruction.
-  for (auto &FI : *I) {
+  // Creating all basic blocks before creating any instruction. SPIR-V requires
+  // that blocks appear after their dominators, so stablePreDominatorTraversal
+  // is used to ensure blocks are written in the right order.
+  const DominatorTree DT (*I);
+  for (BasicBlock& FI : stablePreDominatorTraversal(*I, DT)) {
     transValue(&FI, nullptr);
   }
   for (auto &FI : *I) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4398,7 +4398,7 @@ static auto stablePreDominatorTraversal(Function &F, const DominatorTree &DT) {
     const DominatorTree *DT;
 
     // The set of basic blocks already visited in this traversal.
-    DenseSet<const BasicBlock *> VisitedBBs;
+    SmallPtrSet<const BasicBlock *, 4> VisitedBBs;
 
     // The next basic block in original function order, or nullptr if the
     // traversal is over.
@@ -4421,7 +4421,7 @@ static auto stablePreDominatorTraversal(Function &F, const DominatorTree &DT) {
       BasicBlock *const Dominator = DomNode->getBlock();
 
       // If the dominator's been visited, BB can now be visited.
-      if (VisitedBBs.count(Dominator))
+      if (VisitedBBs.contains(Dominator))
         return BB;
 
       // Otherwise, find the dominator's visitable dominator instead.
@@ -4437,7 +4437,7 @@ static auto stablePreDominatorTraversal(Function &F, const DominatorTree &DT) {
         return nullptr;
 
       // Check if NextBB has already been visited; if so, advance past it.
-      if (VisitedBBs.count(NextBB)) {
+      if (VisitedBBs.contains(NextBB)) {
         NextBB = NextBB->getNextNode();
         return next();
       }

--- a/test/DebugInfo/Generic/debug-info-eis-option.ll
+++ b/test/DebugInfo/Generic/debug-info-eis-option.ll
@@ -33,7 +33,7 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup.lo
 
 for.body:                                         ; preds = %for.body, %for.body.preheader
 ; CHECK: ![[X:[0-9]+]] = !DILocalVariable(name: "x",
-; CHECK-LABEL: bb.3.for.body:
+; CHECK-LABEL: bb.2.for.body:
 ; CHECK: DBG_VALUE {{.*}} ![[X]], !DIExpression()
 ; CHECK: DBG_VALUE {{.*}} ![[X]], !DIExpression()
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %for.body.preheader ]

--- a/test/DebugInfo/Generic/linear-dbg-value.ll
+++ b/test/DebugInfo/Generic/linear-dbg-value.ll
@@ -33,7 +33,7 @@ for.cond.cleanup:                                 ; preds = %for.cond.cleanup.lo
 
 for.body:                                         ; preds = %for.body, %for.body.preheader
 ; CHECK: ![[X:[0-9]+]] = !DILocalVariable(name: "x",
-; CHECK-LABEL: bb.3.for.body:
+; CHECK-LABEL: bb.2.for.body:
 ; CHECK: DBG_VALUE {{.*}} ![[X]], !DIExpression()
 ; CHECK: DBG_VALUE {{.*}} ![[X]], !DIExpression()
   %indvars.iv = phi i64 [ %indvars.iv.next, %for.body ], [ 0, %for.body.preheader ]

--- a/test/create-placeholders-for-phi-operands.ll
+++ b/test/create-placeholders-for-phi-operands.ll
@@ -30,7 +30,7 @@ BB.0:
   %or.cond = select i1 %cmp41, i1 true, i1 %cmp42.not104
   br i1 %or.cond, label %BB.2, label %BB.3
 
-BB.1:                                             ; preds = %BB.12, %BB.7
+BB.1:                                             ; preds = %BB.12.loopexit, %BB.11.loopexit
   %savedstack.sink = phi i8* [ %savedstack, %BB.12.loopexit ], [ %savedstack.us, %BB.11.loopexit ]
   call void @llvm.stackrestore(i8* %savedstack.sink), !llvm.access.group !9
   br label %BB.2

--- a/test/create-placeholders-for-phi-operands.ll
+++ b/test/create-placeholders-for-phi-operands.ll
@@ -31,7 +31,7 @@ BB.0:
   br i1 %or.cond, label %BB.2, label %BB.3
 
 BB.1:                                             ; preds = %BB.12, %BB.7
-  %savedstack.sink = phi i8* [ %savedstack, %BB.12 ], [ %savedstack.us, %BB.7 ]
+  %savedstack.sink = phi i8* [ %savedstack, %BB.12.loopexit ], [ %savedstack.us, %BB.11.loopexit ]
   call void @llvm.stackrestore(i8* %savedstack.sink), !llvm.access.group !9
   br label %BB.2
 
@@ -64,7 +64,10 @@ BB.6:                                             ; preds = %BB.4
 BB.7:                                             ; preds = %BB.8
   %indvars.iv.next27 = add nuw nsw i64 %indvars.iv26, 1
   %exitcond29.not = icmp eq i64 %indvars.iv.next27, %7
-  br i1 %exitcond29.not, label %BB.1, label %BB.11, !llvm.loop !11
+  br i1 %exitcond29.not, label %BB.11.loopexit, label %BB.11, !llvm.loop !11
+
+BB.11.loopexit:
+  br label %BB.1
 
 BB.8:                                             ; preds = %BB.11, %BB.8
   %indvars.iv22 = phi i64 [ 0, %BB.11 ], [ %indvars.iv.next23, %BB.8 ]
@@ -96,7 +99,10 @@ BB.12:                                            ; preds = %BB.12, %BB.5
   %indvars.iv33 = phi i64 [ 0, %BB.5 ], [ %indvars.iv.next34, %BB.12 ]
   %indvars.iv.next34 = add nuw nsw i64 %indvars.iv33, 1
   %exitcond35.not = icmp eq i64 %indvars.iv.next34, 624
-  br i1 %exitcond35.not, label %BB.1, label %BB.12, !llvm.loop !11
+  br i1 %exitcond35.not, label %BB.12.loopexit, label %BB.12, !llvm.loop !11
+
+BB.12.loopexit:
+  br label %BB.1
 }
 
 declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr

--- a/test/dominator-order.ll
+++ b/test/dominator-order.ll
@@ -1,0 +1,43 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+; This test checks that basic blocks are reordered in SPIR-V so that dominators
+; are emitted ahead of their dominated blocks as required by the SPIR-V
+; specification.
+
+; CHECK-DAG: Name [[#ENTRY:]] "entry"
+; CHECK-DAG: Name [[#FOR_BODY137_LR_PH:]] "for.body137.lr.ph"
+; CHECK-DAG: Name [[#FOR_BODY:]] "for.body"
+
+; CHECK: Label [[#ENTRY]]
+; CHECK: Label [[#FOR_BODY]]
+; CHECK: Label [[#FOR_BODY137_LR_PH]]
+
+source_filename = "reproducer.cl"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @test(i8 addrspace(1)* %arg) local_unnamed_addr #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !4 {
+entry:
+  br label %for.body
+
+for.body137.lr.ph:                                ; preds = %for.body
+  ret void
+
+for.body:                                         ; preds = %for.body, %entry
+  br i1 undef, label %for.body, label %for.body137.lr.ph
+}
+
+attributes #0 = { "use-soft-float"="false" }
+attributes #1 = { nounwind readnone speculatable }
+
+!llvm.ident = !{!0}
+
+!0 = !{!"clang version 9.0.0 "}
+!1 = !{i32 1}
+!2 = !{!"none"}
+!3 = !{!"uchar*"}
+!4 = !{!""}

--- a/test/transcoding/SPV_INTEL_variable_length_array/complex-cfg.ll
+++ b/test/transcoding/SPV_INTEL_variable_length_array/complex-cfg.ll
@@ -21,6 +21,25 @@ newFuncRoot:
   %temp = alloca i32, align 4
   br label %fallthru
 
+; CHECK-LABEL: fallthru
+; CHECK-LLVM: %"ascastB$val41" = alloca i32, i64 %div.3
+fallthru:                          ; preds = %newFuncRoot
+  %"$stacksave37" = call spir_func i8* @llvm.stacksave()
+  %S.ul.GEP.1_fetch.194 = load i32, i32 addrspace(4)* %S.ul.GEP.1.value, align 1
+  %int_sext39 = sext i32 %S.ul.GEP.1_fetch.194 to i64
+  %rel.39 = icmp sgt i32 0, %S.ul.GEP.1_fetch.194
+  %slct.13 = select i1 %rel.39, i32 0, i32 %S.ul.GEP.1_fetch.194
+  %int_sext40 = sext i32 %slct.13 to i64
+  %mul.11 = mul nsw i64 %int_sext40, 4
+  %div.3 = sdiv i64 %mul.11, 4
+  %"ascastB$val41" = alloca i32, i64 %div.3, align 4
+  store i64 1, i64* %"var$102", align 1
+  store i32 %S.ul.GEP.1_fetch.194, i32* %temp, align 1
+  store i32 1, i32* %"var$103", align 1
+  %"ascastB$val_fetch.197" = load i32, i32* %temp, align 1
+  %rel.40 = icmp slt i32 %"ascastB$val_fetch.197", 1
+  br i1 %rel.40, label %bb270, label %bb269.preheader
+
 ; CHECK-LABEL: bb269
 ; CHECK-LLVM: %1 = getelementptr inbounds i32, ptr %"ascastB$val41", i64 %0
 bb269:                                            ; preds = %bb269.preheader, %bb269
@@ -92,24 +111,6 @@ loop_body328:                                     ; preds = %loop_test327
 
 loop_exit329:                                     ; preds = %loop_test327
   ret void
-; CHECK-LABEL: fallthru
-; CHECK-LLVM: %"ascastB$val41" = alloca i32, i64 %div.3
-fallthru:                          ; preds = %newFuncRoot
-  %"$stacksave37" = call spir_func i8* @llvm.stacksave()
-  %S.ul.GEP.1_fetch.194 = load i32, i32 addrspace(4)* %S.ul.GEP.1.value, align 1
-  %int_sext39 = sext i32 %S.ul.GEP.1_fetch.194 to i64
-  %rel.39 = icmp sgt i32 0, %S.ul.GEP.1_fetch.194
-  %slct.13 = select i1 %rel.39, i32 0, i32 %S.ul.GEP.1_fetch.194
-  %int_sext40 = sext i32 %slct.13 to i64
-  %mul.11 = mul nsw i64 %int_sext40, 4
-  %div.3 = sdiv i64 %mul.11, 4
-  %"ascastB$val41" = alloca i32, i64 %div.3, align 4
-  store i64 1, i64* %"var$102", align 1
-  store i32 %S.ul.GEP.1_fetch.194, i32* %temp, align 1
-  store i32 1, i32* %"var$103", align 1
-  %"ascastB$val_fetch.197" = load i32, i32* %temp, align 1
-  %rel.40 = icmp slt i32 %"ascastB$val_fetch.197", 1
-  br i1 %rel.40, label %bb270, label %bb269.preheader
 
 bb269.preheader:                                  ; preds = %fallthru
   br label %bb269


### PR DESCRIPTION
This implements the block ordering rule in section 2.16.1 of the SPIR-V specification:

> The order of blocks in a function must satisfy the rule that blocks appear
before all blocks they dominate.

This fixes #205.