### PR TITLE
[DebugInfo] Add DW_ATE_complex_float translation

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -572,9 +572,15 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgBaseType(const DIBasicType *BT) {
   auto Encoding = static_cast<dwarf::TypeKind>(BT->getEncoding());
   SPIRVDebug::EncodingTag EncTag = SPIRVDebug::Unspecified;
   SPIRV::DbgEncodingMap::find(Encoding, &EncTag);
+  // Unset encoding if it's complex and NonSemantic.Shader.DebugInfo.200 is not
+  // enabled
+  if (EncTag == SPIRVDebug::Complex &&
+      BM->getDebugInfoEIS() != SPIRVEIS_NonSemantic_Shader_DebugInfo_200)
+    EncTag = SPIRVDebug::Unspecified;
   Ops[EncodingIdx] = EncTag;
-  if (isNonSemanticDebugInfo())
+  if (isNonSemanticDebugInfo()) {
     transformToConstant(Ops, {EncodingIdx});
+  }
   return BM->addDebugInfo(SPIRVDebug::TypeBasic, getVoidTy(), Ops);
 }
 

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -578,9 +578,8 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgBaseType(const DIBasicType *BT) {
       BM->getDebugInfoEIS() != SPIRVEIS_NonSemantic_Shader_DebugInfo_200)
     EncTag = SPIRVDebug::Unspecified;
   Ops[EncodingIdx] = EncTag;
-  if (isNonSemanticDebugInfo()) {
+  if (isNonSemanticDebugInfo())
     transformToConstant(Ops, {EncodingIdx});
-  }
   return BM->addDebugInfo(SPIRVDebug::TypeBasic, getVoidTy(), Ops);
 }
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2364,6 +2364,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       return mapValue(BV, transOCLBuiltinFromExtInst(ExtInst, BB));
     case SPIRVEIS_Debug:
     case SPIRVEIS_OpenCL_DebugInfo_100:
+    case SPIRVEIS_NonSemantic_Shader_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_200:
       return mapValue(BV, DbgTran->transDebugIntrinsic(ExtInst, BB));
     default:

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -89,7 +89,7 @@ enum EncodingTag {
   SignedChar   = 5,
   Unsigned     = 6,
   UnsignedChar = 7,
-  Complex = 8
+  Complex      = 8
 };
 
 enum CompositeTypeTag {

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -88,7 +88,8 @@ enum EncodingTag {
   Signed       = 4,
   SignedChar   = 5,
   Unsigned     = 6,
-  UnsignedChar = 7
+  UnsignedChar = 7,
+  Complex = 8
 };
 
 enum CompositeTypeTag {
@@ -1000,6 +1001,7 @@ inline void DbgEncodingMap::init() {
   add(dwarf::DW_ATE_signed_char,       SPIRVDebug::SignedChar);
   add(dwarf::DW_ATE_unsigned,          SPIRVDebug::Unsigned);
   add(dwarf::DW_ATE_unsigned_char,     SPIRVDebug::UnsignedChar);
+  add(dwarf::DW_ATE_complex_float,     SPIRVDebug::Complex);
 }
 
 typedef SPIRVMap<dwarf::Tag, SPIRVDebug::TypeQualifierTag> DbgTypeQulifierMap;

--- a/test/DebugInfo/NonSemantic/Shader200/FortranComplex.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranComplex.ll
@@ -35,7 +35,7 @@
 ; CHECK-LLVM-200: ![[#]] = !DILocalVariable(name: "a", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type:]])
 ; CHECK-LLVM-200: ![[#Type]] = !DIBasicType(name: "COMPLEX*8", size: 64, encoding: DW_ATE_complex_float)
 ; CHECK-LLVM-200: ![[#]] = !DILocalVariable(name: "b", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type]])
-; CHECK-LLVM-200: ![[#]] = !DILocalVariable(name: "c", scope: !9, file: !3, line: 3, type: ![[#Type]])
+; CHECK-LLVM-200: ![[#]] = !DILocalVariable(name: "c", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type]])
 
 ; CHECK-SPIRV-100-DAG: ExtInstImport [[#Import:]] "NonSemantic.Shader.DebugInfo.100
 ; CHECK-SPIRV-100-DAG: String [[#Name:]] "COMPLEX*8"
@@ -49,7 +49,7 @@
 ; CHECK-LLVM-100: ![[#]] = !DILocalVariable(name: "a", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type:]])
 ; CHECK-LLVM-100: ![[#Type]] = !DIBasicType(tag: DW_TAG_unspecified_type, name: "COMPLEX*8")
 ; CHECK-LLVM-100: ![[#]] = !DILocalVariable(name: "b", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type]])
-; CHECK-LLVM-100: ![[#]] = !DILocalVariable(name: "c", scope: !9, file: !3, line: 3, type: ![[#Type]])
+; CHECK-LLVM-100: ![[#]] = !DILocalVariable(name: "c", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type]])
 
 ; ModuleID = 'test.f90'
 source_filename = "test.f90"

--- a/test/DebugInfo/NonSemantic/Shader200/FortranComplex.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranComplex.ll
@@ -1,0 +1,108 @@
+;; Tests for Fortran's complex type encoding in debug info
+;; Compiled from the following Fortran source
+;;
+;; program complex_numbers
+;;   implicit none
+;;   complex :: a, b, c
+;;
+;;   a = (1.0, 2.0)
+;;   b = (2.0, -1.0)
+;;
+;;   c = a + b
+;;
+;; end program complex_numbers
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-200 -o - | FileCheck %s --check-prefix=CHECK-SPIRV-200
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM-200
+
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-100 -o - | FileCheck %s --check-prefix=CHECK-SPIRV-100
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM-100
+
+; CHECK-SPIRV-200-DAG: ExtInstImport [[#Import:]] "NonSemantic.Shader.DebugInfo.200
+; CHECK-SPIRV-200-DAG: String [[#Name:]] "COMPLEX*8"
+; CHECK-SPIRV-200-DAG: Constant [[#]] [[#Size:]] 64
+; CHECK-SPIRV-200-DAG: Constant [[#]] [[#Encoding:]] 8
+; CHECK-SPIRV-200-DAG: ExtInst [[#]] [[#Type:]] [[#Import]] DebugTypeBasic [[#Name]] [[#Size]] [[#Encoding]]
+; CHECK-SPIRV-200-DAG: ExtInst [[#]] [[#]] [[#Import]] DebugLocalVariable [[#]] [[#Type]]
+; CHECK-SPIRV-200-DAG: ExtInst [[#]] [[#]] [[#Import]] DebugLocalVariable [[#]] [[#Type]]
+; CHECK-SPIRV-200-DAG: ExtInst [[#]] [[#]] [[#Import]] DebugLocalVariable [[#]] [[#Type]]
+
+; CHECK-LLVM-200: ![[#]] = !DILocalVariable(name: "a", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type:]])
+; CHECK-LLVM-200: ![[#Type]] = !DIBasicType(name: "COMPLEX*8", size: 64, encoding: DW_ATE_complex_float)
+; CHECK-LLVM-200: ![[#]] = !DILocalVariable(name: "b", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type]])
+; CHECK-LLVM-200: ![[#]] = !DILocalVariable(name: "c", scope: !9, file: !3, line: 3, type: ![[#Type]])
+
+; CHECK-SPIRV-100-DAG: ExtInstImport [[#Import:]] "NonSemantic.Shader.DebugInfo.100
+; CHECK-SPIRV-100-DAG: String [[#Name:]] "COMPLEX*8"
+; CHECK-SPIRV-100-DAG: Constant [[#]] [[#Size:]] 64
+; CHECK-SPIRV-100-DAG: Constant [[#]] [[#Encoding:]] 0
+; CHECK-SPIRV-100-DAG: ExtInst [[#]] [[#Type:]] [[#Import]] DebugTypeBasic [[#Name]] [[#Size]] [[#Encoding]]
+; CHECK-SPIRV-100-DAG: ExtInst [[#]] [[#]] [[#Import]] DebugLocalVariable [[#]] [[#Type]]
+; CHECK-SPIRV-100-DAG: ExtInst [[#]] [[#]] [[#Import]] DebugLocalVariable [[#]] [[#Type]]
+; CHECK-SPIRV-100-DAG: ExtInst [[#]] [[#]] [[#Import]] DebugLocalVariable [[#]] [[#Type]]
+
+; CHECK-LLVM-100: ![[#]] = !DILocalVariable(name: "a", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type:]])
+; CHECK-LLVM-100: ![[#Type]] = !DIBasicType(tag: DW_TAG_unspecified_type, name: "COMPLEX*8")
+; CHECK-LLVM-100: ![[#]] = !DILocalVariable(name: "b", scope: ![[#]], file: ![[#]], line: [[#]], type: ![[#Type]])
+; CHECK-LLVM-100: ![[#]] = !DILocalVariable(name: "c", scope: !9, file: !3, line: 3, type: ![[#Type]])
+
+; ModuleID = 'test.f90'
+source_filename = "test.f90"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir64-unknown-unknown"
+
+@0 = internal unnamed_addr constant i32 65536, align 4
+@1 = internal unnamed_addr constant i32 2, align 4
+
+; Function Attrs: nounwind uwtable
+define void @MAIN__() local_unnamed_addr !dbg !4 !llfort.type_idx !12 {
+alloca_0:
+  %func_result = tail call i32 @for_set_fpe_(ptr nonnull @0), !dbg !13, !llfort.type_idx !14
+  %func_result2 = tail call i32 @for_set_reentrancy(ptr nonnull @1), !dbg !13, !llfort.type_idx !14
+  call void @llvm.dbg.value(metadata float 1.000000e+00, metadata !11, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 32)), !dbg !15
+  call void @llvm.dbg.value(metadata float 2.000000e+00, metadata !11, metadata !DIExpression(DW_OP_LLVM_fragment, 32, 32)), !dbg !15
+  call void @llvm.dbg.value(metadata float 2.000000e+00, metadata !10, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 32)), !dbg !15
+  call void @llvm.dbg.value(metadata float -1.000000e+00, metadata !10, metadata !DIExpression(DW_OP_LLVM_fragment, 32, 32)), !dbg !15
+  call void @llvm.dbg.value(metadata float poison, metadata !8, metadata !DIExpression(DW_OP_LLVM_fragment, 0, 32)), !dbg !15
+  call void @llvm.dbg.value(metadata float poison, metadata !8, metadata !DIExpression(DW_OP_LLVM_fragment, 32, 32)), !dbg !15
+  ret void, !dbg !16
+}
+
+declare !llfort.intrin_id !17 !llfort.type_idx !18 i32 @for_set_fpe_(ptr nocapture readonly) local_unnamed_addr
+
+; Function Attrs: nofree
+declare !llfort.intrin_id !19 !llfort.type_idx !20 i32 @for_set_reentrancy(ptr nocapture readonly) local_unnamed_addr
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+!omp_offload.info = !{}
+
+!0 = !{i32 2, !"Debug Info Version", i32 3}
+!1 = !{i32 2, !"Dwarf Version", i32 4}
+!2 = distinct !DICompileUnit(language: DW_LANG_Fortran95, file: !3, producer: "Intel(R) Fortran", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, splitDebugInlining: false, nameTableKind: None)
+!3 = !DIFile(filename: "test.f90", directory: "complex")
+!4 = distinct !DISubprogram(name: "complex_numbers", linkageName: "MAIN__", scope: !3, file: !3, line: 1, type: !5, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !2, retainedNodes: !7)
+!5 = !DISubroutineType(types: !6)
+!6 = !{null}
+!7 = !{!8, !10, !11}
+!8 = !DILocalVariable(name: "c", scope: !4, file: !3, line: 3, type: !9)
+!9 = !DIBasicType(name: "COMPLEX*8", size: 64, encoding: DW_ATE_complex_float)
+!10 = !DILocalVariable(name: "b", scope: !4, file: !3, line: 3, type: !9)
+!11 = !DILocalVariable(name: "a", scope: !4, file: !3, line: 3, type: !9)
+!12 = !{i64 23}
+!13 = !DILocation(line: 1, column: 9, scope: !4)
+!14 = !{i64 2}
+!15 = !DILocation(line: 0, scope: !4)
+!16 = !DILocation(line: 9, column: 1, scope: !4)
+!17 = !{i32 97}
+!18 = !{i64 27}
+!19 = !{i32 98}
+!20 = !{i64 29}

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -744,7 +744,7 @@ int main(int Ac, char **Av) {
           SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_200)
         Opts.setAllowExtraDIExpressionsEnabled(true);
       if (DebugEIS.getValue() ==
-          SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_200 ||
+          SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_100 ||
           DebugEIS.getValue() ==
           SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_200)
         Opts.setAllowedToUseExtension(


### PR DESCRIPTION
It's mapped on new Encoding value for DebugBasicType in NonSemantic.Shader.DebugInfo.200 spec.
If another DebugInfo instruction set is specified - it's mapped to DW_TAG_unspecified_type

Spec:
https://github.com/KhronosGroup/SPIRV-Registry/pull/186 (TBD)