### PR TITLE
Fix build after llvm-project@7c59e80

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -656,7 +656,7 @@ public:
 } // unnamed namespace
 
 static StringRef stringify(const itanium_demangle::NameType *Node) {
-  const itanium_demangle::StringView Str = Node->getName();
+  const std::string_view Str = Node->getName();
   return StringRef(Str.begin(), Str.size());
 }
 


### PR DESCRIPTION
`llvm::StringView` is replaced with `std::string_view` in LLVM lib