### PR TITLE
[NFC][OpaquePointers] Remove deprecated functions: setOpaquePointer, isOpaqueOrPointeeTypeMatches

### DIFF
--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -236,12 +236,8 @@ Value *BuiltinCallHelper::addSPIRVCall(IRBuilder<> &Builder, spv::Op Opcode,
   // Copy the types into the mangling info.
   BuiltinFuncMangleInfo BtnInfo;
   for (unsigned I = 0; I < ArgTys.size(); I++) {
-    if (Args[I]->getType()->isPointerTy()) {
-      assert(cast<PointerType>(Args[I]->getType())
-                 ->isOpaqueOrPointeeTypeMatches(
-                     cast<TypedPointerType>(ArgTys[I])->getElementType()));
+    if (Args[I]->getType()->isPointerTy())
       BtnInfo.getTypeMangleInfo(I).PointerTy = ArgTys[I];
-    }
   }
 
   // Create the function and the call.

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -151,11 +151,8 @@ std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed, Type *PET) {
   // value of some SPIR-V instructions may be represented as pointer to a struct
   // in LLVM IR) we can mangle the type.
   BuiltinFuncMangleInfo MangleInfo;
-  if (Ty->isPointerTy()) {
-    assert(cast<PointerType>(const_cast<Type *>(Ty))
-               ->isOpaqueOrPointeeTypeMatches(PET));
+  if (Ty->isPointerTy())
     Ty = TypedPointerType::get(PET, Ty->getPointerAddressSpace());
-  }
   std::string MangledName =
       mangleBuiltin("", const_cast<Type *>(Ty), &MangleInfo);
   // Remove "_Z0"(3 characters) from the front of the name
@@ -998,12 +995,9 @@ CallInst *addCallInstSPIRV(Module *M, StringRef FuncName, Type *RetTy,
                            Instruction *Pos, StringRef InstName) {
   BuiltinFuncMangleInfo BtnInfo;
   for (unsigned I = 0; I < PointerElementTypes.size(); I++) {
-    if (Args[I]->getType()->isPointerTy()) {
-      assert(cast<PointerType>(Args[I]->getType())
-                 ->isOpaqueOrPointeeTypeMatches(PointerElementTypes[I]));
+    if (Args[I]->getType()->isPointerTy())
       BtnInfo.getTypeMangleInfo(I).PointerTy = TypedPointerType::get(
           PointerElementTypes[I], Args[I]->getType()->getPointerAddressSpace());
-    }
   }
   return addCallInst(M, FuncName, RetTy, Args, Attrs, Pos, &BtnInfo, InstName);
 }
@@ -1493,8 +1487,6 @@ Value *getScalarOrArrayConstantInt(Instruction *Pos, Type *T, unsigned Len,
     unsigned PointerSize =
         Pos->getModule()->getDataLayout().getPointerTypeSizeInBits(T);
     auto *ET = Type::getIntNTy(T->getContext(), PointerSize);
-    assert(cast<PointerType>(T)->isOpaqueOrPointeeTypeMatches(ET) &&
-           "Pointer-to-non-size_t arguments are not valid for this call");
     auto AT = ArrayType::get(ET, Len);
     std::vector<Constant *> EV(Len, ConstantInt::get(ET, V, IsSigned));
     auto CA = ConstantArray::get(AT, EV);

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -381,8 +381,7 @@ static bool isFileEmpty(const std::string &FileName) {
 
 static int convertSPIRVToLLVM(const SPIRV::TranslatorOpts &Opts) {
   LLVMContext Context;
-  Context.setOpaquePointers(EmitOpaquePointers);
-
+  
   std::ifstream IFS(InputFile, std::ios::binary);
   Module *M;
   std::string Err;


### PR DESCRIPTION
Removes use of 
1. setOpaquePointer --> Can be removed without any side effect.
2. isOpaqueOrPointeeTypeMatches --> is always true.

Thanks