### PR TITLE
[OpaquePointers] Rewrite the type scavenger.

### DIFF
--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -33,8 +33,85 @@
 //===----------------------------------------------------------------------===//
 //
 // This file implements the necessary logic to recover pointer types from LLVM
-// IR for the output SPIR-V file after LLVM IR completes its transition to
-// opaque pointers.
+// IR for the output SPIR-V file from the opaque pointers in LLVM IR.
+//
+// The core algorithm being implemented is rather simple, although there are
+// several complications that make its implementation more difficult. At its
+// core, the algorithm work like this:
+//
+// 1. Replace every instance of an opaque pointer type with a typed pointer that
+//    points to an unknown type variable.
+// 2. Convert each instruction into a series of typing rules. For example,
+//    load i8, ptr %ptr implies that %ptr must be typedptr(i8, 0).
+// 3. Based on the typing rules, resolve the type variables to concrete types.
+// 4. If the typing rules produce a contradiction (e.g., i8 == i32), insert a
+//    synthetic bitcast to represent the bitcast that would have been present in
+//    a typed pointer IR.
+// 5. If any type variables are unresolved at the end of the typing process,
+//    assign i8 to them instead.
+//
+// Typed pointers are represented with the TypedPointerType. Type variables are
+// represented as target("typevar", i), where i is an integer.
+//
+// Step 3 of the above algorithm is represented by unifyType, which implements a
+// unification-based type algorithm. This means there exists essentially just
+// four cases that need to be considered:
+// * unify(type var, concrete type):
+//   In this case, the concrete type is assigned to the type variable
+//   Note: It is possible for concrete type to contain nested type variables,
+//         e.g., typedptr(target("typevar", 3), 4)
+// * unify(type var, concrete type containing type var):
+//   Unification fails in this case. This can come up if you have code like
+//   this:
+//     %ptr = alloca ptr
+//     store ptr %ptr, ptr %ptr
+// * unify(type var, type var):
+//   In this case, the two type variables are unified into one so that they get
+//   the same concrete type. This uses IntEqClasses as the implementation of the
+//   union-find data structure.
+// * unify(concrete type, same concrete type):
+//   There is nothing to do in this case
+// * unify(concrete type, different concrete type):
+//   Unification fails in this case, and a bitcast needs to be generated.
+//
+// Note that this algorithm does not attempt to seek a minimal set of bitcasts
+// that need to be added to produce a correctly-typed program.
+//
+// Type rules are represented by the SPIRVTypeScavenger::TypeRule class, and
+// should be constructed using the provided static methods (which are easier to
+// understand than the constructor itself). Type rules boil down to the
+// following categories:
+// * operand I has type T
+// * operand I has the same type as operand J
+// * the return value has type T
+// * the return value has the same type as operand I
+// with any of the above operands, types, or return values potentially having a
+// level of indirection. For example, the rule for an addrspacecast is that the
+// return value points to the same type that its sole operand points to. The
+// indirection effectively means T->getScalarType()->getPointerElementType().
+// Note: When constructing type rules fixing an operand or the return to a
+//       particular type T, the type must be a type using typed pointers and/or
+//       type variables in lieu of ptr.
+// Note: getTypeRules may be called twice on an instruction, so if a new type
+//       variable needs to be created for type rules, it needs to be saved in
+//       the AssociatedTypeVariables method to ensure proper functioning. This
+//       is particularly important if you need to use the type variable both in
+//       constraining the return value and an operand.
+//
+// Now for the complications to the above algorithm:
+//
+// The most notable issue is that LLVM does not allow no-op constant
+// expressions to be created. This means that we have to be very careful about
+// the types of constant values. As the SPIR-V translator expands most constant
+// expressions into instructions, this isn't much of an issue, but where it
+// really comes into play is with global variable initializers, which don't have
+// that luxury. Global variable typing therefore pays careful attention to the
+// type of the initializer.
+//
+// Constructing type variables is a slightly expensive step, so before
+// attempting to create a type variable for the return of an instruction, we
+// instead look through the type rules to see if we can get the type of the
+// return value from one of its input operands.
 //
 //===----------------------------------------------------------------------===//
 
@@ -53,90 +130,361 @@
 
 using namespace llvm;
 
+namespace {
+static bool isTypeVariable(Type *T, unsigned &TypeVarNum) {
+  if (auto *TET = dyn_cast<TargetExtType>(T))
+    if (TET->getName() == "typevar") {
+      TypeVarNum = TET->getIntParameter(0);
+      return true;
+    }
+  return false;
+}
+
+/// Convert Ty to a type that can be unified with a type-variable-ified L, given
+/// that either or both types may have an indirection.
+/// For example, adjust(L, true, Ty, false) will extract the element type of Ty
+/// for unifying with L.
+/// In this method, L is expected to be a type of a value, while Ty (and the
+/// return value) will use TypedPointerType instead of PointerType.
+static Type *adjustIndirect(Type *L, bool LIndirect, Type *Ty, bool TIndirect) {
+  if (LIndirect)
+    Ty = cast<TypedPointerType>(Ty->getScalarType())->getElementType();
+  if (TIndirect) {
+    unsigned AS = L->getScalarType()->getPointerAddressSpace();
+    Ty = TypedPointerType::get(Ty, AS);
+    if (auto *VT = dyn_cast<VectorType>(L))
+      Ty = VectorType::get(Ty, VT->getElementCount());
+  }
+  return Ty;
+}
+
+template <typename Fn> Type *mutateType(Type *T, Fn MutatePointer) {
+  if (T->isPointerTy()) {
+    return MutatePointer(T->getPointerAddressSpace());
+  }
+  if (auto *VT = dyn_cast<VectorType>(T)) {
+    return VectorType::get(mutateType(VT->getScalarType(), MutatePointer),
+                           VT->getElementCount());
+  }
+  if (auto *AT = dyn_cast<ArrayType>(T)) {
+    return ArrayType::get(mutateType(AT->getElementType(), MutatePointer),
+                          AT->getNumElements());
+  }
+  if (auto *FT = dyn_cast<FunctionType>(T)) {
+    SmallVector<Type *, 4> ParamTypes;
+    for (Type *Inner : FT->params())
+      ParamTypes.push_back(mutateType(Inner, MutatePointer));
+    Type *ReturnTy = mutateType(FT->getReturnType(), MutatePointer);
+    return FunctionType::get(ReturnTy, ParamTypes, FT->isVarArg());
+  }
+  // TODO: support literal structs
+  return T;
+}
+
+/// Return true if the type is an opaque pointer, or contains an opaque pointer
+/// that needs to be typed.
+bool hasPointerType(Type *T) {
+  if (T->isPtrOrPtrVectorTy())
+    return true;
+  if (auto *AT = dyn_cast<ArrayType>(T))
+    return hasPointerType(AT->getElementType());
+  if (auto *FT = dyn_cast<FunctionType>(T)) {
+    for (Type *Inner : FT->params())
+      if (hasPointerType(Inner))
+        return true;
+    return hasPointerType(FT->getReturnType());
+  }
+  // TODO: literal structs
+  return false;
+}
+
+/// Get a type where all internal pointer types are replaced with i8*.
+Type *getUnknownTyped(Type *T) {
+  Type *Int8Ty = Type::getInt8Ty(T->getContext());
+  return mutateType(
+      T, [=](unsigned AS) { return TypedPointerType::get(Int8Ty, AS); });
+}
+
+bool hasTypeVariable(Type *T, unsigned TypeVarNum) {
+  if (auto *TPT = dyn_cast<TypedPointerType>(T))
+    return hasTypeVariable(TPT->getElementType(), TypeVarNum);
+  if (auto *VT = dyn_cast<VectorType>(T))
+    return hasTypeVariable(VT->getElementType(), TypeVarNum);
+  if (auto *AT = dyn_cast<ArrayType>(T))
+    return hasTypeVariable(AT->getElementType(), TypeVarNum);
+  if (auto *FT = dyn_cast<FunctionType>(T)) {
+    for (Type *Inner : FT->params())
+      if (hasTypeVariable(Inner, TypeVarNum))
+        return true;
+    return hasTypeVariable(FT->getReturnType(), TypeVarNum);
+  }
+  unsigned CheckNum;
+  if (isTypeVariable(T, CheckNum)) {
+    return TypeVarNum == CheckNum;
+  }
+  return false;
+}
+} // anonymous namespace
+
+Type *SPIRVTypeScavenger::substituteTypeVariables(Type *T) {
+  if (auto *TPT = dyn_cast<TypedPointerType>(T))
+    return TypedPointerType::get(substituteTypeVariables(TPT->getElementType()),
+                                 TPT->getAddressSpace());
+  if (auto *VT = dyn_cast<VectorType>(T))
+    return VectorType::get(substituteTypeVariables(VT->getElementType()),
+                           VT->getElementCount());
+  if (auto *AT = dyn_cast<ArrayType>(T))
+    return ArrayType::get(substituteTypeVariables(AT->getElementType()),
+                          AT->getNumElements());
+  if (auto *FT = dyn_cast<FunctionType>(T)) {
+    SmallVector<Type *, 4> ParamTypes;
+    for (Type *Inner : FT->params())
+      ParamTypes.push_back(substituteTypeVariables(Inner));
+    Type *ReturnTy = substituteTypeVariables(FT->getReturnType());
+    return FunctionType::get(ReturnTy, ParamTypes, FT->isVarArg());
+  }
+  unsigned TypeVarNum;
+  if (isTypeVariable(T, TypeVarNum)) {
+    TypeVarNum = UnifiedTypeVars.join(TypeVarNum, TypeVarNum);
+    Type *&SubstTy = TypeVariables[TypeVarNum];
+    // A value in TypeVariables may itself contain type variables that need to
+    // be substituted. Substitute these as well.
+    if (SubstTy)
+      return SubstTy = substituteTypeVariables(SubstTy);
+    // Even if it's not fully resolved, return the leader of the current
+    // equivalence class instead. This allows for easier scanning of recursive
+    // type declarations.
+    return TargetExtType::get(T->getContext(), "typevar", {}, {TypeVarNum});
+  }
+  return T;
+}
+
+bool SPIRVTypeScavenger::unifyType(Type *T1, Type *T2) {
+  T1 = substituteTypeVariables(T1);
+  T2 = substituteTypeVariables(T2);
+  if (T1 == T2)
+    return true;
+
+  auto SetTypeVar = [&](unsigned TypeVarNum, Type *ActualTy) {
+    // .findLeader doesn't work in uncompressed mode, so use .join with itself
+    // to find the leader.
+    unsigned Leader = UnifiedTypeVars.join(TypeVarNum, TypeVarNum);
+
+    // This method might be called with T1 as a concrete type containing
+    // pointers, and we want to make sure those don't leak into type variables.
+    // Guard against that here.
+    ActualTy = allocateTypeVariable(ActualTy);
+
+    // Check for recursion in type variables. Such recursive types generally
+    // cannot be correctly typed.
+    if (hasTypeVariable(ActualTy, Leader))
+      return false;
+
+    LLVM_DEBUG(dbgs() << "Type variable " << TypeVarNum << " is " << *ActualTy
+                      << "\n");
+    assert(!TypeVariables[Leader] && "Type was already fixed?");
+    TypeVariables[Leader] = ActualTy;
+    return true;
+  };
+
+  unsigned T1Num, T2Num;
+  if (isTypeVariable(T1, T1Num)) {
+    if (isTypeVariable(T2, T2Num)) {
+      // Two type variables. Unify the two of them into the same type.
+      if (T1Num != T2Num) {
+        UnifiedTypeVars.join(T1Num, T2Num);
+        LLVM_DEBUG(dbgs() << "Joining typevar " << T1Num << " and " << T2Num
+                          << "\n");
+      }
+      return true;
+    }
+    return SetTypeVar(T1Num, T2);
+  }
+
+  if (isTypeVariable(T2, T2Num)) {
+    // We know that T1 can't be a type variable, so the only possibility is that
+    // we assign T2 to T1.
+    return SetTypeVar(T2Num, T1);
+  }
+
+  // At this point, we know that neither type is a type variable. If the two
+  // types have a different structure, we can't unify them.
+  if (auto *TPT1 = dyn_cast<TypedPointerType>(T1)) {
+    if (auto *TPT2 = dyn_cast<TypedPointerType>(T2)) {
+      if (TPT1->getAddressSpace() != TPT2->getAddressSpace())
+        return false;
+      return unifyType(TPT1->getElementType(), TPT2->getElementType());
+    }
+    return false;
+  }
+
+  // We can also call unifyType(ptr, T2) (this is useful for propagating types
+  // to return values of instructions). In such a case, the ptr type is
+  // equivalent to typedptr(target("typevar")), for some type variable we
+  // haven't yet allocated. In this use case, it suffices to know that T2 is
+  // also a typed pointer type, as the case where T2 is a type variable was
+  // handled earlier.
+  if (isa<PointerType>(T1)) {
+    if (auto *TPT2 = dyn_cast<TypedPointerType>(T2))
+      return TPT2->getAddressSpace() == T1->getPointerAddressSpace();
+    return false;
+  }
+
+  if (auto *FT1 = dyn_cast<FunctionType>(T1)) {
+    if (auto *FT2 = dyn_cast<FunctionType>(T2)) {
+      if (FT1->getNumParams() != FT2->getNumParams())
+        return false;
+      if (FT1->isVarArg() != FT2->isVarArg())
+        return false;
+      if (!unifyType(FT1->getReturnType(), FT2->getReturnType()))
+        return false;
+      for (auto [PT1, PT2] : zip(FT1->params(), FT2->params()))
+        if (!unifyType(PT1, PT2))
+          return false;
+      return true;
+    }
+    return false;
+  }
+
+  if (auto *VT1 = dyn_cast<VectorType>(T1)) {
+    if (auto *VT2 = dyn_cast<VectorType>(T2)) {
+      if (VT1->getElementCount() != VT2->getElementCount())
+        return false;
+      return unifyType(VT1->getScalarType(), VT2->getScalarType());
+    }
+    return false;
+  }
+
+  if (auto *AT1 = dyn_cast<ArrayType>(T1)) {
+    if (auto *AT2 = dyn_cast<ArrayType>(T2)) {
+      if (AT1->getNumElements() != AT2->getNumElements())
+        return false;
+      return unifyType(AT1->getElementType(), AT2->getElementType());
+    }
+    return false;
+  }
+
+  // We already established T1 != T2 earlier, so there's no way we're capable of
+  // unifying at this point.
+  return false;
+}
+
 void SPIRVTypeScavenger::typeModule(Module &M) {
   // If typed pointers are in effect, we need to do nothing here.
   if (M.getContext().supportsTypedPointers())
     return;
 
-  // Try to fill in any known types for function parameters.
+  // Generate corrected function types for all functions in the module.
   for (auto &F : M.functions()) {
     deduceFunctionType(F);
   }
 
-  // Collect types for all pertinent values in the module.
+  // Now that we have function types, type the global variables. We have
+  // restrictions on our ability to do typing on constant initializers, so we
+  // need to make sure that global variables get typed.
+  for (auto &GV : M.globals())
+    typeGlobalValue(GV, GV.hasInitializer() ? GV.getInitializer() : nullptr);
+
+  // SPIR-V doesn't support global aliases, so pass through all of the types of
+  // global aliasees to the global alias (this at least ensures correct typing
+  // of uses of the global alias).
+  for (auto &GA : M.aliases()) {
+    Type *ScavengedTy = getScavengedType(GA.getAliasee());
+    DeducedTypes[&GA] = ScavengedTy;
+    LLVM_DEBUG(dbgs() << "Type of " << GA << " is " << *ScavengedTy << "\n");
+  }
+
+  // Type all instructions in the module.
   for (auto &F : M.functions()) {
-    for (Argument &Arg : F.args())
-      if (Arg.getType()->isPointerTy())
-        computePointerElementType(&Arg);
+    LLVM_DEBUG(dbgs() << "Typing function " << F.getName() << "\n");
     for (BasicBlock &BB : F) {
       for (Instruction &I : BB) {
-        if (I.getType()->isPointerTy())
-          computePointerElementType(&I);
+        getTypeAfterRules(&I);
         correctUseTypes(I);
       }
     }
   }
 
-  // Go through all of the types we have collected, and if any are still
-  // deferred, assign them a fallback i8* type.
+  // If there are any type variables we couldn't resolve, fallback to assigning
+  // them as an i8* type.
   Type *Int8Ty = Type::getInt8Ty(M.getContext());
-  for (const auto &Pair : DeducedTypes) {
-    if (auto *Untyped = dyn_cast<DeferredType *>(Pair.second)) {
-      LLVM_DEBUG(dbgs() << "No inferrable type for " << *Pair.first << "\n");
-      fixType(*Untyped, Int8Ty);
-      DeducedTypes[Pair.first] = Int8Ty;
+  for (auto [TypeVarNum, TypeVar] : enumerate(TypeVariables)) {
+    unsigned PrimaryVar = UnifiedTypeVars.join(TypeVarNum, TypeVarNum);
+    Type *LeaderTy = TypeVariables[PrimaryVar];
+    if (TypeVar)
+      TypeVar = substituteTypeVariables(TypeVar);
+    if (LeaderTy)
+      LeaderTy = substituteTypeVariables(LeaderTy);
+    assert((!TypeVar || LeaderTy == TypeVar) &&
+           "Inconsistent type variable unification");
+    if (!TypeVar) {
+      TypeVar = LeaderTy ? LeaderTy : Int8Ty;
     }
+    TypeVariables[TypeVarNum] = TypeVar;
+    LLVM_DEBUG(dbgs() << "Type variable " << TypeVarNum << " resolved to "
+                      << *TypeVar << "\n");
   }
   return;
 }
 
-static Type *getPointerUseType(Function *F, Op Opcode, unsigned ArgNo) {
-  switch (Opcode) {
-  case OpAtomicLoad:
-  case OpAtomicExchange:
-  case OpAtomicCompareExchange:
-  case OpAtomicIAdd:
-  case OpAtomicISub:
-  case OpAtomicFAddEXT:
-  case OpAtomicSMin:
-  case OpAtomicUMin:
-  case OpAtomicFMinEXT:
-  case OpAtomicSMax:
-  case OpAtomicUMax:
-  case OpAtomicFMaxEXT:
-  case OpAtomicAnd:
-  case OpAtomicOr:
-  case OpAtomicXor:
-    if (ArgNo == 0)
-      return F->getReturnType();
-    return nullptr;
-  case OpAtomicStore:
-    if (ArgNo == 0)
-      return F->getArg(3)->getType();
-    return nullptr;
-  default:
-    return nullptr;
-  }
-}
-
 bool SPIRVTypeScavenger::typeIntrinsicCall(
-    CallBase &CB, SmallVectorImpl<std::pair<unsigned, DeducedType>> &ArgTys) {
+    CallBase &CB, SmallVectorImpl<TypeRule> &TypeRules) {
   Function *TargetFn = CB.getCalledFunction();
   assert(TargetFn && TargetFn->isDeclaration() &&
          "Call is not an intrinsic function call");
   LLVMContext &Ctx = TargetFn->getContext();
 
+  StringRef DemangledName;
+  if (oclIsBuiltin(TargetFn->getName(), DemangledName) ||
+      isDecoratedSPIRVFunc(TargetFn, DemangledName)) {
+    Op OC = getSPIRVFuncOC(DemangledName);
+    switch (OC) {
+    case OpAtomicLoad:
+    case OpAtomicExchange:
+    case OpAtomicCompareExchange:
+    case OpAtomicIAdd:
+    case OpAtomicISub:
+    case OpAtomicFAddEXT:
+    case OpAtomicSMin:
+    case OpAtomicUMin:
+    case OpAtomicFMinEXT:
+    case OpAtomicSMax:
+    case OpAtomicUMax:
+    case OpAtomicFMaxEXT:
+    case OpAtomicAnd:
+    case OpAtomicOr:
+    case OpAtomicXor:
+      TypeRules.push_back(TypeRule::pointsTo(CB, 0, CB.getType()));
+      return true;
+    case OpAtomicStore:
+      TypeRules.push_back(
+          TypeRule::pointsTo(CB, 0, CB.getArgOperand(3)->getType()));
+      return true;
+    case OpGenericCastToPtr:
+    case OpGenericCastToPtrExplicit: {
+      Type *Ty =
+          cast<TypedPointerType>(getFunctionType(TargetFn)->getParamType(0))
+              ->getElementType();
+      TypeRules.push_back(TypeRule::pointsTo(CB, 0, Ty));
+      TypeRules.push_back(TypeRule::returnsPointerTo(Ty));
+      return true;
+    }
+    default:
+      // Do nothing
+      break;
+    }
+  }
+
   if (auto IntrinID = TargetFn->getIntrinsicID()) {
     switch (IntrinID) {
     case Intrinsic::memcpy: {
-      // First two parameters are pointers, but it may be any pointer type.
-      DeducedType MemcpyTy = new DeferredType;
-      ArgTys.emplace_back(0, MemcpyTy);
-      ArgTys.emplace_back(1, MemcpyTy);
+      // First two parameters are pointers, but they point to the same thing
+      // (albeit maybe in different address spaces).
+      TypeRules.push_back(TypeRule::isIndirect(CB, 0, 1));
       break;
     }
     case Intrinsic::memset:
-      ArgTys.emplace_back(0, Type::getInt8Ty(Ctx));
+      TypeRules.push_back(TypeRule::pointsTo(CB, 0, Type::getInt8Ty(Ctx)));
       break;
     case Intrinsic::lifetime_start:
     case Intrinsic::lifetime_end:
@@ -144,19 +492,25 @@ bool SPIRVTypeScavenger::typeIntrinsicCall(
       // These intrinsics were stored as i8* as typed pointers, and the SPIR-V
       // writer will expect these to be i8*, even if they can be any pointer
       // type.
-      ArgTys.emplace_back(1, Type::getInt8Ty(Ctx));
+      TypeRules.push_back(TypeRule::pointsTo(CB, 1, Type::getInt8Ty(Ctx)));
       break;
     case Intrinsic::invariant_end:
       // This is like invariant_start with an extra string parameter in the
       // beginning (so the pointer object moves to argument two).
-      ArgTys.emplace_back(0, Type::getInt8Ty(Ctx));
-      ArgTys.emplace_back(2, Type::getInt8Ty(Ctx));
+      TypeRules.push_back(TypeRule::pointsTo(CB, 0, Type::getInt8Ty(Ctx)));
+      TypeRules.push_back(TypeRule::pointsTo(CB, 2, Type::getInt8Ty(Ctx)));
       break;
     case Intrinsic::var_annotation:
-    case Intrinsic::ptr_annotation:
       // The first parameter of these is an i8*.
-      ArgTys.emplace_back(0, Type::getInt8Ty(Ctx));
-      [[fallthrough]];
+      // (See below for notes on the latter parameters).
+      TypeRules.push_back(TypeRule::pointsTo(CB, 0, Type::getInt8Ty(Ctx)));
+      break;
+    case Intrinsic::ptr_annotation:
+      // Returns the first argument.
+      // (See below for notes on the latter parameters).
+      TypeRules.push_back(TypeRule::pointsTo(CB, 0, Type::getInt8Ty(Ctx)));
+      TypeRules.push_back(TypeRule::returnsPointerTo(Type::getInt8Ty(Ctx)));
+      break;
     case Intrinsic::annotation:
       // Second and third parameters are strings, which should be constants
       // for global variables. Nominally, this is i8*, but we specifically
@@ -164,17 +518,17 @@ bool SPIRVTypeScavenger::typeIntrinsicCall(
       // global constants).
       break;
     case Intrinsic::stacksave:
-      // TODO: support return type.
+      TypeRules.push_back(TypeRule::returnsPointerTo(Type::getInt8Ty(Ctx)));
       break;
     case Intrinsic::stackrestore:
-      ArgTys.emplace_back(0, Type::getInt8Ty(Ctx));
+      TypeRules.push_back(TypeRule::pointsTo(CB, 0, Type::getInt8Ty(Ctx)));
       break;
     case Intrinsic::instrprof_cover:
     case Intrinsic::instrprof_increment:
     case Intrinsic::instrprof_increment_step:
     case Intrinsic::instrprof_value_profile:
       // llvm.instrprof.* intrinsics are not supported
-      ArgTys.emplace_back(0, Type::getInt8Ty(Ctx));
+      TypeRules.push_back(TypeRule::pointsTo(CB, 0, Type::getInt8Ty(Ctx)));
       break;
     // TODO: handle masked gather/scatter intrinsics. This requires support
     // for vector-of-pointers in the type scavenger.
@@ -182,25 +536,90 @@ bool SPIRVTypeScavenger::typeIntrinsicCall(
       return false;
     }
   } else if (TargetFn->getName().startswith("_Z18__spirv_ocl_printf")) {
-    ArgTys.emplace_back(0, Type::getInt8Ty(Ctx));
+    TypeRules.push_back(TypeRule::pointsTo(CB, 0, Type::getInt8Ty(Ctx)));
   } else if (TargetFn->getName() == "__spirv_GetKernelWorkGroupSize__") {
-    ArgTys.emplace_back(1, Type::getInt8Ty(Ctx));
+    TypeRules.push_back(TypeRule::pointsTo(CB, 1, Type::getInt8Ty(Ctx)));
   } else if (TargetFn->getName() ==
              "__spirv_GetKernelPreferredWorkGroupSizeMultiple__") {
-    ArgTys.emplace_back(1, Type::getInt8Ty(Ctx));
+    TypeRules.push_back(TypeRule::pointsTo(CB, 1, Type::getInt8Ty(Ctx)));
   } else if (TargetFn->getName() ==
              "__spirv_GetKernelNDrangeMaxSubGroupSize__") {
-    ArgTys.emplace_back(2, Type::getInt8Ty(Ctx));
+    TypeRules.push_back(TypeRule::pointsTo(CB, 2, Type::getInt8Ty(Ctx)));
   } else if (TargetFn->getName() == "__spirv_GetKernelNDrangeSubGroupCount__") {
-    ArgTys.emplace_back(2, Type::getInt8Ty(Ctx));
+    TypeRules.push_back(TypeRule::pointsTo(CB, 2, Type::getInt8Ty(Ctx)));
   } else if (TargetFn->getName().starts_with("__spirv_EnqueueKernel__")) {
-    ArgTys.emplace_back(4, TargetExtType::get(Ctx, "spirv.DeviceEvent"));
-    ArgTys.emplace_back(5, TargetExtType::get(Ctx, "spirv.DeviceEvent"));
-    ArgTys.emplace_back(7, Type::getInt8Ty(Ctx));
+    Type *DevEvent = TargetExtType::get(Ctx, "spirv.DeviceEvent");
+    TypeRules.push_back(TypeRule::pointsTo(CB, 4, DevEvent));
+    TypeRules.push_back(TypeRule::pointsTo(CB, 5, DevEvent));
+    TypeRules.push_back(TypeRule::pointsTo(CB, 7, Type::getInt8Ty(Ctx)));
   } else
     return false;
 
   return true;
+}
+
+void SPIRVTypeScavenger::typeFunctionParams(
+    CallBase &CB, FunctionType *FT, unsigned ArgStart, bool IncludeRet,
+    SmallVectorImpl<TypeRule> &TypeRules) {
+  for (auto [U, ArgTy] : zip(drop_begin(CB.args(), ArgStart), FT->params())) {
+    if (hasPointerType(U->getType())) {
+      TypeRules.push_back(TypeRule::is(U, ArgTy));
+    }
+  }
+  if (IncludeRet) {
+    if (hasPointerType(CB.getType()))
+      TypeRules.push_back(TypeRule::returns(FT->getReturnType()));
+  }
+}
+
+void SPIRVTypeScavenger::typeGlobalValue(GlobalValue &GV, Constant *Init) {
+  auto GetNaturalType = [&](Value *C) -> Type * {
+    if (isa<GlobalValue>(C)) {
+      auto It = DeducedTypes.find(C);
+      if (It != DeducedTypes.end())
+        return It->second;
+    }
+
+    return getUnknownTyped(C->getType());
+  };
+
+  Type *Ty = GV.getValueType();
+  Type *MemType = nullptr;
+  // If the initializer is an array or vector of globals that all have the same
+  // type, prefer to use that type.
+  if (Init && (isa<ConstantArray>(Init) || isa<ConstantVector>(Init))) {
+    Type *InnerTy = Init->getType()->getContainedType(0);
+    if (InnerTy->isPointerTy()) {
+      Type *CommonTy = allocateTypeVariable(InnerTy);
+      bool Successful = true;
+      for (Value *Op : Init->operand_values()) {
+        Successful &= unifyType(CommonTy, GetNaturalType(Op));
+        if (!Successful)
+          break;
+      }
+      if (Successful) {
+        CommonTy = substituteTypeVariables(CommonTy);
+        if (isa<ConstantArray>(Init))
+          MemType = ArrayType::get(CommonTy, Ty->getArrayNumElements());
+        else
+          MemType = VectorType::get(CommonTy,
+                                    cast<VectorType>(Ty)->getElementCount());
+      }
+    }
+  }
+
+  // If there's an initializer, give it a fixed type based on the initializer.
+  if (Init && !MemType)
+    MemType = GetNaturalType(Init);
+
+  // At this point, use a fixed type based on the value type of the global value
+  // if we didn't compute it already.
+  if (!MemType)
+    MemType = getUnknownTyped(GV.getValueType());
+
+  Type *TypedTy = TypedPointerType::get(MemType, GV.getAddressSpace());
+  LLVM_DEBUG(dbgs() << "@" << GV.getName() << " has type " << *TypedTy << "\n");
+  DeducedTypes[&GV] = TypedTy;
 }
 
 static Type *getParamType(const AttributeList &AL, unsigned ArgNo) {
@@ -218,9 +637,28 @@ static Type *getParamType(const AttributeList &AL, unsigned ArgNo) {
 }
 
 void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
+  // Start by constructing a basic function type that replaces all pointer
+  // types in arguments (and the return type) with type variables. We may
+  // resolve those type variables almost immediately, but this is a starting
+  // point.
+  FunctionType *FuncTy = F.getFunctionType();
+  if (hasPointerType(FuncTy))
+    FuncTy = cast<FunctionType>(allocateTypeVariable(F.getFunctionType()));
+  DeducedTypes[&F] = TypedPointerType::get(FuncTy, F.getAddressSpace());
+
+  auto TypeArgument = [&](Argument *Arg, Type *T) {
+    [[maybe_unused]] bool Successful =
+        unifyType(FuncTy->getParamType(Arg->getArgNo()), T);
+    assert(Successful && "Unification of argument type failed?");
+    LLVM_DEBUG(dbgs() << "  Arg " << *Arg << " is known to be " << *T << "\n");
+    DeducedTypes[Arg] = T;
+  };
+
+  // Gather a list of arguments that have unresolved type variables.
   SmallVector<Argument *, 8> PointerArgs;
   for (Argument &Arg : F.args()) {
-    if (Arg.getType()->isPointerTy())
+    DeducedTypes[&Arg] = FuncTy->getParamType(Arg.getArgNo());
+    if (hasPointerType(Arg.getType()))
       PointerArgs.push_back(&Arg);
   }
 
@@ -228,7 +666,8 @@ void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
   for (Argument *Arg : PointerArgs) {
     Type *Ty = getParamType(F.getAttributes(), Arg->getArgNo());
     if (Ty)
-      DeducedTypes[Arg] = Ty;
+      TypeArgument(Arg, TypedPointerType::get(
+                            Ty, Arg->getType()->getPointerAddressSpace()));
   }
 
   // The first non-sret argument of block_invoke functions is the block capture
@@ -238,57 +677,32 @@ void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
   if (BlockInvokeRegex.match(F.getName())) {
     for (Argument *Arg : PointerArgs) {
       if (!Arg->hasAttribute(Attribute::StructRet)) {
-        DeducedTypes[Arg] = Type::getInt8Ty(F.getContext());
-        LLVM_DEBUG(dbgs() << "Arg " << Arg->getArgNo() << " of " << F.getName()
-                          << " has type i8\n");
+        TypeArgument(Arg, getUnknownTyped(Arg->getType()));
         break;
       }
     }
   }
 
-  // At this point, anything that we can get definitively correct is going to
-  // come from declarations of builtins. If we have the actual implementation of
-  // the function available, we should try to recover types from the function
-  // definition itself. By early returning here, we ensure that remaining
-  // arguments will get deferred types that will follow the regular typing
-  // process.
-  if (!F.isDeclaration())
-    return;
-
-  // Recover known information from known SPIR-V builtin operations represented
-  // as functions.
-  StringRef DemangledName;
-  if (oclIsBuiltin(F.getName(), DemangledName) ||
-      isDecoratedSPIRVFunc(&F, DemangledName)) {
-    Op OC = getSPIRVFuncOC(DemangledName);
-    if (OC != OpNop) {
-      for (Argument *Arg : PointerArgs) {
-        Type *PointeeTy = getPointerUseType(&F, OC, Arg->getArgNo());
-        if (PointeeTy) {
-          DeducedTypes[Arg] = PointeeTy;
-          LLVM_DEBUG(dbgs()
-                     << "Arg " << Arg->getArgNo() << " of " << F.getName()
-                     << " has type " << *PointeeTy << "\n");
+  // If the function is a mangled name, try to recover types from the Itanium
+  // name mangling. Do this only for function types that without bodies, where
+  // existing code can propagate types to the parameters.
+  // TODO: Investigate if target extension types and the specially-handled
+  // SPIR-V intrinsics renders this code unnecessary.
+  if (F.isDeclaration() && F.getName().startswith("_Z")) {
+    if (F.getName().startswith("_Z")) {
+      SmallVector<Type *, 8> ParamTypes;
+      if (getParameterTypes(&F, ParamTypes)) {
+        for (Argument *Arg : PointerArgs) {
+          if (auto *Ty =
+                  dyn_cast<TypedPointerType>(ParamTypes[Arg->getArgNo()]))
+            TypeArgument(Arg, Ty);
         }
       }
     }
   }
 
-  // If the function is a mangled name, try to recover types from the Itanium
-  // name mangling.
-  if (F.getName().startswith("_Z")) {
-    SmallVector<Type *, 8> ParamTypes;
-    if (!getParameterTypes(&F, ParamTypes)) {
-      return;
-    }
-    for (Argument *Arg : PointerArgs) {
-      if (auto *Ty = dyn_cast<TypedPointerType>(ParamTypes[Arg->getArgNo()])) {
-        DeducedTypes[Arg] = Ty->getElementType();
-        LLVM_DEBUG(dbgs() << "Arg " << Arg->getArgNo() << " of " << F.getName()
-                          << " has type " << *Ty->getElementType() << "\n");
-      }
-    }
-  }
+  LLVM_DEBUG(dbgs() << "Type of @" << F.getName() << " is "
+                    << *substituteTypeVariables(FuncTy) << "\n");
 }
 
 /// Certain constant types (null, undef, and poison) will get their type from
@@ -300,220 +714,223 @@ static bool doesNotImplyType(Value *V) {
   return isa<ConstantPointerNull>(V) || isa<UndefValue>(V);
 }
 
-SPIRVTypeScavenger::DeducedType
-SPIRVTypeScavenger::computePointerElementType(Value *V) {
-  assert(V->getType()->isPtrOrPtrVectorTy() &&
-         "Trying to get the pointer type of a non-pointer value?");
+Type *SPIRVTypeScavenger::getTypeAfterRules(Value *V) {
+  auto *Ty = V->getType();
+  if (!hasPointerType(Ty))
+    return Ty;
 
   // Don't try to store null, undef, or poison in our type map. We'll call these
   // i8* by default; if any use has a different type, a bitcast will be added
   // later.
   if (doesNotImplyType(V)) {
-    return Type::getInt8Ty(V->getContext());
+    return getUnknownTyped(Ty);
   }
 
   // Check if we've already deduced a type for the value.
-  DeducedType Ty = DeducedTypes[V];
-  if (Ty) {
-    return Ty;
-  }
+  Type *KnownType = DeducedTypes.lookup(V);
+  if (KnownType)
+    return substituteTypeVariables(KnownType);
+
+  assert(
+      !isa<GlobalValue>(V) && !isa<Argument>(V) &&
+      "Globals and arguments must be fully handled before calling this method");
+
+  // All constants will have their pointer types handled as i8*.
+  if (!isa<Instruction>(V))
+    return getUnknownTyped(Ty);
 
   assert(!is_contained(VisitStack, V) && "Found cycle in type scavenger");
   VisitStack.push_back(V);
 
-  // There are basically three categories of pointer-typed values:
-  // 1. Values that have a well-defined pointee type (e.g., alloca). Return the
-  //    known type from this method.
-  // 2. Values that have no intrinsic type (e.g., inttoptr). A new deferred
-  //    type construct will be created that will allow a use to identify the
-  //    type instead.
-  // 3. Values that propagate their source type (e.g., phi). This wil return
-  //    the type of their source argument, whether it is deferred or known.
+  // Try to propagate from type rules constraining the return value.
+  SmallVector<TypeRule, 4> TypeRules;
+  getTypeRules(*cast<Instruction>(V), TypeRules);
+  for (TypeRule &Rule : TypeRules) {
+    if (Rule.OpNo != RETURN_OPERAND)
+      continue;
 
-  // This lambda does the logic to propagate the third category.
-  auto PropagateType = [&](Value *Source) -> DeducedType {
-    // If the source argument is null, undef, or poison, then consider the
-    // propagation to be untyped. This will fall through to the case where we
-    // construct a nw
-    if (doesNotImplyType(Source))
-      return nullptr;
+    // Get the target type from the rule. If it comes from an operand,
+    // recursively attempt to find the type from the operand (but avoid any
+    // cycles).
+    Type *TargetTy;
+    if (auto *UsedTy = dyn_cast<Type *>(Rule.Target)) {
+      TargetTy = allocateTypeVariable(UsedTy);
+    } else {
+      Value *Arg = cast<Use *>(Rule.Target)->get();
+      if (is_contained(VisitStack, Arg))
+        continue;
 
-    DeducedType SourceTy = computePointerElementType(Source);
-    if (auto *Deferred = dyn_cast<DeferredType *>(SourceTy)) {
-      LLVM_DEBUG(dbgs() << *Source << " will receive the same type as " << *V
-                        << "\n");
-      Deferred->Values.push_back(V);
+      Value *Source = cast<Use *>(Rule.Target)->get();
+      // If the source argument is null, undef, or poison, then move on to
+      // another rule to give better type hints.
+      if (doesNotImplyType(Source))
+        continue;
+
+      TargetTy = substituteTypeVariables(getTypeAfterRules(Source));
     }
-    return SourceTy;
+
+    // If the argument is a null pointer, try another operand instead.
+    if (!TargetTy)
+      continue;
+    KnownType =
+        adjustIndirect(Ty, Rule.LhsIndirect, TargetTy, Rule.RhsIndirect);
+    // Make sure that the type is consistent with the type format of Ty.
+    if (!unifyType(Ty, KnownType))
+      KnownType = nullptr;
+    break;
+  }
+
+  // If we still haven't gotten a type at this point, just construct a new type
+  // variable and rely on later uses to recover the type.
+  if (!KnownType) {
+    LLVM_DEBUG(dbgs() << *V << " matched no typing rules\n");
+    KnownType = allocateTypeVariable(Ty);
+  }
+
+  DeducedTypes[V] = KnownType;
+  VisitStack.pop_back();
+
+  LLVM_DEBUG(dbgs() << "Assigned type " << *KnownType << " to " << *V << "\n");
+  return KnownType;
+}
+
+void SPIRVTypeScavenger::getTypeRules(Instruction &I,
+                                      SmallVectorImpl<TypeRule> &TypeRules) {
+  auto GetAssociatedTypeVariable = [&](Type *T) {
+    Type *&TypeVar = AssociatedTypeVariables[&I];
+    if (TypeVar)
+      return TypeVar;
+    return TypeVar = allocateTypeVariable(T);
   };
 
-  // These values have a natural pointer type (category 1).
-  if (auto *GV = dyn_cast<GlobalValue>(V))
-    Ty = GV->getValueType();
-  else if (auto *Alloca = dyn_cast<AllocaInst>(V))
-    Ty = Alloca->getAllocatedType();
-  else if (auto *GEP = dyn_cast<GEPOperator>(V))
-    Ty = GEP->getResultElementType();
+  if (auto *GEP = dyn_cast<GetElementPtrInst>(&I)) {
+    Type *GepTy = GEP->getSourceElementType();
+    Type *ReturnTy = GEP->getResultElementType();
+    if (hasPointerType(GepTy)) {
+      GepTy = GetAssociatedTypeVariable(GepTy);
+      // Iterate the indices to find the return type, based on the version of
+      // the type using type variables and typed pointer types instead.
+      ReturnTy = GepTy;
+      for (Use &U : drop_begin(GEP->indices()))
+        ReturnTy = GetElementPtrInst::getTypeAtIndex(ReturnTy, U.get());
+    } else {
+      // It's possible that ReturnTy might be a type containing a ptr. However,
+      // if we aren't typing the struct type specifically, then this type is
+      // going to be coerced by the writer to i8*, so don't allocate any type
+      // variables for it.
+      ReturnTy = getUnknownTyped(ReturnTy);
+    }
+    TypeRules.push_back(TypeRule::pointsTo(I, 0, GepTy));
+    TypeRules.push_back(TypeRule::returnsPointerTo(ReturnTy));
+  } else if (isa<LoadInst>(&I)) {
+    TypeRules.push_back(
+        TypeRule::pointsToReturn(I, LoadInst::getPointerOperandIndex()));
+  } else if (isa<StoreInst>(&I)) {
+    TypeRules.push_back(
+        TypeRule::pointsTo(I, StoreInst::getPointerOperandIndex(), 0U));
+  } else if (auto *AI = dyn_cast<AtomicCmpXchgInst>(&I)) {
+    TypeRules.push_back(
+        TypeRule::pointsTo(I, AtomicCmpXchgInst::getPointerOperandIndex(), 1));
+    if (hasPointerType(AI->getCompareOperand()->getType()))
+      TypeRules.push_back(TypeRule::is(I, 1, 2));
+  } else if (auto *AI = dyn_cast<AtomicRMWInst>(&I)) {
+    TypeRules.push_back(
+        TypeRule::pointsTo(I, AtomicRMWInst::getPointerOperandIndex(), 1));
+    if (hasPointerType(AI->getValOperand()->getType()))
+      TypeRules.push_back(TypeRule::propagates(I, 1));
+  } else if (auto *AI = dyn_cast<AllocaInst>(&I)) {
+    TypeRules.push_back(TypeRule::returnsPointerTo(AI->getAllocatedType()));
+  } else if (auto *CI = dyn_cast<ICmpInst>(&I)) {
+    // icmp can compare pointers. If it isn't, ignore the instruction.
+    if (!hasPointerType(CI->getOperand(0)->getType()))
+      return;
 
-  // These values have no intrinsic type (category 2).
-  else if (isa<IntToPtrInst>(V) || isa<BitCastInst>(V))
-    Ty = nullptr;
+    // The two pointer operands should have the same type.
+    TypeRules.push_back(TypeRule::is(I, 1, 0));
+  } else if (auto *SI = dyn_cast<SelectInst>(&I)) {
+    if (!hasPointerType(SI->getType()))
+      return;
 
-  // These values propagate the source type (category 3).
-  else if (auto *AS = dyn_cast<AddrSpaceCastInst>(V))
-    Ty = PropagateType(AS->getPointerOperand());
-  else if (auto *Freeze = dyn_cast<FreezeInst>(V))
-    Ty = PropagateType(Freeze->getOperand(0));
-  // Yes, atomicrmw xchg can exchange a ptr type. This will also be considered
-  // to propagate the source type.
-  else if (auto *AI = dyn_cast<AtomicRMWInst>(V))
-    Ty = PropagateType(AI->getValOperand());
+    // Both selected values should have the same type as the result.
+    TypeRules.push_back(TypeRule::propagates(I, 1));
+    TypeRules.push_back(TypeRule::propagates(I, 2));
+  } else if (auto *Phi = dyn_cast<PHINode>(&I)) {
+    if (!hasPointerType(Phi->getType()))
+      return;
 
-  // Selects and phis propagate types as well. Only investigate one of the
-  // sources here as the type of the operation: if the primary operand has a
-  // deferred type and a secondary operand has a known type, we'll discover that
-  // when we handle uses anyways.
-  else if (auto *Select = dyn_cast<SelectInst>(V))
-    Ty = PropagateType(Select->getTrueValue());
-  else if (auto *Phi = dyn_cast<PHINode>(V)) {
-    // If we specifically tried the first argument (or any particular argument),
-    // we could end up in a situation where we get caught in a cycle:
-    // %a = phi(%b, %c)
-    // %b = phi(%a, %d)
-    // So pick the first argument that whose type we are not trying to compute
-    // right now. In the rare case that we have an unreachable block, we could
-    // exhaust all possible options, in which case we'll fall through to having
-    // an unknown type.
-    for (Value *Arg : Phi->incoming_values()) {
-      if (!is_contained(VisitStack, Arg)) {
-        Ty = PropagateType(Arg);
-        break;
+    for (Use &U : Phi->incoming_values()) {
+      TypeRules.push_back(TypeRule::propagates(U));
+    }
+  } else if (isa<FreezeInst>(&I)) {
+    if (!hasPointerType(I.getType()))
+      return;
+    TypeRules.push_back(TypeRule::propagates(I, 0));
+  } else if (auto *AS = dyn_cast<AddrSpaceCastInst>(&I)) {
+    TypeRules.push_back(TypeRule::propagatesIndirect(*AS, 0));
+  } else if (isa<ReturnInst>(&I)) {
+    if (!hasPointerType(I.getFunction()->getReturnType()))
+      return;
+    Type *ExpectedTy = getFunctionType(I.getFunction())->getReturnType();
+    TypeRules.push_back(TypeRule::is(0, ExpectedTy));
+  } else if (auto *CB = dyn_cast<CallBase>(&I)) {
+    // If we have an identified function for the call instruction, map the
+    // arguments we pass in to the argument requirements of the function.
+    if (Function *F = CB->getCalledFunction()) {
+      if (!F->isDeclaration() || !typeIntrinsicCall(*CB, TypeRules)) {
+        typeFunctionParams(*CB, getFunctionType(F), 0, true, TypeRules);
       }
+    } else {
+      // In the case of function pointers, we need to also assert the function
+      // type of the call instruction itself.
+      // In the case of inline assembly, the inline asm type is typed as if all
+      // ptr parameters are i8* by the writer, so force all pointer to those
+      // types here.
+      FunctionType *FT =
+          cast<FunctionType>(GetAssociatedTypeVariable(CB->getFunctionType()));
+      if (isa<InlineAsm>(CB->getCalledOperand()))
+        FT = cast<FunctionType>(getUnknownTyped(CB->getFunctionType()));
+      else
+        TypeRules.push_back(TypeRule::pointsTo(CB->getCalledOperandUse(), FT));
+      typeFunctionParams(*CB, FT, 0, true, TypeRules);
     }
   }
 
-  else if (auto *Arg = dyn_cast<Argument>(V)) {
-    // Check for an sret/byval/etc. attribute on the argument. If it doesn't
-    // have one, then it will return null. There are other cases where we can
-    // pre-fill the type of an argument, but that is handled in an earlier
-    // pre-pass.
-    unsigned ArgNo = Arg->getArgNo();
-    Ty = getParamType(Arg->getParent()->getAttributes(), ArgNo);
-  } else if (auto *CB = dyn_cast<CallBase>(V)) {
-    // TODO: Handle return types properly.
-    Ty = Type::getInt8Ty(CB->getContext());
+  // TODO: Handle insertvalue, extractvalue that work with pointers (requires
+  // literal struct support)
+}
+
+std::pair<Use &, Type *>
+SPIRVTypeScavenger::getTypeCheck(Instruction &I, const TypeRule &Rule) {
+  auto MakeCheck = [&](Use &U, bool UIndirect, Type *Ty, bool TIndirect) {
+    return std::pair<Use &, Type *>(
+        U, adjustIndirect(U->getType(), UIndirect, Ty, TIndirect));
+  };
+  bool LIndirect = Rule.LhsIndirect, RIndirect = Rule.RhsIndirect;
+  // If we have typeof(return) == typeof(operand) check, reverse the check for
+  // typing rules.
+  if (Rule.OpNo == RETURN_OPERAND) {
+    Use &U = *cast<Use *>(Rule.Target);
+    Type *Ty = getTypeAfterRules(&I);
+    return MakeCheck(U, RIndirect, Ty, LIndirect);
+  }
+  Type *TargetTy;
+  if (auto *UsedTy = dyn_cast<Type *>(Rule.Target)) {
+    TargetTy = UsedTy;
   } else {
-    // TODO: handle pointer-valued extractvalue, which probably comes from
-    // cmpxchg or inlineasm.
-    LLVM_DEBUG(
-        dbgs()
-        << "Value " << *V << " is not a known type of "
-        << "pointer-valued instruction, this logic is probably wrong!\n");
+    TargetTy = getTypeAfterRules(cast<Use *>(Rule.Target)->get());
   }
-
-  // If we haven't gotten a type at this point, we need to construct a new
-  // deferred type to handle this value. This also considers cases where we
-  // were trying to propagate a null constant.
-  if (!Ty) {
-    LLVM_DEBUG(dbgs() << "Value " << *V
-                      << " has no known type, creating a new type for it\n");
-    DeferredType *Deferred = new DeferredType;
-    Deferred->Values.push_back(V);
-    Ty = Deferred;
-  }
-
-  DeducedTypes[V] = Ty;
-  VisitStack.pop_back();
-  return Ty;
+  Use &U = I.getOperandUse(Rule.OpNo);
+  return MakeCheck(U, LIndirect, TargetTy, RIndirect);
 }
 
 void SPIRVTypeScavenger::correctUseTypes(Instruction &I) {
   // This represents the types of all pointer-valued operands of the
   // instruction.
-  SmallVector<std::pair<unsigned, DeducedType>, 4> PointerOperands;
+  SmallVector<TypeRule, 4> TypeRules;
+  getTypeRules(I, TypeRules);
 
-  // For instructions which operate with memory (e.g., load, store), this is the
-  // value whose type will determine the type of the operand. When the memory
-  // type is just a generic `ptr` type, this will be used to generate a
-  // pointer-to-pointer-to-something type.
-  auto GetMemoryType = [&](Value *V) -> DeducedType {
-    if (V->getType()->isPointerTy())
-      return V;
-    return V->getType();
-  };
-
-  // Basic instructions that have a clearly fixed type.
-  if (auto *GEP = dyn_cast<GetElementPtrInst>(&I)) {
-    PointerOperands.emplace_back(GetElementPtrInst::getPointerOperandIndex(),
-                                 GEP->getSourceElementType());
-  } else if (auto *LI = dyn_cast<LoadInst>(&I)) {
-    PointerOperands.emplace_back(LoadInst::getPointerOperandIndex(),
-                                 GetMemoryType(LI));
-  } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
-    PointerOperands.emplace_back(StoreInst::getPointerOperandIndex(),
-                                 GetMemoryType(SI->getValueOperand()));
-  } else if (auto *AI = dyn_cast<AtomicCmpXchgInst>(&I)) {
-    PointerOperands.emplace_back(AtomicCmpXchgInst::getPointerOperandIndex(),
-                                 GetMemoryType(AI->getCompareOperand()));
-  } else if (auto *AI = dyn_cast<AtomicRMWInst>(&I)) {
-    PointerOperands.emplace_back(AtomicRMWInst::getPointerOperandIndex(),
-                                 GetMemoryType(AI->getValOperand()));
-  } else if (auto *CI = dyn_cast<ICmpInst>(&I)) {
-    // icmp can compare pointers. If it isn't, ignore the instruction.
-    if (!CI->getOperand(0)->getType()->isPointerTy())
-      return;
-
-    // The two pointer operands should have the same type.
-    PointerOperands.emplace_back(1,
-                                 computePointerElementType(CI->getOperand(0)));
-  } else if (auto *SI = dyn_cast<SelectInst>(&I)) {
-    if (!SI->getType()->isPointerTy())
-      return;
-
-    // Both selected values should have the same type as the result.
-    DeducedType Ty = computePointerElementType(SI);
-    PointerOperands.emplace_back(1, Ty);
-    PointerOperands.emplace_back(2, Ty);
-  } else if (auto *Phi = dyn_cast<PHINode>(&I)) {
-    if (!Phi->getType()->isPointerTy())
-      return;
-
-    DeducedType Ty = computePointerElementType(Phi);
-    for (Use &U : Phi->incoming_values()) {
-      PointerOperands.emplace_back(U.getOperandNo(), Ty);
-    }
-  } else if (isa<FreezeInst>(&I) || isa<AddrSpaceCastInst>(&I)) {
-    if (!I.getType()->isPointerTy())
-      return;
-    PointerOperands.emplace_back(0, computePointerElementType(&I));
-  } else if (auto *RI = dyn_cast<ReturnInst>(&I)) {
-    if (!RI->getReturnValue() ||
-        !RI->getReturnValue()->getType()->isPointerTy())
-      return;
-    // TODO: Handle return types properly.
-    PointerOperands.emplace_back(0, Type::getInt8Ty(I.getContext()));
-  } else if (auto *CB = dyn_cast<CallBase>(&I)) {
-    PointerOperands.emplace_back(CB->getCalledOperandUse().getOperandNo(),
-                                 CB->getFunctionType());
-    // If we have an identified function for the call instruction, map the
-    // arguments we pass in to the argument requirements of the function.
-    if (Function *F = CB->getCalledFunction()) {
-      if (!F->isDeclaration() || !typeIntrinsicCall(*CB, PointerOperands)) {
-        for (Use &U : CB->args()) {
-          // If we're calling a var-arg method, we have more operands than the
-          // function has parameters. Bail out if we hit that point.
-          unsigned ArgNo = CB->getArgOperandNo(&U);
-          if (ArgNo >= F->arg_size())
-            break;
-          if (U->getType()->isPointerTy())
-            PointerOperands.emplace_back(
-                U.getOperandNo(), computePointerElementType(F->getArg(ArgNo)));
-        }
-      }
-    }
-  }
-
-  // TODO: Handle insertvalue instructions that insert pointers.
+  if (!TypeRules.empty())
+    LLVM_DEBUG(dbgs() << "Typing uses of " << I << "\n");
 
   // Now that we've collected all the pointer-valued operands in the
   // instruction, go through and insert bitcasts for any operands that have the
@@ -521,10 +938,13 @@ void SPIRVTypeScavenger::correctUseTypes(Instruction &I) {
   // deferred types that need to have the same type.
   IRBuilder<NoFolder> Builder(&I);
 
-  for (auto &Pair : PointerOperands) {
-    Use &U = I.getOperandUse(Pair.first);
-    DeducedType UsedTy = Pair.second;
-    DeducedType SourceTy = computePointerElementType(U);
+  for (auto &Rule : TypeRules) {
+    // No type checking needs to happen for a returns-type rule, since there's
+    // no operands of this instruction to check.
+    if (Rule.OpNo == RETURN_OPERAND && isa<Type *>(Rule.Target))
+      continue;
+    auto [U, UsedTy] = getTypeCheck(I, Rule);
+    Type *SourceTy = getTypeAfterRules(U);
 
     // If we're handling a PHI node, we need to insert in the basic block that
     // the value comes in from, not immediately before this instruction.
@@ -533,128 +953,76 @@ void SPIRVTypeScavenger::correctUseTypes(Instruction &I) {
       Builder.SetInsertPoint(SourceBlock->getTerminator());
     }
 
-    auto InsertCast = [&]() {
-      if (isa<Type *>(UsedTy)) {
-        LLVM_DEBUG(dbgs() << "Inserting bitcast of " << *U.get()
-                          << " to change its type to " << *cast<Type *>(UsedTy)
-                          << " because of use in " << *U.getUser() << "\n");
-      } else {
-        LLVM_DEBUG(dbgs() << "Inserting bitcast of " << *U.get()
-                          << " for indirect pointer use of "
-                          << *cast<Value *>(UsedTy) << " because of use in "
-                          << *U.getUser() << "\n");
-      }
+    bool CanUnify = unifyType(SourceTy, UsedTy);
+    LLVM_DEBUG(dbgs() << "  " << *SourceTy << " == " << *UsedTy << "? "
+                      << (CanUnify ? "yes" : "no") << "\n");
+    if (!CanUnify) {
+      LLVM_DEBUG({
+        dbgs() << "  Inserting bitcast of ";
+        U->printAsOperand(dbgs(), true,
+                          I.getParent()->getParent()->getParent());
+        dbgs() << "\n";
+      });
       Value *CastedValue =
           Builder.Insert(CastInst::CreatePointerCast(U, U->getType()));
       DeducedTypes[CastedValue] = UsedTy;
       U.set(CastedValue);
-    };
-
-    // This handles the scenario where a deferred type gets resolved to a fixed
-    // type during handling of this instruction, and another operand is using
-    // the same deferred type later in the instruction.
-    auto ReplaceTypeInOperands = [&](DeducedType From, DeducedType To) {
-      for (auto &ReplacePair : PointerOperands) {
-        if (ReplacePair.second == From)
-          ReplacePair.second = To;
-      }
-    };
-
-    if (isa<Value *>(UsedTy)) {
-      // When the use is of an indirect-pointer type, insert a bitcast to the
-      // use type only for this use. This prevents indirect pointers from
-      // generally leaking into more of the type system and causing potential
-      // issues.
-      InsertCast();
-    } else if (auto *FixedTy = dyn_cast<Type *>(SourceTy)) {
-      if (auto *FixedUseTy = dyn_cast<Type *>(UsedTy)) {
-        // Both source and use type are fixed -> insert a bitcast are different.
-        if (FixedTy != FixedUseTy) {
-          InsertCast();
-        }
-      } else if (auto *DeferredUseTy = dyn_cast<DeferredType *>(UsedTy)) {
-        // Source type is fixed, use type is deferred: set the deferred type to
-        // the fixed type.
-        ReplaceTypeInOperands(DeferredUseTy, FixedTy);
-        fixType(*DeferredUseTy, FixedTy);
-      }
-    } else if (auto *DeferredTy = dyn_cast<DeferredType *>(SourceTy)) {
-      if (auto *FixedUseTy = dyn_cast<Type *>(UsedTy)) {
-        // Source type is fixed, use type is deferred: set the deferred type to
-        // the fixed type.
-        ReplaceTypeInOperands(DeferredTy, FixedUseTy);
-        fixType(*DeferredTy, FixedUseTy);
-      } else if (auto *DeferredUseTy = dyn_cast<DeferredType *>(UsedTy)) {
-        // If they're both deferred, merge the two types together.
-        ReplaceTypeInOperands(DeferredUseTy, DeferredTy);
-        mergeType(DeferredTy, DeferredUseTy);
-      }
     }
   }
 }
 
-void SPIRVTypeScavenger::fixType(DeferredType &Ty, Type *ActualTy) {
-  for (Value *V : Ty.Values) {
-    LLVM_DEBUG(dbgs() << "Inferred type of " << *V << " to be " << *ActualTy
-                      << "\n");
-    DeducedTypes[V] = ActualTy;
-  }
-  delete &Ty;
+Type *SPIRVTypeScavenger::allocateTypeVariable(Type *Base) {
+  LLVMContext &Ctx = Base->getContext();
+  return mutateType(Base, [&](unsigned AS) {
+    unsigned VarIndex = TypeVariables.size();
+    UnifiedTypeVars.grow(VarIndex + 1);
+    TypeVariables.push_back(nullptr);
+    Type *InnerTy = TargetExtType::get(Ctx, "typevar", {}, {VarIndex});
+    return TypedPointerType::get(InnerTy, AS);
+  });
 }
 
-void SPIRVTypeScavenger::mergeType(DeferredType *Ty1, DeferredType *Ty2) {
-  // It's possible we're trying to merge the same type into itself.
-  if (Ty1 == Ty2)
-    return;
-
-  for (Value *V : Ty2->Values) {
-    DeducedTypes[V] = Ty1;
-    Ty1->Values.push_back(V);
-  }
-  delete Ty2;
+FunctionType *SPIRVTypeScavenger::getFunctionType(Function *F) {
+  TypedPointerType *Ty =
+      cast<TypedPointerType>(substituteTypeVariables(DeducedTypes[F]));
+  return cast<FunctionType>(Ty->getElementType());
 }
 
-SPIRVTypeScavenger::PointeeType
-SPIRVTypeScavenger::getPointerElementType(Value *V) {
-  PointerType *Ty = dyn_cast<PointerType>(V->getType());
-  assert(Ty && "Non-pointer types don't have pointee types");
+Type *SPIRVTypeScavenger::getScavengedType(Value *V) {
+  Type *Ty = V->getType();
+  // If we're called in a typed pointer context, the real type is always the
+  // correct type.
+  if (Ty->getContext().supportsTypedPointers())
+    return Ty;
 
-  if (!Ty->isOpaquePointerTy())
-    return Ty->getNonOpaquePointerElementType();
-
-  // Global values have a natural pointee type that we can use.
-  if (auto *GV = dyn_cast<GlobalValue>(V))
-    return GV->getValueType();
+  if (!hasPointerType(Ty))
+    return Ty;
 
   // If we get a null/undef/poison value (this should be rare, but it can
   // happen if you use, e.g., store ptr null, ptr %val), then assume the result
   // should be an i8. This aligns with the use in the original deduction.
-  if (doesNotImplyType(V)) {
-    return Type::getInt8Ty(V->getContext());
-  }
+  if (doesNotImplyType(V))
+    return getUnknownTyped(Ty);
 
-  // If it's a constant expression, we won't have a type for it. Constant
-  // expressions are currently translated via converting them to instructions
-  // without a basic block.
-  bool IsFromConstantExpr =
-      isa<ConstantExpr>(V) ||
-      (isa<Instruction>(V) && !cast<Instruction>(V)->getParent());
-  (void)IsFromConstantExpr;
   auto It = DeducedTypes.find(V);
-  assert((It != DeducedTypes.end() || IsFromConstantExpr) &&
-         "How have we not typed the value?");
   if (It != DeducedTypes.end()) {
-    if (auto *Ty = dyn_cast<Type *>(It->second))
-      return Ty;
-    if (auto *ValTy = dyn_cast<Value *>(It->second))
-      return ValTy;
-    llvm_unreachable("Deferred types should have been resolved before now");
+    return substituteTypeVariables(It->second);
   }
 
-  return Type::getInt8Ty(V->getContext());
-}
+  assert(
+      (!isa<Instruction>(V) || !cast<Instruction>(V)->getParent()) &&
+      !isa<Argument>(V) && !isa<GlobalValue>(V) &&
+      "Global values, arguments, and instructions should all have been typed.");
 
-Type *SPIRVTypeScavenger::getArgumentPointerElementType(Function *F,
-                                                        unsigned ArgNo) {
-  return cast<Type *>(getPointerElementType(F->getArg(ArgNo)));
+  // A constant array or constant vector that is used as a global variable
+  // initializer should get the type of that global variable.
+  if (isa<ConstantArray>(V) || isa<ConstantVector>(V)) {
+    for (User *U : V->users()) {
+      if (isa<GlobalVariable>(U)) {
+        return cast<TypedPointerType>(getScavengedType(U))->getElementType();
+      }
+    }
+  }
+
+  return getUnknownTyped(Ty);
 }

--- a/lib/SPIRV/SPIRVTypeScavenger.h
+++ b/lib/SPIRV/SPIRVTypeScavenger.h
@@ -41,6 +41,7 @@
 #ifndef SPIRVTYPESCAVENGER_H
 #define SPIRVTYPESCAVENGER_H
 
+#include "llvm/ADT/IntEqClasses.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
@@ -48,45 +49,128 @@
 
 using namespace llvm;
 
-/// This class allows for the recovery of pointer element types from LLVM
-/// opaque pointer types.
+/// This class allows for the recovery of typed pointer types from LLVM opaque
+/// pointer types. A detailed description of how this algorithm works may be
+/// found in the file comment of SPIRVTypeScavenger.cpp.
 class SPIRVTypeScavenger {
-  /// A representation of a pointer whose type will be determined by uses. This
-  /// will include every value that needs to be assigned the same type.
-  struct DeferredType {
-    std::vector<Value *> Values;
+  /// The mapping from type variables to concrete types.
+  std::vector<Type *> TypeVariables;
+  /// The structure storing which type variables have been unified.
+  IntEqClasses UnifiedTypeVars;
+
+  /// Replace all ptr types found within T with new type variables.
+  Type *allocateTypeVariable(Type *T);
+
+  /// Replace all type variables found within T with their concrete types. If
+  /// the type variable doesn't have a concrete type yet, the type variable will
+  /// be retained.
+  Type *substituteTypeVariables(Type *T);
+
+  /// Try to resolve all type variables into concrete types using knowledge that
+  /// T1 and T2 have to be the same type. If T1 and T2 cannot be made the same
+  /// type, return false (and callers will know they need to insert synthetic
+  /// bitcasts to guarantee equality).
+  bool unifyType(Type *T1, Type *T2);
+
+  /// This stores the Value -> corrected type mapping for the module. It is
+  /// expected that all instructions, arguments, and global values will appear
+  /// in this mapping, while constants are not expected to be listed here.
+  ValueMap<Value *, Type *> DeducedTypes;
+
+  /// Store associated type variables for certain instructions. In the case
+  /// where a return value has an association with an operand, it's necessary
+  /// that the type variable used to generate type rules be the same for all
+  /// invocations of getTypeRules. This variable allows storage of such
+  /// variables.
+  ValueMap<Value *, Type *> AssociatedTypeVariables;
+
+  /// A type rule, which expresses that the given operand of a User must have
+  /// the given type (which may contain type variables).
+  struct TypeRule {
+    unsigned OpNo;
+    bool LhsIndirect;
+    bool RhsIndirect;
+    PointerUnion<Type *, Use *> Target;
+    TypeRule(unsigned A, bool AIndirect, Type *B, bool BIndirect)
+        : OpNo(A), LhsIndirect(AIndirect), RhsIndirect(BIndirect), Target(B) {}
+    TypeRule(unsigned A, bool AIndirect, Use *B, bool BIndirect)
+        : OpNo(A), LhsIndirect(AIndirect), RhsIndirect(BIndirect), Target(B) {}
+
+    /// Establishes typeof(operand) == concrete type
+    static TypeRule is(unsigned OpIndex, Type *Ty) {
+      return TypeRule(OpIndex, false, Ty, false);
+    }
+    /// Establishes typeof(operand) == concrete type
+    static TypeRule is(Use &U, Type *Ty) {
+      return TypeRule(U.getOperandNo(), false, Ty, false);
+    }
+    /// Establishes typeof(operand) == typeof(operand)
+    static TypeRule is(User &U, unsigned Op1, unsigned Op2) {
+      return TypeRule(Op1, false, &U.getOperandUse(Op2), false);
+    }
+    /// Establishes typedptr(typeof(operand)) == typedptr(typeof(operand))
+    static TypeRule isIndirect(User &U, unsigned Op1, unsigned Op2) {
+      return TypeRule(Op1, true, &U.getOperandUse(Op2), true);
+    }
+    /// Establishes typeof(operand) == typedptr(concrete type)
+    static TypeRule pointsTo(Use &U, Type *Ty) {
+      return TypeRule(U.getOperandNo(), false, Ty, true);
+    }
+    /// Establishes typeof(operand) == typedptr(concrete type)
+    static TypeRule pointsTo(User &U, unsigned OpIndex, Type *Ty) {
+      return TypeRule::pointsTo(U.getOperandUse(OpIndex), Ty);
+    }
+    /// Establishes typeof(mem operand) == typedptr(typeof(val operand))
+    static TypeRule pointsTo(User &U, unsigned MemIndex, unsigned ValIndex) {
+      return TypeRule(MemIndex, false, &U.getOperandUse(ValIndex), true);
+    }
+    /// Establishes typeof(operand) == typedptr(typeof(return))
+    static TypeRule pointsToReturn(User &U, unsigned OpIndex) {
+      return TypeRule(RETURN_OPERAND, true, &U.getOperandUse(OpIndex), false);
+    }
+    /// Establishes typeof(return) == concrete type
+    static TypeRule returns(Type *Ty) {
+      return TypeRule(RETURN_OPERAND, false, Ty, false);
+    }
+    /// Establishes typeof(return) == typedptr(concrete type)
+    static TypeRule returnsPointerTo(Type *Ty) {
+      return TypeRule(RETURN_OPERAND, false, Ty, true);
+    }
+    /// Establishes typeof(return) == typeof(operand)
+    static TypeRule propagates(Use &U) {
+      return TypeRule(RETURN_OPERAND, false, &U, false);
+    }
+    /// Establishes typeof(return) == typeof(operand)
+    static TypeRule propagates(User &U, unsigned OpIndex) {
+      return TypeRule::propagates(U.getOperandUse(OpIndex));
+    }
+    /// Establishes typedptr(typeof(return)) == typedptr(typeof(operand))
+    static TypeRule propagatesIndirect(Use &U) {
+      return TypeRule(RETURN_OPERAND, true, &U, true);
+    }
+    /// Establishes typedptr(typeof(return)) == typedptr(typeof(operand))
+    static TypeRule propagatesIndirect(User &U, unsigned OpIndex) {
+      return TypeRule::propagatesIndirect(U.getOperandUse(OpIndex));
+    }
   };
 
-  /// This is called when a deferred type is fixed to a known use.
-  void fixType(DeferredType &Deferred, Type *AssignedType);
+  /// This is a value that allows the ability to express the type of a value as
+  /// a whole in a typing rule.
+  static constexpr unsigned RETURN_OPERAND = ~0U;
 
-  /// This merges two deferred types into one deferred type.
-  void mergeType(DeferredType *A, DeferredType *B);
+  /// Turn a type rule into an operand and a type to check for. If the type of
+  /// the operand and the type to check against cannot be unified, then a
+  /// bitcast will need to be inserted for the use.
+  std::pair<Use &, Type *> getTypeCheck(Instruction &I, const TypeRule &Rule);
 
-  /// A representation of the possible states of a type internal to this pass:
-  /// it may be either
-  /// * Something with a fixed LLVM type (this is a Type *)
-  /// * A type whose pointer element type is yet unknown (DeferredType *)
-  /// * A multi-level pointer type (this is a Value *, whose type is what this
-  ///   pointer type will point to). The latter should only exist for
-  ///   pointer operands of memory operations that return ptr.
-  typedef PointerUnion<Type *, DeferredType *, Value *> DeducedType;
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, DeducedType Ty) {
-    if (auto *AsTy = dyn_cast<Type *>(Ty))
-      return OS << *AsTy;
-    if (auto *AsDeferred = dyn_cast<DeferredType *>(Ty))
-      return OS << "deferred type for " << *AsDeferred->Values[0];
-    if (auto *AsValue = dyn_cast<Value *>(Ty))
-      return OS << "points to " << *AsValue;
-    return OS;
-  }
+  /// Retrieve the list of typing rules for an instruction.
+  void getTypeRules(Instruction &I, SmallVectorImpl<TypeRule> &Rules);
 
-  /// Compute the pointer element type of a value, solely based on its
-  /// definition. The value must be pointer-valued.
-  DeducedType computePointerElementType(Value *V);
-
-  /// This stores the Value -> pointer element type mapping for the module.
-  ValueMap<Value *, DeducedType> DeducedTypes;
+  /// Get the best guess for the type of the value, applying any type rules to
+  /// the return value of an instruction that exist. The return type may refer
+  /// to type variables that have yet to be resolved, if the type rules are
+  /// insufficient to establish a typed pointer type for the instruction.
+  Type *getTypeAfterRules(Value *V);
 
   /// Enforce that the pointer element types of all operands of the instruction
   /// matches the type that the instruction itself requires. If a pointer
@@ -99,17 +183,21 @@ class SPIRVTypeScavenger {
   /// analysis on the module.
   void deduceFunctionType(Function &F);
 
-  /// This computes the known types of a call to an LLVM intrinsic or specific
-  /// well-known function name. Returns true if the call filled in type
-  /// information.
-  ///
-  /// The ArgTys parameter contains a list of known type uses for the parameters
-  /// of the function call. Each element is a pair, with the first being the
-  /// operand number, and the second indicating either a known type or an
-  /// unknown type variable (DeferredType).
-  bool
-  typeIntrinsicCall(CallBase &CB,
-                    SmallVectorImpl<std::pair<unsigned, DeducedType>> &ArgTys);
+  /// This computes known type rules of a call to an LLVM intrinsic or specific
+  /// well-known function name. Returns true if the call was known to this
+  /// function.
+  bool typeIntrinsicCall(CallBase &CB, SmallVectorImpl<TypeRule> &TypeRules);
+
+  /// Get the type rules for checking argument and return value compatibility
+  /// for the function type being called. This is meant to help unify cases
+  /// for indirect function calls.
+  void typeFunctionParams(CallBase &CB, FunctionType *FT, unsigned ArgStart,
+                          bool IncludeRet,
+                          SmallVectorImpl<TypeRule> &TypeRules);
+
+  /// Compute the type of a global variable or global alias, based on the type
+  /// of the initializer (which may be null for global variables).
+  void typeGlobalValue(GlobalValue &GV, Constant *Init);
 
   /// Compute pointer element types for all pertinent values in the module.
   void typeModule(Module &M);
@@ -119,24 +207,17 @@ class SPIRVTypeScavenger {
   std::vector<Value *> VisitStack;
 
 public:
-  explicit SPIRVTypeScavenger(Module &M) { typeModule(M); }
+  explicit SPIRVTypeScavenger(Module &M) : UnifiedTypeVars(1024) {
+    typeModule(M);
+  }
 
-  /// This type represents the type that a pointer element type of a type. If it
-  /// is a Type value, then the pointee type represents a pointer to that type.
-  /// If it is a Value value, then the pointee type is the type of that value
-  /// (which should be a pointer-typed value.)
-  typedef PointerUnion<Type *, Value *> PointeeType;
+  /// Get the type of the value, with pointer types replaced with
+  /// TypedPointerType types instead.
+  Type *getScavengedType(Value *V);
 
-  /// Get the pointer element type of the value.
-  /// If the type is a multi-level pointer, then PointeeType will be a Value
-  /// whose pointee type can be recursively queried through this method.
-  /// Otherwise, it will be a pointer to the Type returned by this method.
-  PointeeType getPointerElementType(Value *V);
-
-  /// Get the pointer element type of an argument of the given function. Since
-  /// this type is guaranteed to not be a multi-level pointer type, the result
-  /// is an LLVM type instead of a PointeeType.
-  Type *getArgumentPointerElementType(Function *F, unsigned ArgNo);
+  /// Get the deduced function type for a function, with pointer types replaced
+  /// with TypedPointerTypes (maybe including type variables).
+  FunctionType *getFunctionType(Function *F);
 };
 
 #endif // SPIRVTYPESCAVENGER_H

--- a/lib/SPIRV/SPIRVTypeScavenger.h
+++ b/lib/SPIRV/SPIRVTypeScavenger.h
@@ -55,6 +55,7 @@ using namespace llvm;
 class SPIRVTypeScavenger {
   /// The mapping from type variables to concrete types.
   std::vector<Type *> TypeVariables;
+
   /// The structure storing which type variables have been unified.
   IntEqClasses UnifiedTypeVars;
 
@@ -102,13 +103,14 @@ class SPIRVTypeScavenger {
     }
     /// Establishes typeof(operand) == concrete type
     static TypeRule is(Use &U, Type *Ty) {
-      return TypeRule(U.getOperandNo(), false, Ty, false);
+      return TypeRule::is(U.getOperandNo(), Ty);
     }
     /// Establishes typeof(operand) == typeof(operand)
     static TypeRule is(User &U, unsigned Op1, unsigned Op2) {
       return TypeRule(Op1, false, &U.getOperandUse(Op2), false);
     }
     /// Establishes typedptr(typeof(operand)) == typedptr(typeof(operand))
+    /// (this is useful when the address spaces do not need to match).
     static TypeRule isIndirect(User &U, unsigned Op1, unsigned Op2) {
       return TypeRule(Op1, true, &U.getOperandUse(Op2), true);
     }

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -819,11 +819,12 @@ bool getParameterTypes(Function *F, SmallVectorImpl<Type *> &ArgTys,
       assert(!HasSret && &Arg == F->getArg(0) &&
              "sret parameter should only appear on the first argument");
       HasSret = true;
+      unsigned AS = Arg.getType()->getPointerAddressSpace();
       if (auto *STy = dyn_cast<StructType>(Ty))
         ArgTys.push_back(
-            TypedPointerType::get(GetStructType(STy->getName()), 0));
+            TypedPointerType::get(GetStructType(STy->getName()), AS));
       else
-        ArgTys.push_back(TypedPointerType::get(Ty, 0));
+        ArgTys.push_back(TypedPointerType::get(Ty, AS));
     } else {
       ArgTys.push_back(Arg.getType());
     }
@@ -894,6 +895,11 @@ bool getParameterTypes(Function *F, SmallVectorImpl<Type *> &ArgTys,
       DemangledSuccessfully = false;
     } else if (ArgTy->isTargetExtTy() || !DemangledTy)
       DemangledTy = ArgTy;
+    if (auto *TPT = dyn_cast<TypedPointerType>(DemangledTy))
+      if (ArgTy->isPointerTy() &&
+          TPT->getAddressSpace() != ArgTy->getPointerAddressSpace())
+        DemangledTy = TypedPointerType::get(TPT->getElementType(),
+                                            ArgTy->getPointerAddressSpace());
     *ArgIter++ = DemangledTy;
   }
   return DemangledSuccessfully;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -350,7 +350,8 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
   }
 
   if (auto *VecTy = dyn_cast<FixedVectorType>(T)) {
-    if (VecTy->getElementType()->isPointerTy()) {
+    if (VecTy->getElementType()->isPointerTy() ||
+        isa<TypedPointerType>(VecTy->getElementType())) {
       // SPV_INTEL_masked_gather_scatter extension changes 2.16.1. Universal
       // Validation Rules:
       // Vector types must be parameterized only with numerical types,
@@ -381,12 +382,21 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
       OS << *T;
       SPIRVCK(T->getArrayNumElements() >= 1, InvalidArraySize, OS.str());
     }
-    return mapType(T, BM->addArrayType(
-                          transType(T->getArrayElementType()),
-                          static_cast<SPIRVConstant *>(transValue(
-                              ConstantInt::get(getSizetType(),
-                                               T->getArrayNumElements(), false),
-                              nullptr))));
+    Type *ElTy = T->getArrayElementType();
+    SPIRVType *TransType = BM->addArrayType(
+        transType(ElTy),
+        static_cast<SPIRVConstant *>(transValue(
+            ConstantInt::get(getSizetType(), T->getArrayNumElements(), false),
+            nullptr)));
+    mapType(T, TransType);
+    if (ElTy->isOpaquePointerTy()) {
+      mapType(
+          ArrayType::get(TypedPointerType::get(Type::getInt8Ty(*Ctx),
+                                               ElTy->getPointerAddressSpace()),
+                         T->getArrayNumElements()),
+          TransType);
+    }
+    return TransType;
   }
 
   if (T->isStructTy() && !T->isSized()) {
@@ -785,22 +795,17 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(StringRef STName,
 }
 
 SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
-  Type *Ty = V->getType();
-  if (!Ty->isPointerTy())
-    return transType(Ty);
-
   if (auto *F = dyn_cast<Function>(V)) {
-    SPIRVType *RT = transType(F->getReturnType());
+    FunctionType *FnTy = F->getType()->isOpaquePointerTy()
+                             ? Scavenger->getFunctionType(F)
+                             : F->getFunctionType();
+    SPIRVType *RT = transType(FnTy->getReturnType());
     std::vector<SPIRVType *> PT;
     for (Argument &Arg : F->args()) {
       assert(OCLTypeToSPIRVPtr);
       Type *Ty = OCLTypeToSPIRVPtr->getAdaptedArgumentType(F, Arg.getArgNo());
       if (!Ty) {
-        Ty = Arg.getType();
-        if (Ty->isPointerTy())
-          Ty = TypedPointerType::get(
-              Scavenger->getArgumentPointerElementType(F, Arg.getArgNo()),
-              Ty->getPointerAddressSpace());
+        Ty = FnTy->getParamType(Arg.getArgNo());
       }
       PT.push_back(transType(Ty));
     }
@@ -808,12 +813,7 @@ SPIRVType *LLVMToSPIRVBase::transScavengedType(Value *V) {
     return getSPIRVFunctionType(RT, PT);
   }
 
-  auto PointeeTy = Scavenger->getPointerElementType(V);
-  auto AddrSpace = Ty->getPointerAddressSpace();
-  if (auto *AsTy = dyn_cast<Type *>(PointeeTy))
-    return transPointerType(AsTy, AddrSpace);
-  return transPointerType(transScavengedType(cast<Value *>(PointeeTy)),
-                          AddrSpace);
+  return transType(Scavenger->getScavengedType(V));
 }
 
 SPIRVType *
@@ -1201,12 +1201,12 @@ void LLVMToSPIRVBase::transAuxDataInst(SPIRVFunction *BF, Function *F) {
   }
 }
 
-SPIRVValue *LLVMToSPIRVBase::transConstantUse(Constant *C) {
+SPIRVValue *LLVMToSPIRVBase::transConstantUse(Constant *C,
+                                              SPIRVType *ExpectedType) {
   // Constant expressions expect their pointer types to be i8* in opaque pointer
   // mode, but the value may have a different "natural" type. If that is the
   // case, we need to adjust the type of the constant.
   SPIRVValue *Trans = transValue(C, nullptr, true, FuncTransMode::Pointer);
-  SPIRVType *ExpectedType = transType(C->getType());
   if (Trans->getType() == ExpectedType || Trans->getType()->isTypePipeStorage())
     return Trans;
 
@@ -1228,12 +1228,12 @@ SPIRVValue *LLVMToSPIRVBase::transConstantUse(Constant *C) {
 }
 
 SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
-  if (auto CPNull = dyn_cast<ConstantPointerNull>(V))
-    return BM->addNullConstant(
-        bcast<SPIRVTypePointer>(transType(CPNull->getType())));
+  SPIRVType *ExpectedType = transScavengedType(V);
+  if (isa<ConstantPointerNull>(V))
+    return BM->addNullConstant(bcast<SPIRVTypePointer>(ExpectedType));
 
   if (isa<ConstantTargetNone>(V))
-    return BM->addNullConstant(transType(V->getType()));
+    return BM->addNullConstant(ExpectedType);
 
   if (auto CAZero = dyn_cast<ConstantAggregateZero>(V)) {
     Type *AggType = CAZero->getType();
@@ -1252,43 +1252,47 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
           BM->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_arbitrary_precision_integers),
           SPIRVEC_InvalidBitWidth, std::to_string(BitWidth));
-      return BM->addConstant(transType(V->getType()), ConstI->getValue());
+      return BM->addConstant(ExpectedType, ConstI->getValue());
     }
-    return BM->addConstant(transType(V->getType()), ConstI->getZExtValue());
+    return BM->addConstant(ExpectedType, ConstI->getZExtValue());
   }
 
   if (auto ConstFP = dyn_cast<ConstantFP>(V)) {
-    auto BT = static_cast<SPIRVType *>(transType(V->getType()));
+    auto *BT = static_cast<SPIRVType *>(ExpectedType);
     return BM->addConstant(
         BT, ConstFP->getValueAPF().bitcastToAPInt().getZExtValue());
   }
 
   if (auto ConstDA = dyn_cast<ConstantDataArray>(V)) {
+    SPIRVType *InnerTy = ExpectedType->getArrayElementType();
     std::vector<SPIRVValue *> BV;
     for (unsigned I = 0, E = ConstDA->getNumElements(); I != E; ++I)
-      BV.push_back(transConstantUse(ConstDA->getElementAsConstant(I)));
-    return BM->addCompositeConstant(transType(V->getType()), BV);
+      BV.push_back(transConstantUse(ConstDA->getElementAsConstant(I), InnerTy));
+    return BM->addCompositeConstant(ExpectedType, BV);
   }
 
   if (auto ConstA = dyn_cast<ConstantArray>(V)) {
+    SPIRVType *InnerTy = ExpectedType->getArrayElementType();
     std::vector<SPIRVValue *> BV;
     for (auto I = ConstA->op_begin(), E = ConstA->op_end(); I != E; ++I)
-      BV.push_back(transConstantUse(cast<Constant>(*I)));
-    return BM->addCompositeConstant(transType(V->getType()), BV);
+      BV.push_back(transConstantUse(cast<Constant>(*I), InnerTy));
+    return BM->addCompositeConstant(ExpectedType, BV);
   }
 
   if (auto ConstDV = dyn_cast<ConstantDataVector>(V)) {
+    SPIRVType *InnerTy = ExpectedType->getScalarType();
     std::vector<SPIRVValue *> BV;
     for (unsigned I = 0, E = ConstDV->getNumElements(); I != E; ++I)
-      BV.push_back(transConstantUse(ConstDV->getElementAsConstant(I)));
-    return BM->addCompositeConstant(transType(V->getType()), BV);
+      BV.push_back(transConstantUse(ConstDV->getElementAsConstant(I), InnerTy));
+    return BM->addCompositeConstant(ExpectedType, BV);
   }
 
   if (auto ConstV = dyn_cast<ConstantVector>(V)) {
+    SPIRVType *InnerTy = ExpectedType->getScalarType();
     std::vector<SPIRVValue *> BV;
     for (auto I = ConstV->op_begin(), E = ConstV->op_end(); I != E; ++I)
-      BV.push_back(transConstantUse(cast<Constant>(*I)));
-    return BM->addCompositeConstant(transType(V->getType()), BV);
+      BV.push_back(transConstantUse(cast<Constant>(*I), InnerTy));
+    return BM->addCompositeConstant(ExpectedType, BV);
   }
 
   if (const auto *ConstV = dyn_cast<ConstantStruct>(V)) {
@@ -1326,9 +1330,11 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
                                         Capacity);
     }
     std::vector<SPIRVValue *> BV;
-    for (auto I = ConstV->op_begin(), E = ConstV->op_end(); I != E; ++I)
-      BV.push_back(transConstantUse(cast<Constant>(*I)));
-    return BM->addCompositeConstant(transType(V->getType()), BV);
+    for (auto I = ConstV->op_begin(), E = ConstV->op_end(); I != E; ++I) {
+      SPIRVType *InnerTy = ExpectedType->getStructMemberType(BV.size());
+      BV.push_back(transConstantUse(cast<Constant>(*I), InnerTy));
+    }
+    return BM->addCompositeConstant(ExpectedType, BV);
   }
 
   if (auto ConstUE = dyn_cast<ConstantExpr>(V)) {
@@ -1349,7 +1355,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
   }
 
   if (isa<UndefValue>(V)) {
-    return BM->addUndef(transType(V->getType()));
+    return BM->addUndef(ExpectedType);
   }
 
   return nullptr;
@@ -1857,12 +1863,12 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                             SPIRVEC_FunctionPointers, toString(V)))
       return nullptr;
     return BM->addConstantFunctionPointerINTEL(
-        transPointerType(F->getFunctionType(), F->getAddressSpace()),
+        transPointerType(transScavengedType(F), F->getAddressSpace()),
         static_cast<SPIRVFunction *>(transValue(F, nullptr)));
   }
 
   if (auto GV = dyn_cast<GlobalVariable>(V)) {
-    llvm::Type *Ty = GV->getValueType();
+    llvm::Type *Ty = Scavenger->getScavengedType(GV);
     // Though variables with common linkage type are initialized by 0,
     // they can be represented in SPIR-V as uninitialized variables with
     // 'Export' linkage type, just as tentative definitions look in C
@@ -1879,7 +1885,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       Value *SpecialInit = unwrapSpecialTypeInitializer(ConstUE);
       if (auto *SpecialGV = dyn_cast_or_null<GlobalValue>(SpecialInit)) {
         Init = SpecialGV;
-        Ty = SpecialGV->getValueType();
+        Ty = Scavenger->getScavengedType(SpecialGV);
       }
       BVarInit = transValue(Init, nullptr);
     } else if (ST && isa<UndefValue>(Init)) {
@@ -1942,7 +1948,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       StorageClass = SPIRSPIRVAddrSpaceMap::map(AddressSpace);
     }
 
-    SPIRVType *TranslatedTy = transPointerType(Ty, GV->getAddressSpace());
+    SPIRVType *TranslatedTy = transType(Ty);
     auto BVar = static_cast<SPIRVVariable *>(
         BM->addVariable(TranslatedTy, GV->isConstant(), transLinkageType(GV),
                         BVarInit, GV->getName().str(), StorageClass, nullptr));
@@ -2088,8 +2094,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
             BB));
 
   if (AllocaInst *Alc = dyn_cast<AllocaInst>(V)) {
-    SPIRVType *TranslatedTy =
-        transPointerType(Alc->getAllocatedType(), Alc->getAddressSpace());
+    SPIRVType *TranslatedTy = transScavengedType(V);
     if (Alc->isArrayAllocation()) {
       if (!BM->checkExtension(ExtensionID::SPV_INTEL_variable_length_array,
                               SPIRVEC_InvalidInstruction,
@@ -2282,27 +2287,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     }
     // GEP can return a vector of pointers, in this case GEP will calculate
     // addresses for each pointer in the vector
-    SPIRVType *TranslatedTy = nullptr;
-    if (auto *VecPtrTy = dyn_cast<VectorType>(GEP->getType())) {
-      if (!VecPtrTy->getElementType()->isOpaquePointerTy()) {
-        TranslatedTy = transType(GEP->getType());
-      } else {
-        // Re-create vector type from GEP's result element type in opaque
-        // pointers mode
-        llvm::VectorType *GEPReturn = VectorType::get(
-            TypedPointerType::get(GEP->getResultElementType(),
-                                  VecPtrTy->getPointerAddressSpace()),
-            VecPtrTy->getElementCount());
-        TranslatedTy = transType(GEPReturn);
-        // Align Base with the return type
-        if (!GEP->getResultElementType()->isVoidTy())
-          TransPointerOperand = BM->addUnaryInst(OpBitcast, TranslatedTy,
-                                                 TransPointerOperand, BB);
-      }
-    } else {
-      TranslatedTy = transPointerType(GEP->getResultElementType(),
-                                      GEP->getType()->getPointerAddressSpace());
-    }
+    SPIRVType *TranslatedTy = transScavengedType(GEP);
     return mapValue(V,
                     BM->addPtrAccessChainInst(TranslatedTy, TransPointerOperand,
                                               Indices, BB, GEP->isInBounds()));
@@ -4644,10 +4629,9 @@ SPIRVValue *LLVMToSPIRVBase::transDirectCallInst(CallInst *CI,
       }
     }
 
-    // TODO: Check for opaque pointer requirements.
     return addDecorations(
         BM->addExtInst(
-            transType(CI->getType()), BM->getExtInstSetId(ExtSetKind), ExtOp,
+            transScavengedType(CI), BM->getExtInstSetId(ExtSetKind), ExtOp,
             transArguments(CI, BB,
                            SPIRVEntry::createUnique(ExtSetKind, ExtOp).get()),
             BB),
@@ -4680,9 +4664,8 @@ SPIRVValue *LLVMToSPIRVBase::transIndirectCallInst(CallInst *CI,
   if (BM->getErrorLog().checkError(
           BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_function_pointers),
           SPIRVEC_FunctionPointers, CI)) {
-    // TODO: Check for opaque pointer requirements.
     return BM->addIndirectCallInst(
-        transValue(CI->getCalledOperand(), BB), transType(CI->getType()),
+        transValue(CI->getCalledOperand(), BB), transScavengedType(CI),
         transArguments(CI, BB, SPIRVEntry::createUnique(OpFunctionCall).get()),
         BB);
   }
@@ -5145,12 +5128,12 @@ bool LLVMToSPIRVBase::translate() {
   if (isEmptyLLVMModule(M))
     BM->addCapability(CapabilityLinkage);
 
-  // Use the type scavenger to recover pointer element types.
-  Scavenger = std::make_unique<SPIRVTypeScavenger>(*M);
-
   // Transform SPV-IR builtin calls to builtin variables.
   if (!transWorkItemBuiltinCallsToVariables())
     return false;
+
+  // Use the type scavenger to recover pointer element types.
+  Scavenger = std::make_unique<SPIRVTypeScavenger>(*M);
 
   if (!transSourceLanguage())
     return false;
@@ -5928,7 +5911,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       Type *RetTy = CI->getType();
       auto F = CI->getCalledFunction();
       if (!RetTy->isVoidTy()) {
-        SPRetTy = transType(RetTy);
+        SPRetTy = transScavengedType(CI);
       } else if (Args.size() > 0 && F->arg_begin()->hasStructRetAttr()) {
         SPRetTy = transType(F->getParamStructRetType(0));
         Args.erase(Args.begin());

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -137,7 +137,7 @@ public:
   SPIRVValue *transConstant(Value *V);
   /// Translate a reference to a constant in a constant expression. This may
   /// involve inserting extra bitcasts to correct type issues.
-  SPIRVValue *transConstantUse(Constant *V);
+  SPIRVValue *transConstantUse(Constant *V, SPIRVType *ExpectedType);
   SPIRVValue *transValue(Value *V, SPIRVBasicBlock *BB,
                          bool CreateForward = true,
                          FuncTransMode FuncTrans = FuncTransMode::Decl);

--- a/test/OpenCL.std/printf.spvasm
+++ b/test/OpenCL.std/printf.spvasm
@@ -20,8 +20,8 @@
 ; CHECK-CL20: declare spir_func i32 @printf(ptr addrspace(2), ...)
 
 ; CHECK-SPV-BACK: ExtInstImport [[Set:[0-9]+]] "OpenCL.std"
-; CHECK-SPV-BACK: TypeInt [[Int8:[0-9]+]] 8
-; CHECK-SPV-BACK: TypeInt [[Int32:[0-9]+]] 32
+; CHECK-SPV-BACK-DAG: TypeInt [[Int8:[0-9]+]] 8
+; CHECK-SPV-BACK-DAG: TypeInt [[Int32:[0-9]+]] 32
 ; CHECK-SPV-BACK: Constant [[Int32]] [[One:[0-9]+]] 1{{[[:space:]]}}
 ; CHECK-SPV-BACK: TypePointer [[Int8PtrTy:[0-9]+]] 0 [[Int8]]{{[[:space:]]}}
 ; CHECK-SPV-BACK: InBoundsPtrAccessChain [[Int8PtrTy]] [[Int8Ptr:[0-9]+]]

--- a/test/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space/non-constant-printf.ll
+++ b/test/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space/non-constant-printf.ll
@@ -14,12 +14,12 @@
 
 ; CHECK-SPIRV: Extension "SPV_EXT_relaxed_printf_string_address_space"
 ; CHECK-SPIRV: ExtInstImport [[#ExtInstSetId:]] "OpenCL.std"
-; CHECK-SPIRV: TypeInt [[#TypeInt8Id:]] 8 0
-; CHECK-SPIRV: TypeInt [[#TypeInt32Id:]] 32 0
-; CHECK-SPIRV: TypePointer [[#FunctionStorClassPtrTy:]] 7 [[#TypeInt8Id]]
-; CHECK-SPIRV: TypePointer [[#WGStorClassPtrTy:]] 5 [[#TypeInt8Id]]
-; CHECK-SPIRV: TypePointer [[#CrossWFStorClassPtrTy:]] 4 [[#TypeInt8Id]]
-; CHECK-SPIRV: TypePointer [[#GenericStorCalssPtrTy:]] 8 [[#TypeInt8Id]]
+; CHECK-SPIRV-DAG: TypeInt [[#TypeInt8Id:]] 8 0
+; CHECK-SPIRV-DAG: TypeInt [[#TypeInt32Id:]] 32 0
+; CHECK-SPIRV-DAG: TypePointer [[#FunctionStorClassPtrTy:]] 7 [[#TypeInt8Id]]
+; CHECK-SPIRV-DAG: TypePointer [[#WGStorClassPtrTy:]] 5 [[#TypeInt8Id]]
+; CHECK-SPIRV-DAG: TypePointer [[#CrossWFStorClassPtrTy:]] 4 [[#TypeInt8Id]]
+; CHECK-SPIRV-DAG: TypePointer [[#GenericStorCalssPtrTy:]] 8 [[#TypeInt8Id]]
 ; CHECK-SPIRV: InBoundsPtrAccessChain [[#FunctionStorClassPtrTy]] [[#GEP1:]]
 ; CHECK-SPIRV: ExtInst [[#TypeInt32Id]] [[#]] [[#ExtInstSetId:]] printf [[#GEP1]]
 ; CHECK-SPIRV: InBoundsPtrAccessChain [[#WGStorClassPtrTy]] [[#GEP2:]]

--- a/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
@@ -79,7 +79,7 @@ entry:
 ; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a, ptr @[[ANN_STR]], ptr undef, i32 undef, ptr undef)
 ; CHECK-LLVM: %[[BITCAST_CALL1:[[:alnum:].]+]] = bitcast ptr addrspace(4) %[[INTRINSIC_CALL]] to ptr addrspace(4)
 ; CHECK-LLVM: %[[BITCAST_CALL2:[[:alnum:].]+]] = bitcast ptr addrspace(4) %[[BITCAST_CALL1]] to ptr addrspace(4)
-; CHECK-LLVM: store ptr addrspace(4) %2, ptr addrspace(4) %[[BITCAST_CALL2]], align 8
+; CHECK-LLVM: store ptr addrspace(4) %[[#]], ptr addrspace(4) %[[BITCAST_CALL2]], align 8
   %this.addr.ascast.i = addrspacecast ptr %this.addr.i to ptr addrspace(4)
   store ptr addrspace(4) %MyIP.ascast, ptr addrspace(4) %this.addr.ascast.i, align 8
   %this1.i = load ptr addrspace(4), ptr addrspace(4) %this.addr.ascast.i, align 8

--- a/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
@@ -79,7 +79,7 @@ entry:
 ; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a, ptr @[[ANN_STR]], ptr undef, i32 undef, ptr undef)
 ; CHECK-LLVM: %[[BITCAST_CALL1:[[:alnum:].]+]] = bitcast ptr addrspace(4) %[[INTRINSIC_CALL]] to ptr addrspace(4)
 ; CHECK-LLVM: %[[BITCAST_CALL2:[[:alnum:].]+]] = bitcast ptr addrspace(4) %[[BITCAST_CALL1]] to ptr addrspace(4)
-; CHECK-LLVM: store ptr addrspace(4) %4, ptr addrspace(4) %[[BITCAST_CALL2]], align 8
+; CHECK-LLVM: store ptr addrspace(4) %2, ptr addrspace(4) %[[BITCAST_CALL2]], align 8
   %this.addr.ascast.i = addrspacecast ptr %this.addr.i to ptr addrspace(4)
   store ptr addrspace(4) %MyIP.ascast, ptr addrspace(4) %this.addr.ascast.i, align 8
   %this1.i = load ptr addrspace(4), ptr addrspace(4) %this.addr.ascast.i, align 8

--- a/test/extensions/INTEL/SPV_INTEL_function_pointers/const-function-pointer.ll
+++ b/test/extensions/INTEL/SPV_INTEL_function_pointers/const-function-pointer.ll
@@ -9,8 +9,8 @@
 ; CHECK-SPIRV: Extension "SPV_INTEL_function_pointers"
 ; CHECK-SPIRV: Name [[F1Name:[0-9]+]] "f1"
 ; CHECK-SPIRV: Name [[F2Name:[0-9]+]] "f2"
-; CHECK-SPIRV: TypeInt [[Int32:[0-9]+]] 32
-; CHECK-SPIRV: TypeInt [[Int64:[0-9]+]] 64
+; CHECK-SPIRV-DAG: TypeInt [[Int32:[0-9]+]] 32
+; CHECK-SPIRV-DAG: TypeInt [[Int64:[0-9]+]] 64
 ; CHECK-SPIRV-DAG: Constant [[Int32]] [[XArg:[0-9]+]] 32
 ; CHECK-SPIRV-DAG: Constant [[Int32]] [[YArg:[0-9]+]] 2
 

--- a/test/extensions/INTEL/intel-basic-vector-pointers-opaque.ll
+++ b/test/extensions/INTEL/intel-basic-vector-pointers-opaque.ll
@@ -23,7 +23,7 @@
 ; CHECK-SPIRV-DAG: TypePointer [[#TYPEPTR1:]] 5 [[#TYPEINT1]]
 ; CHECK-SPIRV-DAG: TypeVector [[#TYPEVEC1:]] [[#TYPEPTR1]] 4
 ; CHECK-SPIRV-DAG: TypeVoid [[#TYPEVOID:]]
-; CHECK-SPIRV-DAG: TypePointer [[#TYPEPTR2:]] [[#TYPEVOID]] 2
+; CHECK-SPIRV-DAG: TypePointer [[#TYPEPTR2:]] 8 [[#TYPEINT1]]
 ; CHECK-SPIRV-DAG: TypeVector [[#TYPEVEC2:]] [[#TYPEPTR2]] 4
 ; CHECK-SPIRV-DAG: TypePointer [[#PTRTOVECTYPE:]] 7 [[#TYPEVEC2]]
 ; CHECK-SPIRV-DAG: TypePointer [[#TYPEPTR4:]] 5 [[#TYPEINT2]]
@@ -34,8 +34,7 @@
 ; CHECK-SPIRV: Load [[#TYPEVEC2]]
 ; CHECK-SPIRV: Store
 ; CHECK-SPIRV: GenericCastToPtr [[#TYPEVEC1]]
-; CHECK-SPIRV: FunctionCall [[#TYPEVEC1]]
-; CHECK-SPIRV: Bitcast [[#TYPEVEC3]]
+; CHECK-SPIRV: FunctionCall [[#TYPEVEC3]]
 ; CHECK-SPIRV: InBoundsPtrAccessChain [[#TYPEVEC3]]
 
 ; CHECK-LLVM: alloca <4 x i8 addrspace(4)*>
@@ -43,8 +42,7 @@
 ; CHECK-LLVM: load <4 x i8 addrspace(4)*>, <4 x i8 addrspace(4)*>*
 ; CHECK-LLVM: store <4 x i8 addrspace(4)*> %[[#]], <4 x i8 addrspace(4)*>*
 ; CHECK-LLVM: addrspacecast <4 x i8 addrspace(4)*> %{{.*}} to <4 x i8 addrspace(1)*>
-; CHECK-LLVM: call spir_func <4 x i8 addrspace(1)*> @boo(<4 x i8 addrspace(1)*>
-; CHECK-LLVM: bitcast <4 x i8 addrspace(1)*> %{{.*}} to <4 x i32 addrspace(1)*>
+; CHECK-LLVM: call spir_func <4 x i32 addrspace(1)*> @boo(<4 x i8 addrspace(1)*>
 ; CHECK-LLVM: getelementptr inbounds i32, <4 x i32 addrspace(1)*> %{{.*}}, i32 1
 
 ; CHECK-LLVM-OPAQUE: alloca <4 x ptr addrspace(4)>

--- a/test/transcoding/OpSwitch32.ll
+++ b/test/transcoding/OpSwitch32.ll
@@ -30,7 +30,7 @@ target triple = "spir64-unknown-unknown"
 
 ;CHECK-LLVM: test_32
 ;CHECK-LLVM: entry
-;CHECK-LLVM: switch i32 %6, label %sw.epilog
+;CHECK-LLVM: switch i32 %[[#]], label %sw.epilog
 ;CHECK-LLVM: i32 0, label %sw.bb
 ;CHECK-LLVM: i32 1, label %sw.bb1
 

--- a/test/transcoding/OpSwitch32.ll
+++ b/test/transcoding/OpSwitch32.ll
@@ -30,7 +30,7 @@ target triple = "spir64-unknown-unknown"
 
 ;CHECK-LLVM: test_32
 ;CHECK-LLVM: entry
-;CHECK-LLVM: switch i32 %7, label %sw.epilog
+;CHECK-LLVM: switch i32 %6, label %sw.epilog
 ;CHECK-LLVM: i32 0, label %sw.bb
 ;CHECK-LLVM: i32 1, label %sw.bb1
 

--- a/test/transcoding/OpSwitch64.ll
+++ b/test/transcoding/OpSwitch64.ll
@@ -33,7 +33,7 @@ target triple = "spir64-unknown-unknown"
 
 ;CHECK-LLVM: test_64
 ;CHECK-LLVM: entry
-;CHECK-LLVM: switch i64 %6, label %sw.epilog [
+;CHECK-LLVM: switch i64 %[[#]], label %sw.epilog [
 ;CHECK-LLVM: i64 0, label %sw.bb
 ;CHECK-LLVM: i64 1, label %sw.bb1
 ;CHECK-LLVM: i64 21474836481, label %sw.bb3

--- a/test/transcoding/OpSwitch64.ll
+++ b/test/transcoding/OpSwitch64.ll
@@ -33,7 +33,7 @@ target triple = "spir64-unknown-unknown"
 
 ;CHECK-LLVM: test_64
 ;CHECK-LLVM: entry
-;CHECK-LLVM: switch i64 %7, label %sw.epilog [
+;CHECK-LLVM: switch i64 %6, label %sw.epilog [
 ;CHECK-LLVM: i64 0, label %sw.bb
 ;CHECK-LLVM: i64 1, label %sw.bb1
 ;CHECK-LLVM: i64 21474836481, label %sw.bb3

--- a/test/transcoding/OpSwitchChar.ll
+++ b/test/transcoding/OpSwitchChar.ll
@@ -29,7 +29,7 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ;CHECK-LLVM-LABEL: @test_switch
-;CHECK-LLVM: switch i8 %1, label %sw.epilog
+;CHECK-LLVM: switch i8 %0, label %sw.epilog
 ;CHECK-LLVM: i8 0, label %sw.bb
 ;CHECK-LLVM: i8 1, label %sw.bb1
 ;CHECK-LLVM: i8 2, label %sw.bb2

--- a/test/transcoding/OpSwitchChar.ll
+++ b/test/transcoding/OpSwitchChar.ll
@@ -29,7 +29,7 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ;CHECK-LLVM-LABEL: @test_switch
-;CHECK-LLVM: switch i8 %0, label %sw.epilog
+;CHECK-LLVM: switch i8 %[[#]], label %sw.epilog
 ;CHECK-LLVM: i8 0, label %sw.bb
 ;CHECK-LLVM: i8 1, label %sw.bb1
 ;CHECK-LLVM: i8 2, label %sw.bb2

--- a/test/transcoding/constant-vars.ll
+++ b/test/transcoding/constant-vars.ll
@@ -37,8 +37,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: 5 SpecConstantOp [[AS1]] [[I64ARRC2:[0-9]+]] 124 [[I64ARR]]
 ; CHECK-SPIRV: 5 SpecConstantOp [[AS1]] [[STRUCTC:[0-9]+]] 124 [[STRUCT]]
 ; CHECK-SPIRV: 7 SpecConstantOp {{[0-9]+}} [[GEP:[0-9]+]] 70 [[I64ARR]]
-; CHECK-SPIRV: 5 SpecConstantOp [[AS1]] [[I64ARRC3:[0-9]+]] 124 [[GEP]]
-; CHECK-SPIRV: 6 ConstantComposite [[ARRAYTY]] [[ARRAY_INIT:[0-9]+]] [[I64ARRC2]] [[STRUCTC]] [[I64ARRC3]]
+; CHECK-SPIRV: 6 ConstantComposite [[ARRAYTY]] [[ARRAY_INIT:[0-9]+]] [[I64ARRC2]] [[STRUCTC]] [[GEP]]
 ; CHECK-SPIRV: 5 Variable {{[0-9]+}} [[ARRAY:[0-9]+]] 5 [[ARRAY_INIT]]
 
 ; CHECK-LLVM: %structtype = type { ptr addrspace(2), ptr addrspace(1) }

--- a/test/transcoding/global_block.cl
+++ b/test/transcoding/global_block.cl
@@ -24,8 +24,8 @@ kernel void block_kernel(__global int* res) {
 // CHECK-SPIRV1_4: EntryPoint 6 [[#]] "block_kernel" [[#InterfaceId:]]
 // CHECK-SPIRV1_4: Name [[#InterfaceId]] "__block_literal_global"
 // CHECK-SPIRV: Name [[block_invoke:[0-9]+]] "_block_invoke"
-// CHECK-SPIRV: TypeInt [[int:[0-9]+]] 32
-// CHECK-SPIRV: TypeInt [[int8:[0-9]+]] 8
+// CHECK-SPIRV-DAG: TypeInt [[int:[0-9]+]] 32
+// CHECK-SPIRV-DAG: TypeInt [[int8:[0-9]+]] 8
 // CHECK-SPIRV: Constant [[int]] [[five:[0-9]+]] 5
 // CHECK-SPIRV: TypePointer [[int8Ptr:[0-9]+]] 8 [[int8]]
 // CHECK-SPIRV: TypeFunction [[block_invoke_type:[0-9]+]] [[int]] [[int8Ptr]] [[int]]

--- a/test/type-scavenger/call.ll
+++ b/test/type-scavenger/call.ll
@@ -7,16 +7,16 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; CHECK: Name [[CALL:[0-9]+]] "call"
-; CHECK: 4 TypeInt [[INT:[0-9]+]] 32 0
-; CHECK: 4 TypePointer [[INTPTR:[0-9]+]] 7 [[INT]]
-; CHECK: 3 TypeFloat [[FLOAT:[0-9]+]] 32
-; CHECK: 4 TypePointer [[FLOATPTR:[0-9]+]] 7 [[FLOAT]]
-; CHECK: 4 TypeFunction [[CALLTY:[0-9]+]] [[INTPTR]] [[INTPTR]]
+; CHECK: TypeInt [[INT:[0-9]+]] 32 0
+; CHECK: TypePointer [[INTPTR:[0-9]+]] 7 [[INT]]
+; CHECK: TypeFloat [[FLOAT:[0-9]+]] 32
+; CHECK: TypePointer [[FLOATPTR:[0-9]+]] 7 [[FLOAT]]
+; CHECK: TypeFunction [[CALLTY:[0-9]+]] [[INTPTR]] [[INTPTR]]
 
 ; Function Attrs: nounwind
 define spir_kernel void @foo() {
-; CHECK: 4 Variable [[INTPTR]] [[IPTR:[0-9]+]] 7
-; CHECK: 4 Variable [[FLOATPTR]] [[FPTR:[0-9]+]] 7
+; CHECK: Variable [[INTPTR]] [[IPTR:[0-9]+]] 7
+; CHECK: Variable [[FLOATPTR]] [[FPTR:[0-9]+]] 7
 ; CHECK: FunctionCall [[INTPTR]] [[IPTR1:[0-9]+]] [[CALL]] [[IPTR]]
 ; CHECK: Store [[IPTR1]]
 ; CHECK: Bitcast [[INTPTR]] [[FPTR1:[0-9]+]] [[FPTR]]

--- a/test/type-scavenger/call.ll
+++ b/test/type-scavenger/call.ll
@@ -1,0 +1,38 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: Name [[CALL:[0-9]+]] "call"
+; CHECK: 4 TypeInt [[INT:[0-9]+]] 32 0
+; CHECK: 4 TypePointer [[INTPTR:[0-9]+]] 7 [[INT]]
+; CHECK: 3 TypeFloat [[FLOAT:[0-9]+]] 32
+; CHECK: 4 TypePointer [[FLOATPTR:[0-9]+]] 7 [[FLOAT]]
+; CHECK: 4 TypeFunction [[CALLTY:[0-9]+]] [[INTPTR]] [[INTPTR]]
+
+; Function Attrs: nounwind
+define spir_kernel void @foo() {
+; CHECK: 4 Variable [[INTPTR]] [[IPTR:[0-9]+]] 7
+; CHECK: 4 Variable [[FLOATPTR]] [[FPTR:[0-9]+]] 7
+; CHECK: FunctionCall [[INTPTR]] [[IPTR1:[0-9]+]] [[CALL]] [[IPTR]]
+; CHECK: Store [[IPTR1]]
+; CHECK: Bitcast [[INTPTR]] [[FPTR1:[0-9]+]] [[FPTR]]
+; CHECK: FunctionCall [[INTPTR]] [[FPTR2:[0-9]+]] [[CALL]] [[FPTR1]]
+; CHECK: Bitcast [[FLOATPTR]] [[FPTR3:[0-9]+]] [[FPTR2]]
+; CHECK: Store [[FPTR3]]
+entry:
+  %iptr = alloca i32, align 4
+  %fptr = alloca float, align 4
+  %iptr.call = call spir_func ptr @call(ptr %iptr)
+  store i32 0, ptr %iptr.call
+  %fptr.call = call spir_func ptr @call(ptr %fptr)
+  store float 0.0, ptr %fptr.call
+  ret void
+}
+
+define spir_func ptr @call(ptr %a) {
+  ret ptr %a
+}

--- a/test/type-scavenger/globals.ll
+++ b/test/type-scavenger/globals.ll
@@ -1,0 +1,36 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-DAG: 4 TypeInt [[I8:[0-9]+]] 8 0
+; CHECK-DAG: 4 TypeInt [[I16:[0-9]+]] 16 0
+; CHECK-DAG: 4 TypeInt [[I32:[0-9]+]] 32 0
+; CHECK-DAG: 4 TypePointer [[I8PTR:[0-9]+]] 5 [[I8]]
+; CHECK-DAG: 4 TypePointer [[I16PTR:[0-9]+]] 5 [[I16]]
+; CHECK-DAG: 4 TypePointer [[I16PTRPTR:[0-9]+]] 5 [[I16PTR]]
+; CHECK-DAG: 4 TypePointer [[I32PTR:[0-9]+]] 5 [[I32]]
+; CHECK-DAG: 4 TypeArray [[I8PTRx2:[0-9]+]] [[I8PTR]]
+; CHECK-DAG: 4 TypePointer [[I8PTRx2PTR:[0-9]+]] 5 [[I8PTRx2]]
+; CHECK: 5 Variable [[I16PTR]] [[A:[0-9]+]] 5
+; CHECK: 4 Variable [[I32PTR]] [[B:[0-9]+]] 5
+; CHECK: 5 Variable [[I16PTRPTR]] [[C:[0-9]+]] 5 [[A]]
+; CHECK: 5 SpecConstantOp [[I8PTR]] [[AI8:[0-9]+]] 124 [[A]]
+; CHECK: 5 SpecConstantOp [[I8PTR]] [[BI8:[0-9]+]] 124 [[B]]
+; CHECK: 5 ConstantComposite [[I8PTRx2]] [[DINIT:[0-9]+]] [[AI8]] [[BI8]]
+; CHECK: 5 Variable [[I8PTRx2PTR]] [[D:[0-9]+]] 5 [[DINIT]]
+
+@a = addrspace(1) global i16 0
+@b = external addrspace(1) global i32
+@c = addrspace(1) global ptr addrspace(1) @a
+@d = addrspace(1) global [2 x ptr addrspace(1)] [ptr addrspace(1) @a, ptr addrspace(1) @b]
+;@e = global [1 x ptr] [ptr @foo]
+
+; Function Attrs: nounwind
+define spir_kernel void @foo() {
+entry:
+  ret void
+}

--- a/test/type-scavenger/globals.ll
+++ b/test/type-scavenger/globals.ll
@@ -6,22 +6,22 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK-DAG: 4 TypeInt [[I8:[0-9]+]] 8 0
-; CHECK-DAG: 4 TypeInt [[I16:[0-9]+]] 16 0
-; CHECK-DAG: 4 TypeInt [[I32:[0-9]+]] 32 0
-; CHECK-DAG: 4 TypePointer [[I8PTR:[0-9]+]] 5 [[I8]]
-; CHECK-DAG: 4 TypePointer [[I16PTR:[0-9]+]] 5 [[I16]]
-; CHECK-DAG: 4 TypePointer [[I16PTRPTR:[0-9]+]] 5 [[I16PTR]]
-; CHECK-DAG: 4 TypePointer [[I32PTR:[0-9]+]] 5 [[I32]]
-; CHECK-DAG: 4 TypeArray [[I8PTRx2:[0-9]+]] [[I8PTR]]
-; CHECK-DAG: 4 TypePointer [[I8PTRx2PTR:[0-9]+]] 5 [[I8PTRx2]]
-; CHECK: 5 Variable [[I16PTR]] [[A:[0-9]+]] 5
-; CHECK: 4 Variable [[I32PTR]] [[B:[0-9]+]] 5
-; CHECK: 5 Variable [[I16PTRPTR]] [[C:[0-9]+]] 5 [[A]]
-; CHECK: 5 SpecConstantOp [[I8PTR]] [[AI8:[0-9]+]] 124 [[A]]
-; CHECK: 5 SpecConstantOp [[I8PTR]] [[BI8:[0-9]+]] 124 [[B]]
-; CHECK: 5 ConstantComposite [[I8PTRx2]] [[DINIT:[0-9]+]] [[AI8]] [[BI8]]
-; CHECK: 5 Variable [[I8PTRx2PTR]] [[D:[0-9]+]] 5 [[DINIT]]
+; CHECK-DAG: TypeInt [[I8:[0-9]+]] 8 0
+; CHECK-DAG: TypeInt [[I16:[0-9]+]] 16 0
+; CHECK-DAG: TypeInt [[I32:[0-9]+]] 32 0
+; CHECK-DAG: TypePointer [[I8PTR:[0-9]+]] 5 [[I8]]
+; CHECK-DAG: TypePointer [[I16PTR:[0-9]+]] 5 [[I16]]
+; CHECK-DAG: TypePointer [[I16PTRPTR:[0-9]+]] 5 [[I16PTR]]
+; CHECK-DAG: TypePointer [[I32PTR:[0-9]+]] 5 [[I32]]
+; CHECK-DAG: TypeArray [[I8PTRx2:[0-9]+]] [[I8PTR]]
+; CHECK-DAG: TypePointer [[I8PTRx2PTR:[0-9]+]] 5 [[I8PTRx2]]
+; CHECK: Variable [[I16PTR]] [[A:[0-9]+]] 5
+; CHECK: Variable [[I32PTR]] [[B:[0-9]+]] 5
+; CHECK: Variable [[I16PTRPTR]] [[C:[0-9]+]] 5 [[A]]
+; CHECK: SpecConstantOp [[I8PTR]] [[AI8:[0-9]+]] 124 [[A]]
+; CHECK: SpecConstantOp [[I8PTR]] [[BI8:[0-9]+]] 124 [[B]]
+; CHECK: ConstantComposite [[I8PTRx2]] [[DINIT:[0-9]+]] [[AI8]] [[BI8]]
+; CHECK: Variable [[I8PTRx2PTR]] [[D:[0-9]+]] 5 [[DINIT]]
 
 @a = addrspace(1) global i16 0
 @b = external addrspace(1) global i32

--- a/test/type-scavenger/load-indirect.ll
+++ b/test/type-scavenger/load-indirect.ll
@@ -13,18 +13,16 @@ target triple = "spir-unknown-unknown"
 ; CHECK-DAG: 4 TypePointer [[FLOATPTR:[0-9]+]] 7 [[FLOAT]]
 ; CHECK-DAG: 4 TypePointer [[CHARPTR:[0-9]+]] 7 [[CHAR]]
 ; CHECK-DAG: 4 TypePointer [[INTPPTR:[0-9]+]] 7 [[INTPTR]]
-; CHECK-DAG: 4 TypePointer [[FLOATPPTR:[0-9]+]] 7 [[FLOATPTR]]
 ; CHECK-DAG: 4 TypePointer [[CHARPPTR:[0-9]+]] 7 [[CHARPTR]]
 
 ; Function Attrs: nounwind
 define spir_kernel void @foo() {
 ; CHECK: 4 Variable [[INTPTR]] [[IPTR:[0-9]+]] 7
-; CHECK: 4 Variable [[CHARPPTR]] [[PPTR:[0-9]+]] 7
-; CHECK: 4 Bitcast [[INTPPTR]] [[STOREPTR1:[0-9]+]] [[PPTR]]
-; CHECK: Store [[STOREPTR1]] [[IPTR]]
-; CHECK: 4 Bitcast [[FLOATPPTR]] [[LOADPTR1:[0-9]+]] [[PPTR]]
-; CHECK: Load [[FLOATPTR]] [[LOAD1:[0-9]+]] [[LOADPTR1]]
-; CHECK: Load [[FLOAT]] [[LOAD2:[0-9]+]] [[LOAD1]]
+; CHECK: 4 Variable [[INTPPTR]] [[PPTR:[0-9]+]] 7
+; CHECK: Store [[PPTR]] [[IPTR]]
+; CHECK: Load [[INTPTR]] [[LOAD1:[0-9]+]] [[PPTR]]
+; CHECK: 4 Bitcast [[FLOATPTR]] [[LOADPTR2:[0-9]+]] [[LOAD1]]
+; CHECK: Load [[FLOAT]] [[LOAD2:[0-9]+]] [[LOADPTR2]]
 entry:
   %iptr = alloca i32, align 4
   %pptr = alloca ptr, align 4

--- a/test/type-scavenger/load-indirect.ll
+++ b/test/type-scavenger/load-indirect.ll
@@ -17,11 +17,11 @@ target triple = "spir-unknown-unknown"
 
 ; Function Attrs: nounwind
 define spir_kernel void @foo() {
-; CHECK: 4 Variable [[INTPTR]] [[IPTR:[0-9]+]] 7
-; CHECK: 4 Variable [[INTPPTR]] [[PPTR:[0-9]+]] 7
+; CHECK: Variable [[INTPTR]] [[IPTR:[0-9]+]] 7
+; CHECK: Variable [[INTPPTR]] [[PPTR:[0-9]+]] 7
 ; CHECK: Store [[PPTR]] [[IPTR]]
 ; CHECK: Load [[INTPTR]] [[LOAD1:[0-9]+]] [[PPTR]]
-; CHECK: 4 Bitcast [[FLOATPTR]] [[LOADPTR2:[0-9]+]] [[LOAD1]]
+; CHECK: Bitcast [[FLOATPTR]] [[LOADPTR2:[0-9]+]] [[LOAD1]]
 ; CHECK: Load [[FLOAT]] [[LOAD2:[0-9]+]] [[LOADPTR2]]
 entry:
   %iptr = alloca i32, align 4

--- a/test/type-scavenger/recursive-type.ll
+++ b/test/type-scavenger/recursive-type.ll
@@ -1,0 +1,25 @@
+; Check that pointers whose types change are correctly handled by the
+; translator.
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK: 4 TypeInt [[I8:[0-9]+]] 8 0
+; CHECK: 4 TypePointer [[I8PTR:[0-9]+]] 7 [[I8]]
+; CHECK: 4 TypePointer [[I8PTRPTR:[0-9]+]] 7 [[I8PTR]]
+; CHECK: 4 TypePointer [[I8PTRPTRPTR:[0-9]+]] 7 [[I8PTRPTR]]
+
+; Function Attrs: nounwind
+define spir_kernel void @foo() {
+; CHECK: 4 Variable [[I8PTRPTR]] [[PTR:[0-9]+]] 7
+; CHECK: 4 Bitcast [[I8PTRPTRPTR]] [[STOREPTR:[0-9]+]] [[PTR]]
+; CHECK: Store [[STOREPTR]] [[PTR]]
+entry:
+  %ptr = alloca ptr, align 4
+  store ptr %ptr, ptr %ptr
+  ret void
+}

--- a/test/type-scavenger/recursive-type.ll
+++ b/test/type-scavenger/recursive-type.ll
@@ -8,15 +8,15 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
 
-; CHECK: 4 TypeInt [[I8:[0-9]+]] 8 0
-; CHECK: 4 TypePointer [[I8PTR:[0-9]+]] 7 [[I8]]
-; CHECK: 4 TypePointer [[I8PTRPTR:[0-9]+]] 7 [[I8PTR]]
-; CHECK: 4 TypePointer [[I8PTRPTRPTR:[0-9]+]] 7 [[I8PTRPTR]]
+; CHECK: TypeInt [[I8:[0-9]+]] 8 0
+; CHECK: TypePointer [[I8PTR:[0-9]+]] 7 [[I8]]
+; CHECK: TypePointer [[I8PTRPTR:[0-9]+]] 7 [[I8PTR]]
+; CHECK: TypePointer [[I8PTRPTRPTR:[0-9]+]] 7 [[I8PTRPTR]]
 
 ; Function Attrs: nounwind
 define spir_kernel void @foo() {
-; CHECK: 4 Variable [[I8PTRPTR]] [[PTR:[0-9]+]] 7
-; CHECK: 4 Bitcast [[I8PTRPTRPTR]] [[STOREPTR:[0-9]+]] [[PTR]]
+; CHECK: Variable [[I8PTRPTR]] [[PTR:[0-9]+]] 7
+; CHECK: Bitcast [[I8PTRPTRPTR]] [[STOREPTR:[0-9]+]] [[PTR]]
 ; CHECK: Store [[STOREPTR]] [[PTR]]
 entry:
   %ptr = alloca ptr, align 4


### PR DESCRIPTION
This is a massive change, which consists of the following pieces that are not so easily seperable (why this is a large, single commit instead of many smaller ones):
* Use typed pointer types in the external interface of the scavenger.
* Use target extension types in lieu of DeferredType to represent types not yet known. These types are now target("typevar", N), where N is some integer.
* Use TypedPointerType in lieu of DeducedType. This makes multi-level pointer types simpler to use.
* Replace std::pair<unsigned, DeducedType> with a more generalized TypeRule class, which simplifies some of the rules for the typing procedure.
* Make computePointerElementType and correctUseTypes both rely on the same list of type rules, removing duplication.
* Add support for vectors of pointers, arrays of pointers, and function pointers in the type scavenger.
* Allow global variables to have scavenged types.
* Allow return types to not be i8*.
* Add more documentation of the type scavenger process.
* More tests!
* Miscellaneous type rule fixes.

Overall, the logic of the type scavenger largely remains unchanged (albeit with increased functionality), but the way that logic is expressed has changed very significantly, and the easier functionality for handling a few cases causes shifting of expected bitcast placements in existing tests.