### PR TITLE
Add option to control builtin format for reverse translation

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -87,7 +87,7 @@ enum class DebugInfoEIS : uint32_t {
   NonSemantic_Shader_DebugInfo_200
 };
 
-enum class BuiltinFormat : uint32_t { Function, Global, Auto };
+enum class BuiltinFormat : uint32_t { Function, Global };
 
 /// \brief Helper class to manage SPIR-V translation
 class TranslatorOpts {
@@ -249,7 +249,7 @@ private:
 
   bool PreserveAuxData = false;
 
-  BuiltinFormat SPIRVBuiltinFormat = BuiltinFormat::Auto;
+  BuiltinFormat SPIRVBuiltinFormat = BuiltinFormat::Function;
 };
 
 } // namespace SPIRV

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -87,6 +87,8 @@ enum class DebugInfoEIS : uint32_t {
   NonSemantic_Shader_DebugInfo_200
 };
 
+enum class BuiltinFormat : uint32_t { Function, Global, Auto };
+
 /// \brief Helper class to manage SPIR-V translation
 class TranslatorOpts {
 public:
@@ -199,6 +201,11 @@ public:
     PreserveOCLKernelArgTypeMetadataThroughString = Value;
   }
 
+  void setBuiltinFormat(BuiltinFormat Value) noexcept {
+    SPIRVBuiltinFormat = Value;
+  }
+  BuiltinFormat getBuiltinFormat() const noexcept { return SPIRVBuiltinFormat; }
+
 private:
   // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
@@ -241,6 +248,8 @@ private:
   bool PreserveOCLKernelArgTypeMetadataThroughString = false;
 
   bool PreserveAuxData = false;
+
+  BuiltinFormat SPIRVBuiltinFormat = BuiltinFormat::Auto;
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -992,6 +992,13 @@ bool lowerBuiltinVariableToCall(GlobalVariable *GV,
 // Transform all builtin variables into calls
 bool lowerBuiltinVariablesToCalls(Module *M);
 
+// Transform all builtin calls into variables
+bool lowerBuiltinCallsToVariables(Module *M);
+
+//  Transform all builtins into variables or calls
+//  depending on user specification
+bool lowerBuiltins(SPIRVModule *BM, Module *M);
+
 /// \brief Post-process OpenCL or SPIRV builtin function returning struct type.
 ///
 /// Some builtin functions are translated to SPIR-V instructions with

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3363,14 +3363,7 @@ bool SPIRVToLLVM::translate() {
   if (!transSourceExtension())
     return false;
   transGeneratorMD();
-  // TODO: add an option to control the builtin format in SPV-IR.
-  // The primary format should be function calls:
-  //   e.g. call spir_func i32 @_Z29__spirv_BuiltInGlobalLinearIdv()
-  // The secondary format should be global variables:
-  //   e.g. load i32, i32* @__spirv_BuiltInGlobalLinearId, align 4
-  // If the desired format is global variables, we don't have to lower them
-  // as calls.
-  if (!lowerBuiltinVariablesToCalls(M))
+  if (!lowerBuiltins(BM, M))
     return false;
   if (BM->getDesiredBIsRepresentation() == BIsRepresentation::SPIRVFriendlyIR) {
     SPIRVWord SrcLangVer = 0;

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2095,6 +2095,83 @@ bool lowerBuiltinVariablesToCalls(Module *M) {
   return true;
 }
 
+/// Transforms SPV-IR work-item builtin calls to SPIRV builtin variables.
+/// e.g.
+///  SPV-IR: @_Z33__spirv_BuiltInGlobalInvocationIdi(i)
+///    is transformed as:
+///  x = load GlobalInvocationId; extract x, i
+/// e.g.
+///  SPV-IR: @_Z22__spirv_BuiltInWorkDim()
+///    is transformed as:
+///  load WorkDim
+bool lowerBuiltinCallsToVariables(Module *M) {
+  LLVM_DEBUG(dbgs() << "Enter lowerBuiltinCallsToVariables\n");
+  // Store instructions and functions that need to be removed.
+  SmallVector<Value *, 16> ToRemove;
+  for (auto &F : *M) {
+    // Builtins should be declaration only.
+    if (!F.isDeclaration())
+      continue;
+    StringRef DemangledName;
+    if (!oclIsBuiltin(F.getName(), DemangledName))
+      continue;
+    LLVM_DEBUG(dbgs() << "Function demangled name: " << DemangledName << '\n');
+    SmallVector<StringRef, 2> Postfix;
+    // Deprefix "__spirv_"
+    StringRef Name = dePrefixSPIRVName(DemangledName, Postfix);
+    // Lookup SPIRV Builtin map.
+    if (!SPIRVBuiltInNameMap::rfind(Name.str(), nullptr))
+      continue;
+    std::string BuiltinVarName = DemangledName.str();
+    LLVM_DEBUG(dbgs() << "builtin variable name: " << BuiltinVarName << '\n');
+    bool IsVec = F.getFunctionType()->getNumParams() > 0;
+    Type *GVType =
+        IsVec ? FixedVectorType::get(F.getReturnType(), 3) : F.getReturnType();
+    auto *BV = new GlobalVariable(
+        *M, GVType, /*isConstant=*/true, GlobalValue::ExternalLinkage, nullptr,
+        BuiltinVarName, 0, GlobalVariable::NotThreadLocal, SPIRAS_Input);
+    for (auto *U : F.users()) {
+      auto *CI = dyn_cast<CallInst>(U);
+      assert(CI && "invalid instruction");
+      const DebugLoc &DLoc = CI->getDebugLoc();
+      Instruction *NewValue = new LoadInst(GVType, BV, "", CI);
+      if (DLoc)
+        NewValue->setDebugLoc(DLoc);
+      LLVM_DEBUG(dbgs() << "Transform: " << *CI << " => " << *NewValue << '\n');
+      if (IsVec) {
+        NewValue =
+            ExtractElementInst::Create(NewValue, CI->getArgOperand(0), "", CI);
+        if (DLoc)
+          NewValue->setDebugLoc(DLoc);
+        LLVM_DEBUG(dbgs() << *NewValue << '\n');
+      }
+      NewValue->takeName(CI);
+      CI->replaceAllUsesWith(NewValue);
+      ToRemove.push_back(CI);
+    }
+    ToRemove.push_back(&F);
+  }
+  for (auto *V : ToRemove) {
+    if (auto *I = dyn_cast<Instruction>(V))
+      I->eraseFromParent();
+    else if (auto *F = dyn_cast<Function>(V))
+      F->eraseFromParent();
+    else
+      llvm_unreachable("Unexpected value to remove!");
+  }
+  return true;
+}
+
+bool lowerBuiltins(SPIRVModule *BM, Module *M) {
+  auto Format = BM->getBuiltinFormat();
+  assert(Format != BuiltinFormat::Auto);
+  if (Format == BuiltinFormat::Function && !lowerBuiltinVariablesToCalls(M))
+    return false;
+  if (Format == BuiltinFormat::Global && !lowerBuiltinCallsToVariables(M))
+    return false;
+  return true;
+}
+
 bool postProcessBuiltinReturningStruct(Function *F) {
   Module *M = F->getParent();
   LLVMContext *Context = &M->getContext();

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2164,7 +2164,6 @@ bool lowerBuiltinCallsToVariables(Module *M) {
 
 bool lowerBuiltins(SPIRVModule *BM, Module *M) {
   auto Format = BM->getBuiltinFormat();
-  assert(Format != BuiltinFormat::Auto);
   if (Format == BuiltinFormat::Function && !lowerBuiltinVariablesToCalls(M))
     return false;
   if (Format == BuiltinFormat::Global && !lowerBuiltinCallsToVariables(M))

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5063,7 +5063,7 @@ bool LLVMToSPIRVBase::translate() {
   if (isEmptyLLVMModule(M))
     BM->addCapability(CapabilityLinkage);
 
-  if (!lowerBuiltins(BM, M))
+  if (!lowerBuiltinCallsToVariables(M))
     return false;
 
   // Use the type scavenger to recover pointer element types.

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2836,73 +2836,6 @@ bool LLVMToSPIRVBase::transBuiltinSet() {
   return true;
 }
 
-/// Transforms SPV-IR work-item builtin calls to SPIRV builtin variables.
-/// e.g.
-///  SPV-IR: @_Z33__spirv_BuiltInGlobalInvocationIdi(i)
-///    is transformed as:
-///  x = load GlobalInvocationId; extract x, i
-/// e.g.
-///  SPV-IR: @_Z22__spirv_BuiltInWorkDim()
-///    is transformed as:
-///  load WorkDim
-bool LLVMToSPIRVBase::transWorkItemBuiltinCallsToVariables() {
-  LLVM_DEBUG(dbgs() << "Enter transWorkItemBuiltinCallsToVariables\n");
-  // Store instructions and functions that need to be removed.
-  SmallVector<Value *, 16> ToRemove;
-  for (auto &F : *M) {
-    // Builtins should be declaration only.
-    if (!F.isDeclaration())
-      continue;
-    StringRef DemangledName;
-    if (!oclIsBuiltin(F.getName(), DemangledName))
-      continue;
-    LLVM_DEBUG(dbgs() << "Function demangled name: " << DemangledName << '\n');
-    SmallVector<StringRef, 2> Postfix;
-    // Deprefix "__spirv_"
-    StringRef Name = dePrefixSPIRVName(DemangledName, Postfix);
-    // Lookup SPIRV Builtin map.
-    if (!SPIRVBuiltInNameMap::rfind(Name.str(), nullptr))
-      continue;
-    std::string BuiltinVarName = DemangledName.str();
-    LLVM_DEBUG(dbgs() << "builtin variable name: " << BuiltinVarName << '\n');
-    bool IsVec = F.getFunctionType()->getNumParams() > 0;
-    Type *GVType =
-        IsVec ? FixedVectorType::get(F.getReturnType(), 3) : F.getReturnType();
-    auto *BV = new GlobalVariable(
-        *M, GVType, /*isConstant=*/true, GlobalValue::ExternalLinkage, nullptr,
-        BuiltinVarName, 0, GlobalVariable::NotThreadLocal, SPIRAS_Input);
-    for (auto *U : F.users()) {
-      auto *CI = dyn_cast<CallInst>(U);
-      assert(CI && "invalid instruction");
-      const DebugLoc &DLoc = CI->getDebugLoc();
-      Instruction *NewValue = new LoadInst(GVType, BV, "", CI);
-      if (DLoc)
-        NewValue->setDebugLoc(DLoc);
-      LLVM_DEBUG(dbgs() << "Transform: " << *CI << " => " << *NewValue << '\n');
-      if (IsVec) {
-        NewValue =
-            ExtractElementInst::Create(NewValue, CI->getArgOperand(0), "", CI);
-        if (DLoc)
-          NewValue->setDebugLoc(DLoc);
-        LLVM_DEBUG(dbgs() << *NewValue << '\n');
-      }
-      NewValue->takeName(CI);
-      CI->replaceAllUsesWith(NewValue);
-      ToRemove.push_back(CI);
-    }
-    ToRemove.push_back(&F);
-  }
-  for (auto *V : ToRemove) {
-    if (auto *I = dyn_cast<Instruction>(V))
-      I->eraseFromParent();
-    else if (auto *F = dyn_cast<Function>(V))
-      F->eraseFromParent();
-    else
-      llvm_unreachable("Unexpected value to remove!");
-  }
-  return true;
-}
-
 /// Translate sampler* spcv.cast(i32 arg) or
 /// sampler* __translate_sampler_initializer(i32 arg)
 /// Three cases are possible:
@@ -5130,8 +5063,7 @@ bool LLVMToSPIRVBase::translate() {
   if (isEmptyLLVMModule(M))
     BM->addCapability(CapabilityLinkage);
 
-  // Transform SPV-IR builtin calls to builtin variables.
-  if (!transWorkItemBuiltinCallsToVariables())
+  if (!lowerBuiltins(BM, M))
     return false;
 
   // Use the type scavenger to recover pointer element types.

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -106,7 +106,6 @@ public:
   bool transSourceLanguage();
   bool transExtension();
   bool transBuiltinSet();
-  bool transWorkItemBuiltinCallsToVariables();
   bool isKnownIntrinsic(Intrinsic::ID Id);
   SPIRVValue *transIntrinsicInst(IntrinsicInst *Intrinsic, SPIRVBasicBlock *BB);
   SPIRVValue *transFenceInst(FenceInst *FI, SPIRVBasicBlock *BB);

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -530,6 +530,10 @@ public:
     return TranslationOpts.preserveAuxData();
   }
 
+  BuiltinFormat getBuiltinFormat() const noexcept {
+    return TranslationOpts.getBuiltinFormat();
+  }
+
   SPIRVExtInstSetKind getDebugInfoEIS() const {
     switch (TranslationOpts.getDebugInfoEIS()) {
     case DebugInfoEIS::SPIRV_Debug:

--- a/test/builtin-functions.ll
+++ b/test/builtin-functions.ll
@@ -1,18 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
-; RUN: llvm-spirv %t.bc -spirv-text --spirv-builtin-format=function -o %t2
-; RUN: llvm-spirv %t.bc -spirv-text --spirv-builtin-format=global -o %t3
-; RUN: FileCheck --check-prefix=CHECK-AUTO-FORMAT< %t %s
-; RUN: FileCheck --check-prefix=CHECK-FUNCTION-FORMAT< %t2 %s
-; RUN: FileCheck --check-prefix=CHECK-GLOBAL-FORMAT< %t3 %s
-; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR -o %t_rev.bc
-; RUN: llvm-spirv -r %t -spirv-text -o %t_rev_ocl.bc
-; Use opposite format bc for reverse translation to test conversion
-; RUN: llvm-spirv -r %t3 -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=function -o %t2_rev.bc
-; RUN: llvm-spirv -r %t2 -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=global -o %t3_rev.bc
-; RUN: llvm-spirv -r %t3 -spirv-text --spirv-builtin-format=function -o %t2_rev_ocl.bc
-; RUN: llvm-dis < %t_rev.bc | FileCheck --check-prefix=CHECK-AUTO-FORMAT-REV %s
-; RUN: llvm-dis < %t_rev_ocl.bc | FileCheck --check-prefix=CHECK-AUTO-FORMAT-OCL-REV %s 
+; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=function -o %t2_rev.bc
+; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=global -o %t3_rev.bc
+; RUN: llvm-spirv -r %t -spirv-text --spirv-builtin-format=function -o %t2_rev_ocl.bc
 ; RUN: llvm-dis < %t2_rev.bc | FileCheck --check-prefix=CHECK-FUNCTION-FORMAT-REV %s
 ; RUN: llvm-dis < %t3_rev.bc | FileCheck --check-prefix=CHECK-GLOBAL-FORMAT-REV %s
 ; RUN: llvm-dis < %t2_rev_ocl.bc | FileCheck --check-prefix=CHECK-FUNCTION-FORMAT-OCL-REV %s
@@ -23,20 +13,8 @@
 ; RUN: llvm-spirv %t.bc --spirv-builtin-format=global -o %t3.spv
 ; RUN: spirv-val %t3.spv
 
-; CHECK-AUTO-FORMAT: Name [[#ID:]] "__spirv_BuiltInWorkgroupId"
-; CHECK-AUTO-FORMAT: Variable [[#Type:]] [[#ID]]
-
-; CHECK-AUTO-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
-; CHECK-AUTO-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
-
-; CHECK-FUNCTION-FORMAT: Name [[#ID:]] "_Z26__spirv_BuiltInWorkgroupIdi"
-; CHECK-FUNCTION-FORMAT: Function [[#Ret:]] [[#ID]]
-
 ; CHECK-FUNCTION-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
 ; CHECK-FUNCTION-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
-
-; CHECK-GLOBAL-FORMAT: Name [[#ID:]] "__spirv_BuiltInWorkgroupId"
-; CHECK-GLOBAL-FORMAT: Variable [[#Type:]] [[#ID]]
 
 ; CHECK-GLOBAL-FORMAT-REV: @__spirv_BuiltInWorkgroupId = external addrspace(7) constant <3 x i64>
 

--- a/test/builtin-functions.ll
+++ b/test/builtin-functions.ll
@@ -1,0 +1,55 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-builtin-format=function -o %t2
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-builtin-format=global -o %t3
+; RUN: FileCheck --check-prefix=CHECK-AUTO-FORMAT< %t %s
+; RUN: FileCheck --check-prefix=CHECK-FUNCTION-FORMAT< %t2 %s
+; RUN: FileCheck --check-prefix=CHECK-GLOBAL-FORMAT< %t3 %s
+; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR -o %t_rev.bc
+; RUN: llvm-spirv -r %t -spirv-text -o %t_rev_ocl.bc
+; Use opposite format bc for reverse translation to test conversion
+; RUN: llvm-spirv -r %t3 -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=function -o %t2_rev.bc
+; RUN: llvm-spirv -r %t2 -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=global -o %t3_rev.bc
+; RUN: llvm-spirv -r %t3 -spirv-text --spirv-builtin-format=function -o %t2_rev_ocl.bc
+; RUN: llvm-dis < %t_rev.bc | FileCheck --check-prefix=CHECK-AUTO-FORMAT-REV %s
+; RUN: llvm-dis < %t_rev_ocl.bc | FileCheck --check-prefix=CHECK-AUTO-FORMAT-OCL-REV %s 
+; RUN: llvm-dis < %t2_rev.bc | FileCheck --check-prefix=CHECK-FUNCTION-FORMAT-REV %s
+; RUN: llvm-dis < %t3_rev.bc | FileCheck --check-prefix=CHECK-GLOBAL-FORMAT-REV %s
+; RUN: llvm-dis < %t2_rev_ocl.bc | FileCheck --check-prefix=CHECK-FUNCTION-FORMAT-OCL-REV %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.bc --spirv-builtin-format=function -o %t2.spv
+; RUN: spirv-val %t2.spv
+; RUN: llvm-spirv %t.bc --spirv-builtin-format=global -o %t3.spv
+; RUN: spirv-val %t3.spv
+
+; CHECK-AUTO-FORMAT: Name [[#ID:]] "__spirv_BuiltInWorkgroupId"
+; CHECK-AUTO-FORMAT: Variable [[#Type:]] [[#ID]]
+
+; CHECK-AUTO-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
+; CHECK-AUTO-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
+
+; CHECK-FUNCTION-FORMAT: Name [[#ID:]] "_Z26__spirv_BuiltInWorkgroupIdi"
+; CHECK-FUNCTION-FORMAT: Function [[#Ret:]] [[#ID]]
+
+; CHECK-FUNCTION-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
+; CHECK-FUNCTION-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
+
+; CHECK-GLOBAL-FORMAT: Name [[#ID:]] "__spirv_BuiltInWorkgroupId"
+; CHECK-GLOBAL-FORMAT: Variable [[#Type:]] [[#ID]]
+
+; CHECK-GLOBAL-FORMAT-REV: @__spirv_BuiltInWorkgroupId = external addrspace(7) constant <3 x i64>
+
+; ModuleID = 'test.bc'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: nounwind
+declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32) #0
+
+; Function Attrs: convergent norecurse nounwind
+define weak_odr dso_local spir_kernel void @foo() {
+entry:
+  %0 = call spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32 0) #0
+ ret void
+}

--- a/test/builtin-globals.ll
+++ b/test/builtin-globals.ll
@@ -1,0 +1,54 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-builtin-format=function -o %t2
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-builtin-format=global -o %t3
+; RUN: FileCheck --check-prefix=CHECK-AUTO-FORMAT< %t %s
+; RUN: FileCheck --check-prefix=CHECK-FUNCTION-FORMAT< %t2 %s
+; RUN: FileCheck --check-prefix=CHECK-GLOBAL-FORMAT< %t3 %s
+; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR -o %t_rev.bc
+; RUN: llvm-spirv -r %t -spirv-text -o %t_rev_ocl.bc
+; Use opposite format bc for reverse translation to test conversion
+; RUN: llvm-spirv -r %t3 -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=function -o %t2_rev.bc
+; RUN: llvm-spirv -r %t2 -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=global -o %t3_rev.bc
+; RUN: llvm-spirv -r %t3 -spirv-text --spirv-builtin-format=function -o %t2_rev_ocl.bc
+; RUN: llvm-dis < %t_rev.bc | FileCheck --check-prefix=CHECK-AUTO-FORMAT-REV %s
+; RUN: llvm-dis < %t_rev_ocl.bc | FileCheck --check-prefix=CHECK-AUTO-FORMAT-OCL-REV %s 
+; RUN: llvm-dis < %t2_rev.bc | FileCheck --check-prefix=CHECK-FUNCTION-FORMAT-REV %s
+; RUN: llvm-dis < %t3_rev.bc | FileCheck --check-prefix=CHECK-GLOBAL-FORMAT-REV %s
+; RUN: llvm-dis < %t2_rev_ocl.bc | FileCheck --check-prefix=CHECK-FUNCTION-FORMAT-OCL-REV %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.bc --spirv-builtin-format=function -o %t2.spv
+; RUN: spirv-val %t2.spv
+; RUN: llvm-spirv %t.bc --spirv-builtin-format=global -o %t3.spv
+; RUN: spirv-val %t3.spv
+
+; CHECK-AUTO-FORMAT: Name [[#ID:]] "__spirv_BuiltInWorkgroupId"
+; CHECK-AUTO-FORMAT: Variable [[#Type:]] [[#ID]]
+
+; CHECK-AUTO-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
+; CHECK-AUTO-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
+
+; CHECK-FUNCTION-FORMAT: Name [[#ID:]] "_Z26__spirv_BuiltInWorkgroupIdi"
+; CHECK-FUNCTION-FORMAT: Function [[#Ret:]] [[#ID]]
+
+; CHECK-FUNCTION-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
+; CHECK-FUNCTION-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
+
+; CHECK-GLOBAL-FORMAT: Name [[#ID:]] "__spirv_BuiltInWorkgroupId"
+; CHECK-GLOBAL-FORMAT: Variable [[#Type:]] [[#ID]]
+
+; CHECK-GLOBAL-FORMAT-REV: @__spirv_BuiltInWorkgroupId = external addrspace(7) constant <3 x i64>
+
+; ModuleID = 'test.bc'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@__spirv_BuiltInWorkgroupId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+; Function Attrs: convergent norecurse nounwind
+define weak_odr dso_local spir_kernel void @foo() {
+entry:
+  %0 = load i64, i64 addrspace(1)* getelementptr inbounds (<3 x i64>, <3 x i64> addrspace(1)* @__spirv_BuiltInWorkgroupId, i64 0, i64 0), align 32
+ ret void
+}

--- a/test/builtin-globals.ll
+++ b/test/builtin-globals.ll
@@ -1,18 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t
-; RUN: llvm-spirv %t.bc -spirv-text --spirv-builtin-format=function -o %t2
-; RUN: llvm-spirv %t.bc -spirv-text --spirv-builtin-format=global -o %t3
-; RUN: FileCheck --check-prefix=CHECK-AUTO-FORMAT< %t %s
-; RUN: FileCheck --check-prefix=CHECK-FUNCTION-FORMAT< %t2 %s
-; RUN: FileCheck --check-prefix=CHECK-GLOBAL-FORMAT< %t3 %s
-; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR -o %t_rev.bc
-; RUN: llvm-spirv -r %t -spirv-text -o %t_rev_ocl.bc
-; Use opposite format bc for reverse translation to test conversion
-; RUN: llvm-spirv -r %t3 -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=function -o %t2_rev.bc
-; RUN: llvm-spirv -r %t2 -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=global -o %t3_rev.bc
-; RUN: llvm-spirv -r %t3 -spirv-text --spirv-builtin-format=function -o %t2_rev_ocl.bc
-; RUN: llvm-dis < %t_rev.bc | FileCheck --check-prefix=CHECK-AUTO-FORMAT-REV %s
-; RUN: llvm-dis < %t_rev_ocl.bc | FileCheck --check-prefix=CHECK-AUTO-FORMAT-OCL-REV %s 
+; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=function -o %t2_rev.bc
+; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=global -o %t3_rev.bc
+; RUN: llvm-spirv -r %t -spirv-text --spirv-builtin-format=function -o %t2_rev_ocl.bc
 ; RUN: llvm-dis < %t2_rev.bc | FileCheck --check-prefix=CHECK-FUNCTION-FORMAT-REV %s
 ; RUN: llvm-dis < %t3_rev.bc | FileCheck --check-prefix=CHECK-GLOBAL-FORMAT-REV %s
 ; RUN: llvm-dis < %t2_rev_ocl.bc | FileCheck --check-prefix=CHECK-FUNCTION-FORMAT-OCL-REV %s
@@ -23,22 +13,10 @@
 ; RUN: llvm-spirv %t.bc --spirv-builtin-format=global -o %t3.spv
 ; RUN: spirv-val %t3.spv
 
-; CHECK-AUTO-FORMAT: Name [[#ID:]] "__spirv_BuiltInWorkgroupId"
-; CHECK-AUTO-FORMAT: Variable [[#Type:]] [[#ID]]
-
-; CHECK-AUTO-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
-; CHECK-AUTO-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
-
-; CHECK-FUNCTION-FORMAT: Name [[#ID:]] "_Z26__spirv_BuiltInWorkgroupIdi"
-; CHECK-FUNCTION-FORMAT: Function [[#Ret:]] [[#ID]]
-
 ; CHECK-FUNCTION-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
 ; CHECK-FUNCTION-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
 
-; CHECK-GLOBAL-FORMAT: Name [[#ID:]] "__spirv_BuiltInWorkgroupId"
-; CHECK-GLOBAL-FORMAT: Variable [[#Type:]] [[#ID]]
-
-; CHECK-GLOBAL-FORMAT-REV: @__spirv_BuiltInWorkgroupId = external addrspace(7) constant <3 x i64>
+; CHECK-GLOBAL-FORMAT-REV: @__spirv_BuiltInWorkgroupId = external addrspace(1) constant <3 x i64>, align 32
 
 ; ModuleID = 'test.bc'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -254,6 +254,19 @@ static cl::opt<bool> SPIRVReplaceLLVMFmulAddWithOpenCLMad(
              "instruction from OpenCL extended instruction set"),
     cl::init(true));
 
+static cl::opt<SPIRV::BuiltinFormat> SPIRVBuiltinFormat(
+    "spirv-builtin-format", cl::desc("Set SPIRV builtin format:"),
+    cl::init(SPIRV::BuiltinFormat::Auto),
+    cl::values(
+        clEnumValN(SPIRV::BuiltinFormat::Function, "function",
+                   "Use functions to represent builtins"),
+        clEnumValN(SPIRV::BuiltinFormat::Global, "global",
+                   "Use globals to represent builtins"),
+        clEnumValN(
+            SPIRV::BuiltinFormat::Auto, "auto",
+            "Automatically choose a builtin format. For forward translation, "
+            "globals are used. For reverse translation, functions are used.")));
+
 static std::string removeExt(const std::string &FileName) {
   size_t Pos = FileName.find_last_of(".");
   if (Pos != std::string::npos)
@@ -707,6 +720,11 @@ int main(int Ac, char **Av) {
   }
 
   Opts.setFPContractMode(FPCMode);
+  if (SPIRVBuiltinFormat == SPIRV::BuiltinFormat::Auto)
+    Opts.setBuiltinFormat(IsReverse ? SPIRV::BuiltinFormat::Function
+                                    : SPIRV::BuiltinFormat::Global);
+  else
+    Opts.setBuiltinFormat(SPIRVBuiltinFormat);
 
   if (SPIRVMemToReg)
     Opts.setMemToRegEnabled(SPIRVMemToReg);

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -255,7 +255,7 @@ static cl::opt<bool> SPIRVReplaceLLVMFmulAddWithOpenCLMad(
     cl::init(true));
 
 static cl::opt<SPIRV::BuiltinFormat> SPIRVBuiltinFormat(
-    "spirv-builtin-format", cl::desc("Set SPIRV builtin format:"),
+    "spirv-builtin-format", cl::desc("Set SPIR-V builtin format:"),
     cl::init(SPIRV::BuiltinFormat::Auto),
     cl::values(
         clEnumValN(SPIRV::BuiltinFormat::Function, "function",


### PR DESCRIPTION
Currently, we always convert SPIR-V builtins to globals for forward translation and to functions for reverse translation.

I have a use case where I want to keep them as globals for reverse translation, so I added this mode.

Implemenations for both cases already existed, I just consolidated them and added the option.