### PR TITLE
[DebugInfo] Fix translation of SPV_INTEL_debug_module extension

### DIFF
--- a/test/DebugInfo/X86/DIModuleContext.ll
+++ b/test/DebugInfo/X86/DIModuleContext.ll
@@ -4,10 +4,10 @@
 ; RUN: llc -mtriple=x86_64-apple-macosx %t.ll -o - -filetype=obj \
 ; RUN:   | llvm-dwarfdump -debug-info - | FileCheck %s
 
-; RUNx: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
-; RUNx: llc -mtriple=x86_64-apple-macosx %t.ll -o - -filetype=obj \
-; RUNx:   | llvm-dwarfdump -debug-info - | FileCheck %s
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llc -mtriple=x86_64-apple-macosx %t.ll -o - -filetype=obj \
+; RUN:   | llvm-dwarfdump -debug-info - | FileCheck %s
 
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/Fortran-DIModule.ll
+++ b/test/DebugInfo/X86/Fortran-DIModule.ll
@@ -5,10 +5,10 @@
 ; RUN: llc -mtriple=x86_64-unknown-linux-gnu %t.ll -filetype=obj -o - | \
 ; RUN:   llvm-dwarfdump - | FileCheck %s
 
-; RUNx: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
-; RUNx: llc -mtriple=x86_64-unknown-linux-gnu %t.ll -filetype=obj -o - | \
-; RUNx:   llvm-dwarfdump - | FileCheck %s
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu %t.ll -filetype=obj -o - | \
+; RUN:   llvm-dwarfdump - | FileCheck %s
 
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dimodule-external-fortran.ll
+++ b/test/DebugInfo/X86/dimodule-external-fortran.ll
@@ -25,9 +25,9 @@
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
 ; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj  %t.ll -o - | llvm-dwarfdump - | FileCheck %s
 
-; RUNx: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
-; RUNx: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
-; RUNx: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj  %t.ll -o - | llvm-dwarfdump - | FileCheck %s
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_debug_module %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj  %t.ll -o - | llvm-dwarfdump - | FileCheck %s
 
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis -o %t.ll


### PR DESCRIPTION
We support `DebugModuleINTEL` instruction as a part of [SPV_INTEL_debug_module extension](https://github.com/intel/llvm/blob/sycl/sycl/doc/design/spirv-extensions/SPV_INTEL_debug_module.asciidoc).
We also support translation of `DebugModule` instruction as a part of NonSemantic.Shader.200 specification, which is basically the same as for DebugModuleINTEL (introduced in #1878).

There was a problem in reverse translation when the extension and NonSemantic.Shader.100 debug info is enabled, which is fixed by this patch.
The related tests cases are enabled back.