### PR TITLE
[Backmerge to 12] Fix SPIRV->LLVM translation of variable lenght arrays

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1452,10 +1452,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return mapValue(
         BV, new AllocaInst(Ty, SPIRAS_Private, ArrSize, BV->getName(), BB));
   }
-  case OpSaveMemoryINTEL: {
-    Function *StackSave = Intrinsic::getDeclaration(M, Intrinsic::stacksave);
-    return mapValue(BV, CallInst::Create(StackSave, "", BB));
-  }
   case OpRestoreMemoryINTEL: {
     auto *Restore = static_cast<SPIRVRestoreMemoryINTEL *>(BV);
     llvm::Value *Ptr = transValue(Restore->getOperand(0), F, BB, false);
@@ -1513,6 +1509,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   // Translation of instructions
   int OpCode = BV->getOpCode();
   switch (OpCode) {
+  case OpSaveMemoryINTEL: {
+    Function *StackSave = Intrinsic::getDeclaration(M, Intrinsic::stacksave);
+    return mapValue(BV, CallInst::Create(StackSave, "", BB));
+  }
   case OpBranch: {
     auto *BR = static_cast<SPIRVBranch *>(BV);
     auto *BI = BranchInst::Create(

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1445,21 +1445,6 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return mapValue(BV, LVar);
   }
 
-  case OpVariableLengthArrayINTEL: {
-    auto *VLA = static_cast<SPIRVVariableLengthArrayINTEL *>(BV);
-    llvm::Type *Ty = transType(BV->getType()->getPointerElementType());
-    llvm::Value *ArrSize = transValue(VLA->getOperand(0), F, BB, false);
-    return mapValue(
-        BV, new AllocaInst(Ty, SPIRAS_Private, ArrSize, BV->getName(), BB));
-  }
-  case OpRestoreMemoryINTEL: {
-    auto *Restore = static_cast<SPIRVRestoreMemoryINTEL *>(BV);
-    llvm::Value *Ptr = transValue(Restore->getOperand(0), F, BB, false);
-    Function *StackRestore =
-        Intrinsic::getDeclaration(M, Intrinsic::stackrestore);
-    return mapValue(BV, CallInst::Create(StackRestore, {Ptr}, "", BB));
-  }
-
   case OpFunctionParameter: {
     auto BA = static_cast<SPIRVFunctionParameter *>(BV);
     assert(F && "Invalid function");
@@ -1509,10 +1494,27 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   // Translation of instructions
   int OpCode = BV->getOpCode();
   switch (OpCode) {
+  case OpVariableLengthArrayINTEL: {
+    auto *VLA = static_cast<SPIRVVariableLengthArrayINTEL *>(BV);
+    llvm::Type *Ty = transType(BV->getType()->getPointerElementType());
+    llvm::Value *ArrSize = transValue(VLA->getOperand(0), F, BB);
+    return mapValue(
+        BV, new AllocaInst(Ty, SPIRAS_Private, ArrSize, BV->getName(), BB));
+  }
+
+  case OpRestoreMemoryINTEL: {
+    auto *Restore = static_cast<SPIRVRestoreMemoryINTEL *>(BV);
+    llvm::Value *Ptr = transValue(Restore->getOperand(0), F, BB);
+    Function *StackRestore =
+        Intrinsic::getDeclaration(M, Intrinsic::stackrestore);
+    return mapValue(BV, CallInst::Create(StackRestore, {Ptr}, "", BB));
+  }
+
   case OpSaveMemoryINTEL: {
     Function *StackSave = Intrinsic::getDeclaration(M, Intrinsic::stacksave);
     return mapValue(BV, CallInst::Create(StackSave, "", BB));
   }
+
   case OpBranch: {
     auto *BR = static_cast<SPIRVBranch *>(BV);
     auto *BI = BranchInst::Create(

--- a/test/create-placeholders-for-phi-operands.ll
+++ b/test/create-placeholders-for-phi-operands.ll
@@ -1,0 +1,151 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv -spirv-ext=+SPV_INTEL_variable_length_array
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; CHECK-LLVM: phi i8* [ [[savedstack:%.*]], {{.*}} ], [ [[savedstack_us:%.*]], {{.*}} ]
+
+; CHECK-LLVM: BB.{{[0-9]+}}:
+; CHECK-LLVM: [[savedstack]] = call i8* @llvm.stacksave()
+
+; CHECK-LLVM: BB.{{[0-9]+}}:
+; CHECK-LLVM: [[savedstack_us]] = call i8* @llvm.stacksave()
+
+; ModuleID = 's.bc'
+source_filename = "llvm-link"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64"
+
+; Function Attrs: noinline nounwind mustprogress
+define weak dso_local spir_kernel void @Kernel(i32 addrspace(1)* %0, i32 addrspace(1)* %1, i64 %.omp.lb.ascast.val109.zext, i64 %.omp.ub.ascast.val.zext, i64 %.capture_expr.0.ascast.val.zext, i64 %length_.ascast.val.zext) local_unnamed_addr #0 {
+BB.0:
+  %dmt.i = alloca [624 x i32], align 4
+  %length_.ascast.val.zext.trunc = trunc i64 %length_.ascast.val.zext to i32
+  %.capture_expr.0.ascast.val.zext.trunc = trunc i64 %.capture_expr.0.ascast.val.zext to i32
+  %.omp.ub.ascast.val.zext.trunc = trunc i64 %.omp.ub.ascast.val.zext to i32
+  %.omp.lb.ascast.val109.zext.trunc = trunc i64 %.omp.lb.ascast.val109.zext to i32
+  %cmp41 = icmp slt i32 %.capture_expr.0.ascast.val.zext.trunc, 1
+  %cmp42.not104 = icmp sgt i32 %.omp.lb.ascast.val109.zext.trunc, %.omp.ub.ascast.val.zext.trunc
+  %or.cond = select i1 %cmp41, i1 true, i1 %cmp42.not104
+  br i1 %or.cond, label %BB.2, label %BB.3
+
+BB.1:                                             ; preds = %BB.12, %BB.7
+  %savedstack.sink = phi i8* [ %savedstack, %BB.12 ], [ %savedstack.us, %BB.7 ]
+  call void @llvm.stackrestore(i8* %savedstack.sink), !llvm.access.group !9
+  br label %BB.2
+
+BB.2:                                             ; preds = %BB.3, %BB.1, %BB.0
+  ret void
+
+BB.3:                                             ; preds = %BB.0
+  %2 = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %3 = trunc i64 %2 to i32
+  %.not = icmp sgt i32 %3, %.omp.ub.ascast.val.zext.trunc
+  br i1 %.not, label %BB.2, label %BB.4, !prof !10
+
+BB.4:                                             ; preds = %BB.3
+  %div.i = udiv i32 %length_.ascast.val.zext.trunc, 624
+  %4 = icmp ult i32 %length_.ascast.val.zext.trunc, 624
+  br i1 %4, label %BB.5, label %BB.6
+
+BB.5:                                             ; preds = %BB.4
+  %savedstack = call i8* @llvm.stacksave(), !llvm.access.group !9
+  br label %BB.12
+
+BB.6:                                             ; preds = %BB.4
+  %5 = icmp ugt i32 %div.i, 1
+  %umax = select i1 %5, i32 %div.i, i32 1
+  %arrayidx4812.us = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 %2
+  %arrayidx5113.us = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %2
+  %savedstack.us = call i8* @llvm.stacksave(), !llvm.access.group !9
+  br label %BB.9
+
+BB.7:                                             ; preds = %BB.8
+  %indvars.iv.next27 = add nuw nsw i64 %indvars.iv26, 1
+  %exitcond29.not = icmp eq i64 %indvars.iv.next27, %7
+  br i1 %exitcond29.not, label %BB.1, label %BB.11, !llvm.loop !11
+
+BB.8:                                             ; preds = %BB.11, %BB.8
+  %indvars.iv22 = phi i64 [ 0, %BB.11 ], [ %indvars.iv.next23, %BB.8 ]
+  %j.0.i17.us = phi i32 [ 0, %BB.11 ], [ %add.i.us, %BB.8 ]
+  %arrayidx1276.i.us = getelementptr inbounds [624 x i32], [624 x i32]* %dmt.i, i64 0, i64 %indvars.iv22
+  %6 = load i32, i32* %arrayidx1276.i.us, align 4, !alias.scope !14, !noalias !19, !llvm.access.group !9
+  %and.i.us = and i32 %6, -2147483648
+  %indvars.iv.next23 = add nuw nsw i64 %indvars.iv22, 1
+  %add.i.us = add nuw nsw i32 %j.0.i17.us, 1
+  %exitcond25.not = icmp eq i64 %indvars.iv.next23, 624
+  br i1 %exitcond25.not, label %BB.7, label %BB.8, !llvm.loop !26
+
+BB.9:                                             ; preds = %BB.9, %BB.6
+  %indvars.iv = phi i64 [ %indvars.iv.next, %BB.9 ], [ 0, %BB.6 ]
+  %indvars.iv.next = add nuw nsw i64 %indvars.iv, 1
+  %exitcond.not = icmp eq i64 %indvars.iv.next, 624
+  br i1 %exitcond.not, label %BB.10, label %BB.9, !llvm.loop !28
+
+BB.10:                                            ; preds = %BB.9
+  %7 = zext i32 %umax to i64
+  br label %BB.11
+
+BB.11:                                            ; preds = %BB.10, %BB.7
+  %indvars.iv26 = phi i64 [ 0, %BB.10 ], [ %indvars.iv.next27, %BB.7 ]
+  %8 = mul nuw nsw i64 %indvars.iv26, 624
+  br label %BB.8
+
+BB.12:                                            ; preds = %BB.12, %BB.5
+  %indvars.iv33 = phi i64 [ 0, %BB.5 ], [ %indvars.iv.next34, %BB.12 ]
+  %indvars.iv.next34 = add nuw nsw i64 %indvars.iv33, 1
+  %exitcond35.not = icmp eq i64 %indvars.iv.next34, 624
+  br i1 %exitcond35.not, label %BB.1, label %BB.12, !llvm.loop !11
+}
+
+declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr
+
+; Function Attrs: nofree nosync nounwind willreturn
+declare i8* @llvm.stacksave() #1
+
+; Function Attrs: nofree nosync nounwind willreturn
+declare void @llvm.stackrestore(i8*) #1
+
+attributes #0 = { noinline nounwind "contains-openmp-target"="true" "denormal-fp-math"="preserve-sign,preserve-sign" "denormal-fp-math-f32"="ieee,ieee" "frame-pointer"="all" "may-have-openmp-directive"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="true" "no-nans-fp-math"="true" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target.declare"="true" "unsafe-fp-math"="true" }
+attributes #1 = { nofree nosync nounwind willreturn }
+
+!opencl.used.extensions = !{!0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0}
+!opencl.used.optional.core.features = !{!1, !0, !0, !0, !1, !0, !1, !0, !1, !0, !1, !0, !0, !0}
+!opencl.compiler.options = !{!0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0}
+!llvm.ident = !{!2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2}
+!spirv.Source = !{!3, !4, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3, !3}
+!spirv.MemoryModel = !{!5}
+!spirv.ExecutionMode = !{}
+!llvm.module.flags = !{!6, !7, !8}
+!sycl.specialization-constants = !{}
+
+!0 = !{}
+!1 = !{!"cl_doubles"}
+!2 = !{!"Compiler"}
+!3 = !{i32 4, i32 200000}
+!4 = !{i32 3, i32 200000}
+!5 = !{i32 2, i32 2}
+!6 = !{i32 1, !"wchar_size", i32 4}
+!7 = !{i32 7, !"PIC Level", i32 2}
+!8 = !{i32 7, !"frame-pointer", i32 2}
+!9 = distinct !{}
+!10 = !{!"branch_weights", i32 100000, i32 299998}
+!11 = distinct !{!11, !12, !13}
+!12 = !{!"llvm.loop.vectorize.ivdep_loop", i32 0}
+!13 = !{!"llvm.loop.parallel_accesses", !9}
+!14 = !{!15, !17}
+!15 = distinct !{!15, !16}
+!16 = distinct !{!16}
+!17 = distinct !{!17, !18}
+!18 = distinct !{!18}
+!19 = !{!20, !21, !22, !23, !24, !25}
+!20 = distinct !{!20, !16}
+!21 = distinct !{!21, !16}
+!22 = distinct !{!22, !18}
+!23 = distinct !{!23, !18}
+!24 = distinct !{!24, !18}
+!25 = distinct !{!25, !18}
+!26 = distinct !{!26, !27}
+!27 = !{!"llvm.loop.mustprogress"}
+!28 = distinct !{!28, !27}

--- a/test/transcoding/SPV_INTEL_variable_length_array/complex-cfg.ll
+++ b/test/transcoding/SPV_INTEL_variable_length_array/complex-cfg.ll
@@ -1,0 +1,126 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_variable_length_array
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: noinline nounwind optnone uwtable
+define weak dso_local spir_kernel void @K(i32 addrspace(1)* %S.ul.GEP.1) local_unnamed_addr #0 {
+newFuncRoot:
+  %.ascast1 = addrspacecast i32 addrspace(1)* %S.ul.GEP.1 to i32 addrspace(4)*
+  %S.ul.GEP.1.addr = alloca i32 addrspace(4)*, align 8
+  store i32 addrspace(4)* %.ascast1, i32 addrspace(4)** %S.ul.GEP.1.addr, align 8
+  %S.ul.GEP.1.value = load i32 addrspace(4)*, i32 addrspace(4)** %S.ul.GEP.1.addr, align 8
+  %"$loop_ctr46" = alloca i64, align 8
+  %"$loop_ctr50" = alloca i64, align 8
+  %"$loop_ctr38" = alloca i64, align 8
+  %"var$102" = alloca i64, align 8
+  %"var$103" = alloca i32, align 4
+  %temp = alloca i32, align 4
+  br label %fallthru
+
+; CHECK-LABEL: bb269
+; CHECK-LLVM: %1 = getelementptr inbounds i32, i32* %"ascastB$val41", i64 %0
+bb269:                                            ; preds = %bb269.preheader, %bb269
+  %"var$102_fetch.202" = load i64, i64* %"var$102", align 1
+  %0 = sub nsw i64 %"var$102_fetch.202", 1
+  %1 = getelementptr inbounds i32, i32* %"ascastB$val41", i64 %0
+  %add.17 = add nsw i64 %"var$102_fetch.202", 1
+  store i64 %add.17, i64* %"var$102", align 1
+  %"var$103_fetch.203" = load i32, i32* %"var$103", align 1
+  %add.18 = add nsw i32 %"var$103_fetch.203", 1
+  store i32 %add.18, i32* %"var$103", align 1
+  %"var$103_fetch.204" = load i32, i32* %"var$103", align 1
+  %"ascastB$val_fetch.205" = load i32, i32* %temp, align 1
+  %rel.41 = icmp sle i32 %"var$103_fetch.204", %"ascastB$val_fetch.205"
+  br i1 %rel.41, label %bb269, label %bb270.loopexit
+
+bb270.loopexit:                                   ; preds = %bb269
+  br label %bb270
+
+bb270:                                            ; preds = %bb270.loopexit, %fallthru
+  store i64 1, i64* %"$loop_ctr38", align 1
+  br label %loop_test315
+
+loop_test315:                                     ; preds = ,loop_body316, %bb270
+  %"$loop_ctr_fetch.208" = load i64, i64* %"$loop_ctr38", align 1
+  %rel.42 = icmp sle i64 %"$loop_ctr_fetch.208", %int_sext39
+  br i1 %rel.42, label %loop_body316, label %loop_exit317
+
+; CHECK-LABEL: loop_body316
+; CHECK-LLVM: %3 = getelementptr inbounds i32, i32* %"ascastB$val41", i64 %2
+loop_body316:                                     ; preds = %loop_test315
+  %"$loop_ctr_fetch.206" = load i64, i64* %"$loop_ctr38", align 1
+  %2 = sub nsw i64 %"$loop_ctr_fetch.206", 1
+  %3 = getelementptr inbounds i32, i32* %"ascastB$val41", i64 %2
+  %"ascastB$val[]_fetch.207" = load i32, i32* %3, align 1
+  %"$loop_ctr_fetch.195" = load i64, i64* %"$loop_ctr38", align 1
+  br label %loop_test315
+
+loop_exit317:                                     ; preds = %loop_body316
+  call spir_func void @llvm.stackrestore(i8* %"$stacksave37")
+  %S.ul.GEP.1_fetch.210 = load i32, i32 addrspace(4)* %S.ul.GEP.1.value, align 1
+  %int_sext47 = sext i32 %S.ul.GEP.1_fetch.210 to i64
+  store i64 1, i64* %"$loop_ctr46", align 1
+  br label %loop_test323
+
+loop_test323:                                     ; preds = %loop_body324, %loop_exit317
+  %"$loop_ctr_fetch.212" = load i64, i64* %"$loop_ctr46", align 1
+  %rel.45 = icmp sle i64 %"$loop_ctr_fetch.212", %int_sext47
+  br i1 %rel.45, label %loop_body324, label %loop_exit325
+
+loop_body324:                                     ; preds = %loop_test323
+  %"$loop_ctr_fetch.211" = load i64, i64* %"$loop_ctr46", align 1
+  br label %loop_test323
+
+loop_exit325:                                     ; preds = %loop_test323
+  %S.ul.GEP.1_fetch.214 = load i32, i32 addrspace(4)* %S.ul.GEP.1.value, align 1
+  %int_sext51 = sext i32 %S.ul.GEP.1_fetch.214 to i64
+  store i64 1, i64* %"$loop_ctr50", align 1
+  br label %loop_test327
+
+loop_test327:                                     ; preds = %loop_body328, %loop_exit325
+  %"$loop_ctr_fetch.216" = load i64, i64* %"$loop_ctr50", align 1
+  %rel.48 = icmp sle i64 %"$loop_ctr_fetch.216", %int_sext51
+  br i1 %rel.48, label %loop_body328, label %loop_exit329
+
+loop_body328:                                     ; preds = %loop_test327
+  %"$loop_ctr_fetch.215" = load i64, i64* %"$loop_ctr50", align 1
+  br label %loop_test327
+
+loop_exit329:                                     ; preds = %loop_test327
+  ret void
+; CHECK-LABEL: fallthru
+; CHECK-LLVM: %"ascastB$val41" = alloca i32, i64 %div.3
+fallthru:                          ; preds = %newFuncRoot
+  %"$stacksave37" = call spir_func i8* @llvm.stacksave()
+  %S.ul.GEP.1_fetch.194 = load i32, i32 addrspace(4)* %S.ul.GEP.1.value, align 1
+  %int_sext39 = sext i32 %S.ul.GEP.1_fetch.194 to i64
+  %rel.39 = icmp sgt i32 0, %S.ul.GEP.1_fetch.194
+  %slct.13 = select i1 %rel.39, i32 0, i32 %S.ul.GEP.1_fetch.194
+  %int_sext40 = sext i32 %slct.13 to i64
+  %mul.11 = mul nsw i64 %int_sext40, 4
+  %div.3 = sdiv i64 %mul.11, 4
+  %"ascastB$val41" = alloca i32, i64 %div.3, align 4
+  store i64 1, i64* %"var$102", align 1
+  store i32 %S.ul.GEP.1_fetch.194, i32* %temp, align 1
+  store i32 1, i32* %"var$103", align 1
+  %"ascastB$val_fetch.197" = load i32, i32* %temp, align 1
+  %rel.40 = icmp slt i32 %"ascastB$val_fetch.197", 1
+  br i1 %rel.40, label %bb270, label %bb269.preheader
+
+bb269.preheader:                                  ; preds = %fallthru
+  br label %bb269
+}
+
+; Function Attrs: nofree nosync nounwind willreturn mustprogress
+declare void @llvm.stackrestore(i8*) #1
+
+; Function Attrs: nofree nosync nounwind willreturn mustprogress
+declare i8* @llvm.stacksave() #1
+
+attributes #0 = { noinline nounwind optnone uwtable }
+attributes #1 = { nofree nosync nounwind willreturn mustprogress }
+


### PR DESCRIPTION
VLAs were translated in section where non-instruction SPIR-V values are translated. However translation of them produce LLVM IR instructions. This patch moves translation of VLAs to the proper place where other instructions are created, so the placeholder creation logic also works for them. This fixes the case when VLA used in complex control flow graph caused producing of invalid LLVM module during reverse translation.