### PR TITLE
Update for getPrefTypeAlignment API deprecation

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -1403,7 +1403,7 @@ void OCLToSPIRVBase::visitCallEnqueueKernel(CallInst *CI,
   // TODO: these numbers should be obtained from block literal structure
   Type *ParamType = getBlockStructType(BlockLiteral);
   Args.push_back(getInt32(M, DL.getTypeStoreSize(ParamType)));
-  Args.push_back(getInt32(M, DL.getPrefTypeAlignment(ParamType)));
+  Args.push_back(getInt32(M, DL.getPrefTypeAlign(ParamType).value()));
 
   // Local sizes arguments: Sizes of block invoke arguments
   // Clang 6.0 and higher generates local size operands as an array,
@@ -1457,7 +1457,7 @@ void OCLToSPIRVBase::visitCallKernelQuery(CallInst *CI,
         // Add Param Size and Param Align at the end.
         Args[BlockFIdx] = BlockF;
         Args.push_back(getInt32(M, DL.getTypeStoreSize(ParamType)));
-        Args.push_back(getInt32(M, DL.getPrefTypeAlignment(ParamType)));
+        Args.push_back(getInt32(M, DL.getPrefTypeAlign(ParamType).value()));
 
         Op Opcode = OCLSPIRVBuiltinMap::map(DemangledName.str());
         // Adding "__" postfix, so in case we have multiple such


### PR DESCRIPTION
Update for llvm-project commit 89427bb7cbd1 ("[NFC] Deprecate DataLayout::getPrefTypeAlignment", 2023-01-24).