### PR TITLE
[DebugInfo] Support translation of DebugBuildIdentifier/DebugStoragePath instruction

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1405,21 +1405,21 @@ void LLVMToSPIRVDbgTran::generateBuildIdentifierAndStoragePath(
     return;
   }
 
-  // generate BuildIdentifier insn
-  SPIRVWordVec BuildIdentifierOps(
-      SPIRVDebug::Operand::BuildIdentifier::OperandCount);
+  using namespace SPIRVDebug::Operand;
+
+  // generate BuildIdentifier inst
+  SPIRVWordVec BuildIdentifierOps(BuildIdentifier::OperandCount);
   const std::string IdString = std::to_string(BuildIdentifier);
-  BuildIdentifierOps[SPIRVDebug::Operand::BuildIdentifier::IdentifierIdx] =
+  BuildIdentifierOps[BuildIdentifier::IdentifierIdx] =
       BM->getString(IdString)->getId();
-  BuildIdentifierOps[SPIRVDebug::Operand::BuildIdentifier::FlagsIdx] =
+  BuildIdentifierOps[BuildIdentifier::FlagsIdx] =
       BM->getLiteralAsConstant(1)->getId(); // Placeholder value for now
   BM->addDebugInfo(SPIRVDebug::BuildIdentifier, getVoidTy(),
                    BuildIdentifierOps);
 
-  // generate StoragePath insn
-  SPIRVWordVec StoragePathOps(SPIRVDebug::Operand::StoragePath::OperandCount);
-  StoragePathOps[SPIRVDebug::Operand::StoragePath::PathIdx] =
-      BM->getString(StoragePath)->getId();
+  // generate StoragePath inst
+  SPIRVWordVec StoragePathOps(StoragePath::OperandCount);
+  StoragePathOps[StoragePath::PathIdx] = BM->getString(StoragePath)->getId();
   BM->addDebugInfo(SPIRVDebug::StoragePath, getVoidTy(), StoragePathOps);
 
   // record generated information

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -146,8 +146,9 @@ private:
   template <class T> SPIRVExtInst *getSource(const T *DIEntry);
   SPIRVEntry *transDbgFileType(const DIFile *F);
 
-  // Split Debug information
-  template <class T> void genBuildIdentifierAndStoragePath(const T *DIEntry);
+  // Generate instructions recording identifier and file where debug information
+  // was split to
+  void generateBuildIdentifierAndStoragePath(const DICompileUnit *DIEntry);
 
   // Local Variables
   SPIRVEntry *transDbgLocalVariable(const DILocalVariable *Var);
@@ -173,6 +174,10 @@ private:
   std::unordered_map<const DICompileUnit *, SPIRVExtInst *> SPIRVCUMap;
   std::vector<const DbgVariableIntrinsic *> DbgDeclareIntrinsics;
   std::vector<const DbgVariableIntrinsic *> DbgValueIntrinsics;
+
+  inline static bool BuildIdentifierAndStoragePathGenerated{false};
+  inline static uint64_t BuildIdentifier;
+  inline static std::string StoragePath;
 }; // class LLVMToSPIRVDbgTran
 
 } // namespace SPIRV

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -146,6 +146,9 @@ private:
   template <class T> SPIRVExtInst *getSource(const T *DIEntry);
   SPIRVEntry *transDbgFileType(const DIFile *F);
 
+  // Split Debug information
+  template <class T> void genBuildIdentifierAndStoragePath(const T *DIEntry);
+
   // Local Variables
   SPIRVEntry *transDbgLocalVariable(const DILocalVariable *Var);
 

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -175,9 +175,8 @@ private:
   std::vector<const DbgVariableIntrinsic *> DbgDeclareIntrinsics;
   std::vector<const DbgVariableIntrinsic *> DbgValueIntrinsics;
 
-  inline static bool BuildIdentifierAndStoragePathGenerated{false};
-  inline static uint64_t BuildIdentifier;
-  inline static std::string StoragePath;
+  inline static SPIRVExtInst *BuildIdentifierInsn{nullptr};
+  inline static SPIRVExtInst *StoragePathInsn{nullptr};
 }; // class LLVMToSPIRVDbgTran
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1505,7 +1505,9 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
 
 std::tuple<uint64_t, const std::string>
 SPIRVToLLVMDbgTran::getBuildIdentifierAndStoragePath() {
+#ifndef NDEBUG
   bool FoundBuildIdentifier{false};
+#endif
   uint64_t BuildIdentifier = 0;
   const std::string *StoragePathPtr{};
 
@@ -1519,7 +1521,9 @@ SPIRVToLLVMDbgTran::getBuildIdentifierAndStoragePath() {
              "More than one BuildIdentifier instruction not allowed");
       BuildIdentifier = strtoull(
           getString(BuildIdentifierArgs[IdentifierIdx]).c_str(), NULL, 10);
+#ifndef NDEBUG
       FoundBuildIdentifier = true;
+#endif
     } else if (EI->getExtOp() == SPIRVDebug::StoragePath) {
       using namespace SPIRVDebug::Operand::StoragePath;
       SPIRVWordVec StoragePathArgs = EI->getArguments();

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -219,11 +219,12 @@ SPIRVToLLVMDbgTran::transCompilationUnit(const SPIRVExtInst *DebugInst,
   auto Producer = findModuleProducer();
   auto [BuildIdentifier, StoragePath] = getBuildIdentifierAndStoragePath();
 
- if (!StoragePath.empty()) {
-   return BuilderMap[DebugInst->getId()]->createCompileUnit(
-              SourceLang, getFile(Ops[SourceIdx]), Producer, false, "", 0,
-              StoragePath, DICompileUnit::DebugEmissionKind::FullDebug, BuildIdentifier);
- }
+  if (!StoragePath.empty()) {
+    return BuilderMap[DebugInst->getId()]->createCompileUnit(
+        SourceLang, getFile(Ops[SourceIdx]), Producer, false, "", 0,
+        StoragePath, DICompileUnit::DebugEmissionKind::FullDebug,
+        BuildIdentifier);
+  }
 
   return BuilderMap[DebugInst->getId()]->createCompileUnit(
       SourceLang, getFile(Ops[SourceIdx]), Producer, false, Flags, 0);
@@ -406,8 +407,8 @@ SPIRVToLLVMDbgTran::transTypeArrayDynamic(const SPIRVExtInst *DebugInst) {
       getDIBuilder(DebugInst).getOrCreateArray(Subscripts);
   size_t Size = getDerivedSizeInBits(BaseTy) * TotalCount;
 
-  auto TransOperand = [&](SPIRVWord Idx) -> PointerUnion<DIExpression *,
-                                                         DIVariable *> {
+  auto TransOperand =
+      [&](SPIRVWord Idx) -> PointerUnion<DIExpression *, DIVariable *> {
     if (!getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[Idx])) {
       if (const auto *GV = getDbgInst<SPIRVDebug::GlobalVariable>(Ops[Idx]))
         return transDebugInst<DIGlobalVariable>(GV);
@@ -1349,9 +1350,9 @@ MDNode *SPIRVToLLVMDbgTran::transDebugInstImpl(const SPIRVExtInst *DebugInst) {
   case SPIRVDebug::ModuleINTEL:
     return transModule(DebugInst);
 
-  case SPIRVDebug::Operation:       // To be translated with transExpression
-  case SPIRVDebug::Source:          // To be used by other instructions
-  case SPIRVDebug::SourceContinued:        
+  case SPIRVDebug::Operation: // To be translated with transExpression
+  case SPIRVDebug::Source:    // To be used by other instructions
+  case SPIRVDebug::SourceContinued:
   case SPIRVDebug::BuildIdentifier: // To be used by transCompilationUnit
   case SPIRVDebug::StoragePath:     // To be used by transCompilationUnit
     return nullptr;
@@ -1502,53 +1503,35 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
                    getStringContinued(SourceArgs[TextIdx], Source));
 }
 
-std::tuple<uint64_t, const std::string &> SPIRVToLLVMDbgTran::getBuildIdentifierAndStoragePath() {
-  bool                foundBuildIdentifier{false};
-  bool                foundStoragePath{false};
-  static uint64_t     buildIdentifier=0;
-  static std::string  storagePath{""};
-  static bool  initialized=false;
+std::tuple<uint64_t, const std::string>
+SPIRVToLLVMDbgTran::getBuildIdentifierAndStoragePath() {
+  bool FoundBuildIdentifier{false};
+  uint64_t BuildIdentifier = 0;
+  const std::string *StoragePathPtr{};
 
-  if (!initialized)
-    for (SPIRVExtInst *EI : BM->getDebugInstVec()) {
-      if (EI->getExtOp() == SPIRVDebug::BuildIdentifier) {
-        using namespace SPIRVDebug::Operand::BuildIdentifier;
-        SPIRVWordVec BuildIdentifierArgs = EI->getArguments();
-        assert(BuildIdentifierArgs.size() == OperandCount && "Invalid number of operands");
-        auto newBuildIdentifier = strtoull(getString(BuildIdentifierArgs[IdentifierIdx]).c_str(),NULL,10);
-
-        if (foundBuildIdentifier &&
-            buildIdentifier!=newBuildIdentifier) {
-          report_fatal_error(llvm::Twine("Multiple BuildIdentifier values are not allowed: ") +
-                             llvm::Twine(buildIdentifier) +
-                             llvm::Twine(" and ") +
-                             llvm::Twine(newBuildIdentifier));
-        }
-        buildIdentifier=newBuildIdentifier;
-        foundBuildIdentifier=true;
-      } else if (EI->getExtOp() == SPIRVDebug::StoragePath) {
-        using namespace SPIRVDebug::Operand::StoragePath;
-        SPIRVWordVec StoragePathArgs = EI->getArguments();
-        assert(StoragePathArgs.size() == OperandCount && "Invalid number of operands");
-        auto newStoragePath = getString(StoragePathArgs[PathIdx]);
-
-        if (!newStoragePath.empty()) {
-          if (foundStoragePath) {
-            if (storagePath!=newStoragePath)
-              report_fatal_error(llvm::Twine("Multiple StoragePaths are not allowed: ") +
-                                 llvm::Twine(storagePath) +
-                                 llvm::Twine(" and ") +
-                                 llvm::Twine(newStoragePath));
-          } else {
-            storagePath.assign(newStoragePath);
-            foundStoragePath=true;
-          }
-        }
-      }
+  for (SPIRVExtInst *EI : BM->getDebugInstVec()) {
+    if (EI->getExtOp() == SPIRVDebug::BuildIdentifier) {
+      using namespace SPIRVDebug::Operand::BuildIdentifier;
+      SPIRVWordVec BuildIdentifierArgs = EI->getArguments();
+      assert(BuildIdentifierArgs.size() == OperandCount &&
+             "Invalid number of operands");
+      assert(!FoundBuildIdentifier &&
+             "More than one BuildIdentifier instruction not allowed");
+      BuildIdentifier = strtoull(
+          getString(BuildIdentifierArgs[IdentifierIdx]).c_str(), NULL, 10);
+      FoundBuildIdentifier = true;
+    } else if (EI->getExtOp() == SPIRVDebug::StoragePath) {
+      using namespace SPIRVDebug::Operand::StoragePath;
+      SPIRVWordVec StoragePathArgs = EI->getArguments();
+      assert(StoragePathArgs.size() == OperandCount &&
+             "Invalid number of operands");
+      assert(!StoragePathPtr &&
+             "More than one StoragePath instruction not allowed");
+      StoragePathPtr = &getString(StoragePathArgs[PathIdx]);
     }
+  }
 
-  initialized=true;
-  return {buildIdentifier, storagePath};
+  return {BuildIdentifier, StoragePathPtr ? *StoragePathPtr : ""};
 }
 
 DIBuilder &SPIRVToLLVMDbgTran::getDIBuilder(const SPIRVExtInst *DebugInst) {

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -217,7 +217,10 @@ SPIRVToLLVMDbgTran::transCompilationUnit(const SPIRVExtInst *DebugInst,
   // TODO: Remove this workaround once we switch to NonSemantic.Shader.* debug
   // info by default
   auto Producer = findModuleProducer();
-  setBuildIdentifierAndStoragePath();
+  assert(BuilderMap.size() != 0 && "No debug compile units");
+  if (BuilderMap.size()==1)
+    // Only initialize once
+    setBuildIdentifierAndStoragePath();
 
   if (!StoragePath.empty()) {
     return BuilderMap[DebugInst->getId()]->createCompileUnit(

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -217,7 +217,7 @@ SPIRVToLLVMDbgTran::transCompilationUnit(const SPIRVExtInst *DebugInst,
   // TODO: Remove this workaround once we switch to NonSemantic.Shader.* debug
   // info by default
   auto Producer = findModuleProducer();
-  SetBuildIdentifierAndStoragePath();
+  setBuildIdentifierAndStoragePath();
 
   if (!StoragePath.empty()) {
     return BuilderMap[DebugInst->getId()]->createCompileUnit(
@@ -1503,7 +1503,7 @@ DIFile *SPIRVToLLVMDbgTran::getFile(const SPIRVId SourceId) {
                    getStringContinued(SourceArgs[TextIdx], Source));
 }
 
-void SPIRVToLLVMDbgTran::SetBuildIdentifierAndStoragePath() {
+void SPIRVToLLVMDbgTran::setBuildIdentifierAndStoragePath() {
 #ifndef NDEBUG
   bool FoundBuildIdentifier{false};
   bool FoundStoragePath{false};

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -44,8 +44,8 @@
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DebugLoc.h"
 
-#include <unordered_map>
 #include <tuple>
+#include <unordered_map>
 
 namespace llvm {
 class Module;
@@ -90,7 +90,7 @@ public:
 
 private:
   DIFile *getFile(const SPIRVId SourceId);
-  std::tuple<uint64_t, const std::string &> getBuildIdentifierAndStoragePath();
+  std::tuple<uint64_t, const std::string> getBuildIdentifierAndStoragePath();
 
   DIFile *
   getDIFile(const std::string &FileName,

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -44,7 +44,6 @@
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DebugLoc.h"
 
-#include <tuple>
 #include <unordered_map>
 
 namespace llvm {
@@ -90,7 +89,6 @@ public:
 
 private:
   DIFile *getFile(const SPIRVId SourceId);
-  std::tuple<uint64_t, const std::string> getBuildIdentifierAndStoragePath();
 
   DIFile *
   getDIFile(const std::string &FileName,
@@ -206,6 +204,12 @@ private:
                                       const SPIRVExtInstSetKind);
   std::string findModuleProducer();
   std::optional<DIFile::ChecksumInfo<StringRef>> ParseChecksum(StringRef Text);
+
+  // BuildIdentifier and StoragePath must both be set or both unset.
+  // If StoragePath is empty both variables are unset and not valid.
+  uint64_t BuildIdentifier{0};
+  std::string StoragePath{};
+  void SetBuildIdentifierAndStoragePath();
 };
 } // namespace SPIRV
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -45,6 +45,7 @@
 #include "llvm/IR/DebugLoc.h"
 
 #include <unordered_map>
+#include <tuple>
 
 namespace llvm {
 class Module;
@@ -89,6 +90,8 @@ public:
 
 private:
   DIFile *getFile(const SPIRVId SourceId);
+  std::tuple<uint64_t, const std::string &> getBuildIdentifierAndStoragePath();
+
   DIFile *
   getDIFile(const std::string &FileName,
             std::optional<DIFile::ChecksumInfo<StringRef>> CS = std::nullopt,

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -209,7 +209,7 @@ private:
   // If StoragePath is empty both variables are unset and not valid.
   uint64_t BuildIdentifier{0};
   std::string StoragePath{};
-  void SetBuildIdentifierAndStoragePath();
+  void setBuildIdentifierAndStoragePath();
 };
 } // namespace SPIRV
 

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -56,6 +56,8 @@ enum Instruction {
   InstCount                     = 37,
   FunctionDefinition            = 101,
   SourceContinued               = 102,
+  BuildIdentifier               = 105,
+  StoragePath                   = 106,
   EntryPoint                    = 107,
   Module                        = 200,
   TypeSubrange                  = 201,
@@ -306,6 +308,21 @@ enum {
   FileIdx         = 0,
   TextIdx         = 1,
   MinOperandCount = 1
+};
+}
+
+namespace BuildIdentifier {
+enum {
+  IdentifierIdx = 0,
+  FlagsIdx      = 1,
+  OperandCount  = 2
+};
+}
+
+namespace StoragePath {
+enum {
+  PathIdx       = 0,
+  OperandCount  = 1
 };
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVExtInst.h
+++ b/lib/SPIRV/libSPIRV/SPIRVExtInst.h
@@ -264,6 +264,8 @@ template <> inline void SPIRVMap<SPIRVDebugExtOpKind, std::string>::init() {
   add(SPIRVDebug::FunctionDefinition, "DebugFunctionDefinition");
   add(SPIRVDebug::SourceContinued, "DebugSourceContinued");
   add(SPIRVDebug::EntryPoint, "DebugEntryPoint");
+  add(SPIRVDebug::BuildIdentifier, "DebugBuildIdentifier");
+  add(SPIRVDebug::StoragePath, "DebugStoragePath");
 }
 SPIRV_DEF_NAMEMAP(SPIRVDebugExtOpKind, SPIRVDebugExtOpMap)
 

--- a/test/DebugInfo/storagePath_dwo.ll
+++ b/test/DebugInfo/storagePath_dwo.ll
@@ -8,10 +8,10 @@
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
 
-; CHECK-SPIRV: String [[stringA_id:[0-9]+]] "11111"
-; CHECK-SPIRV: String [[stringA_sf:[0-9]+]] "debugA_info.dwo"
-; CHECK-SPIRV: [[buildID_A:[0-9]+]] [[#]] DebugBuildIdentifier [[stringA_id]]
-; CHECK-SPIRV: [[storageID_A:[0-9]+]] [[#]] DebugStoragePath [[stringA_sf]]
+; CHECK-SPIRV: String [[#stringA_id:]] "11111"
+; CHECK-SPIRV: String [[#stringA_sf:]] "debugA_info.dwo"
+; CHECK-SPIRV: [[#buildID_A:]] [[#]] DebugBuildIdentifier [[#stringA_id]]
+; CHECK-SPIRV: [[#storageID_A:]] [[#]] DebugStoragePath [[#stringA_sf]]
 
 ; CHECK-LLVM: !DICompileUnit
 ; CHECK-LLVM-SAME: splitDebugFilename: "debugA_info.dwo"

--- a/test/DebugInfo/storagePath_dwo.ll
+++ b/test/DebugInfo/storagePath_dwo.ll
@@ -1,0 +1,33 @@
+; Test checks that dwoId and splitDebugFilename is preserved from LLVM IR to spirv
+; and spirv to LLVM IR translation.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; CHECK-SPIRV: String [[stringA_id:[0-9]+]] "11111"
+; CHECK-SPIRV: String [[stringA_sf:[0-9]+]] "debugA_info.dwo"
+; CHECK-SPIRV: [[buildID_A:[0-9]+]] [[#]] DebugBuildIdentifier [[stringA_id]]
+; CHECK-SPIRV: [[storageID_A:[0-9]+]] [[#]] DebugStoragePath [[stringA_sf]]
+
+; CHECK-LLVM: !DICompileUnit
+; CHECK-LLVM-SAME: splitDebugFilename: "debugA_info.dwo"
+; CHECK-LLVM-SAME: dwoId: 11111
+; CHECK-LLVM: !DICompileUnit
+; CHECK-LLVM-SAME: splitDebugFilename: "debugA_info.dwo"
+; CHECK-LLVM-SAME: dwoId: 11111
+
+!llvm.dbg.cu = !{!7, !0}
+!llvm.module.flags = !{!3, !4}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "Clang", isOptimized: false, runtimeVersion: 2, splitDebugFilename: "debugA_info.dwo", emissionKind: FullDebug, enums: !2, retainedTypes: !2, globals: !2, imports: !2, dwoId: 11111)
+!1 = !DIFile(filename: "<stdin>", directory: "/")
+!2 = !{}
+!3 = !{i32 2, !"Dwarf Version", i32 4}
+!4 = !{i32 2, !"Debug Info Version", i32 3}
+!5 = !{!6}
+!6 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!7 = distinct !DICompileUnit(language: DW_LANG_C99, file: !1, producer: "Clang", isOptimized: false, runtimeVersion: 2, splitDebugFilename: "debugA_info.dwo", dwoId: 11111, emissionKind: FullDebug, retainedTypes: !5)


### PR DESCRIPTION
LLVM compileUnit dwoId is translated to/from DebugBuildIdentifier.
LLVM compileUnit splitDebugFilename is translated to/from DebugStoragePath.

 Specification:
 https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#DebugBuildIdentifier
 https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc#DebugStoragePath