### PR TITLE
Adjust "Source Lang Literal" logic to support multiple CompileUnits

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -106,6 +106,9 @@ private:
   MDNode *transDebugInlined(const SPIRVExtInst *Inst);
   MDNode *transDebugInlinedNonSemanticShader200(const SPIRVExtInst *Inst);
 
+  void appendToSourceLangLiteral(DICompileUnit *CompileUnit,
+                                 SPIRVWord SourceLang);
+
   DICompileUnit *transCompilationUnit(const SPIRVExtInst *DebugInst,
                                       const std::string CompilerVersion = "",
                                       const std::string Flags = "");

--- a/test/DebugInfo/InvalidSourceLanguageSPIRVtoLLVM.spvasm
+++ b/test/DebugInfo/InvalidSourceLanguageSPIRVtoLLVM.spvasm
@@ -36,5 +36,7 @@
                OpReturn
                OpFunctionEnd
 
-; CHECK: !{i32 2, !"Source Lang Literal", i32 42}
-; CHECK: !DICompileUnit(language: DW_LANG_OpenCL,
+; CHECK: {{![0-9]+}} = !{i32 2, !"Source Lang Literal", [[LIST:![0-9]+]]}
+; CHECK: [[LIST]] = !{[[ENTRY:![0-9]+]]}
+; CHECK: [[ENTRY]] = !{[[CU:![0-9]+]], i32 42}
+; CHECK: [[CU]] = distinct !DICompileUnit(language: DW_LANG_OpenCL


### PR DESCRIPTION
This commit changes "Source Lang Literal" flag from simple a scalar value to a vector of pairs: (compile unit, source language).