### PR TITLE
[NFCI] Use TypedPointerType in more places.

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -944,27 +944,24 @@ void OCLToSPIRVBase::visitCallReadImageWithSampler(CallInst *CI,
   assert(CI->getCalledFunction() && "Unexpected indirect call");
   Function *Func = CI->getCalledFunction();
   bool IsRetScalar = !CI->getType()->isVectorTy();
-  SmallVector<Type *, 3> ArgStructTys;
-  getParameterTypes(CI, ArgStructTys);
   Type *Ret = CI->getType();
-  auto *ImageTy = OCLTypeToSPIRVPtr->getAdaptedArgumentType(Func, 0).second;
+  auto *ImageTy = OCLTypeToSPIRVPtr->getAdaptedArgumentType(Func, 0);
   if (!ImageTy)
-    ImageTy = ArgStructTys[0];
-  ImageTy = adaptSPIRVImageType(M, ImageTy);
-  auto *SampledImgStructTy = getSPIRVStructTypeByChangeBaseTypeName(
-      M, ImageTy, kSPIRVTypeName::Image, kSPIRVTypeName::SampledImg);
-  auto *SampledImgTy = PointerType::get(SampledImgStructTy, SPIRAS_Global);
-  Value *SampledImgArgs[] = {CI->getArgOperand(0), CI->getArgOperand(1)};
-  auto *SampledImg = addCallInstSPIRV(M, getSPIRVFuncName(OpSampledImage),
-                                      SampledImgTy, SampledImgArgs, nullptr,
-                                      {ArgStructTys[0], ArgStructTys[1]}, CI,
-                                      kSPIRVName::TempSampledImage);
+    ImageTy = getCallValueType(CI, 0);
 
   auto Mutator = mutateCallInst(
       CI, getSPIRVFuncName(OpImageSampleExplicitLod,
                            std::string(kSPIRVPostfix::ExtDivider) +
                                getPostfixForReturnType(Ret)));
-  Mutator.replaceArg(0, {SampledImg, SampledImgStructTy}).removeArg(1);
+  Mutator.mapArg(0, [&](IRBuilder<> &Builder, Value *ImgArg, Type *ImgType) {
+    auto *SampledImgTy = adjustImageType(ImageTy, kSPIRVTypeName::Image,
+                                         kSPIRVTypeName::SampledImg);
+    Value *SampledImgArgs[] = {CI->getArgOperand(0), CI->getArgOperand(1)};
+    return addSPIRVCallPair(Builder, OpSampledImage, SampledImgTy,
+                            SampledImgArgs, {ImgType, Mutator.getType(1)},
+                            kSPIRVName::TempSampledImage);
+  });
+  Mutator.removeArg(1);
   unsigned ImgOpMask = getImageSignZeroExt(DemangledName);
   unsigned ImgOpMaskInsIndex = Mutator.arg_size();
   switch (Mutator.arg_size()) {
@@ -997,15 +994,7 @@ void OCLToSPIRVBase::visitCallReadImageWithSampler(CallInst *CI,
 
 void OCLToSPIRVBase::visitCallGetImageSize(CallInst *CI,
                                            StringRef DemangledName) {
-  StringRef TyName;
-  SmallVector<StringRef, 4> SubStrs;
-  SmallVector<Type *, 4> ParamTys;
-  getParameterTypes(CI, ParamTys);
-  auto IsImg = isOCLImageStructType(ParamTys[0], &TyName);
-  (void)IsImg;
-  assert(IsImg);
-  std::string ImageTyName = getImageBaseTypeName(TyName);
-  auto Desc = map<SPIRVTypeImageDescriptor>(ImageTyName);
+  auto Desc = getImageDescriptor(getCallValueType(CI, 0));
   unsigned Dim = getImageDimension(Desc.Dim) + Desc.Arrayed;
   assert(Dim > 0 && "Invalid image dimension.");
   assert(CI->arg_size() == 1);
@@ -1131,8 +1120,10 @@ void OCLToSPIRVBase::visitCallToAddr(CallInst *CI, StringRef DemangledName) {
     Mutator
         .mapArg(Mutator.arg_size() - 1,
                 [&](Value *V) {
-                  return std::pair<Value *, Type *>(
-                      castToInt8Ptr(V, CI), Type::getInt8Ty(V->getContext()));
+                  return std::make_pair(
+                      castToInt8Ptr(V, CI),
+                      TypedPointerType::get(Type::getInt8Ty(V->getContext()),
+                                            SPIRAS_Generic));
                 })
         .appendArg(StorageClass);
   };
@@ -1497,9 +1488,7 @@ void OCLToSPIRVBase::processSubgroupBlockReadWriteINTEL(
 // reads and vector block reads.
 void OCLToSPIRVBase::visitSubgroupBlockReadINTEL(CallInst *CI) {
   OCLBuiltinTransInfo Info;
-  SmallVector<Type *, 2> ParamTys;
-  getParameterTypes(CI, ParamTys);
-  if (isOCLImageStructType(ParamTys[0]))
+  if (isOCLImageType(getCallValueType(CI, 0)))
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupImageBlockReadINTEL);
   else
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupBlockReadINTEL);
@@ -1512,9 +1501,7 @@ void OCLToSPIRVBase::visitSubgroupBlockReadINTEL(CallInst *CI) {
 // instructions.
 void OCLToSPIRVBase::visitSubgroupBlockWriteINTEL(CallInst *CI) {
   OCLBuiltinTransInfo Info;
-  SmallVector<Type *, 3> ParamTys;
-  getParameterTypes(CI, ParamTys);
-  if (isOCLImageStructType(ParamTys[0]))
+  if (isOCLImageType(getCallValueType(CI, 0)))
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupImageBlockWriteINTEL);
   else
     Info.UniqName = getSPIRVFuncName(spv::OpSubgroupBlockWriteINTEL);
@@ -1614,7 +1601,7 @@ void OCLToSPIRVBase::visitSubgroupAVCWrapperBuiltinCall(
   std::string MCETName =
       std::string(kOCLSubgroupsAVCIntel::TypePrefix) + "mce_" + TyKind + "_t";
   auto *MCESTy = getSubgroupAVCIntelMCEType(M, MCETName);
-  auto *MCETy = PointerType::get(MCESTy, SPIRAS_Private);
+  auto *MCETy = TypedPointerType::get(MCESTy, SPIRAS_Private);
   std::string ToMCEFName = Prefix + OpKind + "_convert_to_mce_" + TyKind;
   Op ToMCEOC = OpNop;
   OCLSPIRVSubgroupAVCIntelBuiltinMap::find(ToMCEFName, &ToMCEOC);
@@ -1631,28 +1618,24 @@ void OCLToSPIRVBase::visitSubgroupAVCWrapperBuiltinCall(
 
     mutateCallInst(CI, WrappedOC)
         .mapArg(CI->arg_size() - 1,
-                [&](Value *Arg, Type *ParamTy) {
+                [&](IRBuilder<> &Builder, Value *Arg, Type *ParamTy) {
                   // Create conversion function call for the last operand
-                  return std::pair<Value *, Type *>(
-                      addCallInstSPIRV(M, getSPIRVFuncName(ToMCEOC), MCETy, Arg,
-                                       nullptr, {ParamTy}, CI, ""),
-                      MCESTy);
+                  return addSPIRVCallPair(Builder, ToMCEOC, MCETy, {Arg},
+                                          {ParamTy});
                 })
-        .changeReturnType(MCETy, [=](IRBuilder<> &, CallInst *NewCI) {
+        .changeReturnType(MCETy, [&](IRBuilder<> &Builder, CallInst *NewCI) {
           // Create conversion function call for the return result
-          return addCallInstSPIRV(M, getSPIRVFuncName(FromMCEOC), CI->getType(),
-                                  NewCI, nullptr, {MCESTy}, CI, "");
+          return addSPIRVCall(Builder, FromMCEOC, CI->getType(), {NewCI},
+                              {MCETy});
         });
   } else {
     // Wrapper built-ins which take the 'result_t' argument requires only one
     // conversion for the argument
     mutateCallInst(CI, WrappedOC)
-        .mapArg(CI->arg_size() - 1, [&](Value *Arg, Type *ParamTy) {
+        .mapArg(CI->arg_size() - 1, [&](IRBuilder<> &Builder, Value *Arg,
+                                        Type *ParamTy) {
           // Create conversion function call for the last operand
-          return std::pair<Value *, Type *>(
-              addCallInstSPIRV(M, getSPIRVFuncName(ToMCEOC), MCETy, Arg,
-                               nullptr, {ParamTy}, CI, ""),
-              MCESTy);
+          return addSPIRVCallPair(Builder, ToMCEOC, MCETy, {Arg}, {ParamTy});
         });
   }
 }
@@ -1676,9 +1659,8 @@ void OCLToSPIRVBase::visitSubgroupAVCBuiltinCallWithSampler(
     return; // this is not a VME built-in
 
   SmallVector<Type *, 4> ParamTys;
-  getParameterTypes(CI, ParamTys);
-  auto *TyIt =
-      std::find_if(ParamTys.begin(), ParamTys.end(), isSamplerStructTy);
+  getParameterTypes(CI->getCalledFunction(), ParamTys);
+  auto *TyIt = std::find_if(ParamTys.begin(), ParamTys.end(), isSamplerTy);
   assert(TyIt != ParamTys.end() && "Invalid Subgroup AVC Intel built-in call");
   unsigned SamplerIndex = TyIt - ParamTys.begin();
   Value *SamplerVal = CI->getOperand(SamplerIndex);
@@ -1687,30 +1669,24 @@ void OCLToSPIRVBase::visitSubgroupAVCBuiltinCallWithSampler(
   SmallVector<Type *, 4> AdaptedTys;
   for (unsigned I = 0; I < CI->arg_size(); I++)
     AdaptedTys.push_back(
-        OCLTypeToSPIRVPtr->getAdaptedArgumentType(CI->getCalledFunction(), I)
-            .second);
+        OCLTypeToSPIRVPtr->getAdaptedArgumentType(CI->getCalledFunction(), I));
   auto *AdaptedIter = AdaptedTys.begin();
 
   mutateCallInst(CI, OC)
-      .mapArgs([&](Value *Arg, Type *PointerTy) {
-        if (!isOCLImageStructType(PointerTy))
-          return std::make_pair(Arg, PointerTy);
+      .mapArgs([&](IRBuilder<> &Builder, Value *Arg, Type *ArgTy) {
+        if (!isOCLImageType(ArgTy))
+          return BuiltinCallMutator::ValueTypePair(Arg, ArgTy);
 
         auto *ImageTy = *AdaptedIter++;
         if (!ImageTy)
-          ImageTy = PointerTy;
-        ImageTy = adaptSPIRVImageType(M, ImageTy);
-        auto *SampledImgStructTy = getSPIRVStructTypeByChangeBaseTypeName(
-            M, ImageTy, kSPIRVTypeName::Image, kSPIRVTypeName::VmeImageINTEL);
-        auto *SampledImgTy =
-            PointerType::get(SampledImgStructTy, SPIRAS_Global);
+          ImageTy = ArgTy;
+        auto *SampledImgTy = adjustImageType(ImageTy, kSPIRVTypeName::Image,
+                                             kSPIRVTypeName::VmeImageINTEL);
 
         Value *SampledImgArgs[] = {Arg, SamplerVal};
-        return std::pair<Value *, Type *>(
-            addCallInstSPIRV(M, getSPIRVFuncName(OpVmeImageINTEL), SampledImgTy,
-                             SampledImgArgs, nullptr, {PointerTy, SamplerTy},
-                             CI, kSPIRVName::TempSampledImage),
-            SampledImgStructTy);
+        return addSPIRVCallPair(Builder, OpVmeImageINTEL, SampledImgTy,
+                                SampledImgArgs, {ArgTy, SamplerTy},
+                                kSPIRVName::TempSampledImage);
       })
       .removeArg(SamplerIndex);
 }

--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -59,25 +59,22 @@ public:
 
   bool runOCLTypeToSPIRV(llvm::Module &M);
 
-  /// Returns the adapted type of the corresponding argument for a function.
-  /// The first value of the returned pair is the LLVM type of the argument.
-  /// The second value of the returned pair is the pointer element type of the
-  /// argument, if the type is a pointer.
-  std::pair<llvm::Type *, llvm::Type *>
-  getAdaptedArgumentType(llvm::Function *F, unsigned ArgNo);
+  /// Returns the adapted type of the corresponding argument for a function. If
+  /// the type is a pointer type, it will return a TypedPointerType instead.
+  llvm::Type *getAdaptedArgumentType(llvm::Function *F, unsigned ArgNo);
 
 private:
   llvm::Module *M;
   llvm::LLVMContext *Ctx;
-  // Map of argument/Function -> {pointee type, address space}
-  std::map<llvm::Value *, std::pair<llvm::Type *, unsigned>> AdaptedTy;
+  // Map of argument/Function -> adapted type (probably TypedPointerType)
+  std::map<llvm::Value *, llvm::Type *> AdaptedTy;
   std::set<llvm::Function *> WorkSet; // Functions to be adapted
 
   void adaptFunctionArguments(llvm::Function *F);
   void adaptArgumentsByMetadata(llvm::Function *F);
   void adaptArgumentsBySamplerUse(llvm::Module &M);
   void adaptFunction(llvm::Function *F);
-  void addAdaptedType(llvm::Value *V, llvm::Type *PointeeTy, unsigned AS);
+  void addAdaptedType(llvm::Value *V, llvm::Type *Ty);
   void addWork(llvm::Function *F);
 };
 

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1344,9 +1344,12 @@ Value *unwrapSpecialTypeInitializer(Value *V) {
   return nullptr;
 }
 
-bool isSamplerStructTy(Type *Ty) {
-  auto *STy = dyn_cast_or_null<StructType>(Ty);
-  return STy && STy->hasName() && STy->getName() == kSPR2TypeName::Sampler;
+bool isSamplerTy(Type *Ty) {
+  if (auto *TPT = dyn_cast_or_null<TypedPointerType>(Ty)) {
+    auto *STy = dyn_cast_or_null<StructType>(TPT->getElementType());
+    return STy && STy->hasName() && STy->getName() == kSPR2TypeName::Sampler;
+  }
+  return false;
 }
 
 bool isPipeOrAddressSpaceCastBI(const StringRef MangledName) {

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -499,7 +499,7 @@ bool isEnqueueKernelBI(const StringRef MangledName);
 bool isKernelQueryBI(const StringRef MangledName);
 
 /// Check that the type is the sampler_t
-bool isSamplerStructTy(Type *Ty);
+bool isSamplerTy(Type *Ty);
 
 // Checks if the binary operator is an unfused fmul + fadd instruction.
 bool isUnfusedMulAdd(BinaryOperator *B);

--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -266,7 +266,7 @@ Type *BuiltinCallHelper::adjustImageType(Type *T, StringRef OldImageKind,
 BuiltinCallMutator::ValueTypePair
 BuiltinCallHelper::getCallValue(CallInst *CI, unsigned ArgNo) {
   Function *CalledFunc = CI->getCalledFunction();
-  assert(CalledFunc && "Call must be to a builtin function");
+  assert(CalledFunc && "Unexpected indirect call");
   if (CalledFunc != CachedFunc) {
     CachedFunc = CalledFunc;
     [[maybe_unused]] bool DidDemangle =

--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -64,9 +64,15 @@ BuiltinCallMutator::BuiltinCallMutator(
     : CI(CI), FuncName(FuncName),
       Attrs(CI->getCalledFunction()->getAttributes()), ReturnTy(CI->getType()),
       Args(CI->args()), Rules(Rules), Builder(CI) {
-  getParameterTypes(CI->getCalledFunction(), PointerTypes,
-                    std::move(NameMapFn));
-  PointerTypes.resize(Args.size(), nullptr);
+  bool DidDemangle = getParameterTypes(CI->getCalledFunction(), PointerTypes,
+                                       std::move(NameMapFn));
+  if (!DidDemangle) {
+    // TODO: PipeBlocking.ll causes demangling failures.
+    // assert(isNonMangledOCLBuiltin(CI->getCalledFunction()->getName()) &&
+    //    "SPIR-V builtin functions should be mangled");
+    for (Value *Arg : Args)
+      PointerTypes.push_back(Arg->getType());
+  }
 }
 
 BuiltinCallMutator::BuiltinCallMutator(BuiltinCallMutator &&Other)
@@ -84,9 +90,15 @@ Value *BuiltinCallMutator::doConversion() {
   assert(CI && "Need to have a call instruction to do the conversion");
   auto Mangler = makeMangler(CI, Rules);
   for (unsigned I = 0; I < Args.size(); I++) {
-    Mangler->getTypeMangleInfo(I).PointerTy = PointerTypes[I];
+    Mangler->getTypeMangleInfo(I).PointerTy =
+        dyn_cast<TypedPointerType>(PointerTypes[I]);
   }
   assert(Attrs.getNumAttrSets() <= Args.size() + 2 && "Too many attributes?");
+
+  // Sanitize the return type, in case it's a TypedPointerType.
+  if (auto *TPT = dyn_cast<TypedPointerType>(ReturnTy))
+    ReturnTy = PointerType::get(TPT->getElementType(), TPT->getAddressSpace());
+
   CallInst *NewCall =
       Builder.Insert(addCallInst(CI->getModule(), FuncName, ReturnTy, Args,
                                  &Attrs, nullptr, Mangler.get()));
@@ -110,7 +122,7 @@ BuiltinCallMutator &BuiltinCallMutator::setArgs(ArrayRef<Value *> NewArgs) {
     assert(!Arg->getType()->isPointerTy() &&
            "Cannot use this signature with pointer types");
     Args.push_back(Arg);
-    PointerTypes.emplace_back();
+    PointerTypes.push_back(Arg->getType());
   }
   return *this;
 }
@@ -151,23 +163,10 @@ static void moveAttributes(LLVMContext &Ctx, AttributeList &Attrs,
   Attrs = AttributeList::get(Ctx, NewAttrs);
 }
 
-// Convert a ValueTypePair to a TypedPointerType for storing in the PointerTypes
-// array.
-static TypedPointerType *toTPT(BuiltinCallMutator::ValueTypePair Pair) {
-  if (!Pair.second)
-    return nullptr;
-  unsigned AS = 0;
-  if (auto *TPT = dyn_cast<TypedPointerType>(Pair.first->getType()))
-    AS = TPT->getAddressSpace();
-  else if (isa<PointerType>(Pair.first->getType()))
-    AS = Pair.first->getType()->getPointerAddressSpace();
-  return TypedPointerType::get(Pair.second, AS);
-}
-
 BuiltinCallMutator &BuiltinCallMutator::insertArg(unsigned Index,
                                                   ValueTypePair Arg) {
   Args.insert(Args.begin() + Index, Arg.first);
-  PointerTypes.insert(PointerTypes.begin() + Index, toTPT(Arg));
+  PointerTypes.insert(PointerTypes.begin() + Index, Arg.second);
   moveAttributes(CI->getContext(), Attrs, Index, Args.size() - Index,
                  Index + 1);
   return *this;
@@ -176,7 +175,7 @@ BuiltinCallMutator &BuiltinCallMutator::insertArg(unsigned Index,
 BuiltinCallMutator &BuiltinCallMutator::replaceArg(unsigned Index,
                                                    ValueTypePair Arg) {
   Args[Index] = Arg.first;
-  PointerTypes[Index] = toTPT(Arg);
+  PointerTypes[Index] = Arg.second;
   Attrs = Attrs.removeParamAttributes(CI->getContext(), Index);
   return *this;
 }
@@ -210,4 +209,72 @@ BuiltinCallMutator BuiltinCallHelper::mutateCallInst(CallInst *CI,
 BuiltinCallMutator BuiltinCallHelper::mutateCallInst(CallInst *CI,
                                                      std::string FuncName) {
   return BuiltinCallMutator(CI, std::move(FuncName), Rules, NameMapFn);
+}
+
+Value *BuiltinCallHelper::addSPIRVCall(IRBuilder<> &Builder, spv::Op Opcode,
+                                       Type *ReturnTy, ArrayRef<Value *> Args,
+                                       ArrayRef<Type *> ArgTys,
+                                       const Twine &Name) {
+  // Sanitize the return type, in case it's a TypedPointerType.
+  if (auto *TPT = dyn_cast<TypedPointerType>(ReturnTy))
+    ReturnTy = PointerType::get(TPT->getElementType(), TPT->getAddressSpace());
+
+  // Copy the types into the mangling info.
+  BuiltinFuncMangleInfo BtnInfo;
+  for (unsigned I = 0; I < ArgTys.size(); I++) {
+    if (Args[I]->getType()->isPointerTy()) {
+      assert(cast<PointerType>(Args[I]->getType())
+                 ->isOpaqueOrPointeeTypeMatches(
+                     cast<TypedPointerType>(ArgTys[I])->getElementType()));
+      BtnInfo.getTypeMangleInfo(I).PointerTy = ArgTys[I];
+    }
+  }
+
+  // Create the function and the call.
+  auto *F = getOrCreateFunction(M, ReturnTy, getTypes(Args),
+                                getSPIRVFuncName(Opcode), &BtnInfo);
+  return Builder.CreateCall(F, Args, ReturnTy->isVoidTy() ? "" : Name);
+}
+
+Type *BuiltinCallHelper::adjustImageType(Type *T, StringRef OldImageKind,
+                                         StringRef NewImageKind) {
+  if (auto *TypedPtrTy = dyn_cast<TypedPointerType>(T)) {
+    Type *StructTy = TypedPtrTy->getElementType();
+    // Adapt opencl.* struct type names to spirv.* struct type names.
+    if (isOCLImageType(T)) {
+      auto ImageTypeName = StructTy->getStructName();
+      StringRef Acc = kAccessQualName::ReadOnly;
+      if (hasAccessQualifiedName(ImageTypeName))
+        Acc = getAccessQualifierFullName(ImageTypeName);
+      StructTy = getOrCreateOpaqueStructType(
+          M, mapOCLTypeNameToSPIRV(ImageTypeName, Acc));
+    }
+
+    // Change type name (e.g., spirv.Image -> spirv.SampledImg) if necessary.
+    StringRef Postfixes;
+    if (isSPIRVStructType(StructTy, OldImageKind, &Postfixes))
+      StructTy = getOrCreateOpaqueStructType(
+          M, getSPIRVTypeName(NewImageKind, Postfixes));
+    else {
+      report_fatal_error("Type did not have expected image kind");
+    }
+    return TypedPointerType::get(StructTy, TypedPtrTy->getAddressSpace());
+  }
+  report_fatal_error("Expected type to be a SPIRV image type");
+}
+
+BuiltinCallMutator::ValueTypePair
+BuiltinCallHelper::getCallValue(CallInst *CI, unsigned ArgNo) {
+  Function *CalledFunc = CI->getCalledFunction();
+  assert(CalledFunc && "Call must be to a builtin function");
+  if (CalledFunc != CachedFunc) {
+    CachedFunc = CalledFunc;
+    [[maybe_unused]] bool DidDemangle =
+        getParameterTypes(CalledFunc, CachedParameterTypes, NameMapFn);
+    assert(DidDemangle && "Expected SPIR-V builtins to be properly mangled");
+  }
+
+  Value *ParamValue = CI->getArgOperand(ArgNo);
+  Type *ParamType = CachedParameterTypes[ArgNo];
+  return {ParamValue, ParamType};
 }

--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -80,7 +80,7 @@ class BuiltinCallMutator {
   // The arguments for the new call instruction.
   llvm::SmallVector<llvm::Value *, 8> Args;
   // The pointer element types for the new call instruction.
-  llvm::SmallVector<llvm::TypedPointerType *, 8> PointerTypes;
+  llvm::SmallVector<llvm::Type *, 8> PointerTypes;
   // The mangler rules to use for the new call instruction.
   ManglingRules Rules;
 
@@ -116,11 +116,14 @@ public:
   /// Get the corresponding argument for the new call.
   llvm::Value *getArg(unsigned Index) const { return Args[Index]; }
 
+  llvm::Type *getType(unsigned Index) const { return PointerTypes[Index]; }
+
   /// Return the pointer element type of the corresponding index, or nullptr if
   /// it is not a pointer.
   llvm::Type *getPointerElementType(unsigned Index) const {
-    llvm::TypedPointerType *ElTy = PointerTypes[Index];
-    return ElTy ? ElTy->getElementType() : nullptr;
+    if (auto *TPT = llvm::dyn_cast<llvm::TypedPointerType>(PointerTypes[Index]))
+      return TPT->getElementType();
+    return nullptr;
   }
 
   /// A pair representing both the LLVM value of an argument and its
@@ -128,7 +131,7 @@ public:
   /// implicit conversion from an LLVM value object (but only if it is not of
   /// pointer type), or by the appropriate std::pair type.
   struct ValueTypePair : public std::pair<llvm::Value *, llvm::Type *> {
-    ValueTypePair(llvm::Value *V) : pair(V, nullptr) {
+    ValueTypePair(llvm::Value *V) : pair(V, V->getType()) {
       assert(!V->getType()->isPointerTy() &&
              "Must specify a pointer element type if value is a pointer.");
     }
@@ -181,7 +184,7 @@ public:
   BuiltinCallMutator &moveArg(unsigned FromIndex, unsigned ToIndex) {
     if (FromIndex == ToIndex)
       return *this;
-    ValueTypePair Pair(Args[FromIndex], getPointerElementType(FromIndex));
+    ValueTypePair Pair(Args[FromIndex], getType(FromIndex));
     removeArg(FromIndex);
     insertArg(ToIndex, Pair);
     return *this;
@@ -200,15 +203,15 @@ public:
   /// When present, the IRBuilder parameter corresponds to a builder that is set
   /// to insert immediately before the new call instruction. The Value parameter
   /// corresponds to the argument to be mutated. The Type parameter, when
-  /// present, corresponds to the pointer element type of the argument, or null
-  /// when it is not present.
+  /// present, will be either a TypedPointerType representing the "true" type of
+  /// the value, or the argument's type otherwise.
   template <typename FnType>
   BuiltinCallMutator &mapArg(unsigned Index, FnType Func) {
     using namespace llvm;
     using std::is_invocable;
     IRBuilder<> Builder(CI);
     Value *V = Args[Index];
-    [[maybe_unused]] Type *T = getPointerElementType(Index);
+    [[maybe_unused]] Type *T = getType(Index);
 
     // Dispatch the function call as appropriate, based on the types that the
     // function may be called with.
@@ -272,6 +275,52 @@ public:
   /// to the given SPIR-V opcode (whose name is used in the lookup map of
   /// getSPIRVFuncName).
   BuiltinCallMutator mutateCallInst(llvm::CallInst *CI, spv::Op Opcode);
+
+  /// Create a call to a SPIR-V builtin function (specified via opcode).
+  /// The return type and argument types may be TypedPointerType, if the actual
+  /// LLVM type is a pointer type.
+  llvm::Value *addSPIRVCall(llvm::IRBuilder<> &Builder, spv::Op Opcode,
+                            llvm::Type *ReturnTy,
+                            llvm::ArrayRef<llvm::Value *> Args,
+                            llvm::ArrayRef<llvm::Type *> ArgTys,
+                            const llvm::Twine &Name = "");
+
+  /// Create a call to a SPIR-V builtin function, returning a value and type
+  /// pair suitable for use in BuiltinCallMutator::replaceArg and similar
+  /// functions.
+  BuiltinCallMutator::ValueTypePair
+  addSPIRVCallPair(llvm::IRBuilder<> &Builder, spv::Op Opcode,
+                   llvm::Type *ReturnTy, llvm::ArrayRef<llvm::Value *> Args,
+                   llvm::ArrayRef<llvm::Type *> ArgTys,
+                   const llvm::Twine &Name = "") {
+    llvm::Value *V =
+        addSPIRVCall(Builder, Opcode, ReturnTy, Args, ArgTys, Name);
+    return BuiltinCallMutator::ValueTypePair(V, ReturnTy);
+  }
+
+  /// Adapt the various SPIR-V image types, for example changing a "spirv.Image"
+  /// type into a "spirv.SampledImage" type with identical parameters.
+  ///
+  /// The input type is expected to be a TypedPointerType to either a
+  /// "spirv.*" or "opencl.*" struct type. In the case of "opencl.*" struct
+  /// types, it will first convert it into the corresponding "spirv.Image"
+  /// struct type.
+  ///
+  /// If the image type does not match OldImageKind, this method will abort.
+  llvm::Type *adjustImageType(llvm::Type *T, llvm::StringRef OldImageKind,
+                              llvm::StringRef NewImageKind);
+
+private:
+  llvm::SmallVector<llvm::Type *, 4> CachedParameterTypes;
+  llvm::Function *CachedFunc = nullptr;
+
+public:
+  BuiltinCallMutator::ValueTypePair getCallValue(llvm::CallInst *CI,
+                                                 unsigned ArgNo);
+
+  llvm::Type *getCallValueType(llvm::CallInst *CI, unsigned ArgNo) {
+    return getCallValue(CI, ArgNo).second;
+  }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -614,12 +614,9 @@ Scope getArgAsScope(CallInst *CI, unsigned I);
 /// \param I argument index.
 Decoration getArgAsDecoration(CallInst *CI, unsigned I);
 
-/// Check if a type is SPIRV sampler type.
-bool isSPIRVSamplerType(llvm::Type *Ty);
-
-/// Check if a type is OCL image type (if pointed to).
+/// Check if a type is OCL image type.
 /// \return type name without "opencl." prefix.
-bool isOCLImageStructType(llvm::Type *Ty, StringRef *Name = nullptr);
+bool isOCLImageType(llvm::Type *Ty, StringRef *Name = nullptr);
 
 /// \param BaseTyName is the type name as in spirv.BaseTyName.Postfixes
 /// \param Postfix contains postfixes extracted from the SPIR-V image
@@ -863,12 +860,6 @@ std::string getSPIRVTypeName(StringRef BaseTyName, StringRef Postfixes = "");
 /// Checks if given type name is either ConstantSampler or ConsantPipeStorage.
 bool isSPIRVConstantName(StringRef TyName);
 
-/// Get SPIR-V type by changing the type name from spirv.OldName.Postfixes
-/// to spirv.NewName.Postfixes.
-Type *getSPIRVStructTypeByChangeBaseTypeName(Module *M, Type *T,
-                                             StringRef OldName,
-                                             StringRef NewName);
-
 /// Get the postfixes of SPIR-V image type name as in spirv.Image.postfixes.
 std::string getSPIRVImageTypePostfixes(StringRef SampledType,
                                        SPIRVTypeImageDescriptor Desc,
@@ -878,10 +869,6 @@ std::string getSPIRVImageTypePostfixes(StringRef SampledType,
 /// friendly LLVM IR.
 std::string getSPIRVImageSampledTypeName(SPIRVType *Ty);
 
-/// Translates OpenCL image type names to SPIR-V.
-/// E.g. %opencl.image1d_rw_t -> %spirv.Image._void_0_0_0_0_0_0_2
-Type *adaptSPIRVImageType(Module *M, Type *PointeeType);
-
 /// Get LLVM type for sampled type of SPIR-V image type by postfix.
 Type *getLLVMTypeForSPIRVImageSampledTypePostfix(StringRef Postfix,
                                                  LLVMContext &Ctx);
@@ -889,6 +876,9 @@ Type *getLLVMTypeForSPIRVImageSampledTypePostfix(StringRef Postfix,
 /// Return the unqualified and unsuffixed base name of an image type.
 /// E.g. opencl.image2d_ro_t.3 -> image2d_t
 std::string getImageBaseTypeName(StringRef Name);
+
+/// Extract the image type descriptor from the given image type.
+SPIRVTypeImageDescriptor getImageDescriptor(Type *Ty);
 
 /// Map OpenCL opaque type name to SPIR-V type name.
 std::string mapOCLTypeNameToSPIRV(StringRef Name, StringRef Acc = "");
@@ -943,18 +933,16 @@ bool containsUnsignedAtomicType(StringRef Name);
 std::string mangleBuiltin(StringRef UniqName, ArrayRef<Type *> ArgTypes,
                           BuiltinFuncMangleInfo *BtnInfo);
 
-/// Extract the pointee types of arguments from a mangled function name. If the
-/// corresponding type is not a pointer to a struct type, its value will be a
-/// nullptr instead.
-void getParameterTypes(
+/// Extract the true pointer types, expressed as a TypedPointerType, of
+/// arguments from a mangled function name. If the corresponding type is not a
+/// pointer type, its value will be the argument's actual type instead. Returns
+/// true if the function name was successfully demangled.
+bool getParameterTypes(
     Function *F, SmallVectorImpl<Type *> &ArgTys,
     std::function<std::string(StringRef)> StructNameMapFn = nullptr);
-inline void getParameterTypes(CallInst *CI, SmallVectorImpl<Type *> &ArgTys) {
+inline bool getParameterTypes(CallInst *CI, SmallVectorImpl<Type *> &ArgTys) {
   return getParameterTypes(CI->getCalledFunction(), ArgTys);
 }
-void getParameterTypes(
-    Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
-    std::function<std::string(StringRef)> StructNameMapFn = nullptr);
 
 /// Mangle a function from OpenCL extended instruction set in SPIR-V friendly IR
 /// manner
@@ -1014,6 +1002,10 @@ bool hasLoopMetadata(const Module *M);
 // Check if CI is a call to instruction from OpenCL Extended Instruction Set.
 // If so, return it's extended opcode in ExtOp.
 bool isSPIRVOCLExtInst(const CallInst *CI, OCLExtOpKind *ExtOp);
+
+/// Returns true if a function name corresponds to an OpenCL builtin that is not
+/// expected to have name mangling.
+bool isNonMangledOCLBuiltin(StringRef Name);
 
 // check LLVM Intrinsics type(s) for validity
 bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM);

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -256,33 +256,14 @@ void SPIRVToOCLBase::visitCastInst(CastInst &Cast) {
 
 void SPIRVToOCLBase::visitCallSPIRVImageQuerySize(CallInst *CI) {
   // Get image type
-  SmallVector<Type *, 4> ParamTys;
-  getParameterTypes(CI, ParamTys);
-  StructType *ImgTy = cast<StructType>(ParamTys[0]);
-  assert(ImgTy && ImgTy->isOpaque() &&
-         "image type must be an opaque structure");
-  StringRef ImgTyName = ImgTy->getName();
-  assert(ImgTyName.startswith("opencl.image") && "not an OCL image type");
-
-  unsigned ImgDim = 0;
-  bool ImgArray = false;
-
-  if (ImgTyName.startswith("opencl.image1d")) {
-    ImgDim = 1;
-  } else if (ImgTyName.startswith("opencl.image2d")) {
-    ImgDim = 2;
-  } else if (ImgTyName.startswith("opencl.image3d")) {
-    ImgDim = 3;
-  }
-  assert(ImgDim != 0 && "unexpected image dimensionality");
-
-  if (ImgTyName.count("_array_") != 0) {
-    ImgArray = true;
-  }
+  Type *ImgTy = getCallValueType(CI, 0);
+  auto Desc = getImageDescriptor(ImgTy);
+  unsigned ImgDim = getImageDimension(Desc.Dim);
+  bool ImgArray = Desc.Arrayed;
 
   AttributeList Attributes = CI->getCalledFunction()->getAttributes();
   BuiltinFuncMangleInfo Mangle;
-  Mangle.getTypeMangleInfo(0).PointerTy = TypedPointerType::get(ImgTy, 0);
+  Mangle.getTypeMangleInfo(0).PointerTy = ImgTy;
   Type *Int32Ty = Type::getInt32Ty(*Ctx);
   Instruction *GetImageSize = nullptr;
 
@@ -590,7 +571,8 @@ void SPIRVToOCLBase::visitCallSPIRVPipeBuiltin(CallInst *CI, Op OC) {
       if (T != NewTy) {
         P = Builder.CreatePointerBitCastOrAddrSpaceCast(P, NewTy);
       }
-      return std::pair<Value *, Type *>(P, Builder.getInt8Ty());
+      return std::make_pair(
+          P, TypedPointerType::get(Builder.getInt8Ty(), SPIRAS_Generic));
     });
   }
 }
@@ -758,31 +740,25 @@ void SPIRVToOCLBase::visitCallSPIRVImageSampleExplicitLodBuiltIn(CallInst *CI,
     T = VT->getElementType();
   auto Mutator =
       mutateCallImageOperands(CI, kOCLBuiltinName::SampledReadImage, T, 2);
+
+  CallInst *CallSampledImg = cast<CallInst>(CI->getArgOperand(0));
+  auto Img = getCallValue(CallSampledImg, 0);
+  auto Sampler = getCallValue(CallSampledImg, 1);
   bool IsDepthImage = false;
-  Value *Sampler = nullptr;
-  Type *SamplerTy = nullptr;
   Mutator.mapArg(0, [&](Value *SampledImg) {
-    CallInst *CallSampledImg = cast<CallInst>(SampledImg);
-    SmallVector<Type *, 2> SampledArgTys;
-    getParameterTypes(CallSampledImg, SampledArgTys);
-    Type *ImgTy = SampledArgTys[0];
-    SamplerTy = SampledArgTys[1];
-
     StringRef ImageTypeName;
-    if (isOCLImageStructType(ImgTy, &ImageTypeName))
+    if (isOCLImageType(Img.second, &ImageTypeName))
       IsDepthImage = ImageTypeName.contains("_depth_");
-    auto Img = CallSampledImg->getArgOperand(0);
 
-    Sampler = CallSampledImg->getArgOperand(1);
     if (CallSampledImg->hasOneUse()) {
       CallSampledImg->replaceAllUsesWith(
           UndefValue::get(CallSampledImg->getType()));
       CallSampledImg->dropAllReferences();
       CallSampledImg->eraseFromParent();
     }
-    return std::make_pair(Img, ImgTy);
+    return Img;
   });
-  Mutator.insertArg(1, {Sampler, SamplerTy});
+  Mutator.insertArg(1, Sampler);
   if (IsDepthImage)
     Mutator.changeReturnType(T, [&](IRBuilder<> &Builder, CallInst *NewCI) {
       return Builder.CreateInsertElement(
@@ -878,14 +854,12 @@ void SPIRVToOCLBase::visitCallSPIRVAvcINTELEvaluateBuiltIn(CallInst *CI,
       mutateCallInst(CI, OCLSPIRVSubgroupAVCIntelBuiltinMap::rmap(OC));
   if (NumImages) {
     CallInst *SrcImage = cast<CallInst>(Mutator.getArg(0));
-    SmallVector<Type *, 2> SrcImageTys;
-    getParameterTypes(SrcImage, SrcImageTys);
     if (NumImages == 1) {
       // Multi reference opcode - remove src image OpVmeImageINTEL opcode
       // and replace it with corresponding OpImage and OpSampler arguments
       size_t SamplerPos = Mutator.arg_size() - 1;
-      Mutator.replaceArg(0, {SrcImage->getOperand(0), SrcImageTys[0]});
-      Mutator.insertArg(SamplerPos, {SrcImage->getOperand(1), SrcImageTys[1]});
+      Mutator.replaceArg(0, getCallValue(SrcImage, 0));
+      Mutator.insertArg(SamplerPos, getCallValue(SrcImage, 1));
     } else {
       CallInst *FwdRefImage = cast<CallInst>(Mutator.getArg(1));
       CallInst *BwdRefImage =
@@ -895,17 +869,15 @@ void SPIRVToOCLBase::visitCallSPIRVAvcINTELEvaluateBuiltIn(CallInst *CI,
       // opcodes and OpSampler
       Mutator.removeArgs(0, NumImages);
       // insert source OpImage and OpSampler
-      Mutator.insertArg(0, {SrcImage->getOperand(0), SrcImageTys[0]});
-      Mutator.insertArg(1, {SrcImage->getOperand(1), SrcImageTys[1]});
+      Mutator.insertArg(0, getCallValue(SrcImage, 0));
+      Mutator.insertArg(1, getCallValue(SrcImage, 1));
       // insert reference OpImage
-      getParameterTypes(FwdRefImage, SrcImageTys);
-      Mutator.insertArg(1, {FwdRefImage->getOperand(0), SrcImageTys[0]});
+      Mutator.insertArg(1, getCallValue(FwdRefImage, 0));
       EraseVmeImageCall(SrcImage);
       EraseVmeImageCall(FwdRefImage);
       if (BwdRefImage) {
         // Dual reference opcode - insert second reference OpImage argument
-        getParameterTypes(BwdRefImage, SrcImageTys);
-        Mutator.insertArg(2, {BwdRefImage->getOperand(0), SrcImageTys[0]});
+        Mutator.insertArg(2, getCallValue(BwdRefImage, 0));
         EraseVmeImageCall(BwdRefImage);
       }
     }
@@ -1127,11 +1099,6 @@ std::string SPIRVToOCLBase::translateOpaqueType(StringRef STName) {
     return STName.str();
 
   return OCLOpaqueName;
-}
-
-void SPIRVToOCLBase::getParameterTypes(CallInst *CI,
-                                       SmallVectorImpl<Type *> &Tys) {
-  ::getParameterTypes(CI->getCalledFunction(), Tys, translateOpaqueType);
 }
 
 void addSPIRVBIsLoweringPass(ModulePassManager &PassMgr,

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -280,8 +280,6 @@ private:
   static std::string
   getOCLPipeOpaqueType(SmallVector<std::string, 8> &Postfixes);
 
-  void getParameterTypes(CallInst *CI, SmallVectorImpl<Type *> &Tys);
-
   static std::string translateOpaqueType(StringRef STName);
 
   /// Mutate the call instruction based on (optional) image operands at position

--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -229,13 +229,13 @@ void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
   // If the function is a mangled name, try to recover types from the Itanium
   // name mangling.
   if (F.getName().startswith("_Z")) {
-    SmallVector<Type *, 8> ParameterTypes;
-    getParameterTypes(&F, ParameterTypes);
+    SmallVector<Type *, 8> ParamTypes;
+    getParameterTypes(&F, ParamTypes);
     for (Argument *Arg : PointerArgs) {
-      if (auto *Ty = ParameterTypes[Arg->getArgNo()]) {
-        DeducedTypes[Arg] = Ty;
+      if (auto *Ty = dyn_cast<TypedPointerType>(ParamTypes[Arg->getArgNo()])) {
+        DeducedTypes[Arg] = Ty->getElementType();
         LLVM_DEBUG(dbgs() << "Arg " << Arg->getArgNo() << " of " << F.getName()
-                          << " has type " << *Ty << "\n");
+                          << " has type " << *Ty->getElementType() << "\n");
       }
     }
   }

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -250,19 +250,19 @@ void getFunctionTypeParameterTypes(llvm::FunctionType *FT,
 
 bool isVoidFuncTy(FunctionType *FT) { return FT->getReturnType()->isVoidTy(); }
 
-bool isOCLImageStructType(llvm::Type *Ty, StringRef *Name) {
-  if (auto *ST = dyn_cast_or_null<StructType>(Ty))
-    if (ST->isOpaque()) {
-      auto FullName = ST->getName();
-      if (FullName.find(kSPR2TypeName::ImagePrefix) == 0) {
-        if (Name)
-          *Name = FullName.drop_front(strlen(kSPR2TypeName::OCLPrefix));
-        return true;
+bool isOCLImageType(llvm::Type *Ty, StringRef *Name) {
+  if (auto *TPT = dyn_cast_or_null<TypedPointerType>(Ty))
+    if (auto *ST = dyn_cast_or_null<StructType>(TPT->getElementType()))
+      if (ST->isOpaque()) {
+        auto FullName = ST->getName();
+        if (FullName.find(kSPR2TypeName::ImagePrefix) == 0) {
+          if (Name)
+            *Name = FullName.drop_front(strlen(kSPR2TypeName::OCLPrefix));
+          return true;
+        }
       }
-    }
   return false;
 }
-
 /// \param BaseTyName is the type Name as in spirv.BaseTyName.Postfixes
 /// \param Postfix contains postfixes extracted from the SPIR-V image
 ///   type Name as spirv.BaseTyName.Postfixes.
@@ -720,15 +720,6 @@ static StringRef stringify(const itanium_demangle::NameType *Node) {
   return StringRef(Str.begin(), Str.size());
 }
 
-void getParameterTypes(Function *F, SmallVectorImpl<Type *> &ArgTys,
-                       std::function<std::string(StringRef)> NameMapFn) {
-  SmallVector<TypedPointerType *, 10> PIPs;
-  getParameterTypes(F, PIPs, std::move(NameMapFn));
-  for (auto *Pair : PIPs) {
-    ArgTys.push_back(Pair ? Pair->getElementType() : nullptr);
-  }
-}
-
 template <typename FnType>
 static TypedPointerType *
 parseNode(Module *M, const llvm::itanium_demangle::Node *ParamType,
@@ -836,14 +827,14 @@ parseNode(Module *M, const llvm::itanium_demangle::Node *ParamType,
   return PointeeTy ? TypedPointerType::get(PointeeTy, AS) : nullptr;
 }
 
-void getParameterTypes(Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
+bool getParameterTypes(Function *F, SmallVectorImpl<Type *> &ArgTys,
                        std::function<std::string(StringRef)> NameMapFn) {
   using namespace llvm::itanium_demangle;
   // If there's no mangled name, we can't do anything. Also, if there's no
   // parameters, do nothing.
   StringRef Name = F->getName();
   if (!Name.startswith("_Z") || F->arg_empty())
-    return;
+    return Name.startswith("_Z");
 
   Module *M = F->getParent();
   auto GetStructType = [&](StringRef Name) {
@@ -858,7 +849,7 @@ void getParameterTypes(Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
   bool HasSret = false;
   for (Argument &Arg : F->args()) {
     if (!Arg.getType()->isPointerTy())
-      ArgTys.push_back(nullptr);
+      ArgTys.push_back(Arg.getType());
     else if (Type *Ty = Arg.getParamStructRetType()) {
       assert(!HasSret && &Arg == F->getArg(0) &&
              "sret parameter should only appear on the first argument");
@@ -869,7 +860,7 @@ void getParameterTypes(Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
       else
         ArgTys.push_back(TypedPointerType::get(Ty, 0));
     } else {
-      ArgTys.push_back(nullptr);
+      ArgTys.push_back(Arg.getType());
     }
   }
 
@@ -892,7 +883,7 @@ void getParameterTypes(Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
   // name encoding, bail out.
   auto *RootNode = dyn_cast_or_null<FunctionEncoding>(Demangler.parse());
   if (!RootNode)
-    return;
+    return false;
 
   // Get the parameter list. If the function is a vararg function, drop the last
   // parameter.
@@ -910,7 +901,7 @@ void getParameterTypes(Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
     } else {
       LLVM_DEBUG(dbgs() << "[getParameterTypes] function " << MangledName
                         << " was expected to have a varargs parameter\n");
-      return;
+      return false;
     }
   }
 
@@ -921,21 +912,26 @@ void getParameterTypes(Function *F, SmallVectorImpl<TypedPointerType *> &ArgTys,
                       << " appears to have " << Params.size()
                       << " arguments but has " << (ArgTys.end() - ArgIter)
                       << "\n");
-    return;
+    return false;
   }
 
+  // Overwrite the types of pointer-typed arguments with information from
+  // demangling.
+  bool DemangledSuccessfully = true;
   for (auto *ParamType : Params) {
-    Type *ArgTy = F->getArg(ArgIter - ArgTys.begin())->getType();
-    TypedPointerType *PointeeTy = parseNode(M, ParamType, GetStructType);
-    if (ArgTy->isPointerTy() && PointeeTy == nullptr) {
-      PointeeTy = TypedPointerType::get(Type::getInt8Ty(ArgTy->getContext()),
-                                        ArgTy->getPointerAddressSpace());
-      LLVM_DEBUG(dbgs() << "Failed to recover type of argument "
-                        << (ArgIter - ArgTys.begin()) << " of function "
-                        << F->getName() << "\n");
-    }
-    *ArgIter++ = PointeeTy;
+    Type *ArgTy = *ArgIter;
+    Type *DemangledTy = parseNode(M, ParamType, GetStructType);
+    if (ArgTy->isPointerTy() && DemangledTy == nullptr) {
+      DemangledTy = TypedPointerType::get(Type::getInt8Ty(ArgTy->getContext()),
+                                          ArgTy->getPointerAddressSpace());
+      LLVM_DEBUG(dbgs() << "Failed to recover type of argument " << *ArgTy
+                        << " of function " << F->getName() << "\n");
+      DemangledSuccessfully = false;
+    } else if (!DemangledTy)
+      DemangledTy = ArgTy;
+    *ArgIter++ = DemangledTy;
   }
+  return DemangledSuccessfully;
 }
 
 CallInst *mutateCallInst(
@@ -1551,17 +1547,6 @@ bool isSPIRVConstantName(StringRef TyName) {
   return false;
 }
 
-Type *getSPIRVStructTypeByChangeBaseTypeName(Module *M, Type *T,
-                                             StringRef OldName,
-                                             StringRef NewName) {
-  StringRef Postfixes;
-  if (isSPIRVStructType(T, OldName, &Postfixes))
-    return getOrCreateOpaqueStructType(M, getSPIRVTypeName(NewName, Postfixes));
-  LLVM_DEBUG(dbgs() << " Invalid SPIR-V type " << *T << '\n');
-  llvm_unreachable("Invalid SPIR-V type");
-  return nullptr;
-}
-
 std::string getSPIRVImageTypePostfixes(StringRef SampledType,
                                        SPIRVTypeImageDescriptor Desc,
                                        SPIRVAccessQualifierKind Acc) {
@@ -1661,6 +1646,13 @@ std::string mapOCLTypeNameToSPIRV(StringRef Name, StringRef Acc) {
     llvm_unreachable("Not implemented");
   }
   return getSPIRVTypeName(BaseTy, OS.str());
+}
+
+SPIRVTypeImageDescriptor getImageDescriptor(Type *Ty) {
+  StringRef TyName;
+  [[maybe_unused]] bool IsImg = isOCLImageType(Ty, &TyName);
+  assert(IsImg && "Must be an image type");
+  return map<SPIRVTypeImageDescriptor>(getImageBaseTypeName(TyName));
 }
 
 bool eraseIfNoUse(Function *F) {
@@ -1821,19 +1813,6 @@ StringRef getAccessQualifierFullName(StringRef TyName) {
       .Case(kAccessQualPostfix::ReadOnly, kAccessQualName::ReadOnly)
       .Case(kAccessQualPostfix::WriteOnly, kAccessQualName::WriteOnly)
       .Case(kAccessQualPostfix::ReadWrite, kAccessQualName::ReadWrite);
-}
-
-/// Translates OpenCL image type names to SPIR-V.
-Type *adaptSPIRVImageType(Module *M, Type *PointeeType) {
-  if (isOCLImageStructType(PointeeType)) {
-    auto ImageTypeName = PointeeType->getStructName();
-    StringRef Acc = kAccessQualName::ReadOnly;
-    if (hasAccessQualifiedName(ImageTypeName))
-      Acc = getAccessQualifierFullName(ImageTypeName);
-    return getOrCreateOpaqueStructType(
-        M, mapOCLTypeNameToSPIRV(ImageTypeName, Acc));
-  }
-  return PointeeType;
 }
 
 llvm::PointerType *getOCLClkEventType(Module *M) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -162,7 +162,8 @@ static void translateSEVDecoration(Attribute Sev, SPIRVValue *Val) {
 }
 
 LLVMToSPIRVBase::LLVMToSPIRVBase(SPIRVModule *SMod)
-    : M(nullptr), Ctx(nullptr), BM(SMod), SrcLang(0), SrcLangVer(0) {
+    : BuiltinCallHelper(ManglingRules::None), M(nullptr), Ctx(nullptr),
+      BM(SMod), SrcLang(0), SrcLangVer(0) {
   DbgTran = std::make_unique<LLVMToSPIRVDbgTran>(nullptr, SMod, this);
 }
 
@@ -173,6 +174,7 @@ LLVMToSPIRVBase::~LLVMToSPIRVBase() {
 
 bool LLVMToSPIRVBase::runLLVMToSPIRV(Module &Mod) {
   M = &Mod;
+  initialize(Mod);
   CG = std::make_unique<CallGraph>(Mod);
   Ctx = &M->getContext();
   DbgTran->setModule(M);
@@ -529,8 +531,10 @@ SPIRVType *LLVMToSPIRVBase::transPointerType(Type *ET, unsigned AddrSpc) {
     }
     if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
       assert(AddrSpc == SPIRAS_Global);
-      Type *ImageTy = adaptSPIRVImageType(M, ST);
-      return SaveType(transPointerType(ImageTy, SPIRAS_Global));
+      Type *ImageTy =
+          adjustImageType(TypedPointerType::get(ST, AddrSpc),
+                          kSPIRVTypeName::Image, kSPIRVTypeName::Image);
+      return SaveType(transType(ImageTy));
     }
     if (STName == kSPR2TypeName::Sampler)
       return SaveType(transSPIRVOpaqueType(
@@ -698,19 +702,17 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(StringRef STName,
     return SaveType(BM->addImageType(
         SampledT, Desc, static_cast<spv::AccessQualifier>(Ops[6])));
   } else if (TN == kSPIRVTypeName::SampledImg) {
-    return SaveType(
-        BM->addSampledImageType(static_cast<SPIRVTypeImage *>(transPointerType(
-            getSPIRVStructTypeByChangeBaseTypeName(
-                M, ST, kSPIRVTypeName::SampledImg, kSPIRVTypeName::Image),
-            SPIRAS_Global))));
+    return SaveType(BM->addSampledImageType(static_cast<SPIRVTypeImage *>(
+        transType(adjustImageType(TypedPointerType::get(ST, SPIRAS_Global),
+                                  kSPIRVTypeName::SampledImg,
+                                  kSPIRVTypeName::Image)))));
   } else if (TN == kSPIRVTypeName::VmeImageINTEL) {
     // This type is the same as SampledImageType, but consumed by Subgroup AVC
     // Intel extension instructions.
-    return SaveType(
-        BM->addVmeImageINTELType(static_cast<SPIRVTypeImage *>(transPointerType(
-            getSPIRVStructTypeByChangeBaseTypeName(
-                M, ST, kSPIRVTypeName::VmeImageINTEL, kSPIRVTypeName::Image),
-            SPIRAS_Global))));
+    return SaveType(BM->addVmeImageINTELType(static_cast<SPIRVTypeImage *>(
+        transType(adjustImageType(TypedPointerType::get(ST, SPIRAS_Global),
+                                  kSPIRVTypeName::VmeImageINTEL,
+                                  kSPIRVTypeName::Image)))));
   } else if (TN == kSPIRVTypeName::Sampler)
     return SaveType(BM->addSamplerType());
   else if (TN == kSPIRVTypeName::DeviceEvent)
@@ -735,22 +737,15 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
     SPIRVType *RT = transType(F->getReturnType());
     std::vector<SPIRVType *> PT;
     for (Argument &Arg : F->args()) {
-      auto TypePair =
-          OCLTypeToSPIRVPtr->getAdaptedArgumentType(F, Arg.getArgNo());
-      Type *Ty = TypePair.first;
-      Type *PointeeTy = TypePair.second;
+      Type *Ty = OCLTypeToSPIRVPtr->getAdaptedArgumentType(F, Arg.getArgNo());
       if (!Ty) {
         Ty = Arg.getType();
         if (Ty->isPointerTy())
-          PointeeTy =
-              Scavenger->getArgumentPointerElementType(F, Arg.getArgNo());
+          Ty = TypedPointerType::get(
+              Scavenger->getArgumentPointerElementType(F, Arg.getArgNo()),
+              Ty->getPointerAddressSpace());
       }
-      SPIRVType *TransTy = nullptr;
-      if (Ty->isPointerTy())
-        TransTy = transPointerType(PointeeTy, Ty->getPointerAddressSpace());
-      else
-        TransTy = transType(Ty);
-      PT.push_back(TransTy);
+      PT.push_back(transType(Ty));
     }
 
     return getSPIRVFunctionType(RT, PT);
@@ -5025,15 +5020,13 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     // for this call, because there is no support for type corresponding to
     // OpTypeSampledImage. So, in this case, we create the required type here.
     Value *Image = CI->getArgOperand(0);
-    SmallVector<Type *, 4> ParamTys;
-    getParameterTypes(CI, ParamTys);
-    Type *ImageTy = adaptSPIRVImageType(M, ParamTys[0]);
-    Type *SampledImgTy = getSPIRVStructTypeByChangeBaseTypeName(
-        M, ImageTy, kSPIRVTypeName::Image, kSPIRVTypeName::SampledImg);
+    Type *SampledImgTy =
+        adjustImageType(getCallValueType(CI, 0), kSPIRVTypeName::Image,
+                        kSPIRVTypeName::SampledImg);
     Value *Sampler = CI->getArgOperand(1);
-    return BM->addSampledImageInst(
-        transPointerType(SampledImgTy, SPIRAS_Global), transValue(Image, BB),
-        transValue(Sampler, BB), BB);
+    return BM->addSampledImageInst(transType(SampledImgTy),
+                                   transValue(Image, BB),
+                                   transValue(Sampler, BB), BB);
   }
   case OpFixedSqrtINTEL:
   case OpFixedRecipINTEL:

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -46,6 +46,7 @@
 #include "OCLTypeToSPIRV.h"
 #include "OCLUtil.h"
 #include "SPIRVBasicBlock.h"
+#include "SPIRVBuiltinHelper.h"
 #include "SPIRVEntry.h"
 #include "SPIRVEnum.h"
 #include "SPIRVFunction.h"
@@ -68,7 +69,7 @@ using namespace OCLUtil;
 
 namespace SPIRV {
 
-class LLVMToSPIRVBase {
+class LLVMToSPIRVBase : protected BuiltinCallHelper {
 public:
   LLVMToSPIRVBase(SPIRVModule *SMod);
   bool runLLVMToSPIRV(Module &Mod);


### PR DESCRIPTION
One of the reasons behind this change is to make code more easily deal with the future prospect of opaque types, so that helper methods (like adjusting image types) can handle both pointer type and opaque type representations simply by querying if the input type is a TypedPointerType or an OpaqueType [name for the latter still pending].

The set of changes are:
* OCLTypeToSPIRV now uses TypedPointerType internally
* adaptSPIRVImageType and getSPIRVStructTypeByChangeBaseTypeName are collapsed into one method (adjustImageType) that works with TypedPointerTypes.
* A few is*StructType methods have been reverted back to is*Type methods, taking a TypedPointerType parameter instead.
* BuiltinCallHelper::addSPIRVCall{Pair} allows for the creation of SPIR-V calls that can use TypedPointerType or actual type for parameters and return value.
* BuiltinCallHelper::getCallValue{Type} is a simple helper that hides many of the uses of getParameterTypes.
* The Type* parameter of the callback in BuiltinCallMutator::mapArg now provides a TypedPointerType or the actual type, instead of the pointer element type.
* BuiltinCallMutator::ValueTypePair similarly takes a TypedPointerType or the actual type.
* getParameterTypes (when passed a SmallVector<Type *>) does a similar thing. (The SmallVector<TypedPointerType *> variant has been removed in favor of only using the other one.)

Note that the last few changes do change the semantics of function parameters without changing the function name or signature.