### PR TITLE
[OpaquePointers] Avoid infinite cycles in scavenging the types of PHIs.

### DIFF
--- a/lib/SPIRV/SPIRVTypeScavenger.h
+++ b/lib/SPIRV/SPIRVTypeScavenger.h
@@ -105,6 +105,10 @@ class SPIRVTypeScavenger {
   /// Compute pointer element types for all pertinent values in the module.
   void typeModule(Module &M);
 
+  /// This stores a list of instructions whose pointer element types are
+  /// currently being investigated, to avoid the possibility of infinite cycles.
+  std::vector<Value *> VisitStack;
+
 public:
   explicit SPIRVTypeScavenger(Module &M) { typeModule(M); }
 

--- a/test/type-scavenger/infinite-phi.ll
+++ b/test/type-scavenger/infinite-phi.ll
@@ -1,0 +1,36 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: 4 TypeInt [[INT:[0-9]+]] 32 0
+; CHECK: 4 TypePointer [[INTPTR:[0-9]+]] 7 [[INT]]
+; CHECK: 3 TypeFloat [[FLOAT:[0-9]+]] 32
+; CHECK: 4 TypePointer [[FLOATPTR:[0-9]+]] 7 [[FLOAT]]
+
+; Function Attrs: nounwind
+define spir_kernel void @foo() {
+; CHECK: 4 Variable [[INTPTR]] [[IPTR:[0-9]+]] 7
+; CHECK: 4 Variable [[FLOATPTR]] [[FPTR:[0-9]+]] 7
+; CHECK: 4 Bitcast [[FLOATPTR]] [[IPTRI:[0-9]+]] [[IPTR]]
+; CHECK: 7 Phi [[FLOATPTR]] [[PTR1:[0-9]+]] [[PTR2:[0-9]+]] {{[0-9]+}} [[IPTRI]]
+; CHECK: 7 Phi [[FLOATPTR]] [[PTR2]] [[PTR1]] {{[0-9]+}} [[FPTR]]
+entry:
+  %iptr = alloca i32, align 4
+  %fptr = alloca float, align 4
+  br label %loop
+
+loop:
+  %ptr1 = phi ptr [%ptr2, %loop], [%iptr, %entry]
+  %ptr2 = phi ptr [%ptr1, %loop], [%fptr, %entry]
+  %cond = phi i32 [0, %entry], [%cond.next, %loop]
+  %cond.next = add i32 %cond, 1
+  %cmp = icmp slt i32 %cond.next, 150
+  br i1 %cmp, label %exit, label %loop
+
+exit:
+  ret void
+}


### PR DESCRIPTION
PHI instructions have their type scavenged from one of their incoming values. Originally, this used solely the first one, but it is possible for this to generate an infinite cycle (consider a pointer-swapping loop). This fixes the logic to detect such infinite cycles and to consider other incoming values instead.