### PR TITLE
Fix static analysis issues

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -812,7 +812,8 @@ void OCLToSPIRVBase::visitCallGroupBuiltin(CallInst *CI,
                                   .Case("ballot_exclusive_scan", "add")
                                   .Default(FuncName.take_back(
                                       3)); // assumes op is three characters
-          GroupOp.consume_front("_");      // when op is two characters
+          if (!GroupOp.consume_front("_")) // when op is two characters
+            return true;                   // continue
           assert(!GroupOp.empty() && "Invalid OpenCL group builtin function");
           char OpTyC = 0;
           auto OpTy = F->getReturnType();

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -811,9 +811,8 @@ void OCLToSPIRVBase::visitCallGroupBuiltin(CallInst *CI,
                                   .Case("ballot_inclusive_scan", "add")
                                   .Case("ballot_exclusive_scan", "add")
                                   .Default(FuncName.take_back(
-                                      3)); // assumes op is three characters
-          if (!GroupOp.consume_front("_")) // when op is two characters
-            return true;                   // continue
+                                      3));    // assumes op is three characters
+          (void)(GroupOp.consume_front("_")); // when op is two characters
           assert(!GroupOp.empty() && "Invalid OpenCL group builtin function");
           char OpTyC = 0;
           auto OpTy = F->getReturnType();

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1181,7 +1181,8 @@ public:
     } else if (NameRef.contains("broadcast")) {
       addUnsignedArg(-1);
     } else if (NameRef.startswith(kOCLBuiltinName::SampledReadImage)) {
-      NameRef.consume_front(kOCLBuiltinName::Sampled);
+      if (!NameRef.consume_front(kOCLBuiltinName::Sampled))
+        report_fatal_error(llvm::Twine("Builtin name illformed"));
       addSamplerArg(1);
     } else if (NameRef.contains(kOCLSubgroupsAVCIntel::Prefix)) {
       if (NameRef.contains("evaluate_ipe"))

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -219,7 +219,8 @@ bool isSYCLHalfType(llvm::Type *Ty) {
     if (!ST->hasName())
       return false;
     StringRef Name = ST->getName();
-    Name.consume_front("class.");
+    if (!Name.consume_front("class."))
+      return false;
     if ((Name.startswith("sycl::") || Name.startswith("cl::sycl::") ||
          Name.startswith("__sycl_internal::")) &&
         Name.endswith("::half")) {
@@ -234,7 +235,8 @@ bool isSYCLBfloat16Type(llvm::Type *Ty) {
     if (!ST->hasName())
       return false;
     StringRef Name = ST->getName();
-    Name.consume_front("class.");
+    if (!Name.consume_front("class."))
+      return false;
     if ((Name.startswith("sycl::") || Name.startswith("cl::sycl::") ||
          Name.startswith("__sycl_internal::")) &&
         Name.endswith("::bfloat16")) {


### PR DESCRIPTION
In some cases, return value of consume_front is ignored. This change fixes the issue.

Signed-off-by: Arvind Sudarsanam <arvind.sudarsanam@intel.com>