### PR TITLE
[CMake] Link against LLVMTargetParser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
       Core
       Passes
       Support
+      TargetParser
       TransformUtils
       ${LLVM_TEST_COMPONENTS}
   )

--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -52,6 +52,7 @@ if(LLVM_LINK_LLVM_DYLIB)
       LLVMLinker
       LLVMPasses
       LLVMSupport
+      LLVMTargetParser
       LLVMTransformUtils
   )
 else()
@@ -67,6 +68,7 @@ else()
       Linker
       Passes
       Support
+      TargetParser
       TransformUtils
   DEPENDS
     intrinsics_gen

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
   Core
   Passes
   Support
+  TargetParser
   TransformUtils
 )
 


### PR DESCRIPTION
Update CMakeLists.txt after llvm-project commit f09cf34d0062 ("[Support] Move TargetParsers to new component", 2022-12-20).