### PR TITLE
[Backport to 15] Restore GEP instruction transaltion for vector of pointers

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2037,9 +2037,11 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
         IndexGroupArrayMap[ContainedIndexGroup].insert(AccessedArrayId);
       }
     }
-
-    SPIRVType *TranslatedTy = transPointerType(
-        GEP->getResultElementType(), GEP->getType()->getPointerAddressSpace());
+    SPIRVType *TranslatedTy =
+        GEP->getType()->isVectorTy()
+            ? transType(GEP->getType())
+            : transPointerType(GEP->getResultElementType(),
+                               GEP->getType()->getPointerAddressSpace());
     return mapValue(V,
                     BM->addPtrAccessChainInst(TranslatedTy, TransPointerOperand,
                                               Indices, BB, GEP->isInBounds()));


### PR DESCRIPTION
Like now PtrAccessChain has a pointer as a result type, but should have a vector of pointers result type.

This backports https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1669

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>