### PR TITLE
[NFC] Remove -no-opaque-pointers flag from 2 .cl tests and XFAIL them

### DIFF
--- a/test/transcoding/clk_event_t.cl
+++ b/test/transcoding/clk_event_t.cl
@@ -1,12 +1,14 @@
-// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc -no-opaque-pointers
-// RUN: llvm-spirv -opaque-pointers=0 %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv -opaque-pointers=0 %t.bc -o %t.spv
+// RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -opaque-pointers=0 -r %t.spv -o %t.rev.bc
-// RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-OCL
-// RUN: llvm-spirv -opaque-pointers=0 -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
-// RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPV
-// RUN: llvm-spirv -opaque-pointers=0 %t.rev.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-OCL
+// RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+// RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPV
+// RUN: llvm-spirv %t.rev.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+//
+// XFAIL: *
 
 // CHECK-SPIRV: TypeDeviceEvent
 // CHECK-SPIRV: 5 Function

--- a/test/transcoding/pipe_builtins.cl
+++ b/test/transcoding/pipe_builtins.cl
@@ -1,12 +1,14 @@
 // Pipe built-ins are mangled accordingly to SPIR2.0/C++ ABI.
 
-// RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple spir64-unknown-unknown -emit-llvm-bc -fdeclare-opencl-builtins -finclude-default-header -Dcl_khr_subgroups %s -o %t.bc -no-opaque-pointers
-// RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-text -o %t.spt
+// RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple spir64-unknown-unknown -emit-llvm-bc -fdeclare-opencl-builtins -finclude-default-header -Dcl_khr_subgroups %s -o %t.bc
+// RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
+// RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.bc
 // RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+//
+// XFAIL: *
 
 // CHECK-SPIRV-DAG: TypePipe [[ROPipeTy:[0-9]+]] 0
 // CHECK-SPIRV-DAG: TypePipe [[WOPipeTy:[0-9]+]] 1


### PR DESCRIPTION
Non-opaque pointers are (almost) not supported in LLVM passes, so compilation with higher than O0 optimization level with -no-opaque-pointers flag will result in assertions firing.

To avoid this there are 2 options:
1. Pass -O0 to the tests and update checks;
2. Remove the flag and XFAIL the tests.

Short term option 1. is better, long term - 2. is better.

By this patch I vote for 2.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>