### PR TITLE
Switch the default of reverse translation to emitting opaque pointers.

### DIFF
--- a/test/extensions/INTEL/SPV_INTEL_blocking_pipes/PipeBlocking.ll
+++ b/test/extensions/INTEL/SPV_INTEL_blocking_pipes/PipeBlocking.ll
@@ -3,10 +3,10 @@
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; FIXME: add more negative test cases
 ; RUN: llvm-spirv %t.spt -to-binary -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; RUN: llvm-spirv -r %t.spv -o %t.bc --spirv-target-env=SPV-IR
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc --spirv-target-env=SPV-IR
 ; RUN: llvm-dis -opaque-pointers=0 < %t.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 
 ; ModuleID = 'test/CodeGenOpenCL/pipe_builtin.cl'

--- a/test/extensions/INTEL/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_generic.cl
+++ b/test/extensions/INTEL/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_generic.cl
@@ -3,9 +3,9 @@
 // RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // There is no validation for SPV_INTEL_device_side_avc_motion_estimation implemented in
 // SPIRV-Tools. TODO: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM-COMMON,CHECK-LLVM
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM-COMMON,CHECK-LLVM-SPIRV
 // RUN: llvm-spirv %t.rev.bc -opaque-pointers=0 --spirv-ext=+SPV_INTEL_device_side_avc_motion_estimation -o %t.spv
 // RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/extensions/INTEL/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_types.spt
+++ b/test/extensions/INTEL/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_types.spt
@@ -93,9 +93,9 @@
 1 FunctionEnd 
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.bc | FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-LLVM
-; RUN: llvm-spirv -r %t.spv -o %t.bc --spirv-target-env=SPV-IR
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc --spirv-target-env=SPV-IR
 ; RUN: llvm-dis -opaque-pointers=0 < %t.bc | FileCheck %s --check-prefixes=CHECK-COMMON,CHECK-LLVM-SPIRV
 
 ; CHECK-LLVM: %opencl.intel_sub_group_avc_mce_payload_t = type opaque

--- a/test/extensions/INTEL/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_vme_image.cl
+++ b/test/extensions/INTEL/SPV_INTEL_device_side_avc_motion_esimation/subgroup_avc_intel_vme_image.cl
@@ -3,9 +3,9 @@
 // RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // There is no validation for SPV_INTEL_device_side_avc_motion_estimation implemented in
 // SPIRV-Tools. TODO: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM-COMMON,CHECK-LLVM
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM-COMMON,CHECK-LLVM-SPIRV
 // RUN: llvm-spirv %t.rev.bc -opaque-pointers=0 --spirv-ext=+SPV_INTEL_device_side_avc_motion_estimation -o %t.rev.spv
 // RUN: llvm-spirv %t.rev.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/extensions/INTEL/SPV_INTEL_fpga_loop_controls/FPGAIVDepLoopAttrOnClosure.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_loop_controls/FPGAIVDepLoopAttrOnClosure.ll
@@ -41,7 +41,7 @@
 ; RUN: llvm-spirv -to-text %t.spv -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.rev.bc -o %t.rev.ll
 
 ; CHECK-LLVM is the base prefix, which includes simple checks for

--- a/test/extensions/INTEL/SPV_INTEL_fpga_memory_attributes/IntelFPGAMemoryAttributesForStruct.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_memory_attributes/IntelFPGAMemoryAttributesForStruct.ll
@@ -186,10 +186,10 @@
 ; RUN: llvm-spirv %t.spv --spirv-ext=+SPV_INTEL_fpga_memory_attributes -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; RUN: llvm-spirv -spirv-text -r %t.spt -o %t.rev.bc
+; RUN: llvm-spirv -spirv-text -r -emit-opaque-pointers=0 %t.spt -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; TODO: add a bunch of different tests for --spirv-ext option

--- a/test/extensions/INTEL/SPV_INTEL_fpga_reg/IntelFPGAReg.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_reg/IntelFPGAReg.ll
@@ -60,7 +60,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: Capability FPGARegINTEL

--- a/test/extensions/INTEL/SPV_INTEL_io_pipes/PipeStorageIOINTEL.ll
+++ b/test/extensions/INTEL/SPV_INTEL_io_pipes/PipeStorageIOINTEL.ll
@@ -3,10 +3,10 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; RUN: llvm-spirv -spirv-text -r %t.spt -o %t.rev.bc
+; RUN: llvm-spirv -spirv-text -r -emit-opaque-pointers=0 %t.spt -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM-DAG: %spirv.ConstantPipeStorage = type { i32, i32, i32 }

--- a/test/extensions/INTEL/SPV_INTEL_joint_matrix/joint_matrix.ll
+++ b/test/extensions/INTEL/SPV_INTEL_joint_matrix/joint_matrix.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-ext=+SPV_INTEL_joint_matrix -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: Capability JointMatrixINTEL

--- a/test/extensions/INTEL/SPV_INTEL_joint_matrix/joint_matrix_bfloat16.ll
+++ b/test/extensions/INTEL/SPV_INTEL_joint_matrix/joint_matrix_bfloat16.ll
@@ -8,7 +8,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-REGULARIZED: %[[Alloca:.*]] = alloca %"class.cl::sycl::ext::intel::experimental::bfloat16", align 2

--- a/test/extensions/INTEL/SPV_INTEL_joint_matrix/joint_matrix_half.ll
+++ b/test/extensions/INTEL/SPV_INTEL_joint_matrix/joint_matrix_half.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-ext=+SPV_INTEL_joint_matrix -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV-DAG: TypeFloat [[#FloatTy:]] 32

--- a/test/extensions/INTEL/SPV_INTEL_joint_matrix/joint_matrix_tf32.ll
+++ b/test/extensions/INTEL/SPV_INTEL_joint_matrix/joint_matrix_tf32.ll
@@ -4,7 +4,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV-DAG: Capability TensorFloat32RoundingINTEL

--- a/test/extensions/INTEL/SPV_INTEL_joint_matrix/opaque_joint_matrix.ll
+++ b/test/extensions/INTEL/SPV_INTEL_joint_matrix/opaque_joint_matrix.ll
@@ -3,7 +3,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc -opaque-pointers=0
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc -emit-opaque-pointers=0
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV-DAG: Capability JointMatrixINTEL

--- a/test/extensions/INTEL/SPV_INTEL_masked_gather_scatter/intel-basic-vector-pointers.ll
+++ b/test/extensions/INTEL/SPV_INTEL_masked_gather_scatter/intel-basic-vector-pointers.ll
@@ -3,7 +3,7 @@
 ; RUN: llvm-spirv %t.spv --to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; RUN: not llvm-spirv %t.bc -opaque-pointers=0 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR

--- a/test/extensions/INTEL/SPV_INTEL_masked_gather_scatter/intel-gather-scatter.ll
+++ b/test/extensions/INTEL/SPV_INTEL_masked_gather_scatter/intel-gather-scatter.ll
@@ -3,7 +3,7 @@
 ; RUN: llvm-spirv %t.spv --to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_masked_gather_scatter -o %t.spv -spirv-allow-unknown-intrinsics

--- a/test/extensions/INTEL/SPV_INTEL_media_block_io/SPV_INTEL_media_block_io.cl
+++ b/test/extensions/INTEL/SPV_INTEL_media_block_io/SPV_INTEL_media_block_io.cl
@@ -2,9 +2,9 @@
 // RUN: llvm-spirv --spirv-ext=+SPV_INTEL_media_block_io %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-// RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 
 uchar __attribute__((overloadable)) intel_sub_group_media_block_read_uc(int2 src_offset, int width, int height, read_only image2d_t image);

--- a/test/extensions/INTEL/SPV_INTEL_subgroups/cl_intel_sub_groups.ll
+++ b/test/extensions/INTEL/SPV_INTEL_subgroups/cl_intel_sub_groups.ll
@@ -36,9 +36,9 @@
 ; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o - -spirv-text --spirv-ext=+SPV_INTEL_subgroups | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_subgroups
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r %t.spv -emit-opaque-pointers=0 -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-spirv -r %t.spv -emit-opaque-pointers=0 -o %t.rev.bc --spirv-target-env=SPV-IR
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPIRV
 ; RUN: llvm-spirv %t.rev.bc -o - -spirv-text --spirv-ext=+SPV_INTEL_subgroups | FileCheck %s --check-prefix=CHECK-SPIRV
 

--- a/test/extensions/INTEL/SPV_INTEL_vector_compute/buffer_surface_intel.ll
+++ b/test/extensions/INTEL/SPV_INTEL_vector_compute/buffer_surface_intel.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute --spirv-allow-unknown-intrinsics
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.bc -o %t.ll
 ; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV
 ; RUN: FileCheck %s --input-file %t.ll  -check-prefix=LLVM

--- a/test/extensions/INTEL/SPV_INTEL_vector_compute/decoration_media_block_io.ll
+++ b/test/extensions/INTEL/SPV_INTEL_vector_compute/decoration_media_block_io.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute --spirv-allow-unknown-intrinsics=llvm.genx
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.bc -o %t.ll
 ; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV
 ; RUN: FileCheck %s --input-file %t.ll  -check-prefix=LLVM

--- a/test/image.ll
+++ b/test/image.ll
@@ -1,11 +1,11 @@
 ; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
-; RUN: llvm-spirv %t.rev.bc -opaque-pointers=0 -o %t.rev.spv
+; RUN: llvm-spirv %t.rev.bc -emit-opaque-pointers=0 -o %t.rev.spv
 ; RUN: spirv-val %t.rev.spv
 
 ; CHECK-SPIRV: 2 TypeVoid [[VOID_TY:[0-9]+]]

--- a/test/image_without_access_qualifier.spt
+++ b/test/image_without_access_qualifier.spt
@@ -66,7 +66,7 @@
 
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: %opencl.image2d_ro_t = type opaque

--- a/test/llvm-intrinsics/memset-opaque.ll
+++ b/test/llvm-intrinsics/memset-opaque.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ; RUN: llvm-spirv -r %t.spv -o - -emit-opaque-pointers | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM-OPAQUE

--- a/test/llvm-intrinsics/memset.ll
+++ b/test/llvm-intrinsics/memset.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ; RUN: llvm-spirv -r %t.spv -o - -emit-opaque-pointers | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM-OPAQUE

--- a/test/read_image.cl
+++ b/test/read_image.cl
@@ -2,7 +2,7 @@
 // RUN: llvm-spirv --spirv-max-version=1.3 %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-LLVM
 // RUN: llvm-spirv --spirv-max-version=1.3 %t.rev.bc -o %t.rev.spv
 // RUN: spirv-val %t.rev.spv

--- a/test/transcoding/CreatePipeFromPipeStorage.ll
+++ b/test/transcoding/CreatePipeFromPipeStorage.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
-; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 
 

--- a/test/transcoding/ForwardPtr.ll
+++ b/test/transcoding/ForwardPtr.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as -opaque-pointers=0 < %s | llvm-spirv -opaque-pointers=0 -spirv-ext=+all -o %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: TypeForwardPointer [[#FwdPtr:]] 8

--- a/test/transcoding/OpGroupAsyncCopy.ll
+++ b/test/transcoding/OpGroupAsyncCopy.ll
@@ -3,9 +3,9 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 
 ; CHECK-LLVM: call spir_func %opencl.event_t{{.*}}* @_Z29async_work_group_strided_copyPU3AS1Dv2_hPU3AS3KS_jj9ocl_event(

--- a/test/transcoding/OpImageQuerySize.ll
+++ b/test/transcoding/OpImageQuerySize.ll
@@ -7,7 +7,7 @@ target triple = "spir64-unknown-unknown"
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.bc | FileCheck %s
 
 ; Check conversion of get_image_width, get_image_height, get_image_depth,

--- a/test/transcoding/OpImageReadMS.ll
+++ b/test/transcoding/OpImageReadMS.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef19ocl_image2d_msaa_roDv2_ii(%opencl.image2d_msaa_ro_t

--- a/test/transcoding/OpImageSampleExplicitLod.ll
+++ b/test/transcoding/OpImageSampleExplicitLod.ll
@@ -3,7 +3,7 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: call spir_func float @_Z11read_imagef20ocl_image2d_depth_ro11ocl_samplerDv2_i(%opencl.image2d_depth_ro_t

--- a/test/transcoding/OpImageSampleExplicitLod_arg.cl
+++ b/test/transcoding/OpImageSampleExplicitLod_arg.cl
@@ -3,7 +3,7 @@
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 void __kernel sample_kernel_read( __global float4 *results,

--- a/test/transcoding/PipeStorage.ll
+++ b/test/transcoding/PipeStorage.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM-DAG: %spirv.ConstantPipeStorage = type { i32, i32, i32 }

--- a/test/transcoding/RecursiveType.ll
+++ b/test/transcoding/RecursiveType.ll
@@ -6,10 +6,10 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; RUN: llvm-spirv -r %t.spt -spirv-text -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spt -spirv-text -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/transcoding/SampledImage.cl
+++ b/test/transcoding/SampledImage.cl
@@ -3,9 +3,9 @@
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv --spirv-max-version=1.3 %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-// RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 // RUN: llvm-spirv %t.rev.bc -opaque-pointers=0 -spirv-text -o %t.rev.spt
 // RUN: FileCheck < %t.rev.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/check_ro_qualifier.ll
+++ b/test/transcoding/check_ro_qualifier.ll
@@ -1,9 +1,9 @@
 ; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-LLVM
 ; RUN: llvm-spirv %t.rev.bc -o %t.back.spv
 ; RUN: llvm-spirv %t.back.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/check_wo_qualifier.ll
+++ b/test/transcoding/check_wo_qualifier.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-LLVM: opencl.image2d_array_wo_t = type opaque

--- a/test/transcoding/cl-types.ll
+++ b/test/transcoding/cl-types.ll
@@ -22,7 +22,7 @@
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-text -o %t.spv.txt
 ; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 

--- a/test/transcoding/enqueue_kernel.cl
+++ b/test/transcoding/enqueue_kernel.cl
@@ -3,10 +3,10 @@
 // RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv --spirv-target-env CL2.0 -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv --spirv-target-env CL2.0 -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 %t.rev.bc
 // RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
-// RUN: llvm-spirv -r %t.spv --spirv-target-env SPV-IR -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv --spirv-target-env SPV-IR -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 %t.rev.bc
 // RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-SPV-IR
 

--- a/test/transcoding/enqueue_marker.cl
+++ b/test/transcoding/enqueue_marker.cl
@@ -3,9 +3,9 @@
 // RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
-// RUN: llvm-spirv -r -spirv-target-env="SPV-IR" %t.spv -o %t.rev.bc
+// RUN: llvm-spirv -r -emit-opaque-pointers=0 -spirv-target-env="SPV-IR" %t.spv -o %t.rev.bc
 // RUN: llvm-dis -opaque-pointers=0 %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-SPV-IR
 
 // Check that SPIR-V friendly IR is correctly recognized

--- a/test/transcoding/get_image_num_mip_levels.ll
+++ b/test/transcoding/get_image_num_mip_levels.ll
@@ -2,9 +2,9 @@
 ; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 ; RUN: llvm-spirv -spirv-text %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 

--- a/test/transcoding/image_channel.ll
+++ b/test/transcoding/image_channel.ll
@@ -3,9 +3,9 @@
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc --spirv-target-env=SPV-IR
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-SPIRV
 ; RUN: llvm-spirv %t.rev.bc -o %t.rev.spv
 ; RUN: spirv-val %t.rev.spv

--- a/test/transcoding/image_with_access_qualifiers.ll
+++ b/test/transcoding/image_with_access_qualifiers.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; NOTE: access qualifier infomation is not preserved after round-trip conversion to LLVM

--- a/test/transcoding/memory_access.ll
+++ b/test/transcoding/memory_access.ll
@@ -3,7 +3,7 @@
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 --spirv-target-env=CL2.0 %t.spv -o %t.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV-NOT: 6 Store {{[0-9]+}} {{[0-9]+}} 1 2 8

--- a/test/transcoding/multiple_user_semantic.ll
+++ b/test/transcoding/multiple_user_semantic.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; Check that even when FPGA memory extensions are enabled - yet we have

--- a/test/transcoding/multiple_user_semantic_nonopaque.ll
+++ b/test/transcoding/multiple_user_semantic_nonopaque.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; Check that even when FPGA memory extensions are enabled - yet we have

--- a/test/transcoding/multiple_user_semantic_on_struct.ll
+++ b/test/transcoding/multiple_user_semantic_on_struct.ll
@@ -30,7 +30,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; Check that even when FPGA memory extensions are enabled - yet we have

--- a/test/transcoding/spirv-target-types.ll
+++ b/test/transcoding/spirv-target-types.ll
@@ -7,10 +7,10 @@
 ; RUN: llvm-spirv -to-binary %t.spv.txt -o %t.from-text.spv
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv --spirv-target-env=SPV-IR -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv --spirv-target-env=SPV-IR -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM-SPIRV
 

--- a/test/transcoding/spirv-types.ll
+++ b/test/transcoding/spirv-types.ll
@@ -7,10 +7,10 @@
 ; RUN: llvm-spirv -to-binary %t.spv.txt -o %t.from-text.spv
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv --spirv-target-env=SPV-IR -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv --spirv-target-env=SPV-IR -r -emit-opaque-pointers=0 %t.spv -o %t.rev.bc
 ; RUN: llvm-dis -opaque-pointers=0 %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM-SPIRV
 

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -155,7 +155,7 @@ static cl::opt<bool>
                   cl::desc("Emit textual assembly using SPIRV-Tools"));
 
 static cl::opt<bool>
-    EmitOpaquePointers("emit-opaque-pointers", cl::init(false),
+    EmitOpaquePointers("emit-opaque-pointers", cl::init(true),
                        cl::desc("Emit opaque instead of typed LLVM pointers "
                                 "for the translation from SPIR-V."),
                        cl::Hidden);


### PR DESCRIPTION
Most of the changes are adding -emit-opaque-pointers=0 lines to test code. The code generally works in the forward translation at this point, although there is still substantial work that needs to be done to finish porting the tests.