### PR TITLE
[NFC] Add opening parenthesis to call checks

### DIFF
--- a/test/OpenCL.std/vload_half.spvasm
+++ b/test/OpenCL.std/vload_half.spvasm
@@ -6,22 +6,22 @@
 ;
 ; CHECK-LABEL: spir_kernel void @test
 ;
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh(
 ;
 ; CHECK-CL20: call spir_func float @_Z10vload_halfjPU3AS1KDh
 ; CHECK-CL20: call spir_func float @_Z10vload_halfjPU3AS1KDh

--- a/test/transcoding/OpBitReverse_i32.ll
+++ b/test/transcoding/OpBitReverse_i32.ll
@@ -7,7 +7,7 @@
 ; CHECK-SPIRV: 4 TypeInt [[int:[0-9]+]] 32
 ; CHECK-SPIRV: 4 BitReverse [[int]]
 
-; CHECK-LLVM: call i32 @llvm.bitreverse.i32
+; CHECK-LLVM: call i32 @llvm.bitreverse.i32(
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"

--- a/test/transcoding/OpBitReverse_v2i16.ll
+++ b/test/transcoding/OpBitReverse_v2i16.ll
@@ -8,7 +8,7 @@
 ; CHECK-SPIRV: 4 TypeVector [[short2:[0-9]+]] [[short]] 2
 ; CHECK-SPIRV: 4 BitReverse [[short2]]
 
-; CHECK-LLVM: call <2 x i16> @llvm.bitreverse.v2i16
+; CHECK-LLVM: call <2 x i16> @llvm.bitreverse.v2i16(
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"

--- a/test/transcoding/OpConstantSampler.ll
+++ b/test/transcoding/OpConstantSampler.ll
@@ -23,8 +23,8 @@
 ; CHECK-SPIRV: SampledImage {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[SamplerID0]]
 ; CHECK-SPIRV: SampledImage {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[SamplerID1]]
 
-; CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f
-; CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f
+; CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(
+; CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"

--- a/test/transcoding/OpDot.ll
+++ b/test/transcoding/OpDot.ll
@@ -31,7 +31,7 @@ entry:
 ; CHECK-SPIRV: FunctionEnd
 
 ; CHECK-LLVM-LABEL: @testVector
-; CHECK-LLVM: call spir_func float @_Z3dotDv2_fS_
+; CHECK-LLVM: call spir_func float @_Z3dotDv2_fS_(
 
 ; Function Attrs: nounwind
 define spir_kernel void @testVector(<2 x float> %f) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {

--- a/test/transcoding/OpImageWrite.cl
+++ b/test/transcoding/OpImageWrite.cl
@@ -45,19 +45,19 @@ kernel void test_img2d(write_only image2d_t image_wo, read_write image2d_t image
 // CHECK-SPIRV: ImageWrite [[IMG2D_WO]]
 // CHECK-SPIRV: ImageWrite [[IMG2D_WO]]
 
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_i
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image2d_rwDv2_iDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image2d_rwDv2_iDv4_i
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iiDv4_i
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iDv4_i(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image2d_rwDv2_iDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image2d_rwDv2_iDv4_i(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image2d_woDv2_iiDv4_i(
 
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_i
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_2Dv2_iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_2Dv2_iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_2Dv2_iDv4_i
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_fii
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_iii
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_fii(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_iii(
 
 kernel void test_img2d_array(write_only image2d_array_t image_wo, read_write image2d_array_t image_rw)
 {
@@ -81,19 +81,19 @@ kernel void test_img2d_array(write_only image2d_array_t image_wo, read_write ima
 // CHECK-SPIRV: ImageWrite [[IMG2D_ARRAY_WO]]
 // CHECK-SPIRV: ImageWrite [[IMG2D_ARRAY_WO]]
 
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_array_woDv4_iDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image2d_array_woDv4_iS0_
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_array_rwDv4_iDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image2d_array_rwDv4_iS0_
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_array_woDv4_iiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image2d_array_woDv4_iiS0_
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_array_woDv4_iDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image2d_array_woDv4_iS0_(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_array_rwDv4_iDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image2d_array_rwDv4_iS0_(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_array_woDv4_iiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image2d_array_woDv4_iiS0_(
 
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_1Dv4_iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_1Dv4_iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_1Dv4_iS2_
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_2Dv4_iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_2Dv4_iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_2Dv4_iS2_
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_1Dv4_iDv4_fii
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_1Dv4_iS2_ii
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_1Dv4_iDv4_fii(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_1_0_0_0_1Dv4_iS2_ii(
 
 kernel void test_img1d(write_only image1d_t image_wo, read_write image1d_t image_rw)
 {
@@ -117,19 +117,19 @@ kernel void test_img1d(write_only image1d_t image_wo, read_write image1d_t image
 // CHECK-SPIRV: ImageWrite [[IMG1D_WO]]
 // CHECK-SPIRV: ImageWrite [[IMG1D_WO]]
 
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image1d_woiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image1d_woiDv4_i
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image1d_rwiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image1d_rwiDv4_i
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image1d_woiiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image1d_woiiDv4_i
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image1d_woiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image1d_woiDv4_i(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image1d_rwiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image1d_rwiDv4_i(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image1d_woiiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image1d_woiiDv4_i(
 
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_i
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_2iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_2iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_2iDv4_i
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_fii
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_iii
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_fii(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_iii(
 
 kernel void test_img1d_buffer(write_only image1d_buffer_t image_wo, read_write image1d_buffer_t image_rw)
 {
@@ -147,14 +147,14 @@ kernel void test_img1d_buffer(write_only image1d_buffer_t image_wo, read_write i
 // CHECK-SPIRV: ImageWrite [[IMG1D_BUFFER_RW]]
 // CHECK-SPIRV: ImageWrite [[IMG1D_BUFFER_RW]]
 
-// CHECK-LLVM: call spir_func void @_Z12write_imagef21ocl_image1d_buffer_woiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei21ocl_image1d_buffer_woiDv4_i
-// CHECK-LLVM: call spir_func void @_Z12write_imagef21ocl_image1d_buffer_rwiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei21ocl_image1d_buffer_rwiDv4_i
+// CHECK-LLVM: call spir_func void @_Z12write_imagef21ocl_image1d_buffer_woiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei21ocl_image1d_buffer_woiDv4_i(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef21ocl_image1d_buffer_rwiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei21ocl_image1d_buffer_rwiDv4_i(
 
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_5_0_0_0_0_0_1iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_5_0_0_0_0_0_1iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_5_0_0_0_0_0_1iDv4_i
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_5_0_0_0_0_0_2iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_5_0_0_0_0_0_2iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_5_0_0_0_0_0_2iDv4_i
 
 kernel void test_img1d_array(write_only image1d_array_t image_wo, read_write image1d_array_t image_rw)
@@ -179,19 +179,19 @@ kernel void test_img1d_array(write_only image1d_array_t image_wo, read_write ima
 // CHECK-SPIRV: ImageWrite [[IMG1D_ARRAY_WO]]
 // CHECK-SPIRV: ImageWrite [[IMG1D_ARRAY_WO]]
 
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image1d_array_woDv2_iDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image1d_array_woDv2_iDv4_i
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image1d_array_rwDv2_iDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image1d_array_rwDv2_iDv4_i
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image1d_array_woDv2_iiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image1d_array_woDv2_iiDv4_i
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image1d_array_woDv2_iDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image1d_array_woDv2_iDv4_i(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image1d_array_rwDv2_iDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image1d_array_rwDv2_iDv4_i(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image1d_array_woDv2_iiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei20ocl_image1d_array_woDv2_iiDv4_i(
 
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_1Dv2_iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_1Dv2_iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_1Dv2_iDv4_i
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_2Dv2_iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_2Dv2_iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_2Dv2_iDv4_i
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_1Dv2_iDv4_fii
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_1Dv2_iDv4_iii
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_1Dv2_iDv4_fii(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_1_0_0_0_1Dv2_iDv4_iii(
 
 kernel void test_img2d_depth(write_only image2d_depth_t image_wo)
 {
@@ -208,13 +208,13 @@ kernel void test_img2d_depth(write_only image2d_depth_t image_wo)
 // CHECK-SPIRV: ImageWrite [[IMG2D_DEPTH_WO]]
 // CHECK-SPIRV: ImageWrite [[IMG2D_DEPTH_WO]]
 
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_depth_woDv2_if
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_depth_woDv2_if
-// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_depth_woDv2_iif
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_depth_woDv2_if(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_depth_woDv2_if(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef20ocl_image2d_depth_woDv2_iif(
 
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_0_0_0_0_1Dv2_if
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_0_0_0_0_1Dv2_if
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_0_0_0_0_1Dv2_ifii
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_0_0_0_0_1Dv2_if(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_0_0_0_0_1Dv2_if(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_0_0_0_0_1Dv2_ifii(
 
 kernel void test_img2d_array_depth(write_only image2d_array_depth_t image_wo)
 {
@@ -231,13 +231,13 @@ kernel void test_img2d_array_depth(write_only image2d_array_depth_t image_wo)
 // CHECK-SPIRV: ImageWrite [[IMG2D_ARRAY_DEPTH_WO]]
 // CHECK-SPIRV: ImageWrite [[IMG2D_ARRAY_DEPTH_WO]]
 
-// CHECK-LLVM: call spir_func void @_Z12write_imagef26ocl_image2d_array_depth_woDv4_if
-// CHECK-LLVM: call spir_func void @_Z12write_imagef26ocl_image2d_array_depth_woDv4_if
-// CHECK-LLVM: call spir_func void @_Z12write_imagef26ocl_image2d_array_depth_woDv4_iif
+// CHECK-LLVM: call spir_func void @_Z12write_imagef26ocl_image2d_array_depth_woDv4_if(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef26ocl_image2d_array_depth_woDv4_if(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef26ocl_image2d_array_depth_woDv4_iif(
 
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_1_0_0_0_1Dv4_if
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_1_0_0_0_1Dv4_if
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_1_0_0_0_1Dv4_ifii
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_1_0_0_0_1Dv4_if(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_1_0_0_0_1Dv4_if(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_1_1_0_0_0_1Dv4_ifii(
 
 kernel void test_img3d(write_only image3d_t image_wo, read_write image3d_t image_rw)
 {
@@ -261,16 +261,16 @@ kernel void test_img3d(write_only image3d_t image_wo, read_write image3d_t image
 // CHECK-SPIRV: ImageWrite [[IMG3D_WO]]
 // CHECK-SPIRV: ImageWrite [[IMG3D_WO]]
 
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image3d_woDv4_iS0_
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image3d_rwDv4_iDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image3d_rwDv4_iS0_
-// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iiDv4_f
-// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image3d_woDv4_iiS0_
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image3d_woDv4_iS0_(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image3d_rwDv4_iDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image3d_rwDv4_iS0_(
+// CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image3d_woDv4_iiDv4_f(
+// CHECK-LLVM: call spir_func void @_Z12write_imagei14ocl_image3d_woDv4_iiS0_(
 
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iS2_
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_2Dv4_iDv4_f
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_2Dv4_iDv4_f(
 // CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_2Dv4_iS2_
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iDv4_fii
-// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iS2_ii
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iDv4_fii(
+// CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iS2_ii(

--- a/test/transcoding/OpenCL/atomic_cmpxchg.cl
+++ b/test/transcoding/OpenCL/atomic_cmpxchg.cl
@@ -42,9 +42,9 @@ __kernel void test_atomic_cmpxchg(__global int *p, int cmp, int val) {
 //
 //
 // CHECK-LLVM-LABEL: define spir_kernel void @test_atomic_cmpxchg
-// CHECK-LLVM: call spir_func i32 @_Z14atomic_cmpxchgPU3AS1Viii
+// CHECK-LLVM: call spir_func i32 @_Z14atomic_cmpxchgPU3AS1Viii(
 // TODO: is it an issue that we lost call to @_Z14atomic_cmpxchgPU3AS1jjj here?
-// CHECK-LLVM: call spir_func i32 @_Z14atomic_cmpxchgPU3AS1Viii
+// CHECK-LLVM: call spir_func i32 @_Z14atomic_cmpxchgPU3AS1Viii(
 
 // References:
 // [1]: https://www.khronos.org/registry/OpenCL/sdk/2.0/docs/man/xhtml/atomic_cmpxchg.html

--- a/test/transcoding/OpenCL/atomic_legacy.cl
+++ b/test/transcoding/OpenCL/atomic_legacy.cl
@@ -37,8 +37,8 @@ __kernel void test_legacy_atomics(__global int *p, int val) {
 //
 // CHECK-LLVM-LABEL: define spir_kernel void @test_legacy_atomics
 // Note: the translator generates the OpenCL C 1.1 function name exclusively!
-// CHECK-LLVM: call spir_func i32 @_Z10atomic_addPU3AS1Vii
-// CHECK-LLVM: call spir_func i32 @_Z10atomic_addPU3AS1Vii
+// CHECK-LLVM: call spir_func i32 @_Z10atomic_addPU3AS1Vii(
+// CHECK-LLVM: call spir_func i32 @_Z10atomic_addPU3AS1Vii(
 
 // References:
 // [1]: https://www.khronos.org/registry/OpenCL/specs/3.0-unified/html/OpenCL_C.html#atomic-legacy

--- a/test/transcoding/SPV_KHR_integer_dot_product-nonsat.ll
+++ b/test/transcoding/SPV_KHR_integer_dot_product-nonsat.ll
@@ -27,20 +27,20 @@ target triple = "spir-unknown-unknown"
 ; CHECK-LLVM: @TestNonSatPacked
 ; CHECK-SPIRV: Function
 
-; CHECK-LLVM: call spir_func i8 @_Z21__spirv_SDotKHR_Rchariii
-; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_Rshortiii
-; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_Rintiii
-; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_Rlongiii
+; CHECK-LLVM: call spir_func i8 @_Z21__spirv_SDotKHR_Rchariii(
+; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_Rshortiii(
+; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_Rintiii(
+; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_Rlongiii(
 
-; CHECK-LLVM: call spir_func i8 @_Z22__spirv_UDotKHR_Ruchariii
-; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_Rushortiii
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_Ruintiii
-; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_Rulongiii
+; CHECK-LLVM: call spir_func i8 @_Z22__spirv_UDotKHR_Ruchariii(
+; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_Rushortiii(
+; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_Ruintiii(
+; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_Rulongiii(
 
-; CHECK-LLVM: call spir_func i8 @_Z22__spirv_SUDotKHR_Rchariii
-; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_Rshortiii
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_Rintiii
-; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_Rlongiii
+; CHECK-LLVM: call spir_func i8 @_Z22__spirv_SUDotKHR_Rchariii(
+; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_Rshortiii(
+; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_Rintiii(
+; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_Rlongiii(
 
 ; CHECK-SPIRV: 6 SDotKHR [[#I8]] [[#]] [[#]] [[#]] 0
 ; CHECK-SPIRV: 6 SDotKHR [[#I16]] [[#]] [[#]] [[#]] 0
@@ -80,20 +80,20 @@ define spir_kernel void @TestNonSatPacked(i32 %0, i32 %1) #0 !kernel_arg_addr_sp
 ; CHECK-LLVM: @TestNonSatVec
 ; CHECK-SPIRV: Function
 
-; CHECK-LLVM: call spir_func i8 @_Z21__spirv_SDotKHR_RcharDv4_cS_
-; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_RshortDv4_cS_
-; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_RintDv4_cS_
-; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_RlongDv4_cS_
+; CHECK-LLVM: call spir_func i8 @_Z21__spirv_SDotKHR_RcharDv4_cS_(
+; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_RshortDv4_cS_(
+; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_RintDv4_cS_(
+; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_RlongDv4_cS_(
 
-; CHECK-LLVM: call spir_func i8 @_Z22__spirv_UDotKHR_RucharDv4_cS_
-; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_RushortDv4_cS_
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_RuintDv4_cS_
-; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_RulongDv4_cS_
+; CHECK-LLVM: call spir_func i8 @_Z22__spirv_UDotKHR_RucharDv4_cS_(
+; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_RushortDv4_cS_(
+; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_RuintDv4_cS_(
+; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_RulongDv4_cS_(
 
-; CHECK-LLVM: call spir_func i8 @_Z22__spirv_SUDotKHR_RcharDv4_cS_
-; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_RshortDv4_cS_
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_RintDv4_cS_
-; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_RlongDv4_cS_
+; CHECK-LLVM: call spir_func i8 @_Z22__spirv_SUDotKHR_RcharDv4_cS_(
+; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_RshortDv4_cS_(
+; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_RintDv4_cS_(
+; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_RlongDv4_cS_(
 
 ; CHECK-SPIRV: 5 SDotKHR [[#I8]]
 ; CHECK-SPIRV: 5 SDotKHR [[#I16]]
@@ -133,17 +133,17 @@ define spir_kernel void @TestNonSatVec(<4 x i8> %0, <4 x i8> %1) #0 !kernel_arg_
 ; CHECK-LLVM: @TestNonSatAll
 ; CHECK-SPIRV: Function
 
-; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_RshortDv2_sS_
-; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_RintDv2_sS_
-; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_RlongDv2_sS_
+; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_RshortDv2_sS_(
+; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_RintDv2_sS_(
+; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_RlongDv2_sS_(
 
-; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_RushortDv2_sS_
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_RuintDv2_sS_
-; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_RulongDv2_sS_
+; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_RushortDv2_sS_(
+; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_RuintDv2_sS_(
+; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_RulongDv2_sS_(
 
-; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_RshortDv2_sS_
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_RintDv2_sS_
-; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_RlongDv2_sS_
+; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_RshortDv2_sS_(
+; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_RintDv2_sS_(
+; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_RlongDv2_sS_(
 
 ; CHECK-SPIRV: 5 SDotKHR [[#I16]]
 ; CHECK-SPIRV: 5 SDotKHR [[#I32]]

--- a/test/transcoding/atomic_flag.cl
+++ b/test/transcoding/atomic_flag.cl
@@ -25,9 +25,9 @@ kernel void testAtomicFlag(global int *res) {
 // CHECK-SPIRV: AtomicFlagClear
 
 // CHECK-LLVM-LABEL: @testAtomicFlag
-// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
-// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
-// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
-// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
-// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
-// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope
+// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(
+// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(
+// CHECK-LLVM: call spir_func i1 @_Z33atomic_flag_test_and_set_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(
+// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(
+// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(
+// CHECK-LLVM: call spir_func void @_Z26atomic_flag_clear_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(

--- a/test/transcoding/cl_intel_sub_groups.ll
+++ b/test/transcoding/cl_intel_sub_groups.ll
@@ -110,26 +110,26 @@ define spir_kernel void @test(<2 x float> %x, i32 %c, %opencl.image2d_ro_t addrs
 ; CHECK-LLVM-NEXT:    call spir_func void @_Z31intel_sub_group_block_write_ul2PU3AS1mDv2_m(i64 addrspace(1)* [[LP]], <2 x i64> [[CALL11]])
 ; CHECK-LLVM-NEXT:    ret void
 
-; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z28__spirv_SubgroupShuffleINTELDv2_fj
-; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z32__spirv_SubgroupShuffleDownINTELDv2_fS_j
-; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z30__spirv_SubgroupShuffleUpINTELDv2_fS_j
-; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z31__spirv_SubgroupShuffleXorINTELDv2_fj
+; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z28__spirv_SubgroupShuffleINTELDv2_fj(
+; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z32__spirv_SubgroupShuffleDownINTELDv2_fS_j(
+; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z30__spirv_SubgroupShuffleUpINTELDv2_fS_j(
+; CHECK-LLVM-SPIRV: call spir_func <2 x float> @_Z31__spirv_SubgroupShuffleXorINTELDv2_fj(
 ; CHECK-LLVM-SPIRV: call spir_func <2 x i32> @_Z41__spirv_SubgroupImageBlockReadINTEL_Rint2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
 ; CHECK-LLVM-SPIRV: call spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv2_j(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*
-; CHECK-LLVM-SPIRV: call spir_func <2 x i32> @_Z36__spirv_SubgroupBlockReadINTEL_Rint2PU3AS1Kj
-; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1jDv2_j
+; CHECK-LLVM-SPIRV: call spir_func <2 x i32> @_Z36__spirv_SubgroupBlockReadINTEL_Rint2PU3AS1Kj(
+; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1jDv2_j(
 ; CHECK-LLVM-SPIRV: call spir_func <2 x i16> @_Z43__spirv_SubgroupImageBlockReadINTEL_Rshort2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
 ; CHECK-LLVM-SPIRV: call spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv2_t(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*
-; CHECK-LLVM-SPIRV: call spir_func <2 x i16> @_Z38__spirv_SubgroupBlockReadINTEL_Rshort2PU3AS1Kt
-; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1tDv2_t
+; CHECK-LLVM-SPIRV: call spir_func <2 x i16> @_Z38__spirv_SubgroupBlockReadINTEL_Rshort2PU3AS1Kt(
+; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1tDv2_t(
 ; CHECK-LLVM-SPIRV: call spir_func <2 x i8> @_Z42__spirv_SubgroupImageBlockReadINTEL_Rchar2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
 ; CHECK-LLVM-SPIRV: call spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv2_h(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*
-; CHECK-LLVM-SPIRV: call spir_func <2 x i8> @_Z37__spirv_SubgroupBlockReadINTEL_Rchar2PU3AS1Kh
-; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1hDv2_h
+; CHECK-LLVM-SPIRV: call spir_func <2 x i8> @_Z37__spirv_SubgroupBlockReadINTEL_Rchar2PU3AS1Kh(
+; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1hDv2_h(
 ; CHECK-LLVM-SPIRV: call spir_func <2 x i64> @_Z42__spirv_SubgroupImageBlockReadINTEL_Rlong2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(%spirv.Image._void_1_0_0_0_0_0_0 addrspace(1)*
 ; CHECK-LLVM-SPIRV: call spir_func void @_Z36__spirv_SubgroupImageBlockWriteINTELPU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv2_m(%spirv.Image._void_1_0_0_0_0_0_1 addrspace(1)*
-; CHECK-LLVM-SPIRV: call spir_func <2 x i64> @_Z37__spirv_SubgroupBlockReadINTEL_Rlong2PU3AS1Km
-; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1mDv2_m
+; CHECK-LLVM-SPIRV: call spir_func <2 x i64> @_Z37__spirv_SubgroupBlockReadINTEL_Rlong2PU3AS1Km(
+; CHECK-LLVM-SPIRV: call spir_func void @_Z31__spirv_SubgroupBlockWriteINTELPU3AS1mDv2_m(
 
 entry:
   %call = tail call spir_func <2 x float> @_Z23intel_sub_group_shuffleDv2_fj(<2 x float> %x, i32 %c) #2

--- a/test/transcoding/cl_khr_extended_bit_ops.cl
+++ b/test/transcoding/cl_khr_extended_bit_ops.cl
@@ -8,7 +8,7 @@
 // CHECK-SPIRV: Extension "SPV_KHR_bit_instructions"
 
 // CHECK-LLVM-LABEL: @testInsert
-// CHECK-LLVM: call spir_func <2 x i32> @_Z15bitfield_insertDv2_iS_jj
+// CHECK-LLVM: call spir_func <2 x i32> @_Z15bitfield_insertDv2_iS_jj(
 // CHECK-SPIRV: Function
 // CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[insbase:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[insins:[0-9]+]]
@@ -18,8 +18,8 @@ kernel void testInsert(int2 b, int2 i, global int2 *res) {
 }
 
 // CHECK-LLVM-LABEL: @testExtractS
-// CHECK-LLVM: call spir_func i16 @_Z23bitfield_extract_signedsjj
-// CHECK-LLVM: call spir_func i16 @_Z23bitfield_extract_signedsjj
+// CHECK-LLVM: call spir_func i16 @_Z23bitfield_extract_signedsjj(
+// CHECK-LLVM: call spir_func i16 @_Z23bitfield_extract_signedsjj(
 // CHECK-SPIRV: Function
 // CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[sextrbase:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[sextrbaseu:[0-9]+]]
@@ -31,8 +31,8 @@ kernel void testExtractS(short b, ushort bu, global short *res) {
 }
 
 // CHECK-LLVM-LABEL: @testExtractU
-// CHECK-LLVM: call spir_func <8 x i8> @_Z25bitfield_extract_unsignedDv8_cjj
-// CHECK-LLVM: call spir_func <8 x i8> @_Z25bitfield_extract_unsignedDv8_cjj
+// CHECK-LLVM: call spir_func <8 x i8> @_Z25bitfield_extract_unsignedDv8_cjj(
+// CHECK-LLVM: call spir_func <8 x i8> @_Z25bitfield_extract_unsignedDv8_cjj(
 // CHECK-SPIRV: Function
 // CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[uextrbase:[0-9]+]]
 // CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[uextrbaseu:[0-9]+]]
@@ -44,7 +44,7 @@ kernel void testExtractU(char8 b, uchar8 bu, global uchar8 *res) {
 }
 
 // CHECK-LLVM-LABEL: @testBitReverse
-// CHECK-LLVM: call <4 x i64> @llvm.bitreverse.v4i64
+// CHECK-LLVM: call <4 x i64> @llvm.bitreverse.v4i64(
 // CHECK-SPIRV: Function
 // CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[revbase:[0-9]+]]
 // CHECK-SPIRV: BitReverse {{[0-9]+}} {{[0-9]+}} [[revbase]]

--- a/test/transcoding/clk_event_t.cl
+++ b/test/transcoding/clk_event_t.cl
@@ -20,20 +20,20 @@
 
 // CHECK-LLVM-OCL-LABEL: @clk_event_t_test
 // CHECK-LLVM-OCL: call spir_func %opencl.clk_event_t* @_Z17create_user_eventv()
-// CHECK-LLVM-OCL: call spir_func i1 @_Z14is_valid_event12ocl_clkevent
-// CHECK-LLVM-OCL: call spir_func void @_Z12retain_event12ocl_clkevent
+// CHECK-LLVM-OCL: call spir_func i1 @_Z14is_valid_event12ocl_clkevent(
+// CHECK-LLVM-OCL: call spir_func void @_Z12retain_event12ocl_clkevent(
 // CHECK-LLVM-OCL: call spir_func void @_Z21set_user_event_status12ocl_clkeventi(%opencl.clk_event_t* %{{[a-z]+}}, i32 -42)
 // CHECK-LLVM-OCL: call spir_func void @_Z28capture_event_profiling_info12ocl_clkeventiPU3AS1v(%opencl.clk_event_t* %{{[a-z]+}}, i32 1, i8 addrspace(1)* %prof)
-// CHECK-LLVM-OCL: call spir_func void @_Z13release_event12ocl_clkevent
+// CHECK-LLVM-OCL: call spir_func void @_Z13release_event12ocl_clkevent(
 // CHECK-LLVM-OCL: ret
 
 // CHECK-LLVM-SPV-LABEL: @clk_event_t_test
 // CHECK-LLVM-SPV: call spir_func %spirv.DeviceEvent* @_Z23__spirv_CreateUserEventv()
-// CHECK-LLVM-SPV: call spir_func i1 @_Z20__spirv_IsValidEventP19__spirv_DeviceEvent
-// CHECK-LLVM-SPV: call spir_func void @_Z19__spirv_RetainEventP19__spirv_DeviceEvent
+// CHECK-LLVM-SPV: call spir_func i1 @_Z20__spirv_IsValidEventP19__spirv_DeviceEvent(
+// CHECK-LLVM-SPV: call spir_func void @_Z19__spirv_RetainEventP19__spirv_DeviceEvent(
 // CHECK-LLVM-SPV: call spir_func void @_Z26__spirv_SetUserEventStatusP19__spirv_DeviceEventi(%spirv.DeviceEvent* %{{[a-z]+}}, i32 -42)
 // CHECK-LLVM-SPV: call spir_func void @_Z33__spirv_CaptureEventProfilingInfoP19__spirv_DeviceEventiPU3AS1c(%spirv.DeviceEvent* %{{[a-z]+}}, i32 1, i8 addrspace(1)* %prof)
-// CHECK-LLVM-SPV: call spir_func void @_Z20__spirv_ReleaseEventP19__spirv_DeviceEvent
+// CHECK-LLVM-SPV: call spir_func void @_Z20__spirv_ReleaseEventP19__spirv_DeviceEvent(
 // CHECK-LLVM-SPV: ret
 
 kernel void clk_event_t_test(global int *res, global void *prof) {

--- a/test/transcoding/explicit-conversions.cl
+++ b/test/transcoding/explicit-conversions.cl
@@ -10,10 +10,10 @@
 // CHECK-SPIRV: SatConvertSToU
 
 // CHECK-LLVM-LABEL: @testSToU
-// CHECK-LLVM: call spir_func <2 x i8> @_Z18convert_uchar2_satDv2_i
+// CHECK-LLVM: call spir_func <2 x i8> @_Z18convert_uchar2_satDv2_i(
 
 // CHECK-SPV-IR-LABEL: @testSToU
-// CHECK-SPV-IR: call spir_func <2 x i8> @_Z30__spirv_SatConvertSToU_Ruchar2Dv2_i
+// CHECK-SPV-IR: call spir_func <2 x i8> @_Z30__spirv_SatConvertSToU_Ruchar2Dv2_i(
 
 kernel void testSToU(global int2 *a, global uchar2 *res) {
   res[0] = convert_uchar2_sat(*a);
@@ -22,10 +22,10 @@ kernel void testSToU(global int2 *a, global uchar2 *res) {
 // CHECK-SPIRV: SatConvertUToS
 
 // CHECK-LLVM-LABEL: @testUToS
-// CHECK-LLVM: call spir_func <2 x i8> @_Z17convert_char2_satDv2_j
+// CHECK-LLVM: call spir_func <2 x i8> @_Z17convert_char2_satDv2_j(
 
 // CHECK-SPV-IR-LABEL: @testUToS
-// CHECK-SPV-IR: call spir_func <2 x i8> @_Z29__spirv_SatConvertUToS_Rchar2Dv2_j
+// CHECK-SPV-IR: call spir_func <2 x i8> @_Z29__spirv_SatConvertUToS_Rchar2Dv2_j(
 kernel void testUToS(global uint2 *a, global char2 *res) {
   res[0] = convert_char2_sat(*a);
 }
@@ -33,10 +33,10 @@ kernel void testUToS(global uint2 *a, global char2 *res) {
 // CHECK-SPIRV: ConvertUToF
 
 // CHECK-LLVM-LABEL: @testUToF
-// CHECK-LLVM: call spir_func <2 x float> @_Z18convert_float2_rtzDv2_j
+// CHECK-LLVM: call spir_func <2 x float> @_Z18convert_float2_rtzDv2_j(
 
 // CHECK-SPV-IR-LABEL: @testUToF
-// CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ConvertUToF_Rfloat2_rtzDv2_j
+// CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ConvertUToF_Rfloat2_rtzDv2_j(
 kernel void testUToF(global uint2 *a, global float2 *res) {
   res[0] = convert_float2_rtz(*a);
 }
@@ -44,10 +44,10 @@ kernel void testUToF(global uint2 *a, global float2 *res) {
 // CHECK-SPIRV: ConvertFToU
 
 // CHECK-LLVM-LABEL: @testFToUSat
-// CHECK-LLVM: call spir_func <2 x i32> @_Z21convert_uint2_sat_rtnDv2_f
+// CHECK-LLVM: call spir_func <2 x i32> @_Z21convert_uint2_sat_rtnDv2_f(
 
 // CHECK-SPV-IR-LABEL: @testFToUSat
-// CHECK-SPV-IR: call spir_func <2 x i32> @_Z34__spirv_ConvertFToU_Ruint2_sat_rtnDv2_f
+// CHECK-SPV-IR: call spir_func <2 x i32> @_Z34__spirv_ConvertFToU_Ruint2_sat_rtnDv2_f(
 kernel void testFToUSat(global float2 *a, global uint2 *res) {
   res[0] = convert_uint2_sat_rtn(*a);
 }
@@ -55,10 +55,10 @@ kernel void testFToUSat(global float2 *a, global uint2 *res) {
 // CHECK-SPIRV: UConvert
 
 // CHECK-LLVM-LABEL: @testUToUSat
-// CHECK-LLVM: call spir_func i32 @_Z16convert_uint_sath
+// CHECK-LLVM: call spir_func i32 @_Z16convert_uint_sath(
 
 // CHECK-SPV-IR-LABEL: @testUToUSat
-// CHECK-SPV-IR: call spir_func i32 @_Z26__spirv_UConvert_Ruint_sath
+// CHECK-SPV-IR: call spir_func i32 @_Z26__spirv_UConvert_Ruint_sath(
 kernel void testUToUSat(global uchar *a, global uint *res) {
   res[0] = convert_uint_sat(*a);
 }
@@ -66,10 +66,10 @@ kernel void testUToUSat(global uchar *a, global uint *res) {
 // CHECK-SPIRV: UConvert
 
 // CHECK-LLVM-LABEL: @testUToUSat1
-// CHECK-LLVM: call spir_func i8 @_Z17convert_uchar_satj
+// CHECK-LLVM: call spir_func i8 @_Z17convert_uchar_satj(
 
 // CHECK-SPV-IR-LABEL: @testUToUSat1
-// CHECK-SPV-IR: call spir_func i8 @_Z27__spirv_UConvert_Ruchar_satj
+// CHECK-SPV-IR: call spir_func i8 @_Z27__spirv_UConvert_Ruchar_satj(
 kernel void testUToUSat1(global uint *a, global uchar *res) {
   res[0] = convert_uchar_sat(*a);
 }
@@ -77,10 +77,10 @@ kernel void testUToUSat1(global uint *a, global uchar *res) {
 // CHECK-SPIRV: ConvertFToU
 
 // CHECK-LLVM-LABEL: @testFToU
-// CHECK-LLVM: call spir_func <3 x i32> @_Z17convert_uint3_rtpDv3_f
+// CHECK-LLVM: call spir_func <3 x i32> @_Z17convert_uint3_rtpDv3_f(
 
 // CHECK-SPV-IR-LABEL: @testFToU
-// CHECK-SPV-IR: call spir_func <3 x i32> @_Z30__spirv_ConvertFToU_Ruint3_rtpDv3_f
+// CHECK-SPV-IR: call spir_func <3 x i32> @_Z30__spirv_ConvertFToU_Ruint3_rtpDv3_f(
 kernel void testFToU(global float3 *a, global uint3 *res) {
   res[0] = convert_uint3_rtp(*a);
 }

--- a/test/transcoding/fmod.ll
+++ b/test/transcoding/fmod.ll
@@ -10,7 +10,7 @@
 ; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: 7 ExtInst {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} fmod {{[0-9]+}} {{[0-9]+}}
-; CHECK-LLVM: call spir_func float @_Z4fmodff
+; CHECK-LLVM: call spir_func float @_Z4fmodff(
 ; CHECK-LLVM: declare spir_func float @_Z4fmodff(float, float)
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/test/transcoding/image_builtins.ll
+++ b/test/transcoding/image_builtins.ll
@@ -13,13 +13,13 @@ target triple = "spir-unknown-unknown"
 %opencl.image2d_wo_t = type opaque
 
 ; CHECK-LLVM-LABEL: @nosamp
-; CHECK-LLVM: call spir_func <4 x half> @_Z11read_imageh14ocl_image2d_roDv2_i
+; CHECK-LLVM: call spir_func <4 x half> @_Z11read_imageh14ocl_image2d_roDv2_i(
 
 ; CHECK-LLVM-LABEL: @withsamp
-; CHECK-LLVM: call spir_func <4 x half> @_Z11read_imageh14ocl_image2d_ro11ocl_samplerDv2_i
+; CHECK-LLVM: call spir_func <4 x half> @_Z11read_imageh14ocl_image2d_ro11ocl_samplerDv2_i(
 
 ; CHECK-LLVM-LABEL: @writehalf
-; CHECK-LLVM: call spir_func void @_Z12write_imageh14ocl_image2d_woDv2_iDv4_Dh
+; CHECK-LLVM: call spir_func void @_Z12write_imageh14ocl_image2d_woDv2_iDv4_Dh(
 
 ; Function Attrs: convergent nounwind
 define spir_kernel void @nosamp(%opencl.image2d_ro_t addrspace(1)* %im, <2 x i32> %coord, <4 x half> addrspace(1)* nocapture %res) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !6 !kernel_arg_type_qual !7 {

--- a/test/transcoding/image_channel.ll
+++ b/test/transcoding/image_channel.ll
@@ -20,7 +20,7 @@ target triple = "spir-unknown-unknown"
 
 ; Function Attrs: nounwind
 define spir_kernel void @f(%opencl.image2d_ro_t addrspace(1)* %img, i32 addrspace(1)* nocapture %type, i32 addrspace(1)* nocapture %order) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
-; CHECK-LLVM-DAG: [[DTCALL:%.+]] ={{.*}} call spir_func i32 @_Z27get_image_channel_data_type14ocl_image2d_ro
+; CHECK-LLVM-DAG: [[DTCALL:%.+]] ={{.*}} call spir_func i32 @_Z27get_image_channel_data_type14ocl_image2d_ro(
 ; CHECK-LLVM: [[DTSUB:%.+]] = sub i32 [[DTCALL]], 4304
 ; CHECK-LLVM: [[DTADD:%.+]] = add i32 [[DTSUB]], 4304
 ; CHECK-LLVM: store i32 [[DTADD]]
@@ -35,7 +35,7 @@ define spir_kernel void @f(%opencl.image2d_ro_t addrspace(1)* %img, i32 addrspac
   %1 = tail call spir_func i32 @_Z27get_image_channel_data_type14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)* %img) #2
   store i32 %1, i32 addrspace(1)* %type, align 4
 
-; CHECK-LLVM-DAG: [[OCALL:%.+]] ={{.*}} call spir_func i32 @_Z23get_image_channel_order14ocl_image2d_ro
+; CHECK-LLVM-DAG: [[OCALL:%.+]] ={{.*}} call spir_func i32 @_Z23get_image_channel_order14ocl_image2d_ro(
 ; CHECK-LLVM: [[OSUB:%.+]] = sub i32 [[OCALL]], 4272
 ; CHECK-LLVM: [[OADD:%.+]] = add i32 [[OSUB]], 4272
 ; CHECK-LLVM: store i32 [[OADD]]

--- a/test/transcoding/image_with_suffix.ll
+++ b/test/transcoding/image_with_suffix.ll
@@ -7,7 +7,7 @@
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: call spir_func i32 @_Z15get_image_width14ocl_image1d_ro
+; CHECK-LLVM: call spir_func i32 @_Z15get_image_width14ocl_image1d_ro(
 
 ; ModuleID = 'foo.ll'
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
The affected CHECK lines ended with a function name.  Any spurious trailing characters in those function names would not be detected by the test.  Append the opening parenthesis of the call expression to catch any undesired trailing characters.

This commit only affects tests that do not require any changes besides the trailing parenthesis.