### PR TITLE
[NFC][DebugInfo] Align Instruction names to the specification

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -344,7 +344,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgEntryImpl(const MDNode *MDN) {
 
     // Compilation unit
     case dwarf::DW_TAG_compile_unit:
-      return transDbgCompilationUnit(cast<DICompileUnit>(DIEntry));
+      return transDbgCompileUnit(cast<DICompileUnit>(DIEntry));
 
     // Templates
     case dwarf::DW_TAG_template_type_parameter:
@@ -539,8 +539,7 @@ SPIRVId LLVMToSPIRVDbgTran::getDebugInfoNoneId() {
 
 // Compilation unit
 
-SPIRVEntry *
-LLVMToSPIRVDbgTran::transDbgCompilationUnit(const DICompileUnit *CU) {
+SPIRVEntry *LLVMToSPIRVDbgTran::transDbgCompileUnit(const DICompileUnit *CU) {
   using namespace SPIRVDebug::Operand::CompilationUnit;
   SPIRVWordVec Ops(OperandCount);
   Ops[SPIRVDebugInfoVersionIdx] = SPIRVDebug::DebugInfoVersion;
@@ -977,7 +976,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgInheritance(const DIDerivedType *DT) {
   Ops[FlagsIdx] = transDebugFlags(DT);
   if (isNonSemanticDebugInfo())
     transformToConstant(Ops, {FlagsIdx});
-  return BM->addDebugInfo(SPIRVDebug::Inheritance, getVoidTy(), Ops);
+  return BM->addDebugInfo(SPIRVDebug::TypeInheritance, getVoidTy(), Ops);
 }
 
 SPIRVEntry *LLVMToSPIRVDbgTran::transDbgPtrToMember(const DIDerivedType *DT) {
@@ -992,7 +991,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgPtrToMember(const DIDerivedType *DT) {
 SPIRVEntry *
 LLVMToSPIRVDbgTran::transDbgTemplateParams(DITemplateParameterArray TPA,
                                            const SPIRVEntry *Target) {
-  using namespace SPIRVDebug::Operand::Template;
+  using namespace SPIRVDebug::Operand::TypeTemplate;
   SPIRVWordVec Ops(MinOperandCount);
   Ops[TargetIdx] = Target->getId();
   for (DITemplateParameter *TP : TPA) {
@@ -1003,7 +1002,7 @@ LLVMToSPIRVDbgTran::transDbgTemplateParams(DITemplateParameterArray TPA,
 
 SPIRVEntry *
 LLVMToSPIRVDbgTran::transDbgTemplateParameter(const DITemplateParameter *TP) {
-  using namespace SPIRVDebug::Operand::TemplateParameter;
+  using namespace SPIRVDebug::Operand::TypeTemplateParameter;
   SPIRVWordVec Ops(OperandCount);
   Ops[NameIdx] = BM->getString(TP->getName().str())->getId();
   Ops[TypeIdx] = transDbgEntry(TP->getType())->getId();
@@ -1023,7 +1022,7 @@ LLVMToSPIRVDbgTran::transDbgTemplateParameter(const DITemplateParameter *TP) {
 
 SPIRVEntry *LLVMToSPIRVDbgTran::transDbgTemplateTemplateParameter(
     const DITemplateValueParameter *TVP) {
-  using namespace SPIRVDebug::Operand::TemplateTemplateParameter;
+  using namespace SPIRVDebug::Operand::TypeTemplateTemplateParameter;
   SPIRVWordVec Ops(OperandCount);
   assert(isa<MDString>(TVP->getValue()));
   MDString *Val = cast<MDString>(TVP->getValue());
@@ -1040,7 +1039,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgTemplateTemplateParameter(
 
 SPIRVEntry *LLVMToSPIRVDbgTran::transDbgTemplateParameterPack(
     const DITemplateValueParameter *TVP) {
-  using namespace SPIRVDebug::Operand::TemplateParameterPack;
+  using namespace SPIRVDebug::Operand::TypeTemplateParameterPack;
   SPIRVWordVec Ops(MinOperandCount);
   assert(isa<MDNode>(TVP->getValue()));
   MDNode *Params = cast<MDNode>(TVP->getValue());
@@ -1120,7 +1119,8 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgFunction(const DISubprogram *Func) {
 
   SPIRVEntry *DebugFunc = nullptr;
   if (!Func->isDefinition()) {
-    DebugFunc = BM->addDebugInfo(SPIRVDebug::FunctionDecl, getVoidTy(), Ops);
+    DebugFunc =
+        BM->addDebugInfo(SPIRVDebug::FunctionDeclaration, getVoidTy(), Ops);
   } else {
     // Here we add operands specific function definition
     using namespace SPIRVDebug::Operand::Function;

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -99,7 +99,7 @@ private:
   SPIRVId getDebugInfoNoneId();
 
   // Compilation unit
-  SPIRVEntry *transDbgCompilationUnit(const DICompileUnit *CU);
+  SPIRVEntry *transDbgCompileUnit(const DICompileUnit *CU);
 
   /// The following methods (till the end of the file) implement translation
   /// of debug instrtuctions described in the spec.

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -149,7 +149,7 @@ DIScope *SPIRVToLLVMDbgTran::getScope(const SPIRVEntry *ScopeInst) {
 }
 
 DICompileUnit *
-SPIRVToLLVMDbgTran::transCompileUnit(const SPIRVExtInst *DebugInst) {
+SPIRVToLLVMDbgTran::transCompilationUnit(const SPIRVExtInst *DebugInst) {
   const SPIRVWordVec &Ops = DebugInst->getArguments();
 
   using namespace SPIRVDebug::Operand::CompilationUnit;
@@ -736,9 +736,10 @@ DINode *SPIRVToLLVMDbgTran::transFunction(const SPIRVExtInst *DebugInst) {
 
   // Here we create fake array of template parameters. If it was plain nullptr,
   // the template parameter operand would be removed in DISubprogram::getImpl.
-  // But we want it to be there, because if there is DebugTemplate instruction
-  // refering to this function, TransTemplate method must be able to replace the
-  // template parameter operand, thus it must be in the operands list.
+  // But we want it to be there, because if there is DebugTypeTemplate
+  // instruction refering to this function, transTypeTemplate method must be
+  // able to replace the template parameter operand, thus it must be in the
+  // operands list.
   SmallVector<llvm::Metadata *, 8> Elts;
   DINodeArray TParams = Builder.getOrCreateArray(Elts);
   llvm::DITemplateParameterArray TParamsArray = TParams.get();
@@ -815,9 +816,10 @@ DINode *SPIRVToLLVMDbgTran::transFunctionDecl(const SPIRVExtInst *DebugInst) {
 
   // Here we create fake array of template parameters. If it was plain nullptr,
   // the template parameter operand would be removed in DISubprogram::getImpl.
-  // But we want it to be there, because if there is DebugTemplate instruction
-  // refering to this function, TransTemplate method must be able to replace the
-  // template parameter operand, thus it must be in the operands list.
+  // But we want it to be there, because if there is DebugTypeTemplate
+  // instruction refering to this function, transTypeTemplate method must be
+  // able to replace the template parameter operand, thus it must be in the
+  // operands list.
   SmallVector<llvm::Metadata *, 8> Elts;
   DINodeArray TParams = Builder.getOrCreateArray(Elts);
   llvm::DITemplateParameterArray TParamsArray = TParams.get();
@@ -931,7 +933,8 @@ DINode *SPIRVToLLVMDbgTran::transTypedef(const SPIRVExtInst *DebugInst) {
   return Builder.createTypedef(Ty, Alias, File, LineNo, Scope);
 }
 
-DINode *SPIRVToLLVMDbgTran::transInheritance(const SPIRVExtInst *DebugInst) {
+DINode *
+SPIRVToLLVMDbgTran::transTypeInheritance(const SPIRVExtInst *DebugInst) {
   using namespace SPIRVDebug::Operand::TypeInheritance;
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= OperandCount && "Invalid number of operands");
@@ -952,8 +955,8 @@ DINode *SPIRVToLLVMDbgTran::transInheritance(const SPIRVExtInst *DebugInst) {
 }
 
 DINode *
-SPIRVToLLVMDbgTran::transTemplateParameter(const SPIRVExtInst *DebugInst) {
-  using namespace SPIRVDebug::Operand::TemplateParameter;
+SPIRVToLLVMDbgTran::transTypeTemplateParameter(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeTemplateParameter;
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= OperandCount && "Invalid number of operands");
   StringRef Name = getString(Ops[NameIdx]);
@@ -971,9 +974,9 @@ SPIRVToLLVMDbgTran::transTemplateParameter(const SPIRVExtInst *DebugInst) {
   return Builder.createTemplateTypeParameter(Context, Name, Ty, false);
 }
 
-DINode *SPIRVToLLVMDbgTran::transTemplateTemplateParameter(
+DINode *SPIRVToLLVMDbgTran::transTypeTemplateTemplateParameter(
     const SPIRVExtInst *DebugInst) {
-  using namespace SPIRVDebug::Operand::TemplateTemplateParameter;
+  using namespace SPIRVDebug::Operand::TypeTemplateTemplateParameter;
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= OperandCount && "Invalid number of operands");
   StringRef Name = getString(Ops[NameIdx]);
@@ -983,9 +986,9 @@ DINode *SPIRVToLLVMDbgTran::transTemplateTemplateParameter(
                                                  TemplName);
 }
 
-DINode *
-SPIRVToLLVMDbgTran::transTemplateParameterPack(const SPIRVExtInst *DebugInst) {
-  using namespace SPIRVDebug::Operand::TemplateParameterPack;
+DINode *SPIRVToLLVMDbgTran::transTypeTemplateParameterPack(
+    const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeTemplateParameterPack;
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
   StringRef Name = getString(Ops[NameIdx]);
@@ -998,8 +1001,8 @@ SPIRVToLLVMDbgTran::transTemplateParameterPack(const SPIRVExtInst *DebugInst) {
   return Builder.createTemplateParameterPack(Context, Name, nullptr, Pack);
 }
 
-MDNode *SPIRVToLLVMDbgTran::transTemplate(const SPIRVExtInst *DebugInst) {
-  using namespace SPIRVDebug::Operand::Template;
+MDNode *SPIRVToLLVMDbgTran::transTypeTemplate(const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::TypeTemplate;
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   const size_t NumOps = Ops.size();
   assert(NumOps >= MinOperandCount && "Invalid number of operands");
@@ -1103,7 +1106,7 @@ MDNode *SPIRVToLLVMDbgTran::transDebugInstImpl(const SPIRVExtInst *DebugInst) {
     return nullptr;
 
   case SPIRVDebug::CompilationUnit:
-    return transCompileUnit(DebugInst);
+    return transCompilationUnit(DebugInst);
 
   case SPIRVDebug::TypeBasic:
     return transTypeBasic(DebugInst);
@@ -1150,7 +1153,7 @@ MDNode *SPIRVToLLVMDbgTran::transDebugInstImpl(const SPIRVExtInst *DebugInst) {
   case SPIRVDebug::Function:
     return transFunction(DebugInst);
 
-  case SPIRVDebug::FunctionDecl:
+  case SPIRVDebug::FunctionDeclaration:
     return transFunctionDecl(DebugInst);
 
   case SPIRVDebug::GlobalVariable:
@@ -1165,20 +1168,20 @@ MDNode *SPIRVToLLVMDbgTran::transDebugInstImpl(const SPIRVExtInst *DebugInst) {
   case SPIRVDebug::InlinedAt:
     return transDebugInlined(DebugInst);
 
-  case SPIRVDebug::Inheritance:
-    return transInheritance(DebugInst);
+  case SPIRVDebug::TypeInheritance:
+    return transTypeInheritance(DebugInst);
 
   case SPIRVDebug::TypeTemplateParameter:
-    return transTemplateParameter(DebugInst);
+    return transTypeTemplateParameter(DebugInst);
 
   case SPIRVDebug::TypeTemplateTemplateParameter:
-    return transTemplateTemplateParameter(DebugInst);
+    return transTypeTemplateTemplateParameter(DebugInst);
 
   case SPIRVDebug::TypeTemplateParameterPack:
-    return transTemplateParameterPack(DebugInst);
+    return transTypeTemplateParameterPack(DebugInst);
 
   case SPIRVDebug::TypeTemplate:
-    return transTemplate(DebugInst);
+    return transTypeTemplate(DebugInst);
 
   case SPIRVDebug::ImportedEntity:
     return transImportedEntry(DebugInst);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -103,7 +103,7 @@ private:
 
   MDNode *transDebugInlined(const SPIRVExtInst *Inst);
 
-  DICompileUnit *transCompileUnit(const SPIRVExtInst *DebugInst);
+  DICompileUnit *transCompilationUnit(const SPIRVExtInst *DebugInst);
 
   DIBasicType *transTypeBasic(const SPIRVExtInst *DebugInst);
 
@@ -128,11 +128,11 @@ private:
 
   DINode *transTypeEnum(const SPIRVExtInst *DebugInst);
 
-  DINode *transTemplateParameter(const SPIRVExtInst *DebugInst);
-  DINode *transTemplateTemplateParameter(const SPIRVExtInst *DebugInst);
-  DINode *transTemplateParameterPack(const SPIRVExtInst *DebugInst);
+  DINode *transTypeTemplateParameter(const SPIRVExtInst *DebugInst);
+  DINode *transTypeTemplateTemplateParameter(const SPIRVExtInst *DebugInst);
+  DINode *transTypeTemplateParameterPack(const SPIRVExtInst *DebugInst);
 
-  MDNode *transTemplate(const SPIRVExtInst *DebugInst);
+  MDNode *transTypeTemplate(const SPIRVExtInst *DebugInst);
 
   DINode *transTypeFunction(const SPIRVExtInst *DebugInst);
 
@@ -151,7 +151,7 @@ private:
 
   DINode *transTypedef(const SPIRVExtInst *DebugInst);
 
-  DINode *transInheritance(const SPIRVExtInst *DebugInst);
+  DINode *transTypeInheritance(const SPIRVExtInst *DebugInst);
 
   DINode *transImportedEntry(const SPIRVExtInst *DebugInst);
 

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -26,14 +26,14 @@ enum Instruction {
   TypeEnum                      = 9,
   TypeComposite                 = 10,
   TypeMember                    = 11,
-  Inheritance                   = 12,
+  TypeInheritance               = 12,
   TypePtrToMember               = 13,
   TypeTemplate                  = 14,
   TypeTemplateParameter         = 15,
   TypeTemplateParameterPack     = 16,
   TypeTemplateTemplateParameter = 17,
   GlobalVariable                = 18,
-  FunctionDecl                  = 19,
+  FunctionDeclaration           = 19,
   Function                      = 20,
   LexicalBlock                  = 21,
   LexicalBlockDiscriminator     = 22,
@@ -456,7 +456,7 @@ enum {
 };
 }
 
-namespace Template {
+namespace TypeTemplate {
 enum {
   TargetIdx         = 0,
   FirstParameterIdx = 1,
@@ -464,7 +464,7 @@ enum {
 };
 }
 
-namespace TemplateParameter {
+namespace TypeTemplateParameter {
 enum {
   NameIdx      = 0,
   TypeIdx      = 1,
@@ -476,7 +476,7 @@ enum {
 };
 }
 
-namespace TemplateTemplateParameter {
+namespace TypeTemplateTemplateParameter {
 enum {
   NameIdx         = 0,
   TemplateNameIdx = 1,
@@ -487,7 +487,7 @@ enum {
 };
 }
 
-namespace TemplateParameterPack {
+namespace TypeTemplateParameterPack {
 enum {
   NameIdx           = 0,
   SourceIdx         = 1,

--- a/lib/SPIRV/libSPIRV/SPIRVExtInst.h
+++ b/lib/SPIRV/libSPIRV/SPIRVExtInst.h
@@ -221,7 +221,7 @@ SPIRV_DEF_NAMEMAP(OCLExtOpKind, OCLExtOpMap)
 typedef SPIRVDebug::Instruction SPIRVDebugExtOpKind;
 template <> inline void SPIRVMap<SPIRVDebugExtOpKind, std::string>::init() {
   add(SPIRVDebug::DebugInfoNone, "DebugInfoNone");
-  add(SPIRVDebug::CompilationUnit, "DebugCompileUnit");
+  add(SPIRVDebug::CompilationUnit, "DebugCompilationUnit");
   add(SPIRVDebug::Source, "DebugSource");
   add(SPIRVDebug::TypeBasic, "DebugTypeBasic");
   add(SPIRVDebug::TypePointer, "DebugTypePointer");
@@ -234,19 +234,19 @@ template <> inline void SPIRVMap<SPIRVDebugExtOpKind, std::string>::init() {
   add(SPIRVDebug::TypeMember, "DebugTypeMember");
   add(SPIRVDebug::TypeEnum, "DebugTypeEnum");
   add(SPIRVDebug::Typedef, "DebugTypedef");
-  add(SPIRVDebug::TypeTemplateParameter, "DebugTemplateParameter");
-  add(SPIRVDebug::TypeTemplateParameterPack, "DebugTemplateParameterPack");
+  add(SPIRVDebug::TypeTemplateParameter, "DebugTypeTemplateParameter");
+  add(SPIRVDebug::TypeTemplateParameterPack, "DebugTypeTemplateParameterPack");
   add(SPIRVDebug::TypeTemplateTemplateParameter,
-      "DebugTemplateTemplateParameter");
-  add(SPIRVDebug::TypeTemplate, "DebugTemplate");
+      "DebugTypeTemplateTemplateParameter");
+  add(SPIRVDebug::TypeTemplate, "DebugTypeTemplate");
   add(SPIRVDebug::TypePtrToMember, "DebugTypePtrToMember,");
   add(SPIRVDebug::TypeSubrange, "DebugTypeSubrange");
   add(SPIRVDebug::TypeString, "DebugTypeString");
-  add(SPIRVDebug::Inheritance, "DebugInheritance");
+  add(SPIRVDebug::TypeInheritance, "DebugTypeInheritance");
   add(SPIRVDebug::Function, "DebugFunction");
-  add(SPIRVDebug::FunctionDecl, "DebugFunctionDecl");
+  add(SPIRVDebug::FunctionDeclaration, "DebugFunctionDeclaration");
   add(SPIRVDebug::LexicalBlock, "DebugLexicalBlock");
-  add(SPIRVDebug::LexicalBlockDiscriminator, "LexicalBlockDiscriminator");
+  add(SPIRVDebug::LexicalBlockDiscriminator, "DebugLexicalBlockDiscriminator");
   add(SPIRVDebug::LocalVariable, "DebugLocalVariable");
   add(SPIRVDebug::InlinedVariable, "DebugInlinedVariable");
   add(SPIRVDebug::GlobalVariable, "DebugGlobalVariable");

--- a/test/DebugInfo/DebugFunction.cl
+++ b/test/DebugInfo/DebugFunction.cl
@@ -1,8 +1,8 @@
 // Check for 2 things:
 // - After round trip translation function definition has !dbg metadata attached
 //   specifically if -gline-tables-only was used for Clang
-// - Parent operand of DebugFunction is DebugCompileUnit, not an OpString, even
-//   if in LLVM IR it points to a DIFile instead of DICompileUnit.
+// - Parent operand of DebugFunction is DebugCompilationUnit, not an OpString,
+//   even if in LLVM IR it points to a DIFile instead of DICompileUnit.
 
 // RUN: %clang_cc1 %s -cl-std=clc++ -emit-llvm-bc -triple spir -debug-info-kind=line-tables-only -O0 -o - | llvm-spirv -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
@@ -17,7 +17,7 @@ void kernel k() {
 
 // CHECK-SPIRV: String [[foo:[0-9]+]] "foo"
 // CHECK-SPIRV: String [[k:[0-9]+]] "k"
-// CHECK-SPIRV: [[CU:[0-9]+]] {{[0-9]+}} DebugCompileUnit
+// CHECK-SPIRV: [[CU:[0-9]+]] {{[0-9]+}} DebugCompilationUnit
 // CHECK-SPIRV: DebugFunction [[foo]] {{.*}} [[CU]] {{.*}} [[foo_id:[0-9]+]] {{[0-9]+}} {{$}}
 // CHECK-SPIRV: DebugFunction [[k]] {{.*}} [[CU]] {{.*}} [[k_id:[0-9]+]] {{[0-9]+}} {{$}}
 

--- a/test/DebugInfo/DebugInfoSubrangeWithOnlyCount.spt
+++ b/test/DebugInfo/DebugInfoSubrangeWithOnlyCount.spt
@@ -56,14 +56,14 @@
 
 5 ExtInst 3 27 2 DebugInfoNone 
 7 ExtInst 3 30 2 DebugSource 29 27 
-9 ExtInst 3 31 2 DebugCompileUnit 65536 4 30 21
+9 ExtInst 3 31 2 DebugCompilationUnit 65536 4 30 21
 7 ExtInst 3 32 2 DebugTypeFunction 0 27 
 8 ExtInst 3 35 2 DebugTypeBasic 33 34 3 
 7 ExtInst 3 36 2 DebugTypeArray 35 11 ; Count = 1000
 8 ExtInst 3 37 2 DebugTypePointer 36 4294967295 0 
 16 ExtInst 3 40 2 DebugFunction 38 32 30 25 0 31 39 44 25 27 27 
 12 ExtInst 3 42 2 DebugLocalVariable 41 37 30 15 0 40 0 
-6 ExtInst 3 43 2 DebugTemplate 40 
+6 ExtInst 3 43 2 DebugTypeTemplate 40
 6 ExtInst 3 44 2 DebugOperation 0 
 6 ExtInst 3 45 2 DebugExpression 44 
 

--- a/test/DebugInfo/Generic/tu-member-opaque.spvasm
+++ b/test/DebugInfo/Generic/tu-member-opaque.spvasm
@@ -52,7 +52,7 @@
 
 5 ExtInst 3 7 2 DebugInfoNone
 7 ExtInst 3 10 2 DebugSource 9 7
-9 ExtInst 3 11 2 DebugCompileUnit 65536 0 10 12
+9 ExtInst 3 11 2 DebugCompilationUnit 65536 0 10 12
 7 ExtInst 3 12 2 DebugTypeFunction 0 7
 7 ExtInst 3 16 2 DebugSource 15 7
 8 ExtInst 3 21 2 DebugTypeBasic 20 18 4

--- a/test/DebugInfo/NonSemantic/DebugFunction.cl
+++ b/test/DebugInfo/NonSemantic/DebugFunction.cl
@@ -1,8 +1,8 @@
 // Check for 2 things:
 // - After round trip translation function definition has !dbg metadata attached
 //   specifically if -gline-tables-only was used for Clang
-// - Parent operand of DebugFunction is DebugCompileUnit, not an OpString, even
-//   if in LLVM IR it points to a DIFile instead of DICompileUnit.
+// - Parent operand of DebugFunction is DebugCompilationUnit, not an OpString,
+//   even if in LLVM IR it points to a DIFile instead of DICompileUnit.
 
 // RUN: %clang_cc1 %s -cl-std=clc++ -emit-llvm-bc -triple spir -debug-info-kind=line-tables-only -O0 -o - | llvm-spirv -o %t.spv
 // RUN: llvm-spirv %t.spv --spirv-debug-info-version=nonsemantic-shader-100 -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
@@ -17,7 +17,7 @@ void kernel k() {
 
 // CHECK-SPIRV: String [[foo:[0-9]+]] "foo"
 // CHECK-SPIRV: String [[k:[0-9]+]] "k"
-// CHECK-SPIRV: [[CU:[0-9]+]] {{[0-9]+}} DebugCompileUnit
+// CHECK-SPIRV: [[CU:[0-9]+]] {{[0-9]+}} DebugCompilationUnit
 // CHECK-SPIRV: DebugFunction [[foo]] {{.*}} [[CU]] {{.*}} [[foo_id:[0-9]+]] {{[0-9]+}} {{$}}
 // CHECK-SPIRV: DebugFunction [[k]] {{.*}} [[CU]] {{.*}} [[k_id:[0-9]+]] {{[0-9]+}} {{$}}
 

--- a/test/DebugInfo/NonSemantic/Shader200/DIModule.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DIModule.ll
@@ -34,7 +34,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV-DAG: Constant [[#TypeInt32]] [[#DWARF:]] 4
 
 ; CHECK-SPIRV: ExtInst [[#]] [[#Source:]] [[#]] DebugSource [[#FileName]]
-; CHECK-SPIRV: ExtInst [[#]] [[#Parent:]] [[#]] DebugCompileUnit [[#Version]] [[#DWARF]]
+; CHECK-SPIRV: ExtInst [[#]] [[#Parent:]] [[#]] DebugCompilationUnit [[#Version]] [[#DWARF]]
 ; CHECK-SPIRV: ExtInst [[#]] [[#SourceEmpty:]] [[#]] DebugSource [[#EmptyStr]]
 ; CHECK-SPIRV: ExtInst [[#]] [[#Module:]] [[#]] DebugModule [[#Name]] [[#SourceEmpty]] [[#Constant0]] [[#Parent]] [[#Defines]] [[#IncludePath]] [[#ApiNotes]] [[#Constant0]]
 ; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] DebugImportedEntity [[#]] [[#]] [[#]] [[#Source]] [[#Module]]

--- a/test/DebugInfo/NonSemantic/Shader200/DebugInfoSubrange.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugInfoSubrange.ll
@@ -16,8 +16,8 @@
 ; CHECK-SPIRV: [[#DINoneId:]] [[#EISId]] DebugInfoNone
 
 ; CHECK-SPIRV: [[#DebugFuncId:]] [[#EISId]] DebugFunction
-; CHECK-SPIRV: [[#DebugTemplate:]] [[#EISId]] DebugTemplate [[#DebugFuncId]]
-; CHECK-SPIRV: [[#LocalVarId:]] [[#EISId]] DebugLocalVariable [[#LocalVarNameId]] [[#]] [[#]] [[#]] [[#]] [[#DebugTemplate]]
+; CHECK-SPIRV: [[#DebugTypeTemplate:]] [[#EISId]] DebugTypeTemplate [[#DebugFuncId]]
+; CHECK-SPIRV: [[#LocalVarId:]] [[#EISId]] DebugLocalVariable [[#LocalVarNameId]] [[#]] [[#]] [[#]] [[#]] [[#DebugTypeTemplate]]
 ; CHECK-SPIRV: [[#EISId]] DebugTypeSubrange [[#DINoneId]] [[#Constant1Id]] [[#LocalVarId]]  [[#DINoneId]]
 
 ; CHECK-SPIRV: [[#DIExprId:]] [[#EISId]] DebugExpression

--- a/test/DebugInfo/NonSemantic/Shader200/SourceLanguageLLVMToSPIRV.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/SourceLanguageLLVMToSPIRV.ll
@@ -17,15 +17,15 @@
 ; RUN: llvm-spirv --spirv-debug-info-version=nonsemantic-shader-200 -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-CPP17
 
 ; CHECK-C99: Constant [[#]] [[#Constant:]] 211
-; CHECK-C99: DebugCompileUnit [[#]] [[#]] [[#]] [[#Constant]]
+; CHECK-C99: DebugCompilationUnit [[#]] [[#]] [[#]] [[#Constant]]
 ; CHECK-OPENCLC: Constant [[#]] [[#Constant:]] 3
-; CHECK-OPENCLC: DebugCompileUnit [[#]] [[#]] [[#]] [[#Constant]]
+; CHECK-OPENCLC: DebugCompilationUnit [[#]] [[#]] [[#]] [[#Constant]]
 ; CHECK-CPP: Constant [[#]] [[#Constant:]] 214
-; CHECK-CPP: DebugCompileUnit [[#]] [[#]] [[#]] [[#Constant]]
+; CHECK-CPP: DebugCompilationUnit [[#]] [[#]] [[#]] [[#Constant]]
 ; CHECK-CPP14: Constant [[#]] [[#Constant:]] 217
-; CHECK-CPP14: DebugCompileUnit [[#]] [[#]] [[#]] [[#Constant]]
+; CHECK-CPP14: DebugCompilationUnit [[#]] [[#]] [[#]] [[#Constant]]
 ; CHECK-CPP17: Constant [[#]] [[#Constant:]] 218
-; CHECK-CPP17: DebugCompileUnit [[#]] [[#]] [[#]] [[#Constant]]
+; CHECK-CPP17: DebugCompilationUnit [[#]] [[#]] [[#]] [[#Constant]]
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"

--- a/test/DebugInfo/OpenCL100/DebugInfoSubrange.ll
+++ b/test/DebugInfo/OpenCL100/DebugInfoSubrange.ll
@@ -14,7 +14,7 @@
 ; CHECK-SPIRV: Constant [[#TypeInt64Id]] [[#NegativeCount:]] 4294967295 4294967295
 
 ; CHECK-SPIRV: [[#DbgFuncId:]] [[#]] DebugFunction [[#FuncNameId]]
-; CHECK-SPIRV: [[#DbgTemplateId:]] [[#]] DebugTemplate [[#DbgFuncId]]
+; CHECK-SPIRV: [[#DbgTemplateId:]] [[#]] DebugTypeTemplate [[#DbgFuncId]]
 ; CHECK-SPIRV: [[#]] [[#DbgLocVarId:]] [[#]] DebugLocalVariable [[#VarNameId]] [[#]] [[#]] [[#]] [[#]] [[#DbgTemplateId]]
 ; CHECK-SPIRV: DebugTypeArray [[#]] [[#DbgLocVarId]] [[#LowerBoundId]]
 

--- a/test/DebugInfo/SourceLanguageLLVMToSPIRV.ll
+++ b/test/DebugInfo/SourceLanguageLLVMToSPIRV.ll
@@ -39,5 +39,5 @@ entry:
 !7 = distinct !DISubprogram(name: "func", scope: !8, file: !8, line: 1, scopeLine: 2, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
 !8 = !DIFile(filename: "test.cl", directory: "/tmp", checksumkind: CSK_MD5, checksum: "18aa9ce738eaafc7b7b7181c19092815")
 
-; CHECK-OPENCLC: DebugCompileUnit {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} 3
-; CHECK-CPP4OPENCL: DebugCompileUnit {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} 6
+; CHECK-OPENCLC: DebugCompilationUnit {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} 3
+; CHECK-CPP4OPENCL: DebugCompilationUnit {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} 6


### PR DESCRIPTION
This patch fixes the discovered typos in Debug Instruction names, so we can generate spec-conformant SPIR-V module.
https://registry.khronos.org/SPIR-V/specs/unified1/DebugInfo.html