### PR TITLE
[NFC] Add NOLINTNEXTLINE for static_cast

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -270,6 +270,7 @@ public:
 
   bool exist(SPIRVId) const;
   template <class T> T *get(SPIRVId TheId) const {
+    // NOLINTNEXTLINE
     return static_cast<T *>(getEntry(TheId));
   }
   SPIRVEntry *getEntry(SPIRVId) const;

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1690,6 +1690,7 @@ public:
   SPIRVFunctionCall(SPIRVId TheId, SPIRVFunction *TheFunction,
                     const std::vector<SPIRVWord> &TheArgs, SPIRVBasicBlock *BB);
   SPIRVFunctionCall() : FunctionId(SPIRVID_INVALID) {}
+  // NOLINTNEXTLINE
   SPIRVFunction *getFunction() const { return get<SPIRVFunction>(FunctionId); }
   _SPIRV_DEF_ENCDEC4(Type, Id, FunctionId, Args)
   void validate() const override;

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1690,7 +1690,6 @@ public:
   SPIRVFunctionCall(SPIRVId TheId, SPIRVFunction *TheFunction,
                     const std::vector<SPIRVWord> &TheArgs, SPIRVBasicBlock *BB);
   SPIRVFunctionCall() : FunctionId(SPIRVID_INVALID) {}
-  // NOLINTNEXTLINE
   SPIRVFunction *getFunction() const { return get<SPIRVFunction>(FunctionId); }
   _SPIRV_DEF_ENCDEC4(Type, Id, FunctionId, Args)
   void validate() const override;


### PR DESCRIPTION
Despite multiple inheritance static_cast from 'SPIRVEntry *' to 'SPIRVFunction *' should be safe. Replacing static_cast with dynamic_cast would be even safer, but it would add extra runtime overhead. So add ignore this clang-tidy check.