### PR TITLE
Fix build and tests for LLVM changes

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1547,9 +1547,9 @@ SPIRV::transSPIRVMemoryScopeIntoOCLMemoryScope(Value *MemScope,
     }
   }
 
-  return getOrCreateSwitchFunc(kSPIRVName::TranslateSPIRVMemScope, MemScope,
-                               OCLMemScopeMap::getRMap(),
-                               /* IsReverse */ true, None, InsertBefore);
+  return getOrCreateSwitchFunc(
+      kSPIRVName::TranslateSPIRVMemScope, MemScope, OCLMemScopeMap::getRMap(),
+      /* IsReverse */ true, std::nullopt, InsertBefore);
 }
 
 Value *
@@ -1578,7 +1578,8 @@ SPIRV::transSPIRVMemorySemanticsIntoOCLMemoryOrder(Value *MemorySemantics,
              MemorySemanticsSequentiallyConsistentMask;
   return getOrCreateSwitchFunc(kSPIRVName::TranslateSPIRVMemOrder,
                                MemorySemantics, OCLMemOrderMap::getRMap(),
-                               /* IsReverse */ true, None, InsertBefore, Mask);
+                               /* IsReverse */ true, std::nullopt, InsertBefore,
+                               Mask);
 }
 
 Value *SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
@@ -1594,10 +1595,10 @@ Value *SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
   int Mask = MemorySemanticsWorkgroupMemoryMask |
              MemorySemanticsCrossWorkgroupMemoryMask |
              MemorySemanticsImageMemoryMask;
-  return getOrCreateSwitchFunc(kSPIRVName::TranslateSPIRVMemFence,
-                               MemorySemantics,
-                               OCLMemFenceExtendedMap::getRMap(),
-                               /* IsReverse */ true, None, InsertBefore, Mask);
+  return getOrCreateSwitchFunc(
+      kSPIRVName::TranslateSPIRVMemFence, MemorySemantics,
+      OCLMemFenceExtendedMap::getRMap(),
+      /* IsReverse */ true, std::nullopt, InsertBefore, Mask);
 }
 
 void llvm::mangleOpenClBuiltin(const std::string &UniqName,

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -619,7 +619,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
   if (!LM)
     return;
 
-  auto Temp = MDNode::getTemporary(*Context, None);
+  auto Temp = MDNode::getTemporary(*Context, std::nullopt);
   auto Self = MDNode::get(*Context, Temp.get());
   Self->replaceOperandWith(0, Self);
   SPIRVWord LC = LM->getLoopControl();
@@ -766,7 +766,8 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
           // Emit a distinct index group that will be referenced from
           // llvm.loop.parallel_access_indices metadata; hash the new
           // MDNode for future accesses to the same memory.
-          CurrentDepthIdxGroup = llvm::MDNode::getDistinct(*Context, None);
+          CurrentDepthIdxGroup =
+              llvm::MDNode::getDistinct(*Context, std::nullopt);
           OffsetIdxGroupMap.emplace(Info, CurrentDepthIdxGroup);
         } else {
           // Previous accesses to that field have already been indexed,
@@ -776,7 +777,8 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
       } else /* Regular kernel-scope array/pointer variable */ {
         // Emit a distinct index group that will be referenced from
         // llvm.loop.parallel_access_indices metadata
-        CurrentDepthIdxGroup = llvm::MDNode::getDistinct(*Context, None);
+        CurrentDepthIdxGroup =
+            llvm::MDNode::getDistinct(*Context, std::nullopt);
       }
 
       unsigned Safelen = PointerSflnMap.find(ArrayGEPIt.first)->second;

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -85,8 +85,9 @@ public:
 
 private:
   DIFile *getFile(const SPIRVId SourceId);
-  DIFile *getDIFile(const std::string &FileName,
-                    std::optional<DIFile::ChecksumInfo<StringRef>> CS = None);
+  DIFile *
+  getDIFile(const std::string &FileName,
+            std::optional<DIFile::ChecksumInfo<StringRef>> CS = std::nullopt);
   DIFile *getDIFile(const SPIRVEntry *E);
   unsigned getLineNo(const SPIRVEntry *E);
 

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2910,7 +2910,7 @@ private:
     if (PackFmtIdx == Ops.size() - 1)
       return static_cast<PackedVectorFormat>(Ops[PackFmtIdx]);
 
-    return None;
+    return std::nullopt;
   }
 
   SPIRVCapabilityKind getRequiredCapabilityForOperand(SPIRVId ArgId) const {
@@ -2964,7 +2964,7 @@ public:
       if (Cap == CapabilityBitInstructions)
         return ExtensionID::SPV_KHR_bit_instructions;
     }
-    return None;
+    return std::nullopt;
   }
 };
 

--- a/test/DebugInfo/Generic/multiline.ll
+++ b/test/DebugInfo/Generic/multiline.ll
@@ -33,7 +33,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-NOT: .loc
 ; CHECK: .loc	1 4 15{{$}}
 ; CHECK-NOT: .loc
-; CHECK: .loc	1 5 1 is_stmt 1{{$}}
+; CHECK: .loc	1 5 1 {{(epilogue_begin )?}}is_stmt 1{{$}}
 
 ; INT: {{^}}Address
 ; INT: -----
@@ -44,7 +44,7 @@ target triple = "spir64-unknown-unknown"
 ; INT-NEXT: 4 3 1 0 0 is_stmt{{$}}
 ; INT-NEXT: 4 9 1 0 0 {{$}}
 ; INT-NEXT: 4 15 1 0 0 {{$}}
-; INT-NEXT: 5 1 1 0 0 is_stmt{{$}}
+; INT-NEXT: 5 1 1 0 0 is_stmt{{( epilogue_begin)?}}{{$}}
 
 
 ; Function Attrs: nounwind uwtable


### PR DESCRIPTION
Update test after llvm-project commit 6b2829dd8772 ("Allow epilogue_begin to be emitted when generating DWARF", 2022-12-09).

Update after llvm-project commit f7dffc28b3f8 ("Don't include None.h (NFC)", 2022-12-10).