### PR TITLE
Fix FortranArray test

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -2,6 +2,7 @@
 #define SPIRV_DEBUG_H
 #include "SPIRVUtil.h"
 #include "spirv/unified1/spirv.hpp"
+#include "spirv_internal.hpp"
 #include "llvm/BinaryFormat/Dwarf.h"
 
 namespace SPIRVDebug {
@@ -806,6 +807,8 @@ inline spv::SourceLanguage convertDWARFSourceLangToSPIRV(dwarf::SourceLanguage D
   case dwarf::SourceLanguage::DW_LANG_C99:
   case dwarf::SourceLanguage::DW_LANG_OpenCL:
     return spv::SourceLanguage::SourceLanguageOpenCL_C;
+  case dwarf::SourceLanguage::DW_LANG_Fortran95:
+    return spv::internal::SourceLanguageFortran95;
   default:
     return spv::SourceLanguage::SourceLanguageUnknown;
   }
@@ -821,6 +824,8 @@ inline dwarf::SourceLanguage convertSPIRVSourceLangToDWARF(unsigned SourceLang) 
     // LLVM does not yet define DW_LANG_C_plus_plus_17
     // SourceLang = dwarf::SourceLanguage::DW_LANG_C_plus_plus_17;
     return dwarf::SourceLanguage::DW_LANG_C_plus_plus_14;
+  case spv::internal::SourceLanguageFortran95:
+    return dwarf::SourceLanguage::DW_LANG_Fortran95;
   case spv::SourceLanguage::SourceLanguageOpenCL_C:
   case spv::SourceLanguage::SourceLanguageESSL:
   case spv::SourceLanguage::SourceLanguageGLSL:

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -29,6 +29,10 @@
 namespace spv {
 namespace internal {
 
+enum InternalSourceLanguage {
+  ISourceLanguageFortran95 = 105,
+};
+
 enum InternalLinkageType {
   ILTPrev = LinkageTypeMax - 2,
   ILTInternal
@@ -127,6 +131,9 @@ _SPIRV_OP(Op, MaskedScatterINTEL)
 _SPIRV_OP(Capability, TensorFloat32ConversionINTEL)
 _SPIRV_OP(Op, ConvertFToTF32INTEL)
 #undef _SPIRV_OP
+
+constexpr SourceLanguage SourceLanguageFortran95 =
+    static_cast<SourceLanguage>(ISourceLanguageFortran95);
 
 constexpr Op OpForward = static_cast<Op>(IOpForward);
 constexpr Op OpTypeTokenINTEL = static_cast<Op>(IOpTypeTokenINTEL);

--- a/test/FortranArray.ll
+++ b/test/FortranArray.ll
@@ -1,15 +1,11 @@
 ; RUN: llvm-as %s -o %t.bc
 ; Translation shouldn't crash:
-; RUN: llvm-spirv %t.bc -spirv-text
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-allow-extra-diexpressions
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
-; XFAIL: *
-; The language ID is not preserved when translating from .ll to .spv
-; and back to .ll. This causes the LLVM IR verifier to fail as there
-; are different rules for valid DISubRange depending on language ID.
-
+; CHECK-LLVM: !DICompileUnit(language: DW_LANG_Fortran95
 ; CHECK-LLVM: !DISubrange(lowerBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 64, DW_OP_deref), upperBound: !DIExpression(DW_OP_push_object_address, DW_OP_plus_uconst, 64, DW_OP_deref, DW_OP_push_object_address, DW_OP_plus_uconst, 48, DW_OP_deref, DW_OP_plus, DW_OP_constu, 1, DW_OP_minus))
 
 source_filename = "llvm-link"


### PR DESCRIPTION
The test was originally XFAIL-ed in 9e234d9
The problem described in the comment is fixed by adding Fortran95 language.

Another problem was that DISubrange belongs to extended instruction set. Added the appropriate key to the RUN lines to make test passed.