### PR TITLE
[OpaquePointers] Fix translation of EnqueueKernel and block functions

### DIFF
--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -233,7 +233,8 @@ void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
 
   // The first non-sret argument of block_invoke functions is the block capture
   // struct, which should be passed as an i8*.
-  static Regex BlockInvokeRegex("^(__.+)?_block_invoke(_[0-9]+)?(_kernel)?$");
+  static const Regex BlockInvokeRegex(
+      "^(__.+)?_block_invoke(_[0-9]+)?(_kernel)?$");
   if (BlockInvokeRegex.match(F.getName())) {
     for (Argument *Arg : PointerArgs) {
       if (!Arg->hasAttribute(Attribute::StructRet)) {

--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -47,6 +47,7 @@
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/NoFolder.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/Support/Regex.h"
 
 #define DEBUG_TYPE "type-scavenger"
 
@@ -192,6 +193,10 @@ bool SPIRVTypeScavenger::typeIntrinsicCall(
     ArgTys.emplace_back(2, Type::getInt8Ty(Ctx));
   } else if (TargetFn->getName() == "__spirv_GetKernelNDrangeSubGroupCount__") {
     ArgTys.emplace_back(2, Type::getInt8Ty(Ctx));
+  } else if (TargetFn->getName().starts_with("__spirv_EnqueueKernel__")) {
+    ArgTys.emplace_back(4, TargetExtType::get(Ctx, "spirv.DeviceEvent"));
+    ArgTys.emplace_back(5, TargetExtType::get(Ctx, "spirv.DeviceEvent"));
+    ArgTys.emplace_back(7, Type::getInt8Ty(Ctx));
   } else
     return false;
 
@@ -224,6 +229,20 @@ void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
     Type *Ty = getParamType(F.getAttributes(), Arg->getArgNo());
     if (Ty)
       DeducedTypes[Arg] = Ty;
+  }
+
+  // The first non-sret argument of block_invoke functions is the block capture
+  // struct, which should be passed as an i8*.
+  static Regex BlockInvokeRegex("^(__.+)?_block_invoke(_[0-9]+)?(_kernel)?$");
+  if (BlockInvokeRegex.match(F.getName())) {
+    for (Argument *Arg : PointerArgs) {
+      if (!Arg->hasAttribute(Attribute::StructRet)) {
+        DeducedTypes[Arg] = Type::getInt8Ty(F.getContext());
+        LLVM_DEBUG(dbgs() << "Arg " << Arg->getArgNo() << " of " << F.getName()
+                          << " has type i8\n");
+        break;
+      }
+    }
   }
 
   // At this point, anything that we can get definitively correct is going to

--- a/test/transcoding/block_w_struct_return.cl
+++ b/test/transcoding/block_w_struct_return.cl
@@ -1,14 +1,14 @@
-// RUN: %clang_cc1 -triple spir -cl-std=cl2.0 -disable-llvm-passes -fdeclare-opencl-builtins -finclude-default-header %s -emit-llvm-bc -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 -triple spir -cl-std=cl2.0 -disable-llvm-passes -fdeclare-opencl-builtins -finclude-default-header %s -emit-llvm-bc -o %t.bc
 
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -opaque-pointers=0 -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_1,CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -opaque-pointers=0 -o %t.spirv1.1.spv
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_1,CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spirv1.1.spv
 // RUN: spirv-val --target-env spv1.1 %t.spirv1.1.spv
 // RUN: llvm-spirv -r -emit-opaque-pointers %t.spirv1.1.spv -o %t.rev.bc
 // RUN: llvm-dis %t.rev.bc
 // RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
-// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -opaque-pointers=0 -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_4,CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -opaque-pointers=0 -o %t.spirv1.4.spv
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_4,CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spirv1.4.spv
 // RUN: spirv-val --target-env spv1.4 %t.spirv1.4.spv
 // RUN: llvm-spirv -r -emit-opaque-pointers %t.spirv1.4.spv -o %t.rev.bc
 // RUN: llvm-dis %t.rev.bc
@@ -48,7 +48,7 @@ kernel void block_ret_struct(__global int* res)
 
 // CHECK-SPIRV: 4 Variable [[StructPtrTy]] [[StructArg:[0-9]+]] 7
 // CHECK-SPIRV: 4 Variable [[StructPtrTy]] [[StructRet:[0-9]+]] 7
-// CHECK-SPIRV: 4 PtrCastToGeneric [[Int8Ptr]] [[BlockLit:[0-9]+]] {{[0-9]+}}
+// CHECK-SPIRV: 4 Bitcast [[Int8Ptr]] [[BlockLit:[0-9]+]] {{[0-9]+}}
 // CHECK-SPIRV: 7 FunctionCall {{[0-9]+}} {{[0-9]+}} [[BlockInv]] [[StructRet]] [[BlockLit]] [[StructArg]]
 
 // CHECK-LLVM: %[[StructA:.*]] = type { i32 }

--- a/test/transcoding/global_block.cl
+++ b/test/transcoding/global_block.cl
@@ -3,15 +3,15 @@
 // block-specific instructions, which are redundant in SPIR-V and should be
 // removed
 
-// RUN: %clang_cc1 -O0 -triple spir-unknown-unknown -cl-std=CL2.0 -x cl %s -emit-llvm-bc -o %t.bc -no-opaque-pointers
+// RUN: %clang_cc1 -O0 -triple spir-unknown-unknown -cl-std=CL2.0 -x cl %s -emit-llvm-bc -o %t.bc
 
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -opaque-pointers=0 -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -opaque-pointers=0 -o %t.spirv1.1.spv
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spirv1.1.spv
 // RUN: spirv-val --target-env spv1.1 %t.spirv1.1.spv
 // RUN: llvm-spirv -r -emit-opaque-pointers %t.spirv1.1.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
-// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -opaque-pointers=0 -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_4,CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -opaque-pointers=0 -o %t.spirv1.4.spv
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_4,CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spirv1.4.spv
 // RUN: spirv-val --target-env spv1.4 %t.spirv1.4.spv
 // RUN: llvm-spirv -r -emit-opaque-pointers %t.spirv1.4.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 


### PR DESCRIPTION
This specifies the right parameter types for EnqueueKernel and for block
functions (with mangled names of the form {__*,}_block_invoke{_*,}{_kernel,}),
so that SPIR-V code is generated for these as expected. This fixes a
crash in the Intel OpenCL CPU backend, and likely other SPIR-V
consumers.