### PR TITLE
[NFC][DebugInfo] Rewrite `NonSemantic/DebugInfoProducer` test

### DIFF
--- a/test/DebugInfo/NonSemantic/DebugInfoProducer.ll
+++ b/test/DebugInfo/NonSemantic/DebugInfoProducer.ll
@@ -20,7 +20,8 @@
 ; Check that we don't produce "producer" info for NonSemantic.Shader.DebugInfo.100 as it's not specification conformant
 ; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-100 -spirv-text -o %t.spt
 ; RUN: FileCheck %s --input-file %t.spt --check-prefix CHECK-SPIRV-100
-; RUN: llvm-spirv -spirv-text -r -emit-opaque-pointers %t.spt -o %t.rev.bc
+; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-100 -o %t.spv
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix CHECK-LLVM-100
 
 ; ModuleID = 's.bc'


### PR DESCRIPTION
There is a bug in `-r -spirv-text` mode in translation of Strings with spaces.
Temporary avoid running such pipeline until proper fix is delivered.