### PR TITLE
[NFC] Use typed pointers for null function pointers debug info

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1017,8 +1017,8 @@ LLVMToSPIRVDbgTran::transDbgTemplateParameter(const DITemplateParameter *TP) {
       Constant *C = cast<ConstantAsMetadata>(TVVal)->getValue();
       Ops[ValueIdx] = SPIRVWriter->transValue(C, nullptr)->getId();
     } else {
-      SPIRVType *TyPtr =
-          SPIRVWriter->transType(PointerType::get(M->getContext(), 0));
+      SPIRVType *TyPtr = SPIRVWriter->transType(
+          PointerType::get(Type::getInt8Ty(M->getContext()), 0));
       Ops[ValueIdx] = BM->addNullConstant(TyPtr)->getId();
     }
   }


### PR DESCRIPTION
`PointerType::get(Context` will return typeless/opaque pointer. While it is OK for KHR translator since it's being built on top of LLVM trunk, where opaque pointers are enabled by default - it won't work for intel/llvm, where their generation is disabled.

Upstream of https://github.com/intel/llvm/pull/9118