### PR TITLE
[NFC] Member initialization and code cleanup

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -154,7 +154,7 @@ private:
   DebugInfoFinder DIF;
   SPIRVType *VoidT;
   SPIRVEntry *DebugInfoNone;
-  SPIRVExtInst *SPIRVCU;
+  SPIRVExtInst *SPIRVCU = nullptr;
   std::vector<const DbgVariableIntrinsic *> DbgDeclareIntrinsics;
   std::vector<const DbgVariableIntrinsic *> DbgValueIntrinsics;
 }; // class LLVMToSPIRVDbgTran

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -129,9 +129,8 @@ SPIRVToLLVMDbgTran::transCompileUnit(const SPIRVExtInst *DebugInst) {
   M->addModuleFlag(llvm::Module::Max, "Dwarf Version", Ops[DWARFVersionIdx]);
   unsigned SourceLang = convertSPIRVSourceLangToDWARF(Ops[LanguageIdx]);
   auto Producer = findModuleProducer();
-  CU = Builder.createCompileUnit(SourceLang, getFile(Ops[SourceIdx]), Producer,
-                                 false, "", 0);
-  return CU;
+  return Builder.createCompileUnit(SourceLang, getFile(Ops[SourceIdx]),
+                                   Producer, false, "", 0);
 }
 
 DIBasicType *SPIRVToLLVMDbgTran::transTypeBasic(const SPIRVExtInst *DebugInst) {

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -152,7 +152,6 @@ private:
   Module *M;
   DIBuilder Builder;
   SPIRVToLLVM *SPIRVReader;
-  DICompileUnit *CU;
   bool Enable;
   std::unordered_map<std::string, DIFile *> FileMap;
   std::unordered_map<SPIRVId, DISubprogram *> FuncMap;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -730,6 +730,7 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
     SPIRVType *RT = transType(F->getReturnType());
     std::vector<SPIRVType *> PT;
     for (Argument &Arg : F->args()) {
+      assert(OCLTypeToSPIRVPtr);
       Type *Ty = OCLTypeToSPIRVPtr->getAdaptedArgumentType(F, Arg.getArgNo());
       if (!Ty) {
         Ty = Arg.getType();
@@ -1329,9 +1330,8 @@ class LLVMParallelAccessIndices {
 public:
   LLVMParallelAccessIndices(
       MDNode *Node, LLVMToSPIRVBase::LLVMToSPIRVMetadataMap &IndexGroupArrayMap)
-      : Node(Node), IndexGroupArrayMap(IndexGroupArrayMap) {}
+      : Node(Node), IndexGroupArrayMap(IndexGroupArrayMap) {
 
-  void initialize() {
     assert(isValid() &&
            "LLVMParallelAccessIndices initialized from an invalid MDNode");
 
@@ -1465,7 +1465,6 @@ LLVMToSPIRVBase::getLoopControl(const BranchInst *Branch,
         } else if (S == "llvm.loop.parallel_access_indices") {
           // Intel FPGA IVDep loop attribute
           LLVMParallelAccessIndices IVDep(Node, IndexGroupArrayMap);
-          IVDep.initialize();
           // Store IVDep-specific parameters into an intermediate
           // container to address the case when there're multiple
           // IVDep metadata nodes and this condition gets entered multiple

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -182,7 +182,7 @@ private:
   SPIRVWord SrcLangVer;
   std::unique_ptr<LLVMToSPIRVDbgTran> DbgTran;
   std::unique_ptr<CallGraph> CG;
-  OCLTypeToSPIRVBase *OCLTypeToSPIRVPtr;
+  OCLTypeToSPIRVBase *OCLTypeToSPIRVPtr = nullptr;
   std::vector<llvm::Instruction *> UnboundInst;
   std::unique_ptr<SPIRVTypeScavenger> Scavenger;
 

--- a/lib/SPIRV/libSPIRV/SPIRVAsm.h
+++ b/lib/SPIRV/libSPIRV/SPIRVAsm.h
@@ -89,8 +89,8 @@ protected:
     assert(WordCount > FixedWC);
     assert(OpCode == OC);
   }
-  SPIRVAsmTargetINTEL *Target;
-  SPIRVTypeFunction *FunctionType;
+  SPIRVAsmTargetINTEL *Target = nullptr;
+  SPIRVTypeFunction *FunctionType = nullptr;
   std::string Instructions;
   std::string Constraints;
 };
@@ -134,7 +134,7 @@ protected:
     assert(getBasicBlock() && "Invalid BB");
     assert(getBasicBlock()->getModule() == Asm->getModule());
   }
-  SPIRVAsmINTEL *Asm;
+  SPIRVAsmINTEL *Asm = nullptr;
   std::vector<SPIRVWord> Args;
 };
 

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -539,7 +539,7 @@ public:
 
   _SPIRV_DCL_ENCDEC
 protected:
-  SPIRVExecutionModelKind ExecModel;
+  SPIRVExecutionModelKind ExecModel = ExecutionModelMax;
   std::string Name;
 
 private:

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1050,7 +1050,7 @@ public:
 
   SPIRVLoopMerge()
       : SPIRVInstruction(OC), MergeBlock(SPIRVID_MAX),
-        LoopControl(SPIRVWORD_MAX) {
+        ContinueTarget(SPIRVID_MAX), LoopControl(SPIRVWORD_MAX) {
     setHasNoId();
     setHasNoType();
   }
@@ -2214,8 +2214,8 @@ protected:
     SPIRVInstruction::validate();
   }
   SPIRVId ExecScope;
-  SPIRVId MemScope;
-  SPIRVId MemSema;
+  SPIRVId MemScope = SPIRVID_INVALID;
+  SPIRVId MemSema = SPIRVID_INVALID;
 };
 
 template <Op OC> class SPIRVLifetime : public SPIRVInstruction {

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -777,7 +777,7 @@ public:
 protected:
   _SPIRV_DEF_ENCDEC1(Id)
   void validate() const override { SPIRVEntry::validate(); }
-  SPIRVId Opn;
+  SPIRVId Opn = SPIRVID_INVALID;
 };
 
 template <Op TheOpCode>
@@ -1009,7 +1009,7 @@ public:
 protected:
   _SPIRV_DEF_ENCDEC1(Id)
   void validate() const override { SPIRVEntry::validate(); }
-  SPIRVId Opn;
+  SPIRVId Opn = SPIRVID_INVALID;
 };
 
 template <Op TheOpCode>


### PR DESCRIPTION
This is a collection of small fixes to make the code more static analyzer-friendly:

* Added initialization to some previously-uninitialized fields to make sure they have sensible "null" values even when the full constructor isn't called.
* Removed the CU member from SPIRVToLLVMDbgTran since its only use was effectively as a local variable in SPIRVToLLVMDbgTran::transCompileUnit and so it didn't need to be a member variable.
* Removed the unnecessary initialize method from LLVMParallelAccessIndices in SPIRVWriter and moved initialization logic to the constructor.