### PR TITLE
Fix issue due to ignoring return value

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -471,7 +471,7 @@ bool oclIsBuiltin(StringRef Name, StringRef &DemangledName, bool IsCpp) {
     size_t Start = Name.find_first_not_of("0123456789", DemangledNameLenStart);
     size_t Len = 0;
     if (Name.substr(DemangledNameLenStart, Start - DemangledNameLenStart)
-        .getAsInteger(10, Len))
+            .getAsInteger(10, Len))
       assert(0 && "Error in extracting integer value");
     DemangledName = Name.substr(Start, Len);
   } else {

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -471,8 +471,10 @@ bool oclIsBuiltin(StringRef Name, StringRef &DemangledName, bool IsCpp) {
     size_t Start = Name.find_first_not_of("0123456789", DemangledNameLenStart);
     size_t Len = 0;
     if (Name.substr(DemangledNameLenStart, Start - DemangledNameLenStart)
-            .getAsInteger(10, Len))
-      assert(0 && "Error in extracting integer value");
+            .getAsInteger(10, Len)) {
+      SPIRVDBG(errs() << "Error in extracting integer value");
+      return false;
+    }
     DemangledName = Name.substr(Start, Len);
   } else {
     size_t Start = Name.find_first_not_of("0123456789", 2);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -470,8 +470,9 @@ bool oclIsBuiltin(StringRef Name, StringRef &DemangledName, bool IsCpp) {
     size_t DemangledNameLenStart = NameSpaceStart + 11;
     size_t Start = Name.find_first_not_of("0123456789", DemangledNameLenStart);
     size_t Len = 0;
-    Name.substr(DemangledNameLenStart, Start - DemangledNameLenStart)
-        .getAsInteger(10, Len);
+    if (Name.substr(DemangledNameLenStart, Start - DemangledNameLenStart)
+        .getAsInteger(10, Len))
+      assert(0 && "Error in extracting integer value");
     DemangledName = Name.substr(Start, Len);
   } else {
     size_t Start = Name.find_first_not_of("0123456789", 2);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -650,7 +650,7 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVJointMatrixINTELType(
   auto ParseInteger = [this](StringRef Postfix) -> ConstantInt * {
     unsigned long long N = 0;
     if (consumeUnsignedInteger(Postfix, 10, N)) {
-      SPIRVDBG(errs() << "Error in extracting integer value");
+      BM->getErrorLog().checkError(false, InvalidLlvmModule, "TypeJointMatrixINTEL expects integer parameters");
       return 0;
     }
     return getUInt32(M, N);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -649,8 +649,10 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVJointMatrixINTELType(
 
   auto ParseInteger = [this](StringRef Postfix) -> ConstantInt * {
     unsigned long long N = 0;
-    if (consumeUnsignedInteger(Postfix, 10, N))
-      assert(0 && "Error in extracting integer value");
+    if (consumeUnsignedInteger(Postfix, 10, N)) {
+      SPIRVDBG(errs() << "Error in extracting integer value");
+      return 0;
+    }
     return getUInt32(M, N);
   };
   std::vector<SPIRVValue *> Args;
@@ -4286,8 +4288,10 @@ void LLVMToSPIRVBase::transGlobalAnnotation(GlobalVariable *V) {
         cast<GlobalVariable>(CS->getOperand(1)->stripPointerCasts());
 
     StringRef AnnotationString;
-    if (!getConstantStringInfo(GV, AnnotationString))
-      assert(0 && "Annotation string missing");
+    if (!getConstantStringInfo(GV, AnnotationString)) {
+      assert(!"Annotation string missing");
+      return;
+    }
     DecorationsInfoVec Decorations =
         tryParseAnnotationString(BM, AnnotationString).MemoryAttributesVec;
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -649,7 +649,8 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVJointMatrixINTELType(
 
   auto ParseInteger = [this](StringRef Postfix) -> ConstantInt * {
     unsigned long long N = 0;
-    consumeUnsignedInteger(Postfix, 10, N);
+    if (consumeUnsignedInteger(Postfix, 10, N))
+      assert(0 && "Error in extracting integer value");
     return getUInt32(M, N);
   };
   std::vector<SPIRVValue *> Args;
@@ -4285,8 +4286,8 @@ void LLVMToSPIRVBase::transGlobalAnnotation(GlobalVariable *V) {
         cast<GlobalVariable>(CS->getOperand(1)->stripPointerCasts());
 
     StringRef AnnotationString;
-    bool HasAnno = getConstantStringInfo(GV, AnnotationString);
-    assert(HasAnno && "Annotation string missing");
+    if (!getConstantStringInfo(GV, AnnotationString))
+      assert(0 && "Annotation string missing");
     DecorationsInfoVec Decorations =
         tryParseAnnotationString(BM, AnnotationString).MemoryAttributesVec;
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -650,7 +650,9 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVJointMatrixINTELType(
   auto ParseInteger = [this](StringRef Postfix) -> ConstantInt * {
     unsigned long long N = 0;
     if (consumeUnsignedInteger(Postfix, 10, N)) {
-      BM->getErrorLog().checkError(false, InvalidLlvmModule, "TypeJointMatrixINTEL expects integer parameters");
+      BM->getErrorLog().checkError(
+          false, SPIRVEC_InvalidLlvmModule,
+          "TypeJointMatrixINTEL expects integer parameters");
       return 0;
     }
     return getUInt32(M, N);


### PR DESCRIPTION
This is a minor fix to resolve some issues reported by static analysis:
1. Use 'assert' to NOT ignore return values from getAsInteger and consumeUnsignedInteger.
2. Use 'assert' and other means to NOT ignore return value from getConstantStringInfo.

Thanks


Signed-off-by: Arvind Sudarsanam <arvind.sudarsanam@intel.com>