### PR TITLE
fix ptr.annotation in reverse translator for OpCopyMemorySized

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1821,8 +1821,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     bool IsVolatile = BC->SPIRVMemoryAccess::isVolatile();
     IRBuilder<> Builder(BB);
 
+    // A ptr.annotation may have been generated for the destination variable.
+    replaceOperandWithAnnotationIntrinsicCallResult(F, Dst);
+
     if (!CI) {
       llvm::Value *Src = transValue(BC->getSource(), F, BB);
+
+      // A ptr.annotation may have been generated for the source variable.
+      replaceOperandWithAnnotationIntrinsicCallResult(F, Src);
       CI = Builder.CreateMemCpy(Dst, Align, Src, Align, Size, IsVolatile);
     }
     if (isFuncNoUnwind())

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3650,6 +3650,10 @@ bool allowDecorateWithBufferLocationOrLatencyControlINTEL(IntrinsicInst *II) {
   for (auto &Inst : UserList)
     if (isa<LoadInst>(Inst) || isa<StoreInst>(Inst))
       return true;
+    else if (auto *III = dyn_cast<IntrinsicInst>(Inst)) {
+      if (III->getIntrinsicID() == Intrinsic::memcpy)
+        return true;
+    }
 
   return false;
 }

--- a/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_buffer_location/FPGABufferLocation.ll
@@ -96,8 +96,30 @@ entry:
   ret void
 }
 
+; test3 : memcpy
+; Function Attrs: convergent mustprogress norecurse
+define spir_kernel void @test.3(ptr addrspace(1) align 4 %arg_a, ptr %arg_b) {
+entry:
+  %this.addr.i = alloca ptr addrspace(4), align 8
+  %arg_a.addr = alloca ptr addrspace(1), align 8
+  %MyIP = alloca %struct.MyIP, align 8
+  %arg_a.addr.ascast = addrspacecast ptr %arg_a.addr to ptr addrspace(4)
+  %MyIP.ascast = addrspacecast ptr %MyIP to ptr addrspace(4)
+  store ptr addrspace(1) %arg_a, ptr addrspace(4) %arg_a.addr.ascast, align 8
+  %a = getelementptr inbounds %struct.MyIP, ptr addrspace(4) %MyIP.ascast, i32 0, i32 0
+  %0 = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a, ptr getelementptr inbounds ([19 x i8], ptr @.str.4, i32 0, i32 0), ptr getelementptr inbounds ([9 x i8], ptr @.str.1, i32 0, i32 0), i32 7, ptr null)
+  call void @llvm.memcpy.p4.p0(ptr addrspace(4) %0, ptr %arg_b, i64 4, i1 false)
+; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %a, ptr @[[ANN_STR]], ptr undef, i32 undef, ptr undef)
+; CHECK-LLVM: %[[BITCAST:[[:alnum:].]+]] = bitcast ptr addrspace(4) %[[INTRINSIC_CALL]] to ptr addrspace(4)
+; CHECK-LLVM: llvm.memcpy.p4.p0.i64(ptr addrspace(4) %[[BITCAST]], ptr %arg_b, i64 4, i1 false)
+  ret void
+}
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
 declare ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4), ptr, ptr, i32, ptr) #1
+
+; Function Attrs: argmemonly nofree nounwind willreturn
+declare void @llvm.memcpy.p4.p0(ptr addrspace(4) noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #2
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.ocl.version = !{!0}


### PR DESCRIPTION
For a memcpy call, there also could be `ptr.annotation` generated before the src and dest pointer. Update the code to check `ptr.annotation` for OpCopyMemorySized and update lit test