### PR TITLE
[NFC] Hotfix for LoopUnroll test

### DIFF
--- a/test/transcoding/LoopUnroll.ll
+++ b/test/transcoding/LoopUnroll.ll
@@ -256,9 +256,9 @@ for.end:                                           ; preds = %for.cond
 ; CHECK-SPIRV: Function
 ; CHECK-SPIRV: Label
 ; CHECK-SPIRV: Branch [[#Header:]]
-; CHECK-SPIRV: Label [[#Return:]]
-; CHECK-SPIRV: LoopMerge [[#Return]] [[#Header]] 257 1
+; CHECK-SPIRV: LoopMerge [[#Return:]] [[#Header]] 257 1
 ; CHECK-SPIRV: BranchConditional [[#]] [[#Return]] [[#Header]]
+; CHECK-SPIRV: Label [[#Return]]
 ; Function Attrs: noinline nounwind optnone
 define spir_func void @unroll_full() {
   br label %2


### PR DESCRIPTION
The latest changes got interfered with the patch that fixes blocks ordering. Like this the checks actually make more sense.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>