### PR TITLE
[Backport to 14] Fix delete of functions that becomes unused

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -159,12 +159,8 @@ bool OCLToSPIRVBase::runOCLToSPIRV(Module &Module) {
 
   visit(*M);
 
-  for (auto &I : ValuesToDelete)
-    if (auto Inst = dyn_cast<Instruction>(I))
-      Inst->eraseFromParent();
-  for (auto &I : ValuesToDelete)
-    if (auto GV = dyn_cast<GlobalValue>(I))
-      GV->eraseFromParent();
+  for (Instruction *I : ValuesToDelete)
+    I->eraseFromParent();
 
   eraseUselessFunctions(M); // remove unused functions declarations
   LLVM_DEBUG(dbgs() << "After OCLToSPIRV:\n" << *M);
@@ -1135,7 +1131,6 @@ bool OCLToSPIRVBase::eraseUselessConvert(CallInst *CI, StringRef MangledName,
                     << *CI->getArgOperand(0) << '\n');
     CI->replaceAllUsesWith(CI->getArgOperand(0));
     ValuesToDelete.insert(CI);
-    ValuesToDelete.insert(CI->getCalledFunction());
     return true;
   }
   return false;

--- a/lib/SPIRV/OCLToSPIRV.h
+++ b/lib/SPIRV/OCLToSPIRV.h
@@ -267,7 +267,7 @@ private:
   Module *M;
   LLVMContext *Ctx;
   unsigned CLVer; /// OpenCL version as major*10+minor
-  std::set<Value *> ValuesToDelete;
+  std::set<Instruction *> ValuesToDelete;
   OCLTypeToSPIRVBase *OCLTypeToSPIRVPtr;
 
   ConstantInt *addInt32(int I) { return getInt32(M, I); }


### PR DESCRIPTION
After the first loop of deleting instructions in ValuesToDelete, deleted
instructions in ValuesToDelete are in an unstable state. Then in the
second loop of deleting, dyn_cast to GlobalValue could return true for
an instruction and double eraseFromParent causes crash.

Global values in ValuesToDelete are functions. Unused functions are
deleted by eraseUselessFunctions anyway.

(cherry picked from commit aea1ac74ed4301df12adbffff535f72f37d0bb13)