### PR TITLE
Fix potential pointer lifetime issue in the type scavenger.

### DIFF
--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -293,7 +293,7 @@ SPIRVTypeScavenger::computePointerElementType(Value *V) {
   }
 
   // Check if we've already deduced a type for the value.
-  DeducedType &Ty = DeducedTypes[V];
+  DeducedType Ty = DeducedTypes[V];
   if (Ty) {
     return Ty;
   }
@@ -402,6 +402,7 @@ SPIRVTypeScavenger::computePointerElementType(Value *V) {
     Ty = Deferred;
   }
 
+  DeducedTypes[V] = Ty;
   VisitStack.pop_back();
   return Ty;
 }


### PR DESCRIPTION
As computerPointerElementType is recursive, it's possible for the hash table to be resized during the call to the function. If this happens, then the reference to the value is no longer a valid reference, and may overwrite memory (or just plain segfault).