### PR TITLE
[NFC] Check for nullptr from getDbgInst

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -262,10 +262,11 @@ SPIRVToLLVMDbgTran::transTypeArrayOpenCL(const SPIRVExtInst *DebugInst) {
                                                        UpperBound, nullptr));
       continue;
     }
-    if (auto *ExprUB = getDbgInst<SPIRVDebug::Expression>(Ops[I])) {
+    if (const SPIRVExtInst * ExprUB, *ExprLB;
+        (ExprUB = getDbgInst<SPIRVDebug::Expression>(Ops[I])) &&
+        (ExprLB =
+             getDbgInst<SPIRVDebug::Expression>(Ops[Ops.size() / 2 + I]))) {
       auto *UpperBound = transDebugInst<DIExpression>(ExprUB);
-      auto *ExprLB =
-          getDbgInst<SPIRVDebug::Expression>(Ops[Ops.size() / 2 + I]);
       auto *LowerBound = transDebugInst<DIExpression>(ExprLB);
       Subscripts.push_back(Builder.getOrCreateSubrange(nullptr, LowerBound,
                                                        UpperBound, nullptr));


### PR DESCRIPTION
Ensure that ExprLB is non-NULL before using it.