### PR TITLE
[Backport to 10] Translate readnone attribute as function parameter attribute (#1697)

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -242,6 +242,8 @@ typedef SPIRVMap<Attribute::AttrKind, SPIRVFuncParamAttrKind>
 template <>
 inline void
 SPIRVMap<Attribute::AttrKind, SPIRVFunctionControlMaskKind>::init() {
+  add(Attribute::ReadNone, FunctionControlPureMask);
+  add(Attribute::ReadOnly, FunctionControlConstMask);
   add(Attribute::AlwaysInline, FunctionControlInlineMask);
   add(Attribute::NoInline, FunctionControlDontInlineMask);
   add(Attribute::OptimizeNone, FunctionControlOptNoneINTELMask);

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -233,6 +233,8 @@ inline void SPIRVMap<Attribute::AttrKind, SPIRVFuncParamAttrKind>::init() {
   add(Attribute::StructRet, FunctionParameterAttributeSret);
   add(Attribute::NoAlias, FunctionParameterAttributeNoAlias);
   add(Attribute::NoCapture, FunctionParameterAttributeNoCapture);
+  add(Attribute::ReadOnly, FunctionParameterAttributeNoWrite);
+  add(Attribute::ReadNone, FunctionParameterAttributeNoReadWrite);
 }
 typedef SPIRVMap<Attribute::AttrKind, SPIRVFuncParamAttrKind>
     SPIRSPIRVFuncParamAttrMap;
@@ -240,8 +242,6 @@ typedef SPIRVMap<Attribute::AttrKind, SPIRVFuncParamAttrKind>
 template <>
 inline void
 SPIRVMap<Attribute::AttrKind, SPIRVFunctionControlMaskKind>::init() {
-  add(Attribute::ReadNone, FunctionControlPureMask);
-  add(Attribute::ReadOnly, FunctionControlConstMask);
   add(Attribute::AlwaysInline, FunctionControlInlineMask);
   add(Attribute::NoInline, FunctionControlDontInlineMask);
   add(Attribute::OptimizeNone, FunctionControlOptNoneINTELMask);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2274,8 +2274,6 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF) {
     mapValue(BA, &(*I));
     setName(&(*I), BA);
     BA->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
-      if (Kind == FunctionParameterAttributeNoWrite)
-        return;
       F->addAttribute(I->getArgNo() + 1, SPIRSPIRVFuncParamAttrMap::rmap(Kind));
     });
 
@@ -3390,6 +3388,10 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC,
     F->setCallingConv(CallingConv::SPIR_FUNC);
     if (isFuncNoUnwind())
       F->addFnAttr(Attribute::NoUnwind);
+    if (false) // TODO: isFuncReadNone(UnmangledName)  - see LLVM-11 port
+      for (llvm::Argument &Arg : F->args())
+        if (Arg.getType()->isPointerTy())
+          Arg.addAttr(Attribute::ReadNone);
   }
   auto Args = transValue(BC->getArgValues(), F, BB);
   SPIRVDBG(dbgs() << "[transOCLBuiltinFromExtInst] Function: " << *F

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3388,10 +3388,8 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC,
     F->setCallingConv(CallingConv::SPIR_FUNC);
     if (isFuncNoUnwind())
       F->addFnAttr(Attribute::NoUnwind);
-    if (false) // TODO: isFuncReadNone(UnmangledName)  - see LLVM-11 port
-      for (llvm::Argument &Arg : F->args())
-        if (Arg.getType()->isPointerTy())
-          Arg.addAttr(Attribute::ReadNone);
+    if (isFuncReadNone(UnmangledName))
+      F->addFnAttr(Attribute::ReadNone);
   }
   auto Args = transValue(BC->getArgValues(), F, BB);
   SPIRVDBG(dbgs() << "[transOCLBuiltinFromExtInst] Function: " << *F
@@ -3658,3 +3656,34 @@ bool llvm::getSpecConstInfo(std::istream &IS,
   }
   return !IS.bad();
 }
+
+// clang-format off
+const StringSet<> SPIRVToLLVM::BuiltInConstFunc {
+  "convert", "get_work_dim", "get_global_size", "sub_group_ballot_bit_count",
+  "get_global_id", "get_local_size", "get_local_id", "get_num_groups",
+  "get_group_id", "get_global_offset", "acos", "acosh", "acospi",
+  "asin", "asinh", "asinpi", "atan", "atan2", "atanh", "atanpi",
+  "atan2pi", "cbrt", "ceil", "copysign", "cos", "cosh", "cospi",
+  "erfc", "erf", "exp", "exp2", "exp10", "expm1", "fabs", "fdim",
+  "floor", "fma", "fmax", "fmin", "fmod", "ilogb", "ldexp", "lgamma",
+  "log", "log2", "log10", "log1p", "logb", "mad", "maxmag", "minmag",
+  "nan", "nextafter", "pow", "pown", "powr", "remainder", "rint",
+  "rootn", "round", "rsqrt", "sin", "sinh", "sinpi", "sqrt", "tan",
+  "tanh", "tanpi", "tgamma", "trunc", "half_cos", "half_divide", "half_exp",
+  "half_exp2", "half_exp10", "half_log", "half_log2", "half_log10", "half_powr",
+  "half_recip", "half_rsqrt", "half_sin", "half_sqrt", "half_tan", "native_cos",
+  "native_divide", "native_exp", "native_exp2", "native_exp10", "native_log",
+  "native_log2", "native_log10", "native_powr", "native_recip", "native_rsqrt",
+  "native_sin", "native_sqrt", "native_tan", "abs", "abs_diff", "add_sat", "hadd",
+  "rhadd", "clamp", "clz", "mad_hi", "mad_sat", "max", "min", "mul_hi", "rotate",
+  "sub_sat", "upsample", "popcount", "mad24", "mul24", "degrees", "mix", "radians",
+  "step", "smoothstep", "sign", "cross", "dot", "distance", "length", "normalize",
+  "fast_distance", "fast_length", "fast_normalize", "isequal", "isnotequal",
+  "isgreater", "isgreaterequal", "isless", "islessequal", "islessgreater",
+  "isfinite", "isinf", "isnan", "isnormal", "isordered", "isunordered", "signbit",
+  "any", "all", "bitselect", "select", "shuffle", "shuffle2", "get_image_width",
+  "get_image_height", "get_image_depth", "get_image_channel_data_type",
+  "get_image_channel_order", "get_image_dim", "get_image_array_size",
+  "get_image_array_size", "sub_group_inverse_ballot", "sub_group_ballot_bit_extract",
+};
+// clang-format on

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -44,6 +44,7 @@
 #include "SPIRVModule.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringSet.h"
 #include "llvm/IR/GlobalValue.h" // llvm::GlobalValue::LinkageTypes
 #include "llvm/IR/Metadata.h"    // llvm::Metadata
 
@@ -75,6 +76,11 @@ class SPIRVToLLVMDbgTran;
 class SPIRVToLLVM {
 public:
   SPIRVToLLVM(Module *LLVMModule, SPIRVModule *TheSPIRVModule);
+
+  static const StringSet<> BuiltInConstFunc;
+  std::string getOCLBuiltinName(SPIRVInstruction *BI);
+  std::string getOCLConvertBuiltinName(SPIRVInstruction *BI);
+  std::string getOCLGenericCastToPtrName(SPIRVInstruction *BI);
 
   Type *transType(SPIRVType *BT, bool IsClassMember = false);
   std::string transTypeToOCLTypeName(SPIRVType *BT, bool IsSigned = true);
@@ -172,6 +178,12 @@ private:
   // OpenCL function always has NoUnwind attribute.
   // Change this if it is no longer true.
   bool isFuncNoUnwind() const { return true; }
+
+  bool isFuncReadNone(const std::string &Name) const {
+    return BuiltInConstFunc.count(Name);
+  }
+
+  bool isSPIRVCmpInstTransToLLVMInst(SPIRVInstruction *BI) const;
   bool isDirectlyTranslatedToOCL(Op OpCode) const;
   MDString *transOCLKernelArgTypeName(SPIRVFunctionParameter *);
   Value *mapFunction(SPIRVFunction *BF, Function *F);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1839,8 +1839,10 @@ bool lowerBuiltinVariableToCall(GlobalVariable *GV,
     Func = Function::Create(FT, GlobalValue::ExternalLinkage, MangledName, M);
     Func->setCallingConv(CallingConv::SPIR_FUNC);
     Func->addFnAttr(Attribute::NoUnwind);
-    Func->addFnAttr(Attribute::ReadNone);
     Func->addFnAttr(Attribute::WillReturn);
+    for (llvm::Argument &Arg : Func->args())
+      if (Arg.getType()->isPointerTy())
+        Arg.addAttr(Attribute::ReadNone);
   }
 
   // Collect instructions in these containers to remove them later.

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -591,6 +591,10 @@ SPIRVFunction *LLVMToSPIRV::transFunctionDecl(Function *F) {
       BA->addAttr(FunctionParameterAttributeNoCapture);
     if (I->hasStructRetAttr())
       BA->addAttr(FunctionParameterAttributeSret);
+    if (Attrs.hasParamAttr(ArgNo, Attribute::ReadOnly))
+      BA->addAttr(FunctionParameterAttributeNoWrite);
+    if (Attrs.hasParamAttr(ArgNo, Attribute::ReadNone))
+      BA->addAttr(FunctionParameterAttributeNoReadWrite);
     if (Attrs.hasAttribute(ArgNo + 1, Attribute::ZExt))
       BA->addAttr(FunctionParameterAttributeZext);
     if (Attrs.hasAttribute(ArgNo + 1, Attribute::SExt))

--- a/test/transcoding/OpGenericPtrMemSemantics.ll
+++ b/test/transcoding/OpGenericPtrMemSemantics.ll
@@ -23,7 +23,7 @@ target triple = "spir-unknown-unknown"
 
 @gint = addrspace(1) global i32 1, align 4
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 define spir_func i32 @isFenceValid(i32 %fence) #0 {
 entry:
   %switch = icmp ult i32 %fence, 4
@@ -65,7 +65,7 @@ entry:
 
 declare spir_func i32 @_Z13get_global_idj(i32) #2
 
-attributes #0 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #3 = { nounwind }

--- a/test/transcoding/OpImageSampleExplicitLod.ll
+++ b/test/transcoding/OpImageSampleExplicitLod.ll
@@ -42,14 +42,14 @@ entry:
 ; Function Attrs: nounwind
 declare spir_func float @_Z11read_imagef20ocl_image2d_depth_ro11ocl_samplerDv2_i(%opencl.image2d_depth_ro_t addrspace(1)*, i32, <2 x i32>) #0
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 declare spir_func i32 @_Z13get_global_idj(i32) #1
 
 ; Function Attrs: nounwind
 declare spir_func <2 x i32> @_Z13get_image_dim20ocl_image2d_depth_ro(%opencl.image2d_depth_ro_t addrspace(1)*) #0
 
 attributes #0 = { nounwind }
-attributes #1 = { nounwind readnone }
+attributes #1 = { nounwind }
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.spir.version = !{!6}

--- a/test/transcoding/OpSwitch32.ll
+++ b/test/transcoding/OpSwitch32.ll
@@ -75,12 +75,12 @@ sw.epilog:                                        ; preds = %entry, %sw.bb1, %sw
   ret void
 }
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 declare spir_func i64 @_Z13get_global_idj(i32) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind readnone }
+attributes #1 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.spir.version = !{!6}

--- a/test/transcoding/OpSwitch64.ll
+++ b/test/transcoding/OpSwitch64.ll
@@ -86,12 +86,12 @@ sw.epilog:                                        ; preds = %entry, %sw.bb3, %sw
   ret void
 }
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 declare spir_func i64 @_Z13get_global_idj(i32) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind readnone }
+attributes #1 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.spir.version = !{!6}

--- a/test/transcoding/bitcast.ll
+++ b/test/transcoding/bitcast.ll
@@ -25,12 +25,12 @@ entry:
   ret void
 }
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 declare spir_func i64 @_Z13get_global_idj(i32) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind readnone }
+attributes #1 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.spir.version = !{!6}

--- a/test/transcoding/builtin_calls.ll
+++ b/test/transcoding/builtin_calls.ll
@@ -16,7 +16,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: Variable {{[0-9]+}} [[Id:[0-9]+]]
 ; CHECK-SPIRV: Variable {{[0-9]+}} [[Id:[0-9]+]]
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 define spir_kernel void @f() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
 entry:
   %0 = call spir_func i32 @_Z29__spirv_BuiltInGlobalLinearIdv()

--- a/test/transcoding/builtin_function_readnone_attr.ll
+++ b/test/transcoding/builtin_function_readnone_attr.ll
@@ -29,14 +29,17 @@ entry:
 }
 
 ; Function Attrs: convergent nounwind
+; CHECK-LLVM: declare{{.*}}@_Z3expd{{.*}}#[[#Attrs:]]
 declare dso_local double @_Z3expd(double) local_unnamed_addr #1
 
 ; Function Attrs: convergent nounwind
+; CHECK-LLVM: declare{{.*}}@_Z3cosd{{.*}}#[[#Attrs]]
 declare dso_local double @_Z3cosd(double) local_unnamed_addr #1
 
 attributes #0 = { convergent nofree norecurse nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
+; CHECK-LLVM: attributes #[[#Attrs]] {{.*}} readnone
 attributes #1 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { convergent nounwind }
+attributes #2 = { convergent nounwind readnone }
 
 !llvm.module.flags = !{!0}
 !opencl.ocl.version = !{!1}

--- a/test/transcoding/builtin_function_readnone_attr.ll
+++ b/test/transcoding/builtin_function_readnone_attr.ll
@@ -1,0 +1,55 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: Name [[#A:]] "a"
+; CHECK-SPIRV: Name [[#B:]] "b"
+; CHECK-SPIRV: Decorate [[#A]] FuncParamAttr 5
+; CHECK-SPIRV: Decorate [[#A]] FuncParamAttr 6
+; CHECK-SPIRV: Decorate [[#B]] FuncParamAttr 7
+
+; CHECK-LLVM: {{.*}}void @test_builtin_readnone(double* nocapture readonly %{{.*}}, double* nocapture readnone %{{.*}})
+
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: convergent nofree norecurse nounwind uwtable
+define dso_local spir_kernel void @test_builtin_readnone(double* nocapture readonly %a, double* nocapture readnone %b) local_unnamed_addr #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !4 !kernel_arg_type !5 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+entry:
+  %0 = load double, double* %a, align 8, !tbaa !7
+  %call = tail call double @_Z3expd(double %0) #2
+  store double %call, double* %b, align 8, !tbaa !7
+  %1 = load double, double* %a, align 8, !tbaa !7
+  %call1 = tail call double @_Z3cosd(double %1) #2
+  store double %call1, double* %b, align 8, !tbaa !7
+  ret void
+}
+
+; Function Attrs: convergent nounwind
+declare dso_local double @_Z3expd(double) local_unnamed_addr #1
+
+; Function Attrs: convergent nounwind
+declare dso_local double @_Z3cosd(double) local_unnamed_addr #1
+
+attributes #0 = { convergent nofree norecurse nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { convergent nounwind }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!llvm.ident = !{!2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}
+!2 = !{!"clang version 12.0.0 (https://github.com/intel/llvm 275e05b9dc13deb44eb7c765d23e65358d6bd077)"}
+!3 = !{i32 1, i32 1}
+!4 = !{!"none", !"none"}
+!5 = !{!"double*", !"double*"}
+!6 = !{!"", !""}
+!7 = !{!8, !8, i64 0}
+!8 = !{!"double", !9, i64 0}
+!9 = !{!"omnipotent char", !10, i64 0}
+!10 = !{!"Simple C/C++ TBAA"}

--- a/test/transcoding/builtin_function_readnone_attr.ll
+++ b/test/transcoding/builtin_function_readnone_attr.ll
@@ -28,17 +28,17 @@ entry:
   ret void
 }
 
-; Function Attrs: convergent nounwind
+; Function Attrs: convergent nounwind readnone
 ; CHECK-LLVM: declare{{.*}}@_Z3expd{{.*}}#[[#Attrs:]]
 declare dso_local double @_Z3expd(double) local_unnamed_addr #1
 
-; Function Attrs: convergent nounwind
+; Function Attrs: convergent nounwind readnone
 ; CHECK-LLVM: declare{{.*}}@_Z3cosd{{.*}}#[[#Attrs]]
 declare dso_local double @_Z3cosd(double) local_unnamed_addr #1
 
 attributes #0 = { convergent nofree norecurse nounwind uwtable "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "uniform-work-group-size"="false" "unsafe-fp-math"="false" "use-soft-float"="false" }
 ; CHECK-LLVM: attributes #[[#Attrs]] {{.*}} readnone
-attributes #1 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #1 = { convergent nounwind readnone "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { convergent nounwind readnone }
 
 !llvm.module.flags = !{!0}

--- a/test/transcoding/builtin_vars_arithmetics.ll
+++ b/test/transcoding/builtin_vars_arithmetics.ll
@@ -123,6 +123,8 @@ entry:
 
 attributes #0 = { norecurse "correctly-rounded-divide-sqrt-fp-math"="false" "disable-tail-calls"="false" "frame-pointer"="all" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="test.cpp" "uniform-work-group-size"="true" "unsafe-fp-math"="false" "use-soft-float"="false" }
 
+; CHECK-LLVM-OCL: attributes #1 = { nounwind willreturn }
+
 !llvm.module.flags = !{!0}
 !opencl.spir.version = !{!1}
 !spirv.Source = !{!2}

--- a/test/transcoding/isequal.ll
+++ b/test/transcoding/isequal.ll
@@ -29,15 +29,15 @@ entry:
   ret void
 }
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 declare spir_func i64 @_Z13get_global_idj(i32) #1
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 declare spir_func <8 x i32> @_Z7isequalDv8_fDv8_f(<8 x float>, <8 x float>) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
-attributes #2 = { nounwind readnone }
+attributes #1 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+attributes #2 = { nounwind }
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.spir.version = !{!6}

--- a/test/transcoding/unreachable.ll
+++ b/test/transcoding/unreachable.ll
@@ -30,11 +30,11 @@ define spir_kernel void @unreachable_simple(i32 addrspace(1)* nocapture %in, i32
   ret void
 }
 
-; Function Attrs: nounwind readnone
+; Function Attrs: nounwind
 declare spir_func i64 @_Z13get_global_idj(i32) #1
 
 attributes #0 = { nounwind }
-attributes #1 = { nounwind readnone }
+attributes #1 = { nounwind }
 
 !opencl.enable.FP_CONTRACT = !{}
 !spirv.Source = !{!6}


### PR DESCRIPTION
Community restricted readnone, readonly and writeonly attributes
to be only function parameter attributes. This patch aligns
the translator with llvm.org.

It also fixes a bug, when readnone attribute is being mapped
to NoWrite SPIR-V function parameter attribute.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>