### PR TITLE
[NFC] Update missed error msg/doc with rename of -spirv-ocl-builtins-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ To translate between LLVM IR and SPIR-V:
     llvm-spirv -r input.spv
     ```
     Recommended options:
-    * `-spirv-ocl-builtins-version` - to specify target version of OpenCL builtins to translate to (default CL1.2)
+    * `-spirv-target-env` - to specify target version of OpenCL builtins to translate to (default CL1.2)
 
 3. Other options accepted by `llvm-spirv`
 

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -699,7 +699,7 @@ int main(int Ac, char **Av) {
   SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, ExtensionsStatus);
   if (BIsRepresentation.getNumOccurrences() != 0) {
     if (!IsReverse) {
-      errs() << "Note: --spirv-ocl-builtins-version option ignored as it only "
+      errs() << "Note: --spirv-target-env option ignored as it only "
                 "affects translation from SPIR-V to LLVM IR";
     } else {
       Opts.setDesiredBIsRepresentation(BIsRepresentation);


### PR DESCRIPTION
In https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/667bf137eeda7af93b482552c8959376e9565fc1 we renamed

`-spirv-ocl-builtins-version` to `-spirv-target-env` but we missed updating a couple of spots.
Signed-off-by: Sarnie, Nick <nick.sarnie@intel.com>