### PR TITLE
Update for another parseIR LLVM API change

### DIFF
--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
@@ -94,7 +94,9 @@ void SPIRVLowerSaddWithOverflowBase::visitIntrinsicInst(CallInst &I) {
   auto MB = MemoryBuffer::getMemBuffer(LLVMSaddWithOverflow);
   auto SaddWithOverflowModule =
       parseIR(MB->getMemBufferRef(), Err, *Context,
-              [&](StringRef, StringRef) { return Mod->getDataLayoutStr(); });
+              ParserCallbacks([&](StringRef, StringRef) {
+                return Mod->getDataLayoutStr();
+              }));
   if (!SaddWithOverflowModule) {
     std::string ErrMsg;
     raw_string_ostream ErrStream(ErrMsg);


### PR DESCRIPTION
The parseIR API has been updated again in b56df190b013 to require a ParserCallbacks object which is not implicitly convertible from a lambda. This change adds an explicit conversion to fix the build failure.