### PR TITLE
[DebugInfo] Translate checksum info inside DebugSource instruction

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1347,11 +1347,18 @@ SPIRVExtInst *LLVMToSPIRVDbgTran::getSource(const T *DIEntry) {
   Ops[FileIdx] = BM->getString(FileName)->getId();
   DIFile *F = DIEntry ? DIEntry->getFile() : nullptr;
 
-  if (F && F->getRawChecksum() && !isNonSemanticDebugInfo()) {
+  if (F && F->getRawChecksum()) {
     auto CheckSum = F->getChecksum().value();
-    Ops.push_back(BM->getString("//__" + CheckSum.getKindAsString().str() +
-                                ":" + CheckSum.Value.str())
-                      ->getId());
+
+    if (!isNonSemanticDebugInfo())
+      Ops.push_back(BM->getString("//__" + CheckSum.getKindAsString().str() +
+                                  ":" + CheckSum.Value.str())
+                        ->getId());
+    else if (BM->getDebugInfoEIS() ==
+             SPIRVEIS_NonSemantic_Shader_DebugInfo_200) {
+      Ops.push_back(BM->getString(CheckSum.getKindAsString().str())->getId());
+      Ops.push_back(BM->getString(CheckSum.Value.str())->getId());
+    }
   }
 
   if (F && F->getRawSource() && isNonSemanticDebugInfo()) {
@@ -1361,6 +1368,11 @@ SPIRVExtInst *LLVMToSPIRVDbgTran::getSource(const T *DIEntry) {
     constexpr size_t MaxStrSize = MaxNumWords * 4 - 1;
     const size_t NumWords = getSizeInWords(Str);
 
+    if (BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200 &&
+        Ops.size() == MinOperandCount) {
+      Ops.push_back(getDebugInfoNoneId());
+      Ops.push_back(getDebugInfoNoneId());
+    }
     Ops.push_back(BM->getString(Str.substr(0, MaxStrSize))->getId());
     SPIRVExtInst *Source = static_cast<SPIRVExtInst *>(
         BM->addDebugInfo(SPIRVDebug::Source, getVoidTy(), Ops));

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -196,8 +196,8 @@ private:
     return nullptr;
   }
   const std::string &getString(const SPIRVId Id);
-  const std::string getStringContinued(const SPIRVId Id,
-                                       SPIRVExtInst *DebugInst);
+  const std::string getStringSourceContinued(const SPIRVId Id,
+                                             SPIRVExtInst *DebugInst);
   SPIRVWord getConstantValueOrLiteral(const std::vector<SPIRVWord> &,
                                       const SPIRVWord,
                                       const SPIRVExtInstSetKind);

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -305,7 +305,12 @@ namespace Source {
 enum {
   FileIdx         = 0,
   TextIdx         = 1,
-  MinOperandCount = 1
+  // For NonSemantic.Shader.DebugInfo.200
+  ChecksumKind    = 1,
+  ChecksumValue   = 2,
+  TextNonSemIdx   = 3,
+  MinOperandCount = 1,
+  MaxOperandCount = 4
 };
 }
 

--- a/test/DebugInfo/DebugInfoChecksum.ll
+++ b/test/DebugInfo/DebugInfoChecksum.ll
@@ -11,8 +11,14 @@
 ; ./clang -cc1 -debug-info-kind=standalone -S -emit-llvm -triple spir -gcodeview -gcodeview-ghash main.cpp
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV-OCL
 ; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-200 -o - | FileCheck %s --check-prefix CHECK-SPIRV-200
+; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-200 -o %t.spv
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
@@ -41,9 +47,13 @@ attributes #0 = { noinline norecurse nounwind optnone "correctly-rounded-divide-
 
 ; CHECK-LLVM: !DIFile(filename: "main.cpp"
 ; CHECK-LLVM-SAME: checksumkind: CSK_MD5, checksum: "7bb56387968a9caa6e9e35fff94eaf7b"
-; CHECK-SPIRV: String [[#REG:]] "//__CSK_MD5:7bb56387968a9caa6e9e35fff94eaf7b"
-; CHECK-SPIRV: DebugSource
-; CHECK-SPIRV-SAME: [[#REG]]
+
+; CHECK-SPIRV-OCL: String [[#REG:]] "//__CSK_MD5:7bb56387968a9caa6e9e35fff94eaf7b"
+; CHECK-SPIRV-OCL: DebugSource [[#]] [[#REG]]
+
+; CHECK-SPIRV-200: String [[#Kind:]] "CSK_MD5"
+; CHECK-SPIRV-200: String [[#Val:]] "7bb56387968a9caa6e9e35fff94eaf7b"
+; CHECK-SPIRV-200: DebugSource [[#]] [[#Kind]] [[#Val]]
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 7d09e1d7cf27ce781e83f9d388a7a3e1e6487ead)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
 !1 = !DIFile(filename: "<stdin>", directory: "oneAPI", checksumkind: CSK_MD5, checksum: "7bb56387968a9caa6e9e35fff94eaf7b")

--- a/test/DebugInfo/DebugInfoChecksumCompileUnit.ll
+++ b/test/DebugInfo/DebugInfoChecksumCompileUnit.ll
@@ -1,9 +1,15 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV-OCL
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-200 -spirv-text -o - | FileCheck %s --check-prefix CHECK-SPIRV-200
+; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-200 -o %t.spv
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefixes=CHECK-LLVM,CHECK-LLVM-200
 
 ; ModuleID = 'array-transform.bc'
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
@@ -14,11 +20,18 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-LLVM: !DIFile(filename: "array-transform.cpp"
 ; CHECK-LLVM-SAME: checksumkind: CSK_MD5, checksum: "7768106c1e51aa084de0ffae6fbe50c4"
-; CHECK-SPIRV: String [[#ChecksumInfo:]] "//__CSK_MD5:7768106c1e51aa084de0ffae6fbe50c4"
-; CHECK-SPIRV: DebugSource
-; CHECK-SPIRV-SAME: [[#ChecksumInfo]]
+; CHECK-LLVM-200-SAME: source: "int main() {}"
+
+; CHECK-SPIRV-OCL: String [[#ChecksumInfo:]] "//__CSK_MD5:7768106c1e51aa084de0ffae6fbe50c4"
+; CHECK-SPIRV-OCL: DebugSource
+; CHECK-SPIRV-OCL-SAME: [[#ChecksumInfo]]
+
+; CHECK-SPIRV-200: String [[#Kind:]] "CSK_MD5"
+; CHECK-SPIRV-200: String [[#Val:]] "7768106c1e51aa084de0ffae6fbe50c4"
+; CHECK-SPIRV-200: String [[#Source:]] "int main() {}"
+; CHECK-SPIRV-200: DebugSource [[#]] [[#Kind]] [[#Val]] [[#Source]]
 
 !0 = !{i32 2, !"Debug Info Version", i32 3}
 !1 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !2, producer: "spirv", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3, imports: !3)
-!2 = !DIFile(filename: "array-transform.cpp", directory: "D:\\path\\to", checksumkind: CSK_MD5, checksum: "7768106c1e51aa084de0ffae6fbe50c4")
+!2 = !DIFile(filename: "array-transform.cpp", directory: "D:\\path\\to", checksumkind: CSK_MD5, checksum: "7768106c1e51aa084de0ffae6fbe50c4", source: "int main() {}")
 !3 = !{}

--- a/test/DebugInfo/NonSemantic/DebugSourceContinued.ll
+++ b/test/DebugInfo/NonSemantic/DebugSourceContinued.ll
@@ -1,7 +1,14 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-100 -spirv-text -o %t.spt
-; RUN: FileCheck %s --input-file %t.spt --check-prefix CHECK-SPIRV
+; RUN: FileCheck %s --input-file %t.spt --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-100
 ; RUN: llvm-spirv %t.bc  --spirv-debug-info-version=nonsemantic-shader-100 -o %t.spv
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-200 -spirv-text -o %t.spt
+; RUN: FileCheck %s --input-file %t.spt --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-200
+; RUN: llvm-spirv %t.bc  --spirv-debug-info-version=nonsemantic-shader-200 -o %t.spv
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
@@ -19,7 +26,9 @@
 ; CHECK-SPIRV-SAME-COUNT-262130: A
 ; CHECK-SPIRV: String [[#Str3:]] "A
 ; CHECK-SPIRV-SAME-COUNT-5755: A
-; CHECK-SPIRV: DebugSource [[#]] [[#Str]]
+; CHECK-SPIRV-100: DebugSource [[#]] [[#Str]]
+; CHECK-SPIRV-200: [[#NONE:]] [[#]] DebugInfoNone
+; CHECK-SPIRV-200: DebugSource [[#]] [[#NONE]] [[#NONE]] [[#Str]]
 ; CHECK-SPIRV: DebugSourceContinued [[#Str2]]
 ; CHECK-SPIRV: DebugSourceContinued [[#Str3]]
 


### PR DESCRIPTION
It's done in scope of NonSemantic.Shader.200.DebugInfo spec to have a proper solution for translation of checksum info (instead of the W/A done for OpenCL DebugInfo spec in #936).

DebugSource now have two more optional operands (will be reflected in spec PR later), and the operand list for instruction looks like:

| | Optional | Optional | Optional|
|--------|--------|--------|--------|
| \<id\> File| \<id\> Checksum Kind| \<id\> Checksum Value| \<id\> Text| 

Meaning that if we do have `Text` field, the previous two should be also filled; and if we do have `Checksum Kind`, then it should come in pair with `Checksum Value`.