### PR TITLE
Update for StringExtras.h include change

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -56,6 +56,7 @@
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/IR/Constants.h"


### PR DESCRIPTION
Update after llvm-project commit 3900860b386a ("[Support] Move StringExtras.h include from Error.h to Error.cpp", 2023-07-13).