### PR TITLE
[DebugInfo] Add an option for NonSemantic.Shader.DebugInfo.100

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -83,6 +83,7 @@ enum class FPContractMode : uint32_t { On, Off, Fast };
 enum class DebugInfoEIS : uint32_t {
   SPIRV_Debug,
   OpenCL_DebugInfo_100,
+  NonSemantic_Shader_DebugInfo_100,
   NonSemantic_Kernel_DebugInfo_100
 };
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -92,6 +92,8 @@ SPIRVExtInst *SPIRVToLLVMDbgTran::getDbgInst(const SPIRVId Id) {
     SPIRVExtInst *EI = static_cast<SPIRVExtInst *>(E);
     if (EI->getExtSetKind() == SPIRV::SPIRVEIS_Debug ||
         EI->getExtSetKind() == SPIRV::SPIRVEIS_OpenCL_DebugInfo_100 ||
+        EI->getExtSetKind() ==
+            SPIRV::SPIRVEIS_NonSemantic_Shader_DebugInfo_100 ||
         EI->getExtSetKind() == SPIRV::SPIRVEIS_NonSemantic_Kernel_DebugInfo_100)
       return EI;
   }

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -72,6 +72,8 @@ public:
     assert((DebugInst->getExtSetKind() == SPIRVEIS_Debug ||
             DebugInst->getExtSetKind() == SPIRVEIS_OpenCL_DebugInfo_100 ||
             DebugInst->getExtSetKind() ==
+                SPIRVEIS_NonSemantic_Shader_DebugInfo_100 ||
+            DebugInst->getExtSetKind() ==
                 SPIRVEIS_NonSemantic_Kernel_DebugInfo_100) &&
            "Unexpected extended instruction set");
     auto It = DebugInstCache.find(DebugInst);

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -78,6 +78,7 @@ enum SPIRVExtInstSetKind {
   SPIRVEIS_OpenCL,
   SPIRVEIS_Debug,
   SPIRVEIS_OpenCL_DebugInfo_100,
+  SPIRVEIS_NonSemantic_Shader_DebugInfo_100,
   SPIRVEIS_NonSemantic_Kernel_DebugInfo_100,
   SPIRVEIS_Count,
 };
@@ -130,6 +131,8 @@ template <> inline void SPIRVMap<SPIRVExtInstSetKind, std::string>::init() {
   add(SPIRVEIS_OpenCL, "OpenCL.std");
   add(SPIRVEIS_Debug, "SPIRV.debug");
   add(SPIRVEIS_OpenCL_DebugInfo_100, "OpenCL.DebugInfo.100");
+  add(SPIRVEIS_NonSemantic_Shader_DebugInfo_100,
+      "NonSemantic.Shader.DebugInfo.100");
   add(SPIRVEIS_NonSemantic_Kernel_DebugInfo_100,
       "NonSemantic.Kernel.DebugInfo.100");
 }

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -162,11 +162,15 @@ bool SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
     } else {
       if (Inst->isExtInst(SPIRVEIS_Debug, SPIRVDebug::Scope) ||
           Inst->isExtInst(SPIRVEIS_OpenCL_DebugInfo_100, SPIRVDebug::Scope) ||
+          Inst->isExtInst(SPIRVEIS_NonSemantic_Shader_DebugInfo_100,
+                          SPIRVDebug::Scope) ||
           Inst->isExtInst(SPIRVEIS_NonSemantic_Kernel_DebugInfo_100,
                           SPIRVDebug::Scope)) {
         DebugScope = Inst;
       } else if (Inst->isExtInst(SPIRVEIS_Debug, SPIRVDebug::NoScope) ||
                  Inst->isExtInst(SPIRVEIS_OpenCL_DebugInfo_100,
+                                 SPIRVDebug::NoScope) ||
+                 Inst->isExtInst(SPIRVEIS_NonSemantic_Shader_DebugInfo_100,
                                  SPIRVDebug::NoScope) ||
                  Inst->isExtInst(SPIRVEIS_NonSemantic_Kernel_DebugInfo_100,
                                  SPIRVDebug::NoScope)) {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1762,6 +1762,7 @@ public:
     ExtSetKind = Module->getBuiltinSet(ExtSetId);
     assert((ExtSetKind == SPIRVEIS_OpenCL || ExtSetKind == SPIRVEIS_Debug ||
             ExtSetKind == SPIRVEIS_OpenCL_DebugInfo_100 ||
+            ExtSetKind == SPIRVEIS_NonSemantic_Shader_DebugInfo_100 ||
             ExtSetKind == SPIRVEIS_NonSemantic_Kernel_DebugInfo_100) &&
            "not supported");
   }
@@ -1773,6 +1774,7 @@ public:
       break;
     case SPIRVEIS_Debug:
     case SPIRVEIS_OpenCL_DebugInfo_100:
+    case SPIRVEIS_NonSemantic_Shader_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Kernel_DebugInfo_100:
       getEncoder(O) << ExtOpDebug;
       break;
@@ -1791,6 +1793,7 @@ public:
       break;
     case SPIRVEIS_Debug:
     case SPIRVEIS_OpenCL_DebugInfo_100:
+    case SPIRVEIS_NonSemantic_Shader_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Kernel_DebugInfo_100:
       getDecoder(I) >> ExtOpDebug;
       break;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -643,6 +643,7 @@ void SPIRVModuleImpl::layoutEntry(SPIRVEntry *E) {
     SPIRVExtInst *EI = static_cast<SPIRVExtInst *>(E);
     if ((EI->getExtSetKind() == SPIRVEIS_Debug ||
          EI->getExtSetKind() == SPIRVEIS_OpenCL_DebugInfo_100 ||
+         EI->getExtSetKind() == SPIRVEIS_NonSemantic_Shader_DebugInfo_100 ||
          EI->getExtSetKind() == SPIRVEIS_NonSemantic_Kernel_DebugInfo_100) &&
         EI->getExtOp() != SPIRVDebug::Declare &&
         EI->getExtOp() != SPIRVDebug::Value &&

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -528,6 +528,8 @@ public:
       return SPIRVEIS_Debug;
     case DebugInfoEIS::OpenCL_DebugInfo_100:
       return SPIRVEIS_OpenCL_DebugInfo_100;
+    case DebugInfoEIS::NonSemantic_Shader_DebugInfo_100:
+      return SPIRVEIS_NonSemantic_Shader_DebugInfo_100;
     case DebugInfoEIS::NonSemantic_Kernel_DebugInfo_100:
       return SPIRVEIS_NonSemantic_Kernel_DebugInfo_100;
     }

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -230,6 +230,13 @@ static cl::opt<SPIRV::DebugInfoEIS> DebugEIS(
                    "extended instruction set. This version of SPIR-V debug "
                    "info format is compatible with the SPIRV-Tools"),
         clEnumValN(
+            SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_100,
+            "nonsemantic-shader-100",
+            "Emit debug info compliant with the "
+            "NonSemantic.Shader.DebugInfo.100 extended instruction set. This "
+            "version of SPIR-V debug info format is compatible with the rules "
+            "regarding non-semantic instruction sets."),
+        clEnumValN(
             SPIRV::DebugInfoEIS::NonSemantic_Kernel_DebugInfo_100,
             "nonsemantic-kernel-100",
             "Emit debug info compliant with the "


### PR DESCRIPTION
Under this option this extended instruction set will be implemented Spec:
https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc

TODO: to rename NonSemantic.Kernel.DebugInfo.100 to NonSemantic.Shader.DebugInfo.200 when the name is stable

Signed-off-by: Sidorov, Dmitry dmitry.sidorov@intel.com