### PR TITLE
Support the spirv.BufferSurfaceINTEL target extension type

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -311,6 +311,7 @@ const static char PipeStorage[] = "PipeStorage";
 const static char ConstantPipeStorage[] = "ConstantPipeStorage";
 const static char VmeImageINTEL[] = "VmeImageINTEL";
 const static char JointMatrixINTEL[] = "JointMatrixINTEL";
+const static char BufferSurfaceINTEL[] = "BufferSurfaceINTEL";
 } // namespace kSPIRVTypeName
 
 namespace kSPR2TypeName {
@@ -955,6 +956,7 @@ template <> inline void SPIRVMap<std::string, Op, SPIRVOpaqueType>::init() {
   _SPIRV_OP(AvcRefResultINTEL)
   _SPIRV_OP(AvcSicResultINTEL)
   _SPIRV_OP(VmeImageINTEL)
+  _SPIRV_OP(BufferSurfaceINTEL)
 #undef _SPIRV_OP
   add("JointMatrixINTEL", internal::OpTypeJointMatrixINTEL);
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -519,6 +519,10 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
         return mapType(T, BM->addQueueType());
       case OpTypeDeviceEvent:
         return mapType(T, BM->addDeviceEventType());
+      case OpTypeBufferSurfaceINTEL: {
+        ArrayRef<unsigned> Ops = TargetTy->int_params();
+        return mapType(T, BM->addBufferSurfaceINTELType(CastAccess(Ops[0])));
+      }
       case internal::OpTypeJointMatrixINTEL: {
         // The expected representation is:
         // target("spirv.JointMatrixINTEL", %element_type, %rows%, %cols%,
@@ -787,8 +791,12 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(StringRef STName,
     return SaveType(BM->addQueueType());
   else if (TN == kSPIRVTypeName::PipeStorage)
     return SaveType(BM->addPipeStorageType());
-  else if (TN == kSPIRVTypeName::JointMatrixINTEL) {
+  else if (TN == kSPIRVTypeName::JointMatrixINTEL)
     return SaveType(transSPIRVJointMatrixINTELType(Postfixes));
+  else if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute) &&
+           TN == kSPIRVTypeName::BufferSurfaceINTEL) {
+    auto Access = getAccessQualifier(STName);
+    return SaveType(BM->addBufferSurfaceINTELType(Access));
   } else
     return SaveType(
         BM->addOpaqueGenericType(SPIRVOpaqueTypeOpCodeMap::map(TN)));

--- a/test/transcoding/spirv-target-types-buffer.ll
+++ b/test/transcoding/spirv-target-types-buffer.ll
@@ -1,0 +1,23 @@
+; Check translation of the buffer surface target extension type
+;
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv -spirv-ext=+SPV_INTEL_vector_compute %t.bc -spirv-text -o %t.spv.txt
+; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-SPIRV: Capability VectorComputeINTEL
+; CHECK-SPIRV: Extension "SPV_INTEL_vector_compute"
+; CHECK-SPIRV: Name [[#FuncName:]] "foo"
+; CHECK-SPIRV: Name [[#ParamName:]] "a"
+; CHECK-SPIRV: TypeVoid  [[#VoidT:]]
+; CHECK-SPIRV: TypeBufferSurfaceINTEL [[#BufferID:]]
+; CHECK-SPIRV: Function [[#VoidT]] [[#FuncID:]]
+; CHECK-SPIRV-NEXT: FunctionParameter [[#BufferID]] [[#ParamName]]
+
+define spir_kernel void @foo(target("spirv.BufferSurfaceINTEL", 0) %a) #0 {
+  entry:
+  ret void
+ }
+
+attributes #0 = { noinline norecurse nounwind readnone "VCFunction"}


### PR DESCRIPTION
This target extension type is created here: https://github.com/intel/vc-intrinsics/blob/master/GenXIntrinsics/lib/GenXIntrinsics/GenXSPIRVWriterAdaptor.cpp#L245

As with other target extension types, reverse translation is not yet supported.