### PR TITLE
[DebugInfo] Support translation of DebugEntryPoint instruction

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1217,11 +1217,11 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgFunction(const DISubprogram *Func) {
   }
 
   if (isNonSemanticDebugInfo() &&
-      (Func->isMainSubprogram() || IsEntryPointKernel))
-    [[maybe_unused]] SPIRVEntry *Inst = transDbgEntryPoint(Func, DebugFunc);
+      (Func->isMainSubprogram() || IsEntryPointKernel)) [[maybe_unused]]
+    SPIRVEntry *Inst = transDbgEntryPoint(Func, DebugFunc);
 
-  if (isNonSemanticDebugInfo() && FuncDef)
-    [[maybe_unused]] SPIRVEntry *Inst = transDbgFuncDefinition(FuncDef, DebugFunc);
+  if (isNonSemanticDebugInfo() && FuncDef) [[maybe_unused]]
+    SPIRVEntry *Inst = transDbgFuncDefinition(FuncDef, DebugFunc);
 
   return DebugFunc;
 }

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -135,6 +135,7 @@ private:
   SPIRVEntry *transDbgFunction(const DISubprogram *Func);
 
   SPIRVEntry *transDbgFuncDefinition(SPIRVValue *SPVFunc, SPIRVEntry *DbgFunc);
+  SPIRVEntry *transDbgEntryPoint(const DISubprogram *Func, SPIRVEntry *DbgFunc);
 
   // Location information
   SPIRVEntry *transDbgScope(const DIScope *S);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3335,7 +3335,11 @@ bool SPIRVToLLVM::translate() {
     // Translate Compile Units first.
     if (EI->getExtOp() == SPIRVDebug::CompilationUnit)
       DbgTran->transDebugInst(EI);
+    // And Entry points first
+    if (EI->getExtOp() == SPIRVDebug::EntryPoint)
+      DbgTran->transDebugInst(EI);
   }
+
   // Then translate all debug instructions.
   for (SPIRVExtInst *EI : BM->getDebugInstVec()) {
     DbgTran->transDebugInst(EI);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3330,13 +3330,16 @@ bool SPIRVToLLVM::translate() {
       transGlobalCtorDtors(BV);
   }
 
+  // Entry Points should be translated before all debug intrinsics.
+  for (SPIRVExtInst *EI : BM->getDebugInstVec()) {
+    if (EI->getExtOp() == SPIRVDebug::EntryPoint)
+      DbgTran->transDebugInst(EI);
+  }
+
   // Compile unit might be needed during translation of debug intrinsics.
   for (SPIRVExtInst *EI : BM->getDebugInstVec()) {
     // Translate Compile Units first.
     if (EI->getExtOp() == SPIRVDebug::CompilationUnit)
-      DbgTran->transDebugInst(EI);
-    // And Entry points first
-    if (EI->getExtOp() == SPIRVDebug::EntryPoint)
       DbgTran->transDebugInst(EI);
   }
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -918,8 +918,7 @@ MDNode *SPIRVToLLVMDbgTran::transEntryPoint(const SPIRVExtInst *DebugInst) {
 
   using namespace SPIRVDebug::Operand::EntryPoint;
   const SPIRVWordVec &Ops = DebugInst->getArguments();
-  const size_t NumOps = Ops.size();
-  assert(NumOps == OperandCount && "Invalid number of operands");
+  assert(Ops.size() == OperandCount && "Invalid number of operands");
 
   SPIRVExtInst *EP = BM->get<SPIRVExtInst>(Ops[EntryPointIdx]);
   return transFunction(EP, true /*IsMainSubprogram*/);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -929,7 +929,8 @@ MDNode *SPIRVToLLVMDbgTran::transEntryPoint(const SPIRVExtInst *DebugInst) {
   std::string Producer = getString(Ops[CompilerSignatureIdx]);
   std::string CLArgs = getString(Ops[CommandLineArgsIdx]);
 
-  transCompilationUnit(CU, Producer, CLArgs);
+  [[maybe_unused]] DICompileUnit *C =
+      transCompilationUnit(CU, Producer, CLArgs);
 
   return transFunction(EP, true /*IsMainSubprogram*/);
 }

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -103,7 +103,9 @@ private:
 
   MDNode *transDebugInlined(const SPIRVExtInst *Inst);
 
-  DICompileUnit *transCompilationUnit(const SPIRVExtInst *DebugInst);
+  DICompileUnit *transCompilationUnit(const SPIRVExtInst *DebugInst,
+                                      const std::string CompilerVersion = "",
+                                      const std::string Flags = "");
 
   DIBasicType *transTypeBasic(const SPIRVExtInst *DebugInst);
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -141,11 +141,14 @@ private:
   DINode *transLexicalBlock(const SPIRVExtInst *DebugInst);
   DINode *transLexicalBlockDiscriminator(const SPIRVExtInst *DebugInst);
 
-  DINode *transFunction(const SPIRVExtInst *DebugInst);
+  DINode *transFunction(const SPIRVExtInst *DebugInst,
+                        bool IsMainSubprogram = false);
   DINode *transFunctionDefinition(const SPIRVExtInst *DebugInst);
   void transFunctionBody(DISubprogram *DIS, SPIRVId FuncId);
 
   DINode *transFunctionDecl(const SPIRVExtInst *DebugInst);
+
+  MDNode *transEntryPoint(const SPIRVExtInst *DebugInst);
 
   MDNode *transGlobalVariable(const SPIRVExtInst *DebugInst);
 

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -55,6 +55,7 @@ enum Instruction {
   ModuleINTEL                   = 36,
   InstCount                     = 37,
   FunctionDefinition            = 101,
+  EntryPoint                    = 107,
   Module                        = 200,
   TypeSubrange                  = 201,
   TypeArrayDynamic              = 202,
@@ -548,7 +549,7 @@ enum {
   FunctionIdIdx   = 9,
   DeclarationNonSemIdx = 9,
   DeclarationIdx  = 10,
-  // Only for NonSemantic.Schader.DebugInfo.200
+  // Only for NonSemantic.Shader.DebugInfo.200
   TargetFunctionNameIdx  = 10,
   MinOperandCount = 10
 };
@@ -559,6 +560,16 @@ enum {
   FunctionIdx     = 0,
   DefinitionIdx   = 1,
   OperandCount    = 2
+};
+}
+
+namespace EntryPoint {
+enum {
+  EntryPointIdx        = 0,
+  CompilationUnitIdx   = 1,
+  CompilerSignatureIdx = 2,
+  CommandLineArgsIdx   = 3,
+  OperandCount         = 4
 };
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -879,6 +879,9 @@ inline bool hasDbgInstParentScopeIdx(const uint32_t Kind,
   case SPIRVDebug::Function:
     ParentScopeIdx = Function::ParentIdx;
     return true;
+  case SPIRVDebug::EntryPoint:
+    ParentScopeIdx = EntryPoint::CompilationUnitIdx;
+    return true;
   case SPIRVDebug::LexicalBlock:
     ParentScopeIdx = LexicalBlock::ParentIdx;
     return true;

--- a/lib/SPIRV/libSPIRV/SPIRVExtInst.h
+++ b/lib/SPIRV/libSPIRV/SPIRVExtInst.h
@@ -262,6 +262,7 @@ template <> inline void SPIRVMap<SPIRVDebugExtOpKind, std::string>::init() {
   add(SPIRVDebug::Expression, "DebugExpression");
   add(SPIRVDebug::Operation, "DebugOperation");
   add(SPIRVDebug::FunctionDefinition, "DebugFunctionDefinition");
+  add(SPIRVDebug::EntryPoint, "DebugEntryPoint");
 }
 SPIRV_DEF_NAMEMAP(SPIRVDebugExtOpKind, SPIRVDebugExtOpMap)
 

--- a/test/DebugInfo/NonSemantic/DebugFunction.cl
+++ b/test/DebugInfo/NonSemantic/DebugFunction.cl
@@ -41,5 +41,7 @@ void kernel k() {
 // CHECK-SPIRV: DebugFunctionDefinition [[#FuncK]] [[#k_id]]
 // CHECK-LLVM: define spir_kernel void @k() #{{[0-9]+}} !dbg ![[#k_id:]]
 
-// CHECK-LLVM: ![[#foo_id]] = distinct !DISubprogram(name: "foo", {{.*}} spFlags: DISPFlagDefinition,
-// CHECK-LLVM: ![[#k_id]] = distinct !DISubprogram(name: "k", {{.*}} spFlags: DISPFlagDefinition | DISPFlagMainSubprogram,
+// CHECK-LLVM: ![[#foo_id]] = distinct !DISubprogram(name: "foo"
+// CHECK-LLVM-SAME: spFlags: DISPFlagDefinition,
+// CHECK-LLVM: ![[#k_id]] = distinct !DISubprogram(name: "k"
+// CHECK-LLVM-SAME: spFlags: DISPFlagDefinition | DISPFlagMainSubprogram,

--- a/test/DebugInfo/NonSemantic/DebugFunction.cl
+++ b/test/DebugInfo/NonSemantic/DebugFunction.cl
@@ -22,11 +22,15 @@ void kernel k() {
     float a = foo(2);
 }
 
-// CHECK-SPIRV: String [[foo:[0-9]+]] "foo"
-// CHECK-SPIRV: String [[k:[0-9]+]] "k"
-// CHECK-SPIRV: [[CU:[0-9]+]] {{[0-9]+}} DebugCompilationUnit
-// CHECK-SPIRV: [[#FuncFoo:]] [[#]] DebugFunction [[foo]] {{.*}} [[CU]]
-// CHECK-SPIRV: [[#FuncK:]] [[#]] DebugFunction [[k]] {{.*}} [[CU]]
+// CHECK-SPIRV-DAG: String [[foo:[0-9]+]] "foo"
+// CHECK-SPIRV-DAG: String [[#EmptyStr:]] ""
+// CHECK-SPIRV-DAG: String [[k:[0-9]+]] "k"
+// CHECK-SPIRV-DAG: String [[#CV:]] "clang version [[#]].0.0 (https://github.com/llvm/llvm-project.git
+// CHECK-SPIRV: [[#CU:]] [[#]] DebugCompilationUnit
+// CHECK-SPIRV: [[#FuncFoo:]] [[#]] DebugFunction [[foo]] {{.*}} [[#CU]]
+// CHECK-SPIRV: [[#FuncK:]] [[#]] DebugFunction [[k]] {{.*}} [[#CU]]
+// CHECK-SPIRV: DebugEntryPoint [[#FuncK]] [[#CU]] [[#CV]] [[#EmptyStr]] {{$}}
+// CHECK-SPIRV-NOT: DebugEntryPoint
 // CHECK-SPIRV-NOT: DebugFunctionDefinition
 
 // CHECK-SPIRV: Function {{[0-9]+}} [[#foo_id:]]

--- a/test/DebugInfo/NonSemantic/DebugFunction.cl
+++ b/test/DebugInfo/NonSemantic/DebugFunction.cl
@@ -41,5 +41,5 @@ void kernel k() {
 // CHECK-SPIRV: DebugFunctionDefinition [[#FuncK]] [[#k_id]]
 // CHECK-LLVM: define spir_kernel void @k() #{{[0-9]+}} !dbg ![[#k_id:]]
 
-// CHECK-LLVM: ![[#foo_id]] = distinct !DISubprogram(name: "foo"
-// CHECK-LLVM: ![[#k_id]] = distinct !DISubprogram(name: "k"
+// CHECK-LLVM: ![[#foo_id]] = distinct !DISubprogram(name: "foo", {{.*}} spFlags: DISPFlagDefinition,
+// CHECK-LLVM: ![[#k_id]] = distinct !DISubprogram(name: "k", {{.*}} spFlags: DISPFlagDefinition | DISPFlagMainSubprogram,

--- a/test/DebugInfo/NonSemantic/DebugInfoProducer.ll
+++ b/test/DebugInfo/NonSemantic/DebugInfoProducer.ll
@@ -47,20 +47,23 @@ attributes #0 = { noinline norecurse nounwind optnone "correctly-rounded-divide-
 
 ; CHECK-LLVM-200: !DICompileUnit
 ; CHECK-LLVM-200-SAME: producer: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)"
+; CHECK-LLVM-200-SAME: flags: "-O2"
 ; CHECK-LLVM-200-NOT: producer: "spirv"
 
 ; CHECK-LLVM-100: !DICompileUnit
-; CHECK-LLVM-100-SAME: producer: "spirv"
-; CHECK-LLVM-100-NOT: producer: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)"
+; CHECK-LLVM-100-SAME: producer: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)"
+; CHECK-LLVM-100-SAME: flags: "-O2"
 
 ; CHECK-SPIRV-200: String [[#ProducerId:]] "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)"
 ; CHECK-SPIRV-200: DebugCompilationUnit [[#]] [[#]] [[#]] [[#]] [[#ProducerId]]
+; CHECK-SPIRV-200: DebugEntryPoint [[#]] [[#]] [[#ProducerId]] [[#]] {{$}}
 
-; CHECK-SPIRV-100-NOT: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)"
-; CHECK-SPIRV-100-NOT: DebugCompilationUnit [[#]] [[#]] [[#]] [[#]] [[#]] {{$}}
+; CHECK-SPIRV-100: String [[#ProducerId:]] "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)"
+; CHECK-SPIRV-100-NOT: DebugCompilationUnit [[#]] [[#]] [[#]] [[#]] [[#ProducerId]] {{$}}
+; CHECK-SPIRV-100: DebugEntryPoint [[#]] [[#]] [[#ProducerId]] [[#]] {{$}}
 
 
-!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None, flags: "-O2")
 !1 = !DIFile(filename: "<stdin>", directory: "oneAPI")
 !2 = !{}
 !3 = !{i32 2, !"Debug Info Version", i32 3}
@@ -68,7 +71,7 @@ attributes #0 = { noinline norecurse nounwind optnone "correctly-rounded-divide-
 !5 = !{i32 1, !"ThinLTO", i32 0}
 !6 = !{i32 1, !"EnableSplitLTOUnit", i32 1}
 !7 = !{!"clang version 13.0.0 (https://github.com/llvm/llvm-project.git 16a50c9e642fd085e5ceb68c403b71b5b2e0607c)"}
-!8 = distinct !DISubprogram(name: "main", scope: !9, file: !9, line: 1, type: !10, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!8 = distinct !DISubprogram(name: "main", scope: !9, file: !9, line: 1, type: !10, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagMainSubprogram, unit: !0, retainedNodes: !2)
 !9 = !DIFile(filename: "s.cpp", directory: "C:\\")
 !10 = !DISubroutineType(types: !11)
 !11 = !{!12}

--- a/test/DebugInfo/NonSemantic/Shader200/FortranArray.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranArray.ll
@@ -1,9 +1,19 @@
 ; RUN: llvm-as %s -o %t.bc
 ; Translation shouldn't crash:
-; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-200
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-200 -o %t.spt
+; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+
+; CHECK-SPIRV: [[#None:]] [[#]] DebugInfoNone
+; CHECK-SPIRV: [[#CompUnit:]] [[#]] DebugCompilationUnit
+; CHECK-SPIRV: [[#EntryFunc:]] [[#]] DebugFunction
+; CHECK-SPIRV: [[#BaseTy:]] [[#]] DebugTypeBasic
+; CHECK-SPIRV: [[#Subrange:]] [[#]] DebugTypeSubrange
+; CHECK-SPIRV: DebugTypeArrayDynamic [[#BaseTy]] [[#]] [[#]] [[#None]] [[#None]] [[#Subrange]]
+; CHECK-SPIRV: DebugEntryPoint [[#EntryFunc]] [[#CompUnit]] [[#]] [[#]] {{$}}
 
 ; CHECK-LLVM: !DICompileUnit(language: DW_LANG_Fortran95
 ; CHECK-LLVM: !DICompositeType(tag: DW_TAG_array_type, baseType: ![[#BaseT:]], size: 32, elements: ![[#Elements:]], dataLocation: !DIExpression(DW_OP_push_object_address, DW_OP_deref), associated: !DIExpression(DW_OP_push_object_address, DW_OP_deref, DW_OP_constu, 0, DW_OP_or))


### PR DESCRIPTION
This instruction is generated for DWARF `DISPFlagMainSubprogram` flag of function as well as for `spir_kernel` functions.

Spec:
https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#DebugEntryPoint