### PR TITLE
Update for parseIR LLVM API change

### DIFF
--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
@@ -94,7 +94,7 @@ void SPIRVLowerSaddWithOverflowBase::visitIntrinsicInst(CallInst &I) {
   auto MB = MemoryBuffer::getMemBuffer(LLVMSaddWithOverflow);
   auto SaddWithOverflowModule =
       parseIR(MB->getMemBufferRef(), Err, *Context,
-              [&](StringRef) { return Mod->getDataLayoutStr(); });
+              [&](StringRef, StringRef) { return Mod->getDataLayoutStr(); });
   if (!SaddWithOverflowModule) {
     std::string ErrMsg;
     raw_string_ostream ErrStream(ErrMsg);


### PR DESCRIPTION
Update for llvm-project commit df1a74ac3c64 ("[IR] Support importing modules with invalid data layouts.", 2023-01-12).