### PR TITLE
Remove assert statement to allow for multiple decorations on a given pointer

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1257,10 +1257,8 @@ static void replaceOperandWithAnnotationIntrinsicCallResult(Function *F,
     for (auto *Use : BV->users()) {
       if (auto *II = dyn_cast<IntrinsicInst>(Use)) {
         if (II->getIntrinsicID() == Intrinsic::ptr_annotation &&
-            II->getType() == BV->getType()) {
-          assert(CR == nullptr && "Multiple annotation created for same value");
+            II->getType() == BV->getType())
           CR = II;
-        }
       }
     }
     return CR ? true : false;


### PR DESCRIPTION
This change tries to address corner cases where a single pointer can have multiple decorations associated with it.

Thanks