### PR TITLE
Update spirv-as invocations

### DIFF
--- a/test/GroupAndSubgroupInstructions.spvasm
+++ b/test/GroupAndSubgroupInstructions.spvasm
@@ -31,7 +31,7 @@
 ; spirv-dis tmp.spv -o llvm-spirv/test/GroupAndSubgroupInstructions.spvasm
 
 ; REQUIRES: spirv-as
-; RUN: spirv-as < %s --target-env spv1.0 -o %t.spv
+; RUN: spirv-as %s --target-env spv1.0 -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv --spirv-target-env=CL1.2 -o %t.bc
 ; RUN: llvm-dis %t.bc -o %t.ll


### PR DESCRIPTION
After SPIRV-Tools commit 2e0f4b52 ("tools: refactorize tools flags parsing. (#5111)", 2023-02-27), spirv-as needs to be told explicitly when reading from stdin.