### PR TITLE
Update alloca DebugInfo test

### DIFF
--- a/test/DebugInfo/X86/dbg-declare-alloca.ll
+++ b/test/DebugInfo/X86/dbg-declare-alloca.ll
@@ -27,7 +27,7 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: noinline nounwind uwtable
 define void @use_dbg_declare() #0 !dbg !7 {
 entry:
-  %o = alloca %struct.Foo, align 4
+  %o = alloca %struct.Foo, align 8
   call void @llvm.dbg.declare(metadata %struct.Foo* %o, metadata !10, metadata !15), !dbg !16
   call void @escape_foo(%struct.Foo* %o), !dbg !17
   ret void, !dbg !18


### PR DESCRIPTION
Update a test after llvm-project commit c65b4d64d4b0 ("[SelectionDAG] Do not second-guess alignment for alloca", 2023-02-09).