### PR TITLE
Skip spirv decoration metadata with --spirv-preserve-auxdata

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1181,13 +1181,22 @@ void LLVMToSPIRVBase::transAuxDataInst(SPIRVFunction *BF, Function *F) {
   F->getContext().getMDKindNames(MDNames);
   F->getAllMetadata(AllMD);
   for (auto MD : AllMD) {
+    std::string MDName = MDNames[MD.first].str();
+
+    // spirv.Decorations and spirv.ParameterDecorations are handled
+    // elsewhere for both forward and reverse translation and are complicated
+    // to support here, so just skip them.
+    if (MDName == SPIRV_MD_DECORATIONS ||
+        MDName == SPIRV_MD_PARAMETER_DECORATIONS)
+      continue;
+
     // Format for metadata is:
     // NonSemanticAuxDataFunctionMetadata Fcn MDName MDVals...
     // MDName is always a String, MDVals have different types as explained
     // below. Also note this instruction has a variable number of operands
     std::vector<SPIRVWord> Ops;
     Ops.push_back(BF->getId());
-    Ops.push_back(BM->getString(MDNames[MD.first].str())->getId());
+    Ops.push_back(BM->getString(MDName)->getId());
     for (unsigned int OpIdx = 0; OpIdx < MD.second->getNumOperands(); OpIdx++) {
       const auto &CurOp = MD.second->getOperand(OpIdx);
       if (auto *MDStr = dyn_cast<MDString>(CurOp)) {

--- a/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-all-function-metadata.ll
+++ b/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-all-function-metadata.ll
@@ -32,7 +32,7 @@ ret void
 }
 
 ; CHECK-LLVM: define spir_func void @test_string() {{.*}} !bar ![[#LLVMStr:]]
-define spir_func void @test_string() #1 !bar !2 {
+define spir_func void @test_string() #1 !bar !2 !spirv.Decorations !4 !spirv.ParameterDecorations !3 {
 ret void
 }
 
@@ -40,3 +40,8 @@ ret void
 !1 = !{i32 5}
 ; CHECK-LLVM ![[#LLVMSTR]] = !{!"baz"}
 !2 = !{!"baz"}
+!3 = !{!4, !7, !4}
+!4 = !{!5, !6}
+!5 = !{i32 0, i32 2}
+!6 = !{i32 0, i32 8}
+!7 = !{!6}


### PR DESCRIPTION
It's already explicitly handled for forward and reverse translation, and it's a bit complicated to handle MDNode metadata. Just skip it so we don't assert.

If I see this come up in more cases I will add support for MDNode metadata.