### PR TITLE
Link to SPIRV-Tools via CMake package when pkgconfig is not available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,11 +112,24 @@ endif()
 
 set(LLVM_SPIRV_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+# first try locating SPIRV-Tools via pkgconfig (the old way)
 pkg_search_module(SPIRV_TOOLS SPIRV-Tools)
-if(NOT SPIRV_TOOLS_FOUND)
+if (NOT SPIRV_TOOLS_FOUND)
+  # then try locating SPIRV-Tools via cmake (the new way)
+  find_package(SPIRV-Tools)
+  find_package(SPIRV-Tools-tools)
+  if (SPIRV-Tools_FOUND AND SPIRV-Tools-tools_FOUND)
+    set(SPIRV_TOOLS_FOUND TRUE)
+    set(SPIRV_TOOLS_LDFLAGS SPIRV-Tools-shared)
+    get_target_property(SPIRV_TOOLS_INCLUDE_DIRS SPIRV-Tools-shared INTERFACE_INCLUDE_DIRECTORIES)
+  endif()
+endif()
+
+if (NOT SPIRV_TOOLS_FOUND)
   message(STATUS "SPIRV-Tools not found; project will be built without "
           "--spirv-tools-dis support.")
-endif(NOT SPIRV_TOOLS_FOUND)
+endif()
+
 
 add_subdirectory(lib/SPIRV)
 add_subdirectory(tools/llvm-spirv)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,8 @@ llvm_canonicalize_cmake_booleans(SPIRV_SKIP_DEBUG_INFO_TESTS)
 get_target_property(LLVM_SPIRV_DIR llvm-spirv BINARY_DIR)
 set(LLVM_SPIRV_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(SPIRV_TOOLS_FOUND)
+if(SPIRV_TOOLS_FOUND AND NOT SPIRV-Tools-tools_FOUND)
+  # we found SPIRV-Tools via pkgconfig
   find_program(SPIRV_TOOLS_SPIRV_AS NAMES spirv-as PATHS ${SPIRV_TOOLS_PREFIX}/bin)
   if(SPIRV_TOOLS_SPIRV_AS)
     set(SPIRV_TOOLS_SPIRV_AS_FOUND True)
@@ -22,19 +23,44 @@ if(SPIRV_TOOLS_FOUND)
   endif()
 
   set(SPIRV_TOOLS_BINDIR "${SPIRV_TOOLS_PREFIX}/bin")
+elseif(SPIRV-Tools-tools_FOUND)
+  # we found SPIRV-Tools via cmake targets
+
+  if(TARGET spirv-as)
+    set(SPIRV_TOOLS_SPIRV_AS_FOUND True)
+  endif()
+
+  if(TARGET spirv-link)
+    set(SPIRV_TOOLS_SPIRV_LINK_FOUND True)
+  endif()
+
+  if(TARGET spirv-val)
+    set(SPIRV_TOOLS_SPIRV_VAL_FOUND True)
+  endif()
+
+  get_target_property(SPIRV_AS_PATH spirv-as IMPORTED_LOCATION_RELEASE)
+  if(NOT SPIRV_AS_PATH)
+    get_target_property(SPIRV_AS_PATH spirv-as IMPORTED_LOCATION_DEBUG)
+  endif()
+
+  if(SPIRV_AS_PATH)
+    cmake_path(GET SPIRV_AS_PATH PARENT_PATH SPIRV_AS_PATH)
+  endif()
+
+  set(SPIRV_TOOLS_BINDIR "${SPIRV_AS_PATH}")
 endif()
 
-if(NOT SPIRV_TOOLS_SPIRV_AS)
+if(NOT SPIRV_TOOLS_SPIRV_AS_FOUND)
   message(WARNING "spirv-as not found! SPIR-V assembly tests will not be run.")
   set(SPIRV_TOOLS_SPIRV_AS_FOUND False)
 endif()
 
-if(NOT SPIRV_TOOLS_SPIRV_LINK)
+if(NOT SPIRV_TOOLS_SPIRV_LINK_FOUND)
   message(WARNING "spirv-link not found! SPIR-V test involving the linker will not be run.")
   set(SPIRV_TOOLS_SPIRV_LINK_FOUND False)
 endif()
 
-if(NOT SPIRV_TOOLS_SPIRV_VAL)
+if(NOT SPIRV_TOOLS_SPIRV_VAL_FOUND)
   message(WARNING "spirv-val not found! SPIR-V generated for test suite will not be validated.")
   set(SPIRV_TOOLS_SPIRV_VAL_FOUND False)
 endif()


### PR DESCRIPTION
pkgconfig is usually not available on Windows, so try to use normal CMake modules to locate the binaries for SPIRV-Tools.

The patch doesn't change the existing behavior when the pkgconfig is available, only when it is missing.

The CMake path is available only with this patch that has already been accepted upstream:
https://github.com/KhronosGroup/SPIRV-Tools/pull/5034