### PR TITLE
Fix crash with --spirv-preserve-auxdata and removed function

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3378,14 +3378,15 @@ bool SPIRVToLLVM::translate() {
     if (!postProcessBuiltinsReturningStruct(M, IsCpp))
       return false;
   }
-  eraseUselessFunctions(M);
-
-  DbgTran->addDbgInfoVersion();
-  DbgTran->finalize();
 
   for (SPIRVExtInst *EI : BM->getAuxDataInstVec()) {
     transAuxDataInst(EI);
   }
+
+  eraseUselessFunctions(M);
+
+  DbgTran->addDbgInfoVersion();
+  DbgTran->finalize();
 
   return true;
 }

--- a/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-all-function-attributes-crash.ll
+++ b/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-all-function-attributes-crash.ll
@@ -1,0 +1,23 @@
+; RUN: llvm-as -opaque-pointers=1 %s -o %t.bc
+; RUN: llvm-spirv %t.bc -opaque-pointers=1 --spirv-preserve-auxdata --spirv-text -spirv-allow-unknown-intrinsics=llvm.genx. --spirv-preserve-auxdata -o %t.txt
+; RUN: llvm-spirv --spirv-preserve-auxdata --spirv-target-env=SPV-IR --spirv-text -r %t.txt -o %t.bc
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir-unknown-unknown"
+
+; CHECK-LLVM: define spir_kernel void @test_array
+define spir_kernel void @test_array(ptr addrspace(1) %in, ptr addrspace(1) %out) {
+  call void @llvm.memmove.p1.p1.i32(ptr addrspace(1) %out, ptr addrspace(1) %in, i32 72, i1 false)
+  ret void
+}
+
+; Function Attrs: nounwind
+declare void @llvm.memmove.p1.p1.i32(ptr addrspace(1) nocapture, ptr addrspace(1) nocapture readonly, i32, i1) #0
+; CHECK-SPIRV: Name [[#ID:]] "llvm.memmove.p1.p1.i32"
+; CHECK-LLVM-NOT: llvm.memmove
+
+; CHECK-LLVM: attributes #0 = { nounwind }
+attributes #0 = { nounwind }


### PR DESCRIPTION
In `SPIRVReader`, we erase unused functions pretty late, but we were applying the ExtInst for `--spirv-preserve-auxdata` after that, causing us to try to work on a deleted function which lead to a crash.

This isn't a problem for the `SPIRVWriter` case because the unused function deletion happens way earlier.