### PR TITLE
[DebugInfo] Add Column parameter to DebugInlinedAt instruction

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1378,7 +1378,10 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDebugLoc(const DebugLoc &Loc,
 }
 
 SPIRVEntry *LLVMToSPIRVDbgTran::transDbgInlinedAt(const DILocation *Loc) {
-  using namespace SPIRVDebug::Operand::InlinedAt;
+  // There is a Column operand in NonSemantic.Shader.200 spec
+  if (BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200)
+    return transDbgInlinedAtNonSemanticShader200(Loc);
+  using namespace SPIRVDebug::Operand::InlinedAt::OpenCL;
   SPIRVWordVec Ops(MinOperandCount);
   Ops[LineIdx] = Loc->getLine();
   Ops[ScopeIdx] = getScope(Loc->getScope())->getId();
@@ -1386,6 +1389,19 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgInlinedAt(const DILocation *Loc) {
     Ops.push_back(transDbgEntry(IA)->getId());
   if (isNonSemanticDebugInfo())
     transformToConstant(Ops, {LineIdx});
+  return BM->addDebugInfo(SPIRVDebug::InlinedAt, getVoidTy(), Ops);
+}
+
+SPIRVEntry *LLVMToSPIRVDbgTran::transDbgInlinedAtNonSemanticShader200(
+    const DILocation *Loc) {
+  using namespace SPIRVDebug::Operand::InlinedAt::NonSemantic;
+  SPIRVWordVec Ops(MinOperandCount);
+  Ops[LineIdx] = Loc->getLine();
+  Ops[ColumnIdx] = Loc->getColumn();
+  transformToConstant(Ops, {LineIdx, ColumnIdx});
+  Ops[ScopeIdx] = getScope(Loc->getScope())->getId();
+  if (DILocation *IA = Loc->getInlinedAt())
+    Ops.push_back(transDbgEntry(IA)->getId());
   return BM->addDebugInfo(SPIRVDebug::InlinedAt, getVoidTy(), Ops);
 }
 

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -144,6 +144,7 @@ private:
   SPIRVEntry *transDebugLoc(const DebugLoc &Loc, SPIRVBasicBlock *BB,
                             SPIRVInstruction *InsertBefore = nullptr);
   SPIRVEntry *transDbgInlinedAt(const DILocation *D);
+  SPIRVEntry *transDbgInlinedAtNonSemanticShader200(const DILocation *D);
 
   template <class T> SPIRVExtInst *getSource(const T *DIEntry);
   SPIRVEntry *transDbgFileType(const DIFile *F);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1527,12 +1527,36 @@ DebugLoc SPIRVToLLVMDbgTran::transDebugScope(const SPIRVInstruction *Inst) {
 }
 
 MDNode *SPIRVToLLVMDbgTran::transDebugInlined(const SPIRVExtInst *DebugInst) {
-  using namespace SPIRVDebug::Operand::InlinedAt;
+  // There is a Column operand in NonSemantic.Shader.200 spec
+  if (DebugInst->getExtSetKind() ==
+      SPIRV::SPIRVEIS_NonSemantic_Shader_DebugInfo_200)
+    return transDebugInlinedNonSemanticShader200(DebugInst);
+
+  using namespace SPIRVDebug::Operand::InlinedAt::OpenCL;
   SPIRVWordVec Ops = DebugInst->getArguments();
   assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
   SPIRVWord Line =
       getConstantValueOrLiteral(Ops, LineIdx, DebugInst->getExtSetKind());
   unsigned Col = 0; // DebugInlinedAt instruction has no column operand
+  DILocalScope *Scope =
+      cast<DILocalScope>(getScope(BM->getEntry(Ops[ScopeIdx])));
+  DILocation *InlinedAt = nullptr;
+  if (Ops.size() > InlinedIdx) {
+    InlinedAt =
+        transDebugInst<DILocation>(BM->get<SPIRVExtInst>(Ops[InlinedIdx]));
+  }
+  return DILocation::getDistinct(M->getContext(), Line, Col, Scope, InlinedAt);
+}
+
+MDNode *SPIRVToLLVMDbgTran::transDebugInlinedNonSemanticShader200(
+    const SPIRVExtInst *DebugInst) {
+  using namespace SPIRVDebug::Operand::InlinedAt::NonSemantic;
+  SPIRVWordVec Ops = DebugInst->getArguments();
+  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+  SPIRVWord Line =
+      getConstantValueOrLiteral(Ops, LineIdx, DebugInst->getExtSetKind());
+  unsigned Col =
+      getConstantValueOrLiteral(Ops, ColumnIdx, DebugInst->getExtSetKind());
   DILocalScope *Scope =
       cast<DILocalScope>(getScope(BM->getEntry(Ops[ScopeIdx])));
   DILocation *InlinedAt = nullptr;
@@ -1646,7 +1670,8 @@ DIBuilder &SPIRVToLLVMDbgTran::getDIBuilder(const SPIRVExtInst *DebugInst) {
       return *BuilderMap.begin()->second;
     const SPIRVWordVec &Ops = DebugInst->getArguments();
     SPIRVWord ParentScopeIdx = 0;
-    if (!hasDbgInstParentScopeIdx(DebugInst->getExtOp(), ParentScopeIdx))
+    if (!hasDbgInstParentScopeIdx(DebugInst->getExtOp(), ParentScopeIdx,
+                                  DebugInst->getExtSetKind()))
       return *BuilderMap.begin()->second;
     if (SPIRVEntry *Scope = BM->getEntry(Ops[ParentScopeIdx])) {
       DebugInst = static_cast<SPIRVExtInst *>(Scope);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -104,6 +104,7 @@ private:
   llvm::DebugLoc transDebugScope(const SPIRVInstruction *Inst);
 
   MDNode *transDebugInlined(const SPIRVExtInst *Inst);
+  MDNode *transDebugInlinedNonSemanticShader200(const SPIRVExtInst *Inst);
 
   DICompileUnit *transCompilationUnit(const SPIRVExtInst *DebugInst,
                                       const std::string CompilerVersion = "",

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -1,5 +1,6 @@
 #ifndef SPIRV_DEBUG_H
 #define SPIRV_DEBUG_H
+#include "SPIRVEnum.h"
 #include "SPIRVUtil.h"
 #include "spirv/unified1/spirv.hpp"
 #include "spirv_internal.hpp"
@@ -671,13 +672,25 @@ namespace NoScope {
 }
 
 namespace InlinedAt {
+namespace OpenCL {
 enum {
   LineIdx         = 0,
   ScopeIdx        = 1,
   InlinedIdx      = 2,
   MinOperandCount = 2
 };
-}
+} // namespace OpenCL
+
+namespace NonSemantic {
+enum {
+  LineIdx         = 0,
+  ColumnIdx       = 1,
+  ScopeIdx        = 2,
+  InlinedIdx      = 3,
+  MinOperandCount = 3
+};
+} // namespace NonSemantic
+} // namespace ImportedEntity
 
 namespace LocalVariable {
 enum {
@@ -942,7 +955,8 @@ enum {
 // helper function to get parent scope of debug instruction, to be used
 // to determine with which compile unit the particular instruction relates
 inline bool hasDbgInstParentScopeIdx(const uint32_t Kind,
-                                     uint32_t &ParentScopeIdx) {
+                                     uint32_t &ParentScopeIdx,
+                                     const SPIRV::SPIRVExtInstSetKind ExtKind = SPIRV::SPIRVEIS_OpenCL) {
   switch (Kind) {
   case SPIRVDebug::Typedef:
     ParentScopeIdx = Typedef::ParentIdx;
@@ -975,7 +989,10 @@ inline bool hasDbgInstParentScopeIdx(const uint32_t Kind,
     ParentScopeIdx = Scope::ScopeIdx;
     return true;
   case SPIRVDebug::InlinedAt:
-    ParentScopeIdx = InlinedAt::ScopeIdx;
+    if (ExtKind == SPIRV::SPIRVEIS_NonSemantic_Shader_DebugInfo_200)
+      ParentScopeIdx = InlinedAt::NonSemantic::ScopeIdx;
+    else
+      ParentScopeIdx = InlinedAt::OpenCL::ScopeIdx;
     return true;
   case SPIRVDebug::LocalVariable:
     ParentScopeIdx = LocalVariable::ParentIdx;


### PR DESCRIPTION
The change is done as a part of NonSemantic.Shader.200 spec, and the new arguments for the `DebugInlinedAt` instruction will look like:

| \<id\> Line| \<id\> Column| \<id\> Scope| Optional\<id\> Inlined|
|--------|--------|--------|--------|