### PR TITLE
[DebugInfo] Fix DebugTypeVector Component Count

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -695,6 +695,8 @@ LLVMToSPIRVDbgTran::transDbgArrayTypeNonSemantic(const DICompositeType *AT) {
     if (AT->isVector()) {
       assert(N == 1 && "Multidimensional vector is not expected!");
       Ops[ComponentCountIdx] = static_cast<SPIRVWord>(Count->getZExtValue());
+      if (isNonSemanticDebugInfo())
+        transformToConstant(Ops, {ComponentCountIdx});
       return BM->addDebugInfo(SPIRVDebug::TypeVector, getVoidTy(), Ops);
     }
     Ops[SubrangesIdx + I] = transDbgEntry(SR)->getId();

--- a/test/DebugInfo/X86/rematerialize.ll
+++ b/test/DebugInfo/X86/rematerialize.ll
@@ -5,15 +5,15 @@
 ; RUN: llc -O2 -filetype=obj -mtriple=x86_64-unknown-linux-gnu < %t.ll \
 ; RUN: | llvm-dwarfdump -debug-line - | FileCheck %s
 
-; RUNx: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
-; RUNx: llc -O2 -filetype=obj -mtriple=x86_64-unknown-linux-gnu < %t.ll \
-; RUNx: | llvm-dwarfdump -debug-line - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llc -O2 -filetype=obj -mtriple=x86_64-unknown-linux-gnu < %t.ll \
+; RUN: | llvm-dwarfdump -debug-line - | FileCheck %s
 
-; RUNx: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
-; RUNx: llc -O2 -filetype=obj -mtriple=x86_64-unknown-linux-gnu < %t.ll \
-; RUNx: | llvm-dwarfdump -debug-line - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llc -O2 -filetype=obj -mtriple=x86_64-unknown-linux-gnu < %t.ll \
+; RUN: | llvm-dwarfdump -debug-line - | FileCheck %s
 ;
 ; Generated with clang -O2 -g from
 ;

--- a/test/DebugInfo/X86/sycl-vec-3.ll
+++ b/test/DebugInfo/X86/sycl-vec-3.ll
@@ -3,13 +3,13 @@
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
 
-; RUNx: llvm-spirv %t.bc -o %t.spv -spirv-debug-info-version=nonsemantic-shader-100
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
-; RUNx: llvm-dis %t.rev.bc -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv -spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
 
-; RUNx: llvm-spirv %t.bc -o %t.spv -spirv-debug-info-version=nonsemantic-shader-200
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
-; RUNx: llvm-dis %t.rev.bc -o - | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv -spirv-debug-info-version=nonsemantic-shader-200
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"

--- a/test/DebugInfo/X86/vector.ll
+++ b/test/DebugInfo/X86/vector.ll
@@ -4,15 +4,15 @@
 ; RUN: llc -mtriple=x86_64-linux-gnu -O0 -filetype=obj -o %t %t.ll
 ; RUN: llvm-dwarfdump -debug-info %t | FileCheck %s
 
-; RUNx: llvm-spirv %t.bc -o %t.spv -spirv-debug-info-version=nonsemantic-shader-100
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
-; RUNx: llc -mtriple=x86_64-linux-gnu -O0 -filetype=obj -o %t %t.ll
-; RUNx: llvm-dwarfdump -debug-info %t | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv -spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llc -mtriple=x86_64-linux-gnu -O0 -filetype=obj -o %t %t.ll
+; RUN: llvm-dwarfdump -debug-info %t | FileCheck %s
 
-; RUNx: llvm-spirv %t.bc -o %t.spv -spirv-debug-info-version=nonsemantic-shader-200
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
-; RUNx: llc -mtriple=x86_64-linux-gnu -O0 -filetype=obj -o %t %t.ll
-; RUNx: llvm-dwarfdump -debug-info %t | FileCheck %s
+; RUN: llvm-spirv %t.bc -o %t.spv -spirv-debug-info-version=nonsemantic-shader-200
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llc -mtriple=x86_64-linux-gnu -O0 -filetype=obj -o %t %t.ll
+; RUN: llvm-dwarfdump -debug-info %t | FileCheck %s
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"


### PR DESCRIPTION
It should be OpConstant

Based on top of https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2005