### PR TITLE
Update for llvm::StringView removal

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -656,8 +656,7 @@ public:
 } // unnamed namespace
 
 static StringRef stringify(const itanium_demangle::NameType *Node) {
-  const itanium_demangle::StringView Str = Node->getName();
-  return StringRef(Str.begin(), Str.size());
+  return Node->getName();
 }
 
 /// Convert a mangled name that represents a basic integer, floating-point,


### PR DESCRIPTION
Fix the build after llvm-project commit 7c59e8001a3b ("Reland: [Demangle] replace use of llvm::StringView w/ std::string_view", 2023-04-20).