### PR TITLE
Decorate the pointer argument of OpLoad and Opstore with BufferLocationINTEL

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3369,6 +3369,8 @@ void generateIntelFPGAAnnotation(
   }
   if (E->hasDecorate(DecorationForcePow2DepthINTEL, 0, &Result))
     Out << "{force_pow2_depth:" << Result << '}';
+  if (E->hasDecorate(DecorationBufferLocationINTEL, 0, &Result))
+    Out << "{sycl-buffer-location:" << Result << '}';
 
   unsigned LSUParamsBitmask = 0;
   llvm::SmallString<32> AdditionalParamsStr;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2829,6 +2829,12 @@ using DecorationsInfoVec =
 struct AnnotationDecorations {
   DecorationsInfoVec MemoryAttributesVec;
   DecorationsInfoVec MemoryAccessesVec;
+  DecorationsInfoVec BufferLocationVec;
+
+  bool empty() {
+    return (MemoryAttributesVec.empty() && MemoryAccessesVec.empty() &&
+            BufferLocationVec.empty());
+  }
 };
 
 struct IntelLSUControlsInfo {
@@ -3019,6 +3025,8 @@ AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
       BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fpga_memory_accesses);
   const bool AllowFPGAMemAttr = BM->isAllowedToUseExtension(
       ExtensionID::SPV_INTEL_fpga_memory_attributes);
+  const bool AllowFPGABufLoc =
+      BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fpga_buffer_location);
 
   bool ValidDecorationFound = false;
   DecorationsInfoVec DecorationsVec;
@@ -3037,8 +3045,15 @@ AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
       std::vector<std::string> DecValues;
       if (tryParseAnnotationDecoValues(ValueStr, DecValues)) {
         ValidDecorationFound = true;
-        DecorationsVec.emplace_back(static_cast<Decoration>(DecorationKind),
-                                    std::move(DecValues));
+
+        if (AllowFPGABufLoc &&
+            DecorationKind == DecorationBufferLocationINTEL) {
+          Decorates.BufferLocationVec.emplace_back(
+              static_cast<Decoration>(DecorationKind), std::move(DecValues));
+        } else {
+          DecorationsVec.emplace_back(static_cast<Decoration>(DecorationKind),
+                                      std::move(DecValues));
+        }
       }
       continue;
     }
@@ -3109,6 +3124,7 @@ AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
       DecorationsVec.emplace_back(Dec, std::move(DecValues));
     }
   }
+
   // Even if there is an annotation string that is split in blocks like Intel
   // FPGA annotation, it's not necessarily an FPGA annotation. Translate the
   // whole string as UserSemantic decoration in this case.
@@ -3225,6 +3241,18 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
         E->addDecorate(I.first, Result);
       }
     } break;
+    case DecorationBufferLocationINTEL: {
+      if (M->isAllowedToUseExtension(
+              ExtensionID::SPV_INTEL_fpga_buffer_location)) {
+        M->getErrorLog().checkError(I.second.size() == 1,
+                                    SPIRVEC_InvalidLlvmModule,
+                                    "Decoration requires a single argument.");
+        SPIRVWord Result = 0;
+        StringRef(I.second[0]).getAsInteger(10, Result);
+        E->addDecorate(I.first, Result);
+      }
+    } break;
+
     default:
       // Other decorations are either not supported by the translator or
       // handled in other places.
@@ -3488,6 +3516,26 @@ static bool allowsApproxFunction(IntrinsicInst *II) {
          (Ty->isFloatTy() ||
           (Ty->isVectorTy() &&
            cast<VectorType>(Ty)->getElementType()->isFloatTy()));
+}
+
+bool allowDecorateWithBufferLocationINTEL(IntrinsicInst *II) {
+  SmallVector<Value *, 8> UserList;
+
+  for (auto *Inst : II->users()) {
+    // if castInst, push Successors
+    if (auto *Cast = dyn_cast<CastInst>(Inst)) {
+      for (auto *Successor : Cast->users())
+        UserList.push_back(Successor);
+    } else {
+      UserList.push_back(Inst);
+    }
+  }
+
+  for (auto &Inst : UserList)
+    if (isa<LoadInst>(Inst) || isa<StoreInst>(Inst))
+      return true;
+
+  return false;
 }
 
 SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
@@ -3958,8 +4006,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
 
       // If we didn't find any IntelFPGA-specific decorations, let's add the
       // whole annotation string as UserSemantic Decoration
-      if (Decorations.MemoryAttributesVec.empty() &&
-          Decorations.MemoryAccessesVec.empty()) {
+      if (Decorations.empty()) {
         // TODO: Is there a way to detect that the annotation belongs solely
         // to struct member memory atributes or struct member memory access
         // controls? This would allow emitting just the necessary decoration.
@@ -3976,20 +4023,26 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
         // because multiple accesses to the struct-held memory can require
         // different LSU parameters.
         addAnnotationDecorations(ResPtr, Decorations.MemoryAccessesVec);
+        if (allowDecorateWithBufferLocationINTEL(II))
+          addAnnotationDecorations(ResPtr, Decorations.BufferLocationVec);
       }
       II->replaceAllUsesWith(II->getOperand(0));
     } else {
       // Memory accesses to a standalone pointer variable
       auto *DecSubj = transValue(II->getArgOperand(0), BB);
-      if (Decorations.MemoryAccessesVec.empty())
+      if (Decorations.MemoryAccessesVec.empty() &&
+          Decorations.BufferLocationVec.empty())
         DecSubj->addDecorate(new SPIRVDecorateUserSemanticAttr(
             DecSubj, AnnotationString.c_str()));
-      else
+      else {
         // Apply the LSU parameter decoration to the pointer result of an
         // instruction. Note it's the address to the accessed memory that's
         // loaded from the original pointer variable, and not the value
         // accessed by the latter.
         addAnnotationDecorations(DecSubj, Decorations.MemoryAccessesVec);
+        if (allowDecorateWithBufferLocationINTEL(II))
+          addAnnotationDecorations(DecSubj, Decorations.BufferLocationVec);
+      }
       II->replaceAllUsesWith(II->getOperand(0));
     }
     return nullptr;

--- a/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
@@ -1,13 +1,13 @@
-; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
-; RUN: llvm-spirv %t.bc -opaque-pointers=0 --spirv-ext=+SPV_INTEL_fpga_buffer_location -o %t.spv
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_buffer_location -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; RUN: llvm-spirv -spirv-text -r %t.spt -o %t.rev.bc
-; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -spirv-text -r -emit-opaque-pointers %t.spt -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: 2 Capability FPGABufferLocationINTEL
 ; CHECK-SPIRV: 9 Extension "SPV_INTEL_fpga_buffer_location"
@@ -31,18 +31,18 @@
 ; CHECK-SPIRV: 3 FunctionParameter {{[0-9]+}} [[ARGD]]
 ; CHECK-SPIRV: 3 FunctionParameter {{[0-9]+}} [[ARGE]]
 
-
 ; ModuleID = 'buffer_location.cl'
-source_filename = "buffer_location.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
-@.str.1 = private unnamed_addr constant [9 x i8] c"main.cpp\00", section "llvm.metadata"
-@.str.4 = private unnamed_addr constant [19 x i8] c"{5921:\22123456789\22}\00", section "llvm.metadata"
+%struct.MyIP = type { ptr addrspace(4) }
+
+@.str.4 = internal unnamed_addr constant [19 x i8] c"{5921:\22123456789\22}\00"
+@.str.1 = internal unnamed_addr constant [9 x i8] c"main.cpp\00"
 ; CHECK-LLVM: @[[ANN_STR:[0-9]+]] = private unnamed_addr constant [33 x i8] c"{sycl-buffer-location:123456789}\00"
 
-; Function Attrs: norecurse nounwind readnone
-define spir_kernel void @test(i32 addrspace(1)* %a, float addrspace(1)* %b, i32 addrspace(1)* %c, i32 %d, i32 %e) local_unnamed_addr !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_buffer_location !6
+; Function Attrs: nounwind
+define spir_kernel void @test(ptr addrspace(1) %a, ptr addrspace(1) %b, ptr addrspace(1) %c, i32 %d, i32 %e) local_unnamed_addr !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_buffer_location !6
 ; CHECK-LLVM: !kernel_arg_buffer_location ![[BUFLOC_MD:[0-9]+]]
 {
 entry:
@@ -51,55 +51,47 @@ entry:
 
 ; test1 : direct on kernel argument
 ; Function Attrs: norecurse nounwind readnone
-define spir_kernel void @test.1(i8 addrspace(4)* %a) #0
+define spir_kernel void @test.1(ptr addrspace(4) %a) #0
 ; CHECK-LLVM: !kernel_arg_buffer_location ![[BUFLOC_MD_TEST1:[0-9]+]]
 {
 entry:
-  %0 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %a, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.1, i32 0, i32 0), i32 7, i8* null)
-  store i8 0, i8 addrspace(4)* %0, align 8
+  %0 = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a, ptr getelementptr inbounds ([19 x i8], ptr @.str.4, i32 0, i32 0), ptr getelementptr inbounds ([9 x i8], ptr @.str.1, i32 0, i32 0), i32 7, ptr null)
+  store i8 0, ptr addrspace(4) %0, align 8
   ret void
 }
 
-%struct.MyIP = type { i32 addrspace(4)* }
 $test.2 = comdat any
-
 ; test2 : general
 ; Function Attrs: convergent mustprogress norecurse
-define weak_odr dso_local spir_kernel void @test.2(i32 addrspace(1)* noundef align 4 %arg_a) #0 comdat !kernel_arg_buffer_location !7 {
+define weak_odr dso_local spir_kernel void @test.2(ptr addrspace(1) align 4 %arg_a) #0 comdat !kernel_arg_buffer_location !7 {
 entry:
-  %this.addr.i = alloca %struct.MyIP addrspace(4)*, align 8
-  %arg_a.addr = alloca i32 addrspace(1)*, align 8
+  %this.addr.i = alloca ptr addrspace(4), align 8
+  %arg_a.addr = alloca ptr addrspace(1), align 8
   %MyIP = alloca %struct.MyIP, align 8
-  %arg_a.addr.ascast = addrspacecast i32 addrspace(1)** %arg_a.addr to i32 addrspace(1)* addrspace(4)*
-  %MyIP.ascast = addrspacecast %struct.MyIP* %MyIP to %struct.MyIP addrspace(4)*
-  store i32 addrspace(1)* %arg_a, i32 addrspace(1)* addrspace(4)* %arg_a.addr.ascast, align 8
-  %0 = bitcast %struct.MyIP* %MyIP to i8*
-  %a = getelementptr inbounds %struct.MyIP, %struct.MyIP addrspace(4)* %MyIP.ascast, i32 0, i32 0
-  %1 = bitcast i32 addrspace(4)* addrspace(4)* %a to i8 addrspace(4)*
-  %2 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %1, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.1, i32 0, i32 0), i32 7, i8* null)
-; CHEKC-LLVM: call i32 addrspace(4)* addrspace(4)* @llvm.ptr.annotation.p4p4i32.p0i8(i32 addrspace(4)* addrspace(4)* %a, i8* getelementptr inbounds ([33 x i8], [33 x i8]* @[[ANN_STR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
-  %3 = bitcast i8 addrspace(4)* %2 to i32 addrspace(4)* addrspace(4)*
-  %4 = load i32 addrspace(1)*, i32 addrspace(1)* addrspace(4)* %arg_a.addr.ascast, align 8
-  %5 = addrspacecast i32 addrspace(1)* %4 to i32 addrspace(4)*
-  store i32 addrspace(4)* %5, i32 addrspace(4)* addrspace(4)* %3, align 8
-  %this.addr.ascast.i = addrspacecast %struct.MyIP addrspace(4)** %this.addr.i to %struct.MyIP addrspace(4)* addrspace(4)*
-  store %struct.MyIP addrspace(4)* %MyIP.ascast, %struct.MyIP addrspace(4)* addrspace(4)* %this.addr.ascast.i, align 8
-  %this1.i = load %struct.MyIP addrspace(4)*, %struct.MyIP addrspace(4)* addrspace(4)* %this.addr.ascast.i, align 8
-  %a.i = getelementptr inbounds %struct.MyIP, %struct.MyIP addrspace(4)* %this1.i, i32 0, i32 0
-  %6 = bitcast i32 addrspace(4)* addrspace(4)* %a.i to i8 addrspace(4)*
-  %7 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %6, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.1, i32 0, i32 0), i32 7, i8* null)
-; CHECK-LLVM: call i32 addrspace(4)* addrspace(4)* @llvm.ptr.annotation.p4p4i32.p0i8(i32 addrspace(4)* addrspace(4)* %a.i, i8* getelementptr inbounds ([33 x i8], [33 x i8]* @[[ANN_STR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
-  %8 = bitcast i8 addrspace(4)* %7 to i32 addrspace(4)* addrspace(4)*
-  %9 = load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %8, align 8
-  %10 = load i32, i32 addrspace(4)* %9, align 4
-  %inc.i = add nsw i32 %10, 1
-  store i32 %inc.i, i32 addrspace(4)* %9, align 4
-  %11 = bitcast %struct.MyIP* %MyIP to i8*
+  %arg_a.addr.ascast = addrspacecast ptr %arg_a.addr to ptr addrspace(4)
+  %MyIP.ascast = addrspacecast ptr %MyIP to ptr addrspace(4)
+  store ptr addrspace(1) %arg_a, ptr addrspace(4) %arg_a.addr.ascast, align 8
+  %a = getelementptr inbounds %struct.MyIP, ptr addrspace(4) %MyIP.ascast, i32 0, i32 0
+  %0 = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a, ptr getelementptr inbounds ([33 x i8], ptr @.str.4, i32 0, i32 0), ptr getelementptr inbounds ([9 x i8], ptr @.str.1, i32 0, i32 0), i32 7, ptr null)
+; CHECK-LLVM: call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a, ptr @[[ANN_STR]], ptr undef, i32 undef, ptr undef)
+  %b = load ptr addrspace(1), ptr addrspace(4) %arg_a.addr.ascast, align 8
+  %1 = addrspacecast ptr addrspace(1) %b to ptr addrspace(4)
+  store ptr addrspace(4) %1, ptr addrspace(4) %0, align 8
+  %this.addr.ascast.i = addrspacecast ptr %this.addr.i to ptr addrspace(4)
+  store ptr addrspace(4) %MyIP.ascast, ptr addrspace(4) %this.addr.ascast.i, align 8
+  %this1.i = load ptr addrspace(4), ptr addrspace(4) %this.addr.ascast.i, align 8
+  %a.i = getelementptr inbounds %struct.MyIP, ptr addrspace(4) %this1.i, i32 0, i32 0
+  %2 = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a.i, ptr getelementptr inbounds ([19 x i8], ptr @.str.4, i32 0, i32 0), ptr getelementptr inbounds ([9 x i8], ptr @.str.1, i32 0, i32 0), i32 7, ptr null)
+; CHECK-LLVM: call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a.i, ptr @[[ANN_STR]], ptr undef, i32 undef, ptr undef)
+  %3 = load ptr addrspace(4), ptr addrspace(4) %2, align 8
+  %4 = load i32, ptr addrspace(4) %3, align 4
+  %inc.i = add nsw i32 %4, 1
+  store i32 %inc.i, ptr addrspace(4) %3, align 4
   ret void
 }
 
-; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
-declare i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)*, i8*, i8*, i32, i8*) #2
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4), ptr, ptr, i32, ptr) #1
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.ocl.version = !{!0}

--- a/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
@@ -1,13 +1,13 @@
-; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_buffer_location -o %t.spv
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
+; RUN: llvm-spirv %t.bc -opaque-pointers=0 --spirv-ext=+SPV_INTEL_fpga_buffer_location -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
-; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; RUN: llvm-spirv -spirv-text -r -emit-opaque-pointers %t.spt -o %t.rev.bc
-; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -spirv-text -r %t.spt -o %t.rev.bc
+; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: 2 Capability FPGABufferLocationINTEL
 ; CHECK-SPIRV: 9 Extension "SPV_INTEL_fpga_buffer_location"
@@ -22,6 +22,7 @@
 ; CHECK-SPIRV: 4 Decorate [[ARGB]] BufferLocationINTEL 2
 ; CHECK-SPIRV-NOT: 4 Decorate [[ARGD]] BufferLocationINTEL -1
 ; CHECK-SPIRV-NOT: 4 Decorate [[ARGE]] BufferLocationINTEL 3
+; CHECK-SPIRV-DAG: 4 Decorate {{[0-9]+}} BufferLocationINTEL 123456789
 
 ; CHECK-SPIRV: 5 Function
 ; CHECK-SPIRV: 3 FunctionParameter {{[0-9]+}} [[ARGA]]
@@ -30,19 +31,75 @@
 ; CHECK-SPIRV: 3 FunctionParameter {{[0-9]+}} [[ARGD]]
 ; CHECK-SPIRV: 3 FunctionParameter {{[0-9]+}} [[ARGE]]
 
-; CHECK-LLVM: define spir_kernel void @test{{.*}} !kernel_arg_buffer_location ![[BUFLOC_MD:[0-9]+]] {{.*}}
-; CHECK-LLVM: ![[BUFLOC_MD]] = !{i32 1, i32 2, i32 -1, i32 -1, i32 -1}
 
 ; ModuleID = 'buffer_location.cl'
 source_filename = "buffer_location.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
+@.str.1 = private unnamed_addr constant [9 x i8] c"main.cpp\00", section "llvm.metadata"
+@.str.4 = private unnamed_addr constant [19 x i8] c"{5921:\22123456789\22}\00", section "llvm.metadata"
+; CHECK-LLVM: @[[ANN_STR:[0-9]+]] = private unnamed_addr constant [33 x i8] c"{sycl-buffer-location:123456789}\00"
+
 ; Function Attrs: norecurse nounwind readnone
-define spir_kernel void @test(i32 addrspace(1)* %a, float addrspace(1)* %b, i32 addrspace(1)* %c, i32 %d, i32 %e) local_unnamed_addr !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_buffer_location !6 {
+define spir_kernel void @test(i32 addrspace(1)* %a, float addrspace(1)* %b, i32 addrspace(1)* %c, i32 %d, i32 %e) local_unnamed_addr !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_buffer_location !6
+; CHECK-LLVM: !kernel_arg_buffer_location ![[BUFLOC_MD:[0-9]+]]
+{
 entry:
   ret void
 }
+
+; test1 : direct on kernel argument
+; Function Attrs: norecurse nounwind readnone
+define spir_kernel void @test.1(i8 addrspace(4)* %a) #0
+; CHECK-LLVM: !kernel_arg_buffer_location ![[BUFLOC_MD_TEST1:[0-9]+]]
+{
+entry:
+  %0 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %a, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.1, i32 0, i32 0), i32 7, i8* null)
+  store i8 0, i8 addrspace(4)* %0, align 8
+  ret void
+}
+
+%struct.MyIP = type { i32 addrspace(4)* }
+$test.2 = comdat any
+
+; test2 : general
+; Function Attrs: convergent mustprogress norecurse
+define weak_odr dso_local spir_kernel void @test.2(i32 addrspace(1)* noundef align 4 %arg_a) #0 comdat !kernel_arg_buffer_location !7 {
+entry:
+  %this.addr.i = alloca %struct.MyIP addrspace(4)*, align 8
+  %arg_a.addr = alloca i32 addrspace(1)*, align 8
+  %MyIP = alloca %struct.MyIP, align 8
+  %arg_a.addr.ascast = addrspacecast i32 addrspace(1)** %arg_a.addr to i32 addrspace(1)* addrspace(4)*
+  %MyIP.ascast = addrspacecast %struct.MyIP* %MyIP to %struct.MyIP addrspace(4)*
+  store i32 addrspace(1)* %arg_a, i32 addrspace(1)* addrspace(4)* %arg_a.addr.ascast, align 8
+  %0 = bitcast %struct.MyIP* %MyIP to i8*
+  %a = getelementptr inbounds %struct.MyIP, %struct.MyIP addrspace(4)* %MyIP.ascast, i32 0, i32 0
+  %1 = bitcast i32 addrspace(4)* addrspace(4)* %a to i8 addrspace(4)*
+  %2 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %1, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.1, i32 0, i32 0), i32 7, i8* null)
+; CHEKC-LLVM: call i32 addrspace(4)* addrspace(4)* @llvm.ptr.annotation.p4p4i32.p0i8(i32 addrspace(4)* addrspace(4)* %a, i8* getelementptr inbounds ([33 x i8], [33 x i8]* @[[ANN_STR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  %3 = bitcast i8 addrspace(4)* %2 to i32 addrspace(4)* addrspace(4)*
+  %4 = load i32 addrspace(1)*, i32 addrspace(1)* addrspace(4)* %arg_a.addr.ascast, align 8
+  %5 = addrspacecast i32 addrspace(1)* %4 to i32 addrspace(4)*
+  store i32 addrspace(4)* %5, i32 addrspace(4)* addrspace(4)* %3, align 8
+  %this.addr.ascast.i = addrspacecast %struct.MyIP addrspace(4)** %this.addr.i to %struct.MyIP addrspace(4)* addrspace(4)*
+  store %struct.MyIP addrspace(4)* %MyIP.ascast, %struct.MyIP addrspace(4)* addrspace(4)* %this.addr.ascast.i, align 8
+  %this1.i = load %struct.MyIP addrspace(4)*, %struct.MyIP addrspace(4)* addrspace(4)* %this.addr.ascast.i, align 8
+  %a.i = getelementptr inbounds %struct.MyIP, %struct.MyIP addrspace(4)* %this1.i, i32 0, i32 0
+  %6 = bitcast i32 addrspace(4)* addrspace(4)* %a.i to i8 addrspace(4)*
+  %7 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)* %6, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @.str.4, i32 0, i32 0), i8* getelementptr inbounds ([9 x i8], [9 x i8]* @.str.1, i32 0, i32 0), i32 7, i8* null)
+; CHECK-LLVM: call i32 addrspace(4)* addrspace(4)* @llvm.ptr.annotation.p4p4i32.p0i8(i32 addrspace(4)* addrspace(4)* %a.i, i8* getelementptr inbounds ([33 x i8], [33 x i8]* @[[ANN_STR]], i32 0, i32 0), i8* undef, i32 undef, i8* undef)
+  %8 = bitcast i8 addrspace(4)* %7 to i32 addrspace(4)* addrspace(4)*
+  %9 = load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %8, align 8
+  %10 = load i32, i32 addrspace(4)* %9, align 4
+  %inc.i = add nsw i32 %10, 1
+  store i32 %inc.i, i32 addrspace(4)* %9, align 4
+  %11 = bitcast %struct.MyIP* %MyIP to i8*
+  ret void
+}
+
+; Function Attrs: inaccessiblememonly nofree nosync nounwind willreturn
+declare i8 addrspace(4)* @llvm.ptr.annotation.p4i8(i8 addrspace(4)*, i8*, i8*, i32, i8*) #2
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.ocl.version = !{!0}
@@ -52,6 +109,8 @@ entry:
 !opencl.compiler.options = !{!1}
 !llvm.ident = !{!2}
 
+; CHECK-LLVM: ![[BUFLOC_MD]] = !{i32 1, i32 2, i32 -1, i32 -1, i32 -1}
+; CHECK-LLVM: ![[BUFLOC_MD_TEST1]] = !{i32 123456789}
 !0 = !{i32 2, i32 0}
 !1 = !{}
 !2 = !{!""}
@@ -59,3 +118,4 @@ entry:
 !4 = !{!"none", !"none", !"none"}
 !5 = !{!"int*", !"float*", !"int*"}
 !6 = !{i32 1, i32 2, i32 -1, i32 -1, i32 3}
+!7 = !{i32 -1}


### PR DESCRIPTION
This PR is regarding spec https://github.com/KhronosGroup/SPIRV-Registry/pull/185

This patch parse the string in a "ptr.annotation" call, extracting buffer location information and create a SPIRV decoration on the pointer using the buffer location information. This applies only on the pointer argument of OpLoad/Opstore