### PR TITLE
Change OpFMod and OpFRem implementations to be in line with CTS.

### DIFF
--- a/test/OpFMod_v2f16.spvasm
+++ b/test/OpFMod_v2f16.spvasm
@@ -21,8 +21,5 @@
                OpReturn
                OpFunctionEnd
 
-; CHECK-DAG: %frem.res = frem <2 x half> %a, %b
-; CHECK-DAG: %copysign.res = call <2 x half> @llvm.copysign.v2f16(<2 x half> %frem.res, <2 x half> %b)
-; CHECK-DAG: %fadd.res = fadd <2 x half> {{%frem\.res, %b|%b, %frem\.res}}
-; CHECK-DAG: %cmp.res = fcmp one <2 x half> {{%frem\.res, %copysign\.res|%copysign\.res, %frem\.res}}
-; CHECK: select <2 x i1> %cmp.res, <2 x half> %fadd.res, <2 x half> %copysign.res
+; CHECK-DAG: %[[fmod_res:[a-zA-Z0-9_]*]] = call spir_func <2 x half> @_Z4fmodDv2_DhS_(<2 x half> %a, <2 x half> %b)
+; CHECK-DAG: %copysign.res = call <2 x half> @llvm.copysign.v2f16(<2 x half> %[[fmod_res]], <2 x half> %b)

--- a/test/OpFRem_f32.spvasm
+++ b/test/OpFRem_f32.spvasm
@@ -5,7 +5,7 @@
                OpCapability Addresses
                OpCapability Kernel
                OpMemoryModel Physical32 OpenCL
-               OpEntryPoint Kernel %1 "testFMod_f32"
+               OpEntryPoint Kernel %1 "testFRem_f32"
                OpName %a "a"
                OpName %b "b"
        %void = OpTypeVoid
@@ -15,9 +15,9 @@
           %a = OpFunctionParameter %float
           %b = OpFunctionParameter %float
           %6 = OpLabel
-          %7 = OpFMod %float %a %b
+          %7 = OpFRem %float %a %b
                OpReturn
                OpFunctionEnd
 
-; CHECK-DAG: %[[fmod_res:[a-zA-Z0-9_]*]] = call spir_func float @_Z4fmodff(float %a, float %b)
-; CHECK-DAG: %copysign.res = call float @llvm.copysign.f32(float %[[fmod_res]], float %b)
+; CHECK: %[[fmod_res:[a-zA-Z0-9_]*]] = call spir_func float @_Z4fmodff(float %a, float %b)
+; CHECK-NEXT: ret void

--- a/test/OpFRem_v2f16.spvasm
+++ b/test/OpFRem_v2f16.spvasm
@@ -4,20 +4,22 @@
 ; RUN: llvm-spirv -r -emit-opaque-pointers -o - %t.spv | llvm-dis | FileCheck %s
                OpCapability Addresses
                OpCapability Kernel
+               OpCapability Float16
                OpMemoryModel Physical32 OpenCL
-               OpEntryPoint Kernel %1 "testFMod_f32"
+               OpEntryPoint Kernel %1 "testFRem_v2f16"
                OpName %a "a"
                OpName %b "b"
        %void = OpTypeVoid
-      %float = OpTypeFloat 32
-          %5 = OpTypeFunction %void %float %float
+       %half = OpTypeFloat 16
+      %half2 = OpTypeVector %half 2
+          %5 = OpTypeFunction %void %half2 %half2
           %1 = OpFunction %void None %5
-          %a = OpFunctionParameter %float
-          %b = OpFunctionParameter %float
+          %a = OpFunctionParameter %half2
+          %b = OpFunctionParameter %half2
           %6 = OpLabel
-          %7 = OpFMod %float %a %b
+          %7 = OpFRem %half2 %a %b
                OpReturn
                OpFunctionEnd
 
-; CHECK-DAG: %[[fmod_res:[a-zA-Z0-9_]*]] = call spir_func float @_Z4fmodff(float %a, float %b)
-; CHECK-DAG: %copysign.res = call float @llvm.copysign.f32(float %[[fmod_res]], float %b)
+; CHECK: %[[fmod_res:[a-zA-Z0-9_]*]] = call spir_func <2 x half> @_Z4fmodDv2_DhS_(<2 x half> %a, <2 x half> %b)
+; CHECK-NEXT: ret void

--- a/test/transcoding/frem.ll
+++ b/test/transcoding/frem.ll
@@ -27,7 +27,7 @@
 ; CHECK-SPIRV: 5 FRem [[float]] [[#r6]]
 ; CHECK-SPIRV: 5 FRem [[float]] [[#r7]]
 
-; CHECK-LLVM: %r1 = frem float %a, %b
+; CHECK-LLVM: %r1 = call spir_func float @_Z4fmodff(float %a, float %b)
 ; CHECK-LLVM: %r2 = frem nnan float %a, %b
 ; CHECK-LLVM: %r3 = frem ninf float %a, %b
 ; CHECK-LLVM: %r4 = frem nsz float %a, %b


### PR DESCRIPTION
The CTS expects these instructions to be implemented in terms of the fmod builtin.

See the CTS implementations [here](https://github.com/KhronosGroup/OpenCL-CTS/blob/main/test_conformance/spirv_new/test_op_fmath.cpp#L69).

This contribution is being made by Codeplay on behalf of Samsung