### PR TITLE
[DebugInfo] Fix translation of Target Function operand

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -731,7 +731,9 @@ DINode *SPIRVToLLVMDbgTran::transFunction(const SPIRVExtInst *DebugInst,
                                           bool IsMainSubprogram) {
   using namespace SPIRVDebug::Operand::Function;
   const SPIRVWordVec &Ops = DebugInst->getArguments();
-  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+  assert(Ops.size() >= MinOperandCountNonSem && "Invalid number of operands");
+  if (!isNonSemanticDebugInfo(DebugInst->getExtSetKind()))
+    assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
 
   StringRef Name = getString(Ops[NameIdx]);
   DISubroutineType *Ty =
@@ -767,7 +769,8 @@ DINode *SPIRVToLLVMDbgTran::transFunction(const SPIRVExtInst *DebugInst,
   bool IsLocal = SPIRVDebugFlags & SPIRVDebug::FlagIsLocal;
   bool IsMainSubprogramFlag =
       IsMainSubprogram ||
-      BM->isEntryPoint(spv::ExecutionModelKernel, Ops[FunctionIdIdx]);
+      (!isNonSemanticDebugInfo(DebugInst->getExtSetKind()) &&
+       BM->isEntryPoint(spv::ExecutionModelKernel, Ops[FunctionIdIdx]));
 
   DISubprogram::DISPFlags SPFlags = DISubprogram::toSPFlags(
       IsLocal, IsDefinition, IsOptimized, DISubprogram::SPFlagNonvirtual,
@@ -806,8 +809,10 @@ DINode *SPIRVToLLVMDbgTran::transFunction(const SPIRVExtInst *DebugInst,
   else {
     // Create targetFuncName mostly for Fortran trampoline function if it is
     // the case
-    StringRef TargetFunction;
-    if (Ops.size() > MinOperandCount) {
+    StringRef TargetFunction = "";
+    if (DebugInst->getExtSetKind() ==
+            SPIRVEIS_NonSemantic_Shader_DebugInfo_200 &&
+        Ops.size() > TargetFunctionNameIdx) {
       TargetFunction = getString(Ops[TargetFunctionNameIdx]);
     }
     DIS = getDIBuilder(DebugInst).createFunction(

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -541,21 +541,25 @@ enum {
 
 namespace Function {
 enum {
-  NameIdx         = 0,
-  TypeIdx         = 1,
-  SourceIdx       = 2,
-  LineIdx         = 3,
-  ColumnIdx       = 4,
-  ParentIdx       = 5,
-  LinkageNameIdx  = 6,
-  FlagsIdx        = 7,
-  ScopeLineIdx    = 8,
-  FunctionIdIdx   = 9,
-  DeclarationNonSemIdx = 9,
-  DeclarationIdx  = 10,
+  NameIdx               = 0,
+  TypeIdx               = 1,
+  SourceIdx             = 2,
+  LineIdx               = 3,
+  ColumnIdx             = 4,
+  ParentIdx             = 5,
+  LinkageNameIdx        = 6,
+  FlagsIdx              = 7,
+  ScopeLineIdx          = 8,
+  FunctionIdIdx         = 9,
+  DeclarationIdx        = 10,
+  MinOperandCount       = 10,
+
+// Only for NonSemantic.Shader.DebugInfo.*
+// No operand FunctionId
+  DeclarationNonSemIdx  = 9,
+  MinOperandCountNonSem = 9,
   // Only for NonSemantic.Shader.DebugInfo.200
-  TargetFunctionNameIdx  = 10,
-  MinOperandCount = 10
+  TargetFunctionNameIdx = 10,
 };
 }
 


### PR DESCRIPTION
Before reading Target function name operand of `DebugFunction` we need to make sure it's the translation of appropriate debug extension. Otherwise, we can get in a situation, where we do have 11 operands, but the last one is not a `String` with name, but the `DebugFunctionDeclaration`.

Also added more checks for differing operand numbers in different debug specs.

This is a follow-up/alignment fix for: 55ce223 and 02d37bb