### PR TITLE
[CI] Use clang to generate compile_commands

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -75,7 +75,8 @@ jobs:
       if: ${{ steps.gather-list-of-changes.outputs.HAS_CHANGES }}
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ${{ github.workspace }}
+        cmake -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }} \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ${{ github.workspace }}
 
     - name: Run clang-format
       if: ${{ steps.gather-list-of-changes.outputs.HAS_CHANGES }}


### PR DESCRIPTION
Ensure the code-formatting job uses clang to generate compile_commands.json, to avoid passing GCC-specific flags to clang-format or clang-tidy.