### PR TITLE
[Backmerge to 11] Improve DbgArrayType compatibility (#1901)

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -557,6 +557,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgArrayType(const DICompositeType *AT) {
   // For N-dimensianal arrays AR.getNumElements() == N
   const unsigned N = AR.size();
   Ops.resize(ComponentCountIdx + N);
+  SPIRVWordVec LowerBounds(N);
   for (unsigned I = 0; I < N; ++I) {
     DISubrange *SR = cast<DISubrange>(AR[I]);
     ConstantInt *Count = SR->getCount().get<ConstantInt *>();
@@ -565,9 +566,27 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgArrayType(const DICompositeType *AT) {
       Ops[ComponentCountIdx] = static_cast<SPIRVWord>(Count->getZExtValue());
       return BM->addDebugInfo(SPIRVDebug::TypeVector, getVoidTy(), Ops);
     }
-    SPIRVValue *C = SPIRVWriter->transValue(Count, nullptr);
-    Ops[ComponentCountIdx + I] = C->getId();
+    if (Count) {
+      Ops[ComponentCountIdx + I] =
+          SPIRVWriter->transValue(Count, nullptr)->getId();
+    } else {
+      if (auto *UpperBound = dyn_cast<MDNode>(SR->getRawUpperBound()))
+        Ops[ComponentCountIdx + I] = transDbgEntry(UpperBound)->getId();
+      else
+        Ops[ComponentCountIdx + I] = getDebugInfoNoneId();
+    }
+    if (auto *RawLB = SR->getRawLowerBound()) {
+      if (auto *DIExprLB = dyn_cast<MDNode>(RawLB))
+        LowerBounds[I] = transDbgEntry(DIExprLB)->getId();
+      else {
+        ConstantInt *ConstIntLB = SR->getLowerBound().get<ConstantInt *>();
+        LowerBounds[I] = SPIRVWriter->transValue(ConstIntLB, nullptr)->getId();
+      }
+    } else {
+      LowerBounds[I] = getDebugInfoNoneId();
+    }
   }
+  Ops.insert(Ops.end(), LowerBounds.begin(), LowerBounds.end());
   return BM->addDebugInfo(SPIRVDebug::TypeArray, getVoidTy(), Ops);
 }
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -199,12 +199,38 @@ SPIRVToLLVMDbgTran::transTypeArray(const SPIRVExtInst *DebugInst) {
       transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
   size_t TotalCount = 1;
   SmallVector<llvm::Metadata *, 8> Subscripts;
-  for (size_t I = ComponentCountIdx, E = Ops.size(); I < E; ++I) {
-    SPIRVConstant *C = BM->get<SPIRVConstant>(Ops[I]);
-    int64_t Count = static_cast<int64_t>(C->getZExtIntValue());
-    Subscripts.push_back(Builder.getOrCreateSubrange(0, Count));
-    // Count = -1 means that the array is empty
-    TotalCount *= Count > 0 ? static_cast<size_t>(Count) : 0;
+  // Ops looks like: { BaseType, count1|upperBound1, count2|upperBound2, ...,
+  // countN|upperBoundN, lowerBound1, lowerBound2, ..., lowerBoundN }
+  for (size_t I = ComponentCountIdx, E = Ops.size() / 2 + 1; I < E; ++I) {
+    if (auto *LocalVar = getDbgInst<SPIRVDebug::LocalVariable>(Ops[I])) {
+      auto *UpperBound = transDebugInst<DILocalVariable>(LocalVar);
+      SPIRVConstant *C = BM->get<SPIRVConstant>(Ops[Ops.size() / 2 + I]);
+      int64_t ConstantAsInt = static_cast<int64_t>(C->getZExtIntValue());
+      auto *LowerBound = ConstantAsMetadata::get(
+          ConstantInt::get(M->getContext(), APInt(64, ConstantAsInt)));
+      Subscripts.push_back(Builder.getOrCreateSubrange(nullptr, LowerBound,
+                                                       UpperBound, nullptr));
+      continue;
+    }
+    if (auto *ExprUB = getDbgInst<SPIRVDebug::Expression>(Ops[I])) {
+      auto *UpperBound = transDebugInst<DIExpression>(ExprUB);
+      auto *ExprLB =
+          getDbgInst<SPIRVDebug::Expression>(Ops[Ops.size() / 2 + I]);
+      auto *LowerBound = transDebugInst<DIExpression>(ExprLB);
+      Subscripts.push_back(Builder.getOrCreateSubrange(nullptr, LowerBound,
+                                                       UpperBound, nullptr));
+      continue;
+    }
+    if (!getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[I])) {
+      SPIRVConstant *C = BM->get<SPIRVConstant>(Ops[I]);
+      int64_t Count = static_cast<int64_t>(C->getZExtIntValue());
+      C = BM->get<SPIRVConstant>(Ops[Ops.size() / 2 + I]);
+      int64_t LowerBound = static_cast<int64_t>(C->getZExtIntValue());
+      Subscripts.push_back(Builder.getOrCreateSubrange(LowerBound, Count));
+      // Count = -1 means that the array is empty
+      TotalCount *= Count > 0 ? static_cast<size_t>(Count) : 0;
+      continue;
+    }
   }
   DINodeArray SubscriptArray = Builder.getOrCreateArray(Subscripts);
   size_t Size = getDerivedSizeInBits(BaseTy) * TotalCount;

--- a/test/DebugInfoLowerBound.ll
+++ b/test/DebugInfoLowerBound.ll
@@ -1,0 +1,48 @@
+; RUN: llvm-as %s -o %t.bc
+
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll 
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: TypeInt [[#TypeIntId:]] 64 0
+; CHECK-SPIRV-DAG: Constant [[#TypeIntId]] [[#Cound1Id:]] 2 0 
+; CHECK-SPIRV-DAG: Constant [[#TypeIntId]] [[#LowerBoundId:]] 5 0 
+; CHECK-SPIRV-DAG: Constant [[#TypeIntId]] [[#Cound2Id:]] 3 0 
+; CHECK-SPIRV-DAG: DebugTypeArray {{[0-9 ]+}} [[#Cound1Id]] [[#Cound2Id]] [[#LowerBoundId]] [[#LowerBoundId]] 
+
+; CHECK-LLVM: !DISubrange(count: 2, lowerBound: 5)
+; CHECK-LLVM: !DISubrange(count: 3, lowerBound: 5)
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir64-unknown-unknown"
+
+!llvm.module.flags = !{!11, !12}
+!llvm.dbg.cu = !{!2}
+!opencl.enable.FP_CONTRACT = !{}
+!spirv.Source = !{!13}
+!opencl.spir.version = !{!14}
+!opencl.ocl.version = !{!13}
+!opencl.used.extensions = !{!4}
+!opencl.used.optional.core.features = !{!4}
+!spirv.Generator = !{!15}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "value", scope: !2, file: !3, line: 5, type: !6, isLocal: true, isDefinition: true)
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !3, producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, globals: !5)
+!3 = !DIFile(filename: "kernel.cpp", directory: "/user/matrix/..")
+!4 = !{}
+!5 = !{!0}
+!6 = !DICompositeType(tag: DW_TAG_array_type, baseType: !7, size: 192, elements: !8)
+!7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!8 = !{!9, !10}
+!9 = !DISubrange(count: 2, lowerBound: 5)
+!10 = !DISubrange(count: 3, lowerBound: 5)
+!11 = !{i32 2, !"Dwarf Version", i32 4}
+!12 = !{i32 2, !"Debug Info Version", i32 3}
+!13 = !{i32 0, i32 0}
+!14 = !{i32 1, i32 2}
+!15 = !{i16 6, i16 14}


### PR DESCRIPTION
Backport of https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1901