### PR TITLE
[CI][Backport 9] Upgrade to Ubuntu 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: cpp
 os:
   - linux
 
-# Use Ubuntu 18.04 LTS (Bionic) as the Linux testing environment.
-dist: bionic
+# Use Ubuntu 20.04 LTS (Focal) as the Linux testing environment.
+dist: focal
 sudo: false
 
 git:
@@ -23,9 +23,9 @@ branches:
 addons:
   apt:
     sources:
-    - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+    - sourceline: 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-9 main'
       key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-    - sourceline: 'deb https://packages.lunarg.com/vulkan bionic main'
+    - sourceline: 'deb https://packages.lunarg.com/vulkan focal main'
       key_url: 'http://packages.lunarg.com/lunarg-signing-key-pub.asc'
     packages:
     - llvm-9-tools


### PR DESCRIPTION
The Ubuntu 18.04 image is marked deprecated [1], so move to a newer image.

[1] https://github.com/actions/runner-images

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>