### PR TITLE
[NFC] Avoid use-after-free in translating Constant* types.

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -416,11 +416,9 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
       Name = ST->getName();
 
     if (Name == getSPIRVTypeName(kSPIRVTypeName::ConstantSampler))
-      return transSPIRVOpaqueType(getSPIRVTypeName(kSPIRVTypeName::Sampler),
-                                  SPIRAS_Constant);
+      return transSPIRVOpaqueType("spirv.Sampler", SPIRAS_Constant);
     if (Name == getSPIRVTypeName(kSPIRVTypeName::ConstantPipeStorage))
-      return transSPIRVOpaqueType(getSPIRVTypeName(kSPIRVTypeName::PipeStorage),
-                                  SPIRAS_Constant);
+      return transSPIRVOpaqueType("spirv.PipeStorage", SPIRAS_Constant);
 
     constexpr size_t MaxNumElements = MaxWordCount - SPIRVTypeStruct::FixedWC;
     const size_t NumElements = ST->getNumElements();


### PR DESCRIPTION
The key used for uniquing the SPIR-V opaque types in transSPIRVOpaqueType uses a StringRef. The main use of transSPIRVOpaqueType call it on the name of the LLVM struct type, which lives for as long as the LLVM context is live. But the uses here were relying on a method that returns a std::string, which means the string is freed at the end of the function call, and the value stored in the map is therefore a use-after-free if there is ever another call to translate said type.