### PR TITLE
Fix DebugFunction test

### DIFF
--- a/test/DebugInfo/NonSemantic/DebugFunction.cl
+++ b/test/DebugInfo/NonSemantic/DebugFunction.cl
@@ -25,7 +25,7 @@ void kernel k() {
 // CHECK-SPIRV-DAG: String [[foo:[0-9]+]] "foo"
 // CHECK-SPIRV-DAG: String [[#EmptyStr:]] ""
 // CHECK-SPIRV-DAG: String [[k:[0-9]+]] "k"
-// CHECK-SPIRV-DAG: String [[#CV:]] "clang version [[#]].0.0 (https://github.com/llvm/llvm-project.git
+// CHECK-SPIRV-DAG: String [[#CV:]] "{{.*}}clang version [[#]].0.0
 // CHECK-SPIRV: [[#CU:]] [[#]] DebugCompilationUnit
 // CHECK-SPIRV: [[#FuncFoo:]] [[#]] DebugFunction [[foo]] {{.*}} [[#CU]]
 // CHECK-SPIRV: [[#FuncK:]] [[#]] DebugFunction [[k]] {{.*}} [[#CU]]


### PR DESCRIPTION
It fails in out-of-tree build because the debug info producer looks different for pre-installed LLVM compiler, e.g.:
`Ubuntu clang version 17.0.0 (++20230502031405+3e850a6`