### PR TITLE
[DebugInfo] Fix translation of DebugSource Text argument

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -138,6 +138,8 @@ const std::string &SPIRVToLLVMDbgTran::getString(const SPIRVId Id) {
 const std::string
 SPIRVToLLVMDbgTran::getStringContinued(const SPIRVId Id,
                                        SPIRVExtInst *DebugInst) {
+  if (getDbgInst<SPIRVDebug::DebugInfoNone>(Id))
+    return "";
   std::string Str = BM->get<SPIRVString>(Id)->getStr();
   using namespace SPIRVDebug::Operand::SourceContinued;
   for (auto *I : DebugInst->getContinuedInstructions()) {


### PR DESCRIPTION
Handle the case when we have `DebugInfoNone` for the Text argument which is usually expected to be `OpString`.