### PR TITLE
[DebugInfo] Correctly use cached DICompilationUnit

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -174,7 +174,7 @@ SPIRVToLLVMDbgTran::transCompilationUnit(const SPIRVExtInst *DebugInst,
   // Do nothing in case we have already translated the CU (e.g. during
   // DebugEntryPoint translation)
   if (BuilderMap[DebugInst->getId()])
-    return nullptr;
+    return cast<DICompileUnit>(DebugInstCache[DebugInst]);
 
   const SPIRVWordVec &Ops = DebugInst->getArguments();
 

--- a/test/DebugInfo/NonSemantic/Shader200/DebugTypeDef.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugTypeDef.ll
@@ -5,7 +5,7 @@
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
-; RUN: llvm-dis %t.rev.bc 
+; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: String [[#TestStr:]] "test.cpp"
@@ -50,3 +50,7 @@ attributes #0 = { convergent mustprogress norecurse nounwind }
 !14 = distinct !DISubprogram(name: "_ZTSZ4mainEUlvE_", scope: !1, file: !1, line: 24, type: !15, flags: DIFlagArtificial | DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
 !15 = !DISubroutineType(cc: DW_CC_nocall, types: !16)
 !16 = !{null}
+!17 = !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !18, entity: !19, file: !1, line: 58)
+!18 = !DINamespace(name: "std", scope: null)
+!19 = !DIDerivedType(tag: DW_TAG_typedef, name: "max_align_t", file: !1, baseType: !20)
+!20 = !DICompositeType(tag: DW_TAG_structure_type, file: !8, line: 19, size: 256, flags: DIFlagFwdDecl, elements: !2, identifier: "_ZTS11max_align_t")


### PR DESCRIPTION
Solving the same issue as / follow up for
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2072

Results of all transDebug... function are being stored in cache. This patch fixes a trivial error - we should not rewrite a 'good' value (if it exists) with nullptr.