### PR TITLE
Fix delete of functions that becomes unused

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -176,9 +176,8 @@ bool OCLToSPIRVBase::runOCLToSPIRV(Module &Module) {
 
   visit(*M);
 
-  for (auto &I : ValuesToDelete)
-    if (auto Inst = dyn_cast<Instruction>(I))
-      Inst->eraseFromParent();
+  for (Instruction *I : ValuesToDelete)
+    I->eraseFromParent();
 
   eraseUselessFunctions(M); // remove unused functions declarations
   LLVM_DEBUG(dbgs() << "After OCLToSPIRV:\n" << *M);
@@ -1057,7 +1056,6 @@ bool OCLToSPIRVBase::eraseUselessConvert(CallInst *CI, StringRef MangledName,
                     << *CI->getArgOperand(0) << '\n');
     CI->replaceAllUsesWith(CI->getArgOperand(0));
     ValuesToDelete.insert(CI);
-    ValuesToDelete.insert(CI->getCalledFunction());
     return true;
   }
   return false;

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -179,9 +179,6 @@ bool OCLToSPIRVBase::runOCLToSPIRV(Module &Module) {
   for (auto &I : ValuesToDelete)
     if (auto Inst = dyn_cast<Instruction>(I))
       Inst->eraseFromParent();
-  for (auto &I : ValuesToDelete)
-    if (auto GV = dyn_cast<GlobalValue>(I))
-      GV->eraseFromParent();
 
   eraseUselessFunctions(M); // remove unused functions declarations
   LLVM_DEBUG(dbgs() << "After OCLToSPIRV:\n" << *M);

--- a/lib/SPIRV/OCLToSPIRV.h
+++ b/lib/SPIRV/OCLToSPIRV.h
@@ -268,7 +268,7 @@ public:
 private:
   LLVMContext *Ctx;
   unsigned CLVer; /// OpenCL version as major*10+minor
-  std::set<Value *> ValuesToDelete;
+  std::set<Instruction *> ValuesToDelete;
   OCLTypeToSPIRVBase *OCLTypeToSPIRVPtr;
 
   ConstantInt *addInt32(int I) { return getInt32(M, I); }


### PR DESCRIPTION
After the first loop of deleting instructions in ValuesToDelete, deleted
instructions in ValuesToDelete are in an unstable state. Then in the
second loop of deleting, dyn_cast to GlobalValue could return true for
an instruction and double eraseFromParent causes crash. The crash is
observed in a multi-threaded test case.

Global values in ValuesToDelete are functions. Unused functions are
deleted by eraseUselessFunctions anyway.