### PR TITLE
[NFC] Add gather/scatter intrinsics to 'known'

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3581,6 +3581,8 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::dbg_label:
   case Intrinsic::trap:
   case Intrinsic::arithmetic_fence:
+  case Intrinsic::masked_gather:
+  case Intrinsic::masked_scatter:
     return true;
   default:
     // Unknown intrinsics' declarations should always be translated

--- a/test/extensions/INTEL/SPV_INTEL_masked_gather_scatter/intel-gather-scatter.ll
+++ b/test/extensions/INTEL/SPV_INTEL_masked_gather_scatter/intel-gather-scatter.ll
@@ -6,10 +6,17 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
+; RUN: llvm-spirv %t.bc -opaque-pointers=0 --spirv-ext=+SPV_INTEL_masked_gather_scatter -o %t.spv -spirv-allow-unknown-intrinsics
+; RUN: llvm-spirv %t.spv --to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
 ; RUN: not llvm-spirv %t.bc -opaque-pointers=0 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; CHECK-ERROR: RequiresExtension: Feature requires the following SPIR-V extension:
 ; CHECK-ERROR-NEXT: SPV_INTEL_masked_gather_scatter
 ; CHECK-ERROR-NEXT: NOTE: LLVM module contains vector of pointers, translation of which requires this extension
+
+; CHECK-SPIRV-NOT: Name [[#]] "llvm.masked.gather.v4i32.v4p4"
+; CHECK-SPIRV-NOT: Name [[#]] "llvm.masked.scatter.v4i32.v4p4"
 
 ; CHECK-SPIRV-DAG: Capability MaskedGatherScatterINTEL
 ; CHECK-SPIRV-DAG: Extension "SPV_INTEL_masked_gather_scatter"


### PR DESCRIPTION
It prevents their declaration from generation in case if SPV_INTEL_masked_gather_scatter and -spirv-allow-unknown-intrinsics are both enabled.