### PR TITLE
[NFC] Remove support for legacy pass manager

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -43,9 +43,10 @@
 
 namespace SPIRV {
 
-class SPIRVRegularizeLLVMBase {
+class SPIRVRegularizeLLVMPass
+  : public llvm::PassInfoMixin<SPIRVRegularizeLLVMPass> {
 public:
-  SPIRVRegularizeLLVMBase() : M(nullptr), Ctx(nullptr) {}
+  SPIRVRegularizeLLVMPass() : M(nullptr), Ctx(nullptr) {}
 
   bool runRegularizeLLVM(llvm::Module &M);
   // Lower functions
@@ -106,33 +107,15 @@ public:
 
   static std::string lowerLLVMIntrinsicName(llvm::IntrinsicInst *II);
   static char ID;
-
-private:
-  llvm::Module *M;
-  llvm::LLVMContext *Ctx;
-};
-
-class SPIRVRegularizeLLVMPass
-    : public llvm::PassInfoMixin<SPIRVRegularizeLLVMPass>,
-      public SPIRVRegularizeLLVMBase {
-public:
+  
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM) {
     return runRegularizeLLVM(M) ? llvm::PreservedAnalyses::none()
                                 : llvm::PreservedAnalyses::all();
   }
-};
-
-class SPIRVRegularizeLLVMLegacy : public llvm::ModulePass,
-                                  public SPIRVRegularizeLLVMBase {
-public:
-  SPIRVRegularizeLLVMLegacy() : ModulePass(ID) {
-    initializeSPIRVRegularizeLLVMLegacyPass(*PassRegistry::getPassRegistry());
-  }
-
-  bool runOnModule(llvm::Module &M) override;
-
-  static char ID;
+private:
+  llvm::Module *M;
+  llvm::LLVMContext *Ctx;  
 };
 
 } // namespace SPIRV


### PR DESCRIPTION
Switch to new LLVM pass manager was started on Nov 20, 2020, with old functionality moved to a base class and two derived classes were added (one for new PM and one for legacy PM).  Legacy is no longer needed for SPIRVRegularizeLLVM.  Move all functionality into one class for SPIRVRegularizeLLVM.