### PR TITLE
Update test for typed pointer auto-detection removal

### DIFF
--- a/test/transcoding/optional-core-features-multiple.ll
+++ b/test/transcoding/optional-core-features-multiple.ll
@@ -4,7 +4,7 @@
 ; kernel void test(read_only image2d_t img) {}
 ; -----------------------------------------------
 ;
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv


### PR DESCRIPTION
Update a test for llvm-project commit 9ed2f14c8717 ("[AsmParser] Remove typed pointer auto-detection", 2023-01-18).