### PR TITLE
Use std::optional instead of llvm::Optional

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -39,13 +39,13 @@
 #ifndef SPIRV_LLVMSPIRVOPTS_H
 #define SPIRV_LLVMSPIRVOPTS_H
 
-#include <llvm/ADT/Optional.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 
 #include <cassert>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <unordered_map>
 
 namespace llvm {
@@ -206,7 +206,7 @@ private:
 
   // Unknown LLVM intrinsics will be translated as external function calls in
   // SPIR-V
-  llvm::Optional<ArgList> SPIRVAllowUnknownIntrinsics{};
+  std::optional<ArgList> SPIRVAllowUnknownIntrinsics{};
 
   // Enable support for extra DIExpression opcodes not listed in the SPIR-V
   // DebugInfo specification.

--- a/lib/SPIRV/LLVMSPIRVOpts.cpp
+++ b/lib/SPIRV/LLVMSPIRVOpts.cpp
@@ -40,7 +40,6 @@
 
 #include "LLVMSPIRVOpts.h"
 
-#include <llvm/ADT/Optional.h>
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/IR/IntrinsicInst.h>

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1502,7 +1502,7 @@ void insertImageNameAccessQualifier(SPIRVAccessQualifierKind Acc,
 } // namespace OCLUtil
 
 Value *SPIRV::transOCLMemScopeIntoSPIRVScope(Value *MemScope,
-                                             Optional<int> DefaultCase,
+                                             std::optional<int> DefaultCase,
                                              Instruction *InsertBefore) {
   if (auto *C = dyn_cast<ConstantInt>(MemScope)) {
     return ConstantInt::get(
@@ -1515,8 +1515,10 @@ Value *SPIRV::transOCLMemScopeIntoSPIRVScope(Value *MemScope,
                                DefaultCase, InsertBefore);
 }
 
-Value *SPIRV::transOCLMemOrderIntoSPIRVMemorySemantics(
-    Value *MemOrder, Optional<int> DefaultCase, Instruction *InsertBefore) {
+Value *
+SPIRV::transOCLMemOrderIntoSPIRVMemorySemantics(Value *MemOrder,
+                                                std::optional<int> DefaultCase,
+                                                Instruction *InsertBefore) {
   if (auto *C = dyn_cast<ConstantInt>(MemOrder)) {
     return ConstantInt::get(
         C->getType(), mapOCLMemSemanticToSPIRV(

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -523,7 +523,7 @@ template <class KeyTy, class ValTy, class Identifier = void>
 Instruction *
 getOrCreateSwitchFunc(StringRef MapName, Value *V,
                       const SPIRVMap<KeyTy, ValTy, Identifier> &Map,
-                      bool IsReverse, Optional<int> DefaultCase,
+                      bool IsReverse, std::optional<int> DefaultCase,
                       Instruction *InsertPoint, int KeyMask = 0) {
   static_assert(std::is_convertible<KeyTy, int>::value &&
                     std::is_convertible<ValTy, int>::value,
@@ -586,7 +586,7 @@ getOrCreateSwitchFunc(StringRef MapName, Value *V,
 /// \returns \c Value corresponding to SPIR-V Scope equivalent to OpenCL
 ///          memory_scope passed in \arg MemScope
 Value *transOCLMemScopeIntoSPIRVScope(Value *MemScope,
-                                      Optional<int> DefaultCase,
+                                      std::optional<int> DefaultCase,
                                       Instruction *InsertBefore);
 
 /// Performs conversion from OpenCL memory_order into SPIR-V Memory Semantics.
@@ -603,7 +603,7 @@ Value *transOCLMemScopeIntoSPIRVScope(Value *MemScope,
 /// \returns \c Value corresponding to SPIR-V Memory Semantics equivalent to
 ///          OpenCL memory_order passed in \arg MemOrder
 Value *transOCLMemOrderIntoSPIRVMemorySemantics(Value *MemOrder,
-                                                Optional<int> DefaultCase,
+                                                std::optional<int> DefaultCase,
                                                 Instruction *InsertBefore);
 
 /// Performs conversion from SPIR-V Scope into OpenCL memory_scope.

--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -279,10 +279,9 @@ Type *BuiltinCallHelper::getSPIRVType(spv::Op TypeOpcode,
   return getSPIRVType(TypeOpcode, "", {(unsigned)Access}, UseRealType);
 }
 
-Type *BuiltinCallHelper::getSPIRVType(spv::Op TypeOpcode, Type *InnerType,
-                                      SPIRVTypeImageDescriptor Desc,
-                                      Optional<spv::AccessQualifier> Access,
-                                      bool UseRealType) {
+Type *BuiltinCallHelper::getSPIRVType(
+    spv::Op TypeOpcode, Type *InnerType, SPIRVTypeImageDescriptor Desc,
+    std::optional<spv::AccessQualifier> Access, bool UseRealType) {
   return getSPIRVType(TypeOpcode, convertTypeToPostfix(InnerType),
                       {(unsigned)Desc.Dim, (unsigned)Desc.Depth,
                        (unsigned)Desc.Arrayed, (unsigned)Desc.MS,

--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -43,7 +43,6 @@
 #include "LLVMSPIRVLib.h"
 #include "libSPIRV/SPIRVOpCode.h"
 #include "libSPIRV/SPIRVType.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/IRBuilder.h"
@@ -334,7 +333,7 @@ public:
   /// true, a pointer type will be used instead.
   llvm::Type *getSPIRVType(spv::Op TypeOpcode, llvm::Type *InnerType,
                            SPIRVTypeImageDescriptor Desc,
-                           llvm::Optional<spv::AccessQualifier> Access,
+                           std::optional<spv::AccessQualifier> Access,
                            bool UseRealType = false);
 
   /// Create a new type representing a SPIR-V opaque type that takes arbitrary

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -221,9 +221,9 @@ Value *SPIRVToLLVM::getTranslatedValue(SPIRVValue *BV) {
   return nullptr;
 }
 
-static llvm::Optional<llvm::Attribute>
+static std::optional<llvm::Attribute>
 translateSEVMetadata(SPIRVValue *BV, llvm::LLVMContext &Context) {
-  llvm::Optional<llvm::Attribute> RetAttr;
+  std::optional<llvm::Attribute> RetAttr;
 
   if (!BV->hasDecorate(DecorationSingleElementVectorINTEL))
     return RetAttr;
@@ -306,7 +306,7 @@ std::string SPIRVToLLVM::transVCTypeName(SPIRVTypeBufferSurfaceINTEL *PST) {
 }
 
 template <typename ImageType>
-Optional<SPIRVAccessQualifierKind> getAccessQualifier(ImageType *T) {
+std::optional<SPIRVAccessQualifierKind> getAccessQualifier(ImageType *T) {
   if (!T->hasAccessQualifier())
     return {};
   return T->getAccessQualifier();

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2799,9 +2799,9 @@ struct IntelLSUControlsInfo {
   }
 
   bool BurstCoalesce = false;
-  llvm::Optional<unsigned> CacheSizeInfo;
+  std::optional<unsigned> CacheSizeInfo;
   bool DontStaticallyCoalesce = false;
-  llvm::Optional<unsigned> PrefetchInfo;
+  std::optional<unsigned> PrefetchInfo;
 };
 
 // Handle optional var/ptr/global annotation parameter. It can be for example

--- a/lib/SPIRV/libSPIRV/SPIRVAsm.h
+++ b/lib/SPIRV/libSPIRV/SPIRVAsm.h
@@ -38,7 +38,7 @@ public:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityAsmINTEL);
   }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_inline_assembly;
   }
   const std::string &getTarget() const { return Target; }
@@ -75,7 +75,7 @@ public:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityAsmINTEL);
   }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_inline_assembly;
   }
   const std::string &getInstructions() const { return Instructions; }
@@ -113,7 +113,7 @@ public:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityAsmINTEL);
   }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_inline_assembly;
   }
   bool isOperandLiteral(unsigned int Index) const override { return false; }

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -127,7 +127,7 @@ public:
   // Incomplete constructor
   SPIRVDecorate() : SPIRVDecorateGeneric(OC) {}
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     switch (static_cast<size_t>(Dec)) {
     case DecorationRegisterINTEL:
     case DecorationMemoryINTEL:
@@ -201,7 +201,7 @@ public:
   // Incomplete constructor
   SPIRVDecorateId() : SPIRVDecorateGeneric(OC) {}
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     switch (static_cast<int>(Dec)) {
     case DecorationAliasScopeINTEL:
     case DecorationNoAliasINTEL:
@@ -266,7 +266,7 @@ public:
       Decoder >> Literals;
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     if (getLinkageType() == SPIRVLinkageTypeKind::LinkageTypeLinkOnceODR)
       return ExtensionID::SPV_KHR_linkonce_odr;
     return {};
@@ -292,7 +292,7 @@ public:
   SPIRVMemberDecorate()
       : SPIRVDecorateGeneric(OC), MemberNumber(SPIRVWORD_MAX) {}
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     switch (static_cast<size_t>(Dec)) {
     case DecorationRegisterINTEL:
     case DecorationMemoryINTEL:

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -45,12 +45,11 @@
 #include "SPIRVError.h"
 #include "SPIRVIsValidEnum.h"
 
-#include <llvm/ADT/Optional.h>
-
 #include <cassert>
 #include <iostream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -293,9 +292,7 @@ public:
   Op getOpCode() const { return OpCode; }
   SPIRVModule *getModule() const { return Module; }
   virtual SPIRVCapVec getRequiredCapability() const { return SPIRVCapVec(); }
-  virtual llvm::Optional<ExtensionID> getRequiredExtension() const {
-    return {};
-  }
+  virtual std::optional<ExtensionID> getRequiredExtension() const { return {}; }
   const std::string &getName() const { return Name; }
   size_t getNumDecorations() const { return Decorates.size(); }
   bool hasDecorate(Decoration Kind, size_t Index = 0,
@@ -847,7 +844,7 @@ public:
     }
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     switch (static_cast<unsigned>(Kind)) {
     case CapabilityRoundToInfinityINTEL:
     case CapabilityFloatingPointModeINTEL:
@@ -909,7 +906,7 @@ public:
     return getVec(CapabilityLongConstantCompositeINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_long_constant_composite;
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -187,7 +187,7 @@ public:
   SPIRVFunction *getFunction() const { return get<SPIRVFunction>(TheFunction); }
   _SPIRV_DEF_ENCDEC3(Type, Id, TheFunction)
   void validate() const override { SPIRVValue::validate(); }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_function_pointers;
   }
   SPIRVCapVec getRequiredCapability() const override {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -890,7 +890,7 @@ public:
     return getVec(CapabilityFPGARegINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_fpga_reg;
   }
 
@@ -1619,7 +1619,7 @@ public:
     return getVec(CapabilityUnstructuredLoopControlsINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_unstructured_loop_controls;
   }
 
@@ -1711,7 +1711,7 @@ public:
   _SPIRV_DEF_ENCDEC4(Type, Id, CalledValueId, Args)
   void validate() const override;
   bool isOperandLiteral(unsigned Index) const override { return false; }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_function_pointers;
   }
   SPIRVCapVec getRequiredCapability() const override {
@@ -2539,7 +2539,7 @@ public:
     return getVec(CapabilityGroupNonUniformRotateKHR);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_KHR_subgroup_rotate;
   }
 };
@@ -2557,7 +2557,7 @@ protected:
     return getVec(CapabilityBlockingPipesINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_blocking_pipes;
   }
 };
@@ -2575,7 +2575,7 @@ protected:
     return getVec(CapabilityArbitraryPrecisionFixedPointINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_arbitrary_precision_fixed_point;
   }
 };
@@ -2602,7 +2602,7 @@ protected:
     return getVec(CapabilityArbitraryPrecisionFloatingPointINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_arbitrary_precision_floating_point;
   }
 };
@@ -2694,7 +2694,7 @@ public:
 
 class SPIRVAtomicFAddEXTInst : public SPIRVAtomicInstBase {
 public:
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_EXT_shader_atomic_float_add;
   }
 
@@ -2710,7 +2710,7 @@ public:
 
 class SPIRVAtomicFMinMaxEXTBase : public SPIRVAtomicInstBase {
 public:
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_EXT_shader_atomic_float_min_max;
   }
 
@@ -2836,7 +2836,7 @@ public:
     return getVec(CapabilityExpectAssumeKHR);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_KHR_expect_assume;
   }
 
@@ -2857,7 +2857,7 @@ protected:
     return getVec(CapabilityExpectAssumeKHR);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_KHR_expect_assume;
   }
 };
@@ -2877,7 +2877,7 @@ protected:
     return getVec(ArgCap, CapabilityDotProductKHR);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_KHR_integer_dot_product;
   }
 
@@ -2900,7 +2900,7 @@ private:
             OpCode == OpSUDotAccSatKHR);
   }
 
-  Optional<PackedVectorFormat> getPackedVectorFormat() const {
+  std::optional<PackedVectorFormat> getPackedVectorFormat() const {
     size_t PackFmtIdx = 2;
     if (isAccSat()) {
       // AccSat instructions have an additional Accumulator operand.
@@ -2959,7 +2959,7 @@ public:
     return getVec(CapabilityShader);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     for (auto Cap : getRequiredCapability()) {
       if (Cap == CapabilityBitInstructions)
         return ExtensionID::SPV_KHR_bit_instructions;
@@ -2982,7 +2982,7 @@ protected:
     return getVec(CapabilitySubgroupShuffleINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_subgroups;
   }
 };
@@ -3004,7 +3004,7 @@ protected:
     return getVec(CapabilitySubgroupBufferBlockIOINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_subgroups;
   }
 };
@@ -3024,7 +3024,7 @@ protected:
     return getVec(CapabilitySubgroupImageBlockIOINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_subgroups;
   }
 };
@@ -3044,7 +3044,7 @@ protected:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilitySubgroupImageMediaBlockIOINTEL);
   }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_media_block_io;
   }
 };
@@ -3064,7 +3064,7 @@ protected:
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_device_side_avc_motion_estimation;
   }
 };
@@ -3220,7 +3220,7 @@ protected:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityVariableLengthArrayINTEL);
   }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_variable_length_array;
   }
 };
@@ -3240,7 +3240,7 @@ protected:
     return getVec(internal::CapabilityBfloat16ConversionINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_bfloat16_conversion;
   }
 
@@ -3306,7 +3306,7 @@ _SPIRV_OP(ConvertBF16ToFINTEL)
 
 class SPIRVJointMatrixINTELInstBase : public SPIRVInstTemplateBase {
 protected:
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_joint_matrix;
   }
 };
@@ -3333,7 +3333,7 @@ protected:
     return getVec(CapabilitySplitBarrierINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_split_barrier;
   }
 };
@@ -3351,7 +3351,7 @@ public:
     return getVec(CapabilityGroupUniformArithmeticKHR);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_KHR_uniform_group_instructions;
   }
 };
@@ -3400,7 +3400,7 @@ public:
     return getVec(internal::CapabilityComplexFloatMulDivINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_complex_float_mul_div;
   }
 };
@@ -3419,7 +3419,7 @@ protected:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(internal::CapabilityMaskedGatherScatterINTEL);
   }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_masked_gather_scatter;
   }
 };
@@ -3569,7 +3569,7 @@ protected:
     return getVec(internal::CapabilityTensorFloat32ConversionINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_tensor_float32_conversion;
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVMemAliasingINTEL.h
+++ b/lib/SPIRV/libSPIRV/SPIRVMemAliasingINTEL.h
@@ -71,7 +71,7 @@ public:
     return getVec(CapabilityMemoryAccessAliasingINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_memory_access_aliasing;
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVStream.h
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.h
@@ -170,7 +170,7 @@ const SPIRVDecoder &operator>>(const SPIRVDecoder &I, std::vector<T> &V) {
 }
 
 template <typename T>
-const SPIRVDecoder &operator>>(const SPIRVDecoder &I, llvm::Optional<T> &V) {
+const SPIRVDecoder &operator>>(const SPIRVDecoder &I, std::optional<T> &V) {
   if (V)
     I >> V.value();
   return I;
@@ -204,7 +204,7 @@ const SPIRVEncoder &operator<<(const SPIRVEncoder &O, const std::vector<T> &V) {
 
 template <typename T>
 const SPIRVEncoder &operator<<(const SPIRVEncoder &O,
-                               const llvm::Optional<T> &V) {
+                               const std::optional<T> &V) {
   if (V)
     O << V.value();
   return O;

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -167,7 +167,7 @@ public:
     }
     return CV;
   }
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     switch (BitWidth) {
     case 8:
     case 16:
@@ -895,7 +895,7 @@ public:
     return getVec(CapabilityVectorComputeINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return {ExtensionID::SPV_INTEL_vector_compute};
   }
 
@@ -918,7 +918,7 @@ protected:
   }
 
 private:
-  llvm::Optional<SPIRVAccessQualifierKind> AccessKind;
+  std::optional<SPIRVAccessQualifierKind> AccessKind;
 };
 
 // SPV_INTEL_device_side_avc_motion_estimation extension types
@@ -945,7 +945,7 @@ public:
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_device_side_avc_motion_estimation;
   }
 
@@ -1000,7 +1000,7 @@ public:
     return getVec(CapabilitySubgroupAvcMotionEstimationINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_device_side_avc_motion_estimation;
   }
 
@@ -1051,7 +1051,7 @@ public:
     return getVec(internal::CapabilityTokenTypeINTEL);
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_token_type;
   }
 
@@ -1072,7 +1072,7 @@ public:
   // Incomplete constructor
   SPIRVTypeJointMatrixINTEL();
   _SPIRV_DCL_ENCDEC
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
+  std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_joint_matrix;
   }
   SPIRVCapVec getRequiredCapability() const override {

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -125,8 +125,8 @@ public:
     return Type->getRequiredCapability();
   }
 
-  llvm::Optional<ExtensionID> getRequiredExtension() const override {
-    llvm::Optional<ExtensionID> EV;
+  std::optional<ExtensionID> getRequiredExtension() const override {
+    std::optional<ExtensionID> EV;
     if (!hasType())
       return EV;
     EV = Type->getRequiredExtension();


### PR DESCRIPTION
The LLVM project is migrating away from `llvm::Optional` to `std::optional`.  Update the translator to use `std::optional`.