### PR TITLE
Update for expandMemMoveAsLoop API change

### DIFF
--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -41,6 +41,7 @@
 #include "SPIRVInternal.h"
 #include "libSPIRV/SPIRVDebug.h"
 
+#include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Transforms/Utils/LowerMemIntrinsics.h"
 
@@ -101,7 +102,8 @@ bool SPIRVLowerMemmoveBase::expandMemMoveIntrinsicUses(Function &F) {
   for (User *U : make_early_inc_range(F.users())) {
     MemMoveInst *Inst = cast<MemMoveInst>(U);
     if (!isa<ConstantInt>(Inst->getLength())) {
-      expandMemMoveAsLoop(Inst);
+      expandMemMoveAsLoop(Inst,
+                          TargetTransformInfo(F.getParent()->getDataLayout()));
       Inst->eraseFromParent();
     } else {
       LowerMemMoveInst(*Inst);


### PR DESCRIPTION
Pass a TargetTransformInfo argument after llvm-project commit ee19fabc9847 ("LowerMemIntrinsics: Handle inserting addrspacecast for memmove lowering", 2023-06-12).

Constructing a `TargetTransformInfo` from the DataLayout seems to be the easiest solution, but I'm open to better suggestions.