### PR TITLE
Workaround unsupported freeze insn

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -413,6 +413,14 @@ bool SPIRVRegularizeLLVMBase::regularize() {
           if (isa<PossiblyExactOperator>(BO) && BO->isExact())
             BO->setIsExact(false);
         }
+
+        // FIXME: This is not valid handling for freeze instruction
+        if (auto FI = dyn_cast<FreezeInst>(&II)) {
+          FI->replaceAllUsesWith(FI->getOperand(0));
+          FI->dropAllReferences();
+          ToErase.push_back(FI);
+        }
+
         // Remove metadata not supported by SPIRV
         static const char *MDs[] = {
             "fpmath",

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -415,7 +415,7 @@ bool SPIRVRegularizeLLVMBase::regularize() {
         }
 
         // FIXME: This is not valid handling for freeze instruction
-        if (auto FI = dyn_cast<FreezeInst>(&II)) {
+        if (auto *FI = dyn_cast<FreezeInst>(&II)) {
           FI->replaceAllUsesWith(FI->getOperand(0));
           FI->dropAllReferences();
           ToErase.push_back(FI);

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -417,12 +417,8 @@ bool SPIRVRegularizeLLVMBase::regularize() {
         // FIXME: This is not valid handling for freeze instruction
         if (auto *FI = dyn_cast<FreezeInst>(&II)) {
           auto *V = FI->getOperand(0);
-          if (isa<UndefValue>(V)) {
-            if (V->getType()->isIntegerTy())
-              V = ConstantInt::get(V->getType(), 0);
-            else if (V->getType()->isFPOrFPVectorTy())
-              V = ConstantFP::get(V->getType(), 0.0);
-          }
+          if (isa<UndefValue>(V))
+            V = Constant::getNullValue(V->getType());
           FI->replaceAllUsesWith(V);
           FI->dropAllReferences();
           ToErase.push_back(FI);

--- a/test/freeze.ll
+++ b/test/freeze.ll
@@ -9,6 +9,10 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; test i32
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ; CHECK-LLVM: @testfunction_i32A
 ; Uses of result should be replaced with freeze's source
 ; CHECK-LLVM-NEXT: add nsw i32 %val, 1
@@ -38,6 +42,10 @@ define spir_func i32 @testfunction_i32C(i32 %val) {
    ret i32 %2
 }
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; test float
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
 ; CHECK-LLVM: @testfunction_floatA
 ; freeze should be eliminated.
 ; Uses of result should be replaced with freeze's source
@@ -66,4 +74,38 @@ define spir_func float @testfunction_floatC(float %val) {
    %1 = freeze float undef
    %2 = fadd float %1, 1.0
    ret float %2
+}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; test ptr
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; CHECK-LLVM: @testfunction_ptrA
+; freeze should be eliminated.
+; Uses of result should be replaced with freeze's source
+; CHECK-LLVM-NEXT: ptrtoint ptr %val to i64
+define spir_func i64 @testfunction_ptrA(ptr %val) {
+   %1 = freeze ptr %val
+   %2 = ptrtoint ptr %1 to i64
+   ret i64 %2
+}
+
+; CHECK-LLVM: @testfunction_ptrB
+; Frozen poison/undef should produce a constant.
+; For ptr type this constant is null.
+; CHECK-LLVM-NEXT: ptrtoint ptr null to i64
+define spir_func i64 @testfunction_ptrB(ptr addrspace(1) %val) {
+   %1 = freeze ptr poison
+   %2 = ptrtoint ptr %1 to i64
+   ret i64 %2
+}
+
+; CHECK-LLVM: @testfunction_ptrC
+; Frozen poison/undef should produce a constant.
+; For ptr type this constant is null.
+; CHECK-LLVM-NEXT: ptrtoint ptr null to i64
+define spir_func i64 @testfunction_ptrC(ptr addrspace(1) %val) {
+   %1 = freeze ptr undef
+   %2 = ptrtoint ptr %1 to i64
+   ret i64 %2
 }

--- a/test/freeze.ll
+++ b/test/freeze.ll
@@ -1,0 +1,15 @@
+;; Test to check that freeze instruction does not cause a crash
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o - -spirv-text | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @testfunction(i32 %val) {
+   %1 = freeze i32 %val
+   ret void
+}
+
+; Check there is an entrypoint to ensure llvm-spirv did not crash
+; CHECK-SPIRV: EntryPoint 6 [[#]] "testfunction"


### PR DESCRIPTION
Workaround unsupported freeze insn by:
1. replacing uses of freeze's result with freeze's source or a random (but compilation reproducible) constant if freeze's source is undef/poison
2. deleting freeze insn.

Long term solution is to add a freeze instruction extension in SPIR-V.  Issue is tracked in (https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1140)
