### PR TITLE
Fix standalone builds with LLVM_LINK_LLVM_DYLIB=ON

### DIFF
--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -38,42 +38,23 @@ set(SRC_LIST
   libSPIRV/SPIRVType.cpp
   libSPIRV/SPIRVValue.cpp
 )
-if(LLVM_LINK_LLVM_DYLIB)
-  add_llvm_library(LLVMSPIRVLib STATIC DISABLE_LLVM_LINK_LLVM_DYLIB
-    ${SRC_LIST}
-    DEPENDS
-      intrinsics_gen
-      LLVMAnalysis
-      LLVMBitWriter
-      LLVMCodeGen
-      LLVMCore
-      LLVMDemangle
-      LLVMIRReader
-      LLVMLinker
-      LLVMPasses
-      LLVMSupport
-      LLVMTargetParser
-      LLVMTransformUtils
-  )
-else()
-  add_llvm_library(LLVMSPIRVLib
-    ${SRC_LIST}
-    LINK_COMPONENTS
-      Analysis
-      BitWriter
-      CodeGen
-      Core
-      Demangle
-      IRReader
-      Linker
-      Passes
-      Support
-      TargetParser
-      TransformUtils
+add_llvm_library(LLVMSPIRVLib
+  ${SRC_LIST}
+  LINK_COMPONENTS
+    Analysis
+    BitWriter
+    CodeGen
+    Core
+    Demangle
+    IRReader
+    Linker
+    Passes
+    Support
+    TargetParser
+    TransformUtils
   DEPENDS
     intrinsics_gen
   )
-endif()
 
 target_include_directories(LLVMSPIRVLib
   PRIVATE


### PR DESCRIPTION
Move the LLVM components to LINK_COMPONENTS because the DEPENDS list has the same semantics as add_dependencies(). In this
case it doesn't include the LLVM components when calling the linker.

It's almost complete revert of https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1543