### PR TITLE
[NFC] Use `auto *` for pointer types

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1205,7 +1205,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgFunction(const DISubprogram *Func) {
   Ops[SourceIdx] = getSource(Func)->getId();
   Ops[LineIdx] = Func->getLine();
   Ops[ColumnIdx] = 0; // This version of DISubprogram has no column number
-  auto Scope = Func->getScope();
+  auto *Scope = Func->getScope();
   if (Scope && !isa<DIFile>(Scope)) {
     Ops[ParentIdx] = getScope(Scope)->getId();
   } else {

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -192,7 +192,7 @@ bool OCLToSPIRVBase::runOCLToSPIRV(Module &Module) {
 // there are functions fall into both categories.
 void OCLToSPIRVBase::visitCallInst(CallInst &CI) {
   LLVM_DEBUG(dbgs() << "[visistCallInst] " << CI << '\n');
-  auto F = CI.getCalledFunction();
+  auto *F = CI.getCalledFunction();
   if (!F)
     return;
 
@@ -227,7 +227,7 @@ void OCLToSPIRVBase::visitCallInst(CallInst &CI) {
         isComputeAtomicOCLBuiltin(DemangledName))
       return;
 
-    auto PCI = &CI;
+    auto *PCI = &CI;
     if (DemangledName == kOCLBuiltinName::AtomicInit) {
       visitCallAtomicInit(PCI);
       return;
@@ -493,7 +493,7 @@ CallInst *OCLToSPIRVBase::visitCallAtomicCmpXchg(CallInst *CI) {
 }
 
 void OCLToSPIRVBase::visitCallAtomicInit(CallInst *CI) {
-  auto ST = new StoreInst(CI->getArgOperand(1), CI->getArgOperand(0), CI);
+  auto *ST = new StoreInst(CI->getArgOperand(1), CI->getArgOperand(0), CI);
   ST->takeName(CI);
   CI->dropAllReferences();
   CI->eraseFromParent();
@@ -506,7 +506,7 @@ void OCLToSPIRVBase::visitCallAllAny(spv::Op OC, CallInst *CI) {
   assert(Args.size() == 1);
 
   auto *ArgTy = Args[0]->getType();
-  auto Zero = Constant::getNullValue(Args[0]->getType());
+  auto *Zero = Constant::getNullValue(Args[0]->getType());
 
   auto *Cmp = CmpInst::Create(CmpInst::ICmp, CmpInst::ICMP_SLT, Args[0], Zero,
                               "cast", CI);
@@ -724,8 +724,8 @@ void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
   if (eraseUselessConvert(CI, MangledName, DemangledName))
     return;
   Op OC = OpNop;
-  auto TargetTy = CI->getType();
-  auto SrcTy = CI->getArgOperand(0)->getType();
+  auto *TargetTy = CI->getType();
+  auto *SrcTy = CI->getArgOperand(0)->getType();
   if (auto *VecTy = dyn_cast<VectorType>(TargetTy))
     TargetTy = VecTy->getElementType();
   if (auto *VecTy = dyn_cast<VectorType>(SrcTy))
@@ -768,7 +768,7 @@ void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
 
 void OCLToSPIRVBase::visitCallGroupBuiltin(CallInst *CI,
                                            StringRef OrigDemangledName) {
-  auto F = CI->getCalledFunction();
+  auto *F = CI->getCalledFunction();
   std::vector<int> PreOps;
   std::string DemangledName{OrigDemangledName};
 
@@ -811,7 +811,7 @@ void OCLToSPIRVBase::visitCallGroupBuiltin(CallInst *CI,
           (void)(GroupOp.consume_front("_")); // when op is two characters
           assert(!GroupOp.empty() && "Invalid OpenCL group builtin function");
           char OpTyC = 0;
-          auto OpTy = F->getReturnType();
+          auto *OpTy = F->getReturnType();
           if (OpTy->isFloatingPointTy())
             OpTyC = 'f';
           else if (OpTy->isIntegerTy()) {
@@ -1010,7 +1010,7 @@ void OCLToSPIRVBase::visitCallGetImageSize(CallInst *CI,
           return NCI;
         if (DemangledName == kOCLBuiltinName::GetImageDim) {
           if (Desc.Dim == Dim3D) {
-            auto ZeroVec = ConstantVector::getSplat(
+            auto *ZeroVec = ConstantVector::getSplat(
                 ElementCount::getFixed(3),
                 Constant::getNullValue(
                     cast<VectorType>(NCI->getType())->getElementType()));
@@ -1040,8 +1040,8 @@ void OCLToSPIRVBase::visitCallGetImageSize(CallInst *CI,
 /// Remove trivial conversion functions
 bool OCLToSPIRVBase::eraseUselessConvert(CallInst *CI, StringRef MangledName,
                                          StringRef DemangledName) {
-  auto TargetTy = CI->getType();
-  auto SrcTy = CI->getArgOperand(0)->getType();
+  auto *TargetTy = CI->getType();
+  auto *SrcTy = CI->getArgOperand(0)->getType();
   if (auto *VecTy = dyn_cast<VectorType>(TargetTy))
     TargetTy = VecTy->getElementType();
   if (auto *VecTy = dyn_cast<VectorType>(SrcTy))
@@ -1109,7 +1109,7 @@ void OCLToSPIRVBase::visitCallToAddr(CallInst *CI, StringRef DemangledName) {
   Info.UniqName = DemangledName.str();
   Info.Postfix = std::string(kSPIRVPostfix::Divider) + "To" +
                  SPIRAddrSpaceCapitalizedNameMap::map(AddrSpace);
-  auto StorageClass = addInt32(SPIRSPIRVAddrSpaceMap::map(AddrSpace));
+  auto *StorageClass = addInt32(SPIRSPIRVAddrSpaceMap::map(AddrSpace));
   Info.RetTy = getInt8PtrTy(cast<PointerType>(CI->getType()));
   Info.PostProc = [=](BuiltinCallMutator &Mutator) {
     Mutator
@@ -1537,7 +1537,7 @@ static const char *getSubgroupAVCIntelTyKind(StringRef MangledName) {
 }
 
 static Type *getSubgroupAVCIntelMCEType(Module *M, std::string &TName) {
-  auto Ty = StructType::getTypeByName(M->getContext(), TName);
+  auto *Ty = StructType::getTypeByName(M->getContext(), TName);
   if (Ty)
     return Ty;
 

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -791,7 +791,7 @@ unsigned getOCLVersion(Module *M, bool AllowMulti) {
   // If the module was linked with another module, there may be multiple
   // operands.
   auto GetVer = [=](unsigned I) {
-    auto MD = NamedMD->getOperand(I);
+    auto *MD = NamedMD->getOperand(I);
     return std::make_pair(getMDOperandAsInt(MD, 0), getMDOperandAsInt(MD, 1));
   };
   auto Ver = GetVer(0);

--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -59,48 +59,48 @@ void SPIRVLowerBoolBase::replace(Instruction *I, Instruction *NewI) {
 bool SPIRVLowerBoolBase::isBoolType(Type *Ty) {
   if (Ty->isIntegerTy(1))
     return true;
-  if (auto VT = dyn_cast<VectorType>(Ty))
+  if (auto *VT = dyn_cast<VectorType>(Ty))
     return isBoolType(VT->getElementType());
   return false;
 }
 
 void SPIRVLowerBoolBase::visitTruncInst(TruncInst &I) {
   if (isBoolType(I.getType())) {
-    auto Op = I.getOperand(0);
-    auto And = BinaryOperator::CreateAnd(
+    auto *Op = I.getOperand(0);
+    auto *And = BinaryOperator::CreateAnd(
         Op, getScalarOrVectorConstantInt(Op->getType(), 1, false), "", &I);
     And->setDebugLoc(I.getDebugLoc());
-    auto Zero = getScalarOrVectorConstantInt(Op->getType(), 0, false);
-    auto Cmp = new ICmpInst(&I, CmpInst::ICMP_NE, And, Zero);
+    auto *Zero = getScalarOrVectorConstantInt(Op->getType(), 0, false);
+    auto *Cmp = new ICmpInst(&I, CmpInst::ICMP_NE, And, Zero);
     replace(&I, Cmp);
   }
 }
 
 void SPIRVLowerBoolBase::handleExtInstructions(Instruction &I) {
-  auto Op = I.getOperand(0);
+  auto *Op = I.getOperand(0);
   if (isBoolType(Op->getType())) {
     auto Opcode = I.getOpcode();
-    auto Ty = I.getType();
-    auto Zero = getScalarOrVectorConstantInt(Ty, 0, false);
-    auto One = getScalarOrVectorConstantInt(
+    auto *Ty = I.getType();
+    auto *Zero = getScalarOrVectorConstantInt(Ty, 0, false);
+    auto *One = getScalarOrVectorConstantInt(
         Ty, (Opcode == Instruction::SExt) ? ~0 : 1, false);
     assert(Zero && One && "Couldn't create constant int");
-    auto Sel = SelectInst::Create(Op, One, Zero, "", &I);
+    auto *Sel = SelectInst::Create(Op, One, Zero, "", &I);
     replace(&I, Sel);
   }
 }
 
 void SPIRVLowerBoolBase::handleCastInstructions(Instruction &I) {
-  auto Op = I.getOperand(0);
+  auto *Op = I.getOperand(0);
   auto *OpTy = Op->getType();
   if (isBoolType(OpTy)) {
     Type *Ty = Type::getInt32Ty(*Context);
-    if (auto VT = dyn_cast<FixedVectorType>(OpTy))
+    if (auto *VT = dyn_cast<FixedVectorType>(OpTy))
       Ty = llvm::FixedVectorType::get(Ty, VT->getNumElements());
-    auto Zero = getScalarOrVectorConstantInt(Ty, 0, false);
-    auto One = getScalarOrVectorConstantInt(Ty, 1, false);
+    auto *Zero = getScalarOrVectorConstantInt(Ty, 0, false);
+    auto *One = getScalarOrVectorConstantInt(Ty, 1, false);
     assert(Zero && One && "Couldn't create constant int");
-    auto Sel = SelectInst::Create(Op, One, Zero, "", &I);
+    auto *Sel = SelectInst::Create(Op, One, Zero, "", &I);
     Sel->setDebugLoc(I.getDebugLoc());
     I.setOperand(0, Sel);
   }

--- a/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -115,22 +115,22 @@ bool SPIRVLowerConstExprBase::visit(Module *M) {
     }
     auto FBegin = I.begin();
     while (!WorkList.empty()) {
-      auto II = WorkList.front();
+      auto *II = WorkList.front();
 
       auto LowerOp = [&II, &FBegin, &I, &Changed](Value *V) -> Value * {
         if (isa<Function>(V))
           return V;
         auto *CE = cast<ConstantExpr>(V);
         SPIRVDBG(dbgs() << "[lowerConstantExpressions] " << *CE;)
-        auto ReplInst = CE->getAsInstruction();
-        auto InsPoint = II->getParent() == &*FBegin ? II : &FBegin->back();
+        auto *ReplInst = CE->getAsInstruction();
+        auto *InsPoint = II->getParent() == &*FBegin ? II : &FBegin->back();
         ReplInst->insertBefore(InsPoint);
         SPIRVDBG(dbgs() << " -> " << *ReplInst << '\n';)
         std::vector<Instruction *> Users;
         // Do not replace use during iteration of use. Do it in another loop
-        for (auto U : CE->users()) {
+        for (auto *U : CE->users()) {
           SPIRVDBG(dbgs() << "[lowerConstantExpressions] Use: " << *U << '\n';)
-          if (auto InstUser = dyn_cast<Instruction>(U)) {
+          if (auto *InstUser = dyn_cast<Instruction>(U)) {
             // Only replace users in scope of current function
             if (InstUser->getParent()->getParent() == &I)
               Users.push_back(InstUser);
@@ -152,9 +152,9 @@ bool SPIRVLowerConstExprBase::visit(Module *M) {
         auto *Op = II->getOperand(OI);
         if (auto *CE = dyn_cast<ConstantExpr>(Op)) {
           WorkList.push_front(cast<Instruction>(LowerOp(CE)));
-        } else if (auto MDAsVal = dyn_cast<MetadataAsValue>(Op)) {
+        } else if (auto *MDAsVal = dyn_cast<MetadataAsValue>(Op)) {
           Metadata *MD = MDAsVal->getMetadata();
-          if (auto ConstMD = dyn_cast<ConstantAsMetadata>(MD)) {
+          if (auto *ConstMD = dyn_cast<ConstantAsMetadata>(MD)) {
             Constant *C = ConstMD->getValue();
             Value *ReplInst = nullptr;
             if (auto *CE = dyn_cast<ConstantExpr>(C))

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -248,11 +248,11 @@ translateSEVMetadata(SPIRVValue *BV, llvm::LLVMContext &Context) {
 }
 
 IntrinsicInst *SPIRVToLLVM::getLifetimeStartIntrinsic(Instruction *I) {
-  auto II = dyn_cast<IntrinsicInst>(I);
+  auto *II = dyn_cast<IntrinsicInst>(I);
   if (II && II->getIntrinsicID() == Intrinsic::lifetime_start)
     return II;
   // Bitcast might be inserted during translation of OpLifetimeStart
-  auto BC = dyn_cast<BitCastInst>(I);
+  auto *BC = dyn_cast<BitCastInst>(I);
   if (BC) {
     for (const auto &U : BC->users()) {
       II = dyn_cast<IntrinsicInst>(U);
@@ -275,7 +275,7 @@ void SPIRVToLLVM::setCallingConv(CallInst *Call) {
 // For integer types shorter than 32 bit, unsigned/signedness can be inferred
 // from zext/sext attribute.
 MDString *SPIRVToLLVM::transOCLKernelArgTypeName(SPIRVFunctionParameter *Arg) {
-  auto Ty =
+  auto *Ty =
       Arg->isByVal() ? Arg->getType()->getPointerElementType() : Arg->getType();
   return MDString::get(*Context, transTypeToOCLTypeName(Ty, !Arg->isZext()));
 }
@@ -363,15 +363,15 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
   case OpTypeOpaque:
     return mapType(T, StructType::create(*Context, T->getName()));
   case OpTypeFunction: {
-    auto FT = static_cast<SPIRVTypeFunction *>(T);
-    auto RT = transType(FT->getReturnType());
+    auto *FT = static_cast<SPIRVTypeFunction *>(T);
+    auto *RT = transType(FT->getReturnType());
     std::vector<Type *> PT;
     for (size_t I = 0, E = FT->getNumParameters(); I != E; ++I)
       PT.push_back(transType(FT->getParameterType(I)));
     return mapType(T, FunctionType::get(RT, PT, false));
   }
   case OpTypeImage: {
-    auto ST = static_cast<SPIRVTypeImage *>(T);
+    auto *ST = static_cast<SPIRVTypeImage *>(T);
     if (ST->isOCLImage())
       return mapType(T,
                      getSPIRVType(OpTypeImage, transType(ST->getSampledType()),
@@ -393,10 +393,10 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     // type in the type map, even if UseTPT is true.
     if (Loc != TypeMap.end())
       return Loc->second;
-    auto ST = static_cast<SPIRVTypeStruct *>(T);
+    auto *ST = static_cast<SPIRVTypeStruct *>(T);
     auto Name = ST->getName();
     if (!Name.empty()) {
-      if (auto OldST = StructType::getTypeByName(*Context, Name))
+      if (auto *OldST = StructType::getTypeByName(*Context, Name))
         OldST->setName("");
     } else {
       Name = "structtype";
@@ -413,7 +413,7 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     return StructTy;
   }
   case OpTypePipe: {
-    auto PT = static_cast<SPIRVTypePipe *>(T);
+    auto *PT = static_cast<SPIRVTypePipe *>(T);
     return mapType(T,
                    getSPIRVType(OpTypePipe, PT->getAccessQualifier(), !UseTPT));
   }
@@ -434,7 +434,7 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
                         VT->getDescriptor(), getAccessQualifier(VT), !UseTPT));
   }
   case OpTypeBufferSurfaceINTEL: {
-    auto PST = static_cast<SPIRVTypeBufferSurfaceINTEL *>(T);
+    auto *PST = static_cast<SPIRVTypeBufferSurfaceINTEL *>(T);
     Type *StructTy = getOrCreateOpaqueStructType(M, transVCTypeName(PST));
     Type *PointerTy;
     if (UseTPT)
@@ -593,7 +593,7 @@ std::string SPIRVToLLVM::transTypeToOCLTypeName(SPIRVType *T, bool IsSigned) {
 std::vector<Type *>
 SPIRVToLLVM::transTypeVector(const std::vector<SPIRVType *> &BT, bool UseTPT) {
   std::vector<Type *> T;
-  for (auto I : BT)
+  for (auto *I : BT)
     T.push_back(transType(I, UseTPT));
   return T;
 }
@@ -616,7 +616,7 @@ std::vector<Value *>
 SPIRVToLLVM::transValue(const std::vector<SPIRVValue *> &BV, Function *F,
                         BasicBlock *BB) {
   std::vector<Value *> V;
-  for (auto I : BV)
+  for (auto *I : BV)
     V.push_back(transValue(I, F, BB));
   return V;
 }
@@ -656,7 +656,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
     return;
 
   auto Temp = MDNode::getTemporary(*Context, std::nullopt);
-  auto Self = MDNode::get(*Context, Temp.get());
+  auto *Self = MDNode::get(*Context, Temp.get());
   Self->replaceOperandWith(0, Self);
   SPIRVWord LC = LM->getLoopControl();
   if (LC == LoopControlMaskNone) {
@@ -998,7 +998,7 @@ Value *SPIRVToLLVM::transValue(SPIRVValue *BV, Function *F, BasicBlock *BB,
   SPIRVDBG(spvdbgs() << "[transValue] " << *BV << " -> ";)
   BV->validate();
 
-  auto V = transValueWithoutDecoration(BV, F, BB, CreatePlaceHolder);
+  auto *V = transValueWithoutDecoration(BV, F, BB, CreatePlaceHolder);
   if (!V) {
     SPIRVDBG(dbgs() << " Warning ! nullptr\n";)
     return nullptr;
@@ -1017,8 +1017,8 @@ Value *SPIRVToLLVM::transValue(SPIRVValue *BV, Function *F, BasicBlock *BB,
 Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
                                      BasicBlock *BB) {
   SPIRVUnary *BC = static_cast<SPIRVUnary *>(BV);
-  auto Src = transValue(BC->getOperand(0), F, BB, BB ? true : false);
-  auto Dst = transType(BC->getType());
+  auto *Src = transValue(BC->getOperand(0), F, BB, BB ? true : false);
+  auto *Dst = transType(BC->getType());
   CastInst::CastOps CO = Instruction::BitCast;
   bool IsExt =
       Dst->getScalarSizeInBits() > Src->getType()->getScalarSizeInBits();
@@ -1161,8 +1161,8 @@ Value *SPIRVToLLVM::mapValue(SPIRVValue *BV, Value *V) {
   if (Loc != ValueMap.end()) {
     if (Loc->second == V)
       return V;
-    auto LD = dyn_cast<LoadInst>(Loc->second);
-    auto Placeholder = dyn_cast<GlobalVariable>(LD->getPointerOperand());
+    auto *LD = dyn_cast<LoadInst>(Loc->second);
+    auto *Placeholder = dyn_cast<GlobalVariable>(LD->getPointerOperand());
     assert(LD && Placeholder &&
            Placeholder->getName().startswith(KPlaceholderPrefix) &&
            "A value is translated twice");
@@ -1237,8 +1237,8 @@ Value *SPIRVToLLVM::oclTransConstantPipeStorage(
   string CPSName = string(kSPIRVTypeName::PrefixAndDelim) +
                    kSPIRVTypeName::ConstantPipeStorage;
 
-  auto Int32Ty = IntegerType::getInt32Ty(*Context);
-  auto CPSTy = StructType::getTypeByName(*Context, CPSName);
+  auto *Int32Ty = IntegerType::getInt32Ty(*Context);
+  auto *CPSTy = StructType::getTypeByName(*Context, CPSName);
   if (!CPSTy) {
     Type *CPSElemsTy[] = {Int32Ty, Int32Ty, Int32Ty};
     CPSTy = StructType::create(*Context, CPSElemsTy, CPSName);
@@ -1491,13 +1491,13 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpConstantNull: {
-    auto LT = transType(BV->getType());
+    auto *LT = transType(BV->getType());
     return mapValue(BV, Constant::getNullValue(LT));
   }
 
   case OpConstantComposite:
   case OpSpecConstantComposite: {
-    auto BCC = static_cast<SPIRVConstantComposite *>(BV);
+    auto *BCC = static_cast<SPIRVConstantComposite *>(BV);
     std::vector<Constant *> CV;
     for (auto &I : BCC->getElements())
       CV.push_back(dyn_cast<Constant>(transValue(I, F, BB)));
@@ -1540,7 +1540,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpConstantSampler: {
-    auto BCS = static_cast<SPIRVConstantSampler *>(BV);
+    auto *BCS = static_cast<SPIRVConstantSampler *>(BV);
     // Intentially do not map this value. We want to generate constant
     // sampler initializer every time constant sampler is used, otherwise
     // initializer may not dominate all its uses.
@@ -1548,12 +1548,12 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpConstantPipeStorage: {
-    auto BCPS = static_cast<SPIRVConstantPipeStorage *>(BV);
+    auto *BCPS = static_cast<SPIRVConstantPipeStorage *>(BV);
     return mapValue(BV, oclTransConstantPipeStorage(BCPS));
   }
 
   case OpSpecConstantOp: {
-    auto BI =
+    auto *BI =
         createInstFromSpecConstantOp(static_cast<SPIRVSpecConstantOp *>(BV));
     return mapValue(BV, transValue(BI, nullptr, nullptr, false));
   }
@@ -1570,7 +1570,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return mapValue(BV, UndefValue::get(transType(BV->getType())));
 
   case OpVariable: {
-    auto BVar = static_cast<SPIRVVariable *>(BV);
+    auto *BVar = static_cast<SPIRVVariable *>(BV);
     auto *PreTransTy = BVar->getType()->getPointerElementType();
     auto *Ty = transType(PreTransTy);
     bool IsConst = BVar->isConstant();
@@ -1608,10 +1608,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     SPIRVBuiltinVariableKind BVKind;
     if (BVar->isBuiltin(&BVKind))
       BV->setName(prefixSPIRVName(SPIRVBuiltInNameMap::map(BVKind)));
-    auto LVar = new GlobalVariable(*M, Ty, IsConst, LinkageTy,
+    auto *LVar = new GlobalVariable(*M, Ty, IsConst, LinkageTy,
                                    /*Initializer=*/nullptr, BV->getName(), 0,
                                    GlobalVariable::NotThreadLocal, AddrSpace);
-    auto Res = mapValue(BV, LVar);
+    auto *Res = mapValue(BV, LVar);
     if (Init)
       Initializer = dyn_cast<Constant>(transValue(Init, F, BB, false));
     else if (LinkageTy == GlobalValue::CommonLinkage)
@@ -1646,7 +1646,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpFunctionParameter: {
-    auto BA = static_cast<SPIRVFunctionParameter *>(BV);
+    auto *BA = static_cast<SPIRVFunctionParameter *>(BV);
     assert(F && "Invalid function");
     unsigned ArgNo = 0;
     for (Function::arg_iterator I = F->arg_begin(), E = F->arg_end(); I != E;
@@ -1682,11 +1682,11 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   // Creation of place holder
   if (CreatePlaceHolder) {
     auto *Ty = transType(BV->getType());
-    auto GV =
+    auto *GV =
         new GlobalVariable(*M, Ty, false, GlobalValue::PrivateLinkage, nullptr,
                            std::string(KPlaceholderPrefix) + BV->getName(), 0,
                            GlobalVariable::NotThreadLocal, 0);
-    auto LD = new LoadInst(Ty, GV, BV->getName(), BB);
+    auto *LD = new LoadInst(Ty, GV, BV->getName(), BB);
     PlaceholderMap[BV] = LD;
     return mapValue(BV, LD);
   }
@@ -1734,13 +1734,13 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpPhi: {
-    auto Phi = static_cast<SPIRVPhi *>(BV);
-    auto LPhi = dyn_cast<PHINode>(mapValue(
+    auto *Phi = static_cast<SPIRVPhi *>(BV);
+    auto *LPhi = dyn_cast<PHINode>(mapValue(
         BV, PHINode::Create(transType(Phi->getType()),
                             Phi->getPairs().size() / 2, Phi->getName(), BB)));
     Phi->foreachPair([&](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB,
                          size_t Index) {
-      auto Translated = transValue(IncomingV, F, BB);
+      auto *Translated = transValue(IncomingV, F, BB);
       LPhi->addIncoming(Translated,
                         dyn_cast<BasicBlock>(transValue(IncomingBB, F, BB)));
     });
@@ -1754,7 +1754,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return mapValue(BV, ReturnInst::Create(*Context, BB));
 
   case OpReturnValue: {
-    auto RV = static_cast<SPIRVReturnValue *>(BV);
+    auto *RV = static_cast<SPIRVReturnValue *>(BV);
     return mapValue(
         BV, ReturnInst::Create(*Context,
                                transValue(RV->getReturnValue(), F, BB), BB));
@@ -1779,9 +1779,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     ConstantInt *S = nullptr;
     if (Size)
       S = Builder.getInt64(Size);
-    auto Var = transValue(LTStop->getObject(), F, BB);
+    auto *Var = transValue(LTStop->getObject(), F, BB);
     for (const auto &I : Var->users())
-      if (auto II = getLifetimeStartIntrinsic(dyn_cast<Instruction>(I)))
+      if (auto *II = getLifetimeStartIntrinsic(dyn_cast<Instruction>(I)))
         return mapValue(BV, Builder.CreateLifetimeEnd(II->getOperand(1), S));
     return mapValue(BV, Builder.CreateLifetimeEnd(Var, S));
   }
@@ -1878,9 +1878,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return nullptr;
 
   case OpSwitch: {
-    auto BS = static_cast<SPIRVSwitch *>(BV);
-    auto Select = transValue(BS->getSelect(), F, BB);
-    auto LS = SwitchInst::Create(
+    auto *BS = static_cast<SPIRVSwitch *>(BV);
+    auto *Select = transValue(BS->getSelect(), F, BB);
+    auto *LS = SwitchInst::Create(
         Select, dyn_cast<BasicBlock>(transValue(BS->getDefault(), F, BB)),
         BS->getNumPairs(), BB);
     BS->foreachPair(
@@ -1900,15 +1900,15 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpVectorTimesScalar: {
-    auto VTS = static_cast<SPIRVVectorTimesScalar *>(BV);
+    auto *VTS = static_cast<SPIRVVectorTimesScalar *>(BV);
     IRBuilder<> Builder(BB);
-    auto Scalar = transValue(VTS->getScalar(), F, BB);
-    auto Vector = transValue(VTS->getVector(), F, BB);
+    auto *Scalar = transValue(VTS->getScalar(), F, BB);
+    auto *Vector = transValue(VTS->getVector(), F, BB);
     auto *VecTy = cast<FixedVectorType>(Vector->getType());
     unsigned VecSize = VecTy->getNumElements();
-    auto NewVec = Builder.CreateVectorSplat(VecSize, Scalar, Scalar->getName());
+    auto *NewVec = Builder.CreateVectorSplat(VecSize, Scalar, Scalar->getName());
     NewVec->takeName(Scalar);
-    auto Scale = Builder.CreateFMul(Vector, NewVec, "scale");
+    auto *Scale = Builder.CreateFMul(Vector, NewVec, "scale");
     return mapValue(BV, Scale);
   }
 
@@ -1934,7 +1934,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
     auto *VecTy = cast<FixedVectorType>(Vec->getType());
     FixedVectorType *VTy = FixedVectorType::get(VecTy->getElementType(), M);
-    auto ETy = VTy->getElementType();
+    auto *ETy = VTy->getElementType();
     unsigned N = VecTy->getNumElements();
     Value *V = Builder.CreateVectorSplat(M, ConstantFP::get(ETy, 0.0));
 
@@ -1955,20 +1955,20 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpMatrixTimesScalar: {
-    auto MTS = static_cast<SPIRVMatrixTimesScalar *>(BV);
+    auto *MTS = static_cast<SPIRVMatrixTimesScalar *>(BV);
     IRBuilder<> Builder(BB);
-    auto Scalar = transValue(MTS->getScalar(), F, BB);
-    auto Matrix = transValue(MTS->getMatrix(), F, BB);
+    auto *Scalar = transValue(MTS->getScalar(), F, BB);
+    auto *Matrix = transValue(MTS->getMatrix(), F, BB);
     uint64_t ColNum = Matrix->getType()->getArrayNumElements();
-    auto ColType = cast<ArrayType>(Matrix->getType())->getElementType();
+    auto *ColType = cast<ArrayType>(Matrix->getType())->getElementType();
     auto VecSize = cast<FixedVectorType>(ColType)->getNumElements();
-    auto NewVec = Builder.CreateVectorSplat(VecSize, Scalar, Scalar->getName());
+    auto *NewVec = Builder.CreateVectorSplat(VecSize, Scalar, Scalar->getName());
     NewVec->takeName(Scalar);
 
     Value *V = UndefValue::get(Matrix->getType());
     for (uint64_t Idx = 0; Idx != ColNum; Idx++) {
-      auto Col = Builder.CreateExtractValue(Matrix, Idx);
-      auto I = Builder.CreateFMul(Col, NewVec);
+      auto *Col = Builder.CreateExtractValue(Matrix, Idx);
+      auto *I = Builder.CreateFMul(Col, NewVec);
       V = Builder.CreateInsertValue(V, I, Idx);
     }
 
@@ -2001,7 +2001,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     FixedVectorType *VTy = cast<FixedVectorType>(
         cast<ArrayType>(Mat->getType())->getElementType());
     unsigned N = VTy->getNumElements();
-    auto ETy = VTy->getElementType();
+    auto *ETy = VTy->getElementType();
     Value *V = Builder.CreateVectorSplat(N, ConstantFP::get(ETy, 0.0));
 
     for (unsigned Idx = 0; Idx != M; ++Idx) {
@@ -2059,13 +2059,13 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         cast<FixedVectorType>(cast<ArrayType>(M2->getType())->getElementType());
     unsigned R1 = V1Ty->getNumElements();
     unsigned R2 = V2Ty->getNumElements();
-    auto ETy = V1Ty->getElementType();
+    auto *ETy = V1Ty->getElementType();
 
     (void)C1;
     assert(C1 == R2 && "Unmatched matrix");
 
-    auto VTy = FixedVectorType::get(ETy, R1);
-    auto ResultTy = ArrayType::get(VTy, C2);
+    auto *VTy = FixedVectorType::get(ETy, R1);
+    auto *ResultTy = ArrayType::get(VTy, C2);
 
     Value *Res = UndefValue::get(ResultTy);
 
@@ -2090,16 +2090,16 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpTranspose: {
-    auto TR = static_cast<SPIRVTranspose *>(BV);
+    auto *TR = static_cast<SPIRVTranspose *>(BV);
     IRBuilder<> Builder(BB);
-    auto Matrix = transValue(TR->getMatrix(), F, BB);
+    auto *Matrix = transValue(TR->getMatrix(), F, BB);
     unsigned ColNum = Matrix->getType()->getArrayNumElements();
     FixedVectorType *ColTy = cast<FixedVectorType>(
         cast<ArrayType>(Matrix->getType())->getElementType());
     unsigned RowNum = ColTy->getNumElements();
 
-    auto VTy = FixedVectorType::get(ColTy->getElementType(), ColNum);
-    auto ResultTy = ArrayType::get(VTy, RowNum);
+    auto *VTy = FixedVectorType::get(ColTy->getElementType(), ColNum);
+    auto *ResultTy = ArrayType::get(VTy, RowNum);
     Value *V = UndefValue::get(ResultTy);
 
     SmallVector<Value *, 16> MCache;
@@ -2167,8 +2167,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   case OpInBoundsAccessChain:
   case OpPtrAccessChain:
   case OpInBoundsPtrAccessChain: {
-    auto AC = static_cast<SPIRVAccessChainBase *>(BV);
-    auto Base = transValue(AC->getBase(), F, BB);
+    auto *AC = static_cast<SPIRVAccessChainBase *>(BV);
+    auto *Base = transValue(AC->getBase(), F, BB);
     SPIRVType *BaseSPVTy = AC->getBase()->getType();
     Type *BaseTy =
         BaseSPVTy->isTypeVector()
@@ -2203,7 +2203,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     }
 
     if (BB) {
-      auto GEP =
+      auto *GEP =
           GetElementPtrInst::Create(BaseTy, Base, Index, BV->getName(), BB);
       GEP->setIsInBounds(IsInbound);
       V = GEP;
@@ -2215,7 +2215,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpCompositeConstruct: {
-    auto CC = static_cast<SPIRVCompositeConstruct *>(BV);
+    auto *CC = static_cast<SPIRVCompositeConstruct *>(BV);
     auto Constituents = transValue(CC->getOperands(), F, BB);
     std::vector<Constant *> CV;
     for (const auto &I : Constituents) {
@@ -2272,7 +2272,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpCompositeInsert: {
-    auto CI = static_cast<SPIRVCompositeInsert *>(BV);
+    auto *CI = static_cast<SPIRVCompositeInsert *>(BV);
     IRBuilder<> Builder(*Context);
     if (BB) {
       Builder.SetInsertPoint(BB);
@@ -2305,7 +2305,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpVectorShuffle: {
-    auto VS = static_cast<SPIRVVectorShuffle *>(BV);
+    auto *VS = static_cast<SPIRVVectorShuffle *>(BV);
     std::vector<Constant *> Components;
     IntegerType *Int32Ty = IntegerType::get(*Context, 32);
     for (auto I : VS->getComponents()) {
@@ -2326,7 +2326,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpBitReverse: {
     auto *BR = static_cast<SPIRVUnary *>(BV);
-    auto Ty = transType(BV->getType());
+    auto *Ty = transType(BV->getType());
     Function *intr =
         Intrinsic::getDeclaration(M, llvm::Intrinsic::bitreverse, Ty);
     auto *Call = CallInst::Create(intr, transValue(BR->getOperand(0), F, BB),
@@ -2336,7 +2336,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
   case OpFunctionCall: {
     SPIRVFunctionCall *BC = static_cast<SPIRVFunctionCall *>(BV);
-    auto Call = CallInst::Create(transFunction(BC->getFunction()),
+    auto *Call = CallInst::Create(transFunction(BC->getFunction()),
                                  transValue(BC->getArgumentValues(), F, BB),
                                  BC->getName(), BB);
     setCallingConv(Call);
@@ -2403,7 +2403,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       Builder.SetInsertPoint(BB);
     }
     SPIRVUnary *BC = static_cast<SPIRVUnary *>(BV);
-    auto Neg =
+    auto *Neg =
         Builder.CreateNeg(transValue(BC->getOperand(0), F, BB), BV->getName());
     if (auto *NegInst = dyn_cast<Instruction>(Neg)) {
       applyNoIntegerWrapDecorations(BV, NegInst);
@@ -2419,14 +2419,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     //   result = needs_fixing ? r + b : c
     IRBuilder<> Builder(BB);
     SPIRVFMod *FMod = static_cast<SPIRVFMod *>(BV);
-    auto Dividend = transValue(FMod->getOperand(0), F, BB);
-    auto Divisor = transValue(FMod->getOperand(1), F, BB);
-    auto FRem = Builder.CreateFRem(Dividend, Divisor, "frem.res");
-    auto CopySign = Builder.CreateBinaryIntrinsic(
+    auto *Dividend = transValue(FMod->getOperand(0), F, BB);
+    auto *Divisor = transValue(FMod->getOperand(1), F, BB);
+    auto *FRem = Builder.CreateFRem(Dividend, Divisor, "frem.res");
+    auto *CopySign = Builder.CreateBinaryIntrinsic(
         llvm::Intrinsic::copysign, FRem, Divisor, nullptr, "copysign.res");
-    auto FAdd = Builder.CreateFAdd(FRem, Divisor, "fadd.res");
-    auto Cmp = Builder.CreateFCmpONE(FRem, CopySign, "cmp.res");
-    auto Select = Builder.CreateSelect(Cmp, FAdd, CopySign);
+    auto *FAdd = Builder.CreateFAdd(FRem, Divisor, "fadd.res");
+    auto *Cmp = Builder.CreateFCmpONE(FRem, CopySign, "cmp.res");
+    auto *Select = Builder.CreateSelect(Cmp, FAdd, CopySign);
     return mapValue(BV, Select);
   }
 
@@ -2440,22 +2440,22 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       Builder.SetInsertPoint(BB);
     }
     SPIRVSMod *SMod = static_cast<SPIRVSMod *>(BV);
-    auto Dividend = transValue(SMod->getOperand(0), F, BB);
-    auto Divisor = transValue(SMod->getOperand(1), F, BB);
-    auto SRem = Builder.CreateSRem(Dividend, Divisor, "srem.res");
-    auto Xor = Builder.CreateXor(Dividend, Divisor, "xor.res");
-    auto Zero = ConstantInt::getNullValue(Dividend->getType());
-    auto CmpSign = Builder.CreateICmpSLT(Xor, Zero, "cmpsign.res");
-    auto CmpSRem = Builder.CreateICmpNE(SRem, Zero, "cmpsrem.res");
-    auto Add = Builder.CreateNSWAdd(SRem, Divisor, "add.res");
-    auto Cmp = Builder.CreateAnd(CmpSign, CmpSRem, "cmp.res");
-    auto Select = Builder.CreateSelect(Cmp, Add, SRem);
+    auto *Dividend = transValue(SMod->getOperand(0), F, BB);
+    auto *Divisor = transValue(SMod->getOperand(1), F, BB);
+    auto *SRem = Builder.CreateSRem(Dividend, Divisor, "srem.res");
+    auto *Xor = Builder.CreateXor(Dividend, Divisor, "xor.res");
+    auto *Zero = ConstantInt::getNullValue(Dividend->getType());
+    auto *CmpSign = Builder.CreateICmpSLT(Xor, Zero, "cmpsign.res");
+    auto *CmpSRem = Builder.CreateICmpNE(SRem, Zero, "cmpsrem.res");
+    auto *Add = Builder.CreateNSWAdd(SRem, Divisor, "add.res");
+    auto *Cmp = Builder.CreateAnd(CmpSign, CmpSRem, "cmp.res");
+    auto *Select = Builder.CreateSelect(Cmp, Add, SRem);
     return mapValue(BV, Select);
   }
 
   case OpFNegate: {
     SPIRVUnary *BC = static_cast<SPIRVUnary *>(BV);
-    auto Neg = UnaryOperator::CreateFNeg(transValue(BC->getOperand(0), F, BB),
+    auto *Neg = UnaryOperator::CreateFNeg(transValue(BC->getOperand(0), F, BB),
                                          BV->getName(), BB);
     applyFPFastMathModeDecorations(BV, Neg);
     return mapValue(BV, Neg);
@@ -2648,7 +2648,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       return mapValue(BV, transShiftLogicalBitwiseInst(BV, BB, F));
 
     if (isCvtOpCode(OC) && OC != OpGenericCastToPtrExplicit) {
-      auto BI = static_cast<SPIRVInstruction *>(BV);
+      auto *BI = static_cast<SPIRVInstruction *>(BV);
       Value *Inst = nullptr;
       if (BI->hasFPRoundingMode() || BI->isSaturatedConversion())
         Inst = transSPIRVBuiltinFromInst(BI, BB);
@@ -2690,7 +2690,7 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
 
   Type *RetTy = transType(BI->getType());
 
-  auto Inst = static_cast<SPIRVFixedPointIntelInst *>(BI);
+  auto *Inst = static_cast<SPIRVFixedPointIntelInst *>(BI);
   Type *InTy = transType(Inst->getOperand(0)->getType());
 
   IntegerType *Int32Ty = IntegerType::get(*Context, 32);
@@ -2808,7 +2808,7 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   IntegerType *Int1Ty = Type::getInt1Ty(*Context);
   IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
-  auto Inst = static_cast<SPIRVArbFloatIntelInst *>(BI);
+  auto *Inst = static_cast<SPIRVArbFloatIntelInst *>(BI);
 
   Type *ATy = transType(Inst->getOperand(0)->getType());
   Type *BTy = nullptr;
@@ -3063,7 +3063,7 @@ void SPIRVToLLVM::transOCLBuiltinFromInstPreproc(
     SPIRVInstruction *BI, Type *&RetTy, std::vector<SPIRVValue *> &Args) {
   if (!BI->hasType())
     return;
-  auto BT = BI->getType();
+  auto *BT = BI->getType();
   if (isCmpOpCode(BI->getOpCode())) {
     if (BT->isTypeBool())
       RetTy = IntegerType::getInt32Ty(*Context);
@@ -3109,7 +3109,7 @@ Instruction *SPIRVToLLVM::transWGSizeQueryBI(SPIRVInstruction *BI,
 
   Function *F = M->getFunction(FName);
   if (!F) {
-    auto Int8PtrTyGen = Type::getInt8PtrTy(*Context, SPIRAS_Generic);
+    auto *Int8PtrTyGen = Type::getInt8PtrTy(*Context, SPIRAS_Generic);
     FunctionType *FT = FunctionType::get(Type::getInt32Ty(*Context),
                                          {Int8PtrTyGen, Int8PtrTyGen}, false);
     F = Function::Create(FT, GlobalValue::ExternalLinkage, FName, M);
@@ -3119,7 +3119,7 @@ Instruction *SPIRVToLLVM::transWGSizeQueryBI(SPIRVInstruction *BI,
   auto Ops = BI->getOperands();
   SmallVector<Value *, 2> Args = {transBlockInvoke(Ops[0], BB),
                                   transValue(Ops[1], F, BB, false)};
-  auto Call = CallInst::Create(F, Args, "", BB);
+  auto *Call = CallInst::Create(F, Args, "", BB);
   setName(Call, BI);
   setAttrByCalledFunc(Call);
   return Call;
@@ -3134,7 +3134,7 @@ Instruction *SPIRVToLLVM::transSGSizeQueryBI(SPIRVInstruction *BI,
   auto Ops = BI->getOperands();
   Function *F = M->getFunction(FName);
   if (!F) {
-    auto Int8PtrTyGen = Type::getInt8PtrTy(*Context, SPIRAS_Generic);
+    auto *Int8PtrTyGen = Type::getInt8PtrTy(*Context, SPIRAS_Generic);
     SmallVector<Type *, 3> Tys = {
         transType(Ops[0]->getType()), // ndrange
         Int8PtrTyGen,                 // block_invoke
@@ -3150,7 +3150,7 @@ Instruction *SPIRVToLLVM::transSGSizeQueryBI(SPIRVInstruction *BI,
       transBlockInvoke(Ops[1], BB),     // block_invoke
       transValue(Ops[2], F, BB, false)  // block_literal
   };
-  auto Call = CallInst::Create(F, Args, "", BB);
+  auto *Call = CallInst::Create(F, Args, "", BB);
   setName(Call, BI);
   setAttrByCalledFunc(Call);
   return Call;
@@ -3204,7 +3204,7 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
         isSplitBarrierINTELOpCode(OC) || OC == OpControlBarrier)
       Func->addFnAttr(Attribute::Convergent);
   }
-  auto Call =
+  auto *Call =
       CallInst::Create(Func, transValue(Ops, BB->getParent(), BB), "", BB);
   setName(Call, BI);
   setAttrByCalledFunc(Call);
@@ -3228,10 +3228,10 @@ SPIRVToLLVM::SPIRVToLLVM(Module *LLVMModule, SPIRVModule *TheSPIRVModule)
 std::string getSPIRVFuncSuffix(SPIRVInstruction *BI) {
   string Suffix = "";
   if (BI->getOpCode() == OpCreatePipeFromPipeStorage) {
-    auto CPFPS = static_cast<SPIRVCreatePipeFromPipeStorage *>(BI);
+    auto *CPFPS = static_cast<SPIRVCreatePipeFromPipeStorage *>(BI);
     assert(CPFPS->getType()->isTypePipe() &&
            "Invalid type of CreatePipeFromStorage");
-    auto PipeType = static_cast<SPIRVTypePipe *>(CPFPS->getType());
+    auto *PipeType = static_cast<SPIRVTypePipe *>(CPFPS->getType());
     switch (PipeType->getAccessQualifier()) {
     default:
     case AccessQualifierReadOnly:
@@ -3365,7 +3365,7 @@ bool SPIRVToLLVM::translate() {
   }
 
   for (unsigned I = 0, E = BM->getNumVariables(); I != E; ++I) {
-    auto BV = BM->getVariable(I);
+    auto *BV = BM->getVariable(I);
     if (BV->getStorageClass() != StorageClassFunction)
       transValue(BV, nullptr, nullptr);
     else
@@ -3761,10 +3761,10 @@ void SPIRVToLLVM::transMemAliasingINTELDecorations(SPIRVValue *BV, Value *V) {
 // attach some information on function and propagate that through SPIR-V and
 // ect.)
 void SPIRVToLLVM::transUserSemantic(SPIRV::SPIRVFunction *Fun) {
-  auto TransFun = transFunction(Fun);
+  auto *TransFun = transFunction(Fun);
   for (const auto &UsSem :
        Fun->getDecorationStringLiteral(DecorationUserSemantic)) {
-    auto V = cast<Value>(TransFun);
+    auto *V = cast<Value>(TransFun);
     Constant *StrConstant =
         ConstantDataArray::getString(*Context, StringRef(UsSem));
     auto *GS = new GlobalVariable(
@@ -4063,17 +4063,17 @@ bool SPIRVToLLVM::transMetadata() {
       continue;
 
     // Generate metadata for reqd_work_group_size
-    if (auto EM = BF->getExecutionMode(ExecutionModeLocalSize)) {
+    if (auto *EM = BF->getExecutionMode(ExecutionModeLocalSize)) {
       F->setMetadata(kSPIR2MD::WGSize,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
     // Generate metadata for work_group_size_hint
-    if (auto EM = BF->getExecutionMode(ExecutionModeLocalSizeHint)) {
+    if (auto *EM = BF->getExecutionMode(ExecutionModeLocalSizeHint)) {
       F->setMetadata(kSPIR2MD::WGSizeHint,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
     // Generate metadata for vec_type_hint
-    if (auto EM = BF->getExecutionMode(ExecutionModeVecTypeHint)) {
+    if (auto *EM = BF->getExecutionMode(ExecutionModeVecTypeHint)) {
       std::vector<Metadata *> MetadataVec;
       Type *VecHintTy = decodeVecTypeHint(*Context, EM->getLiterals()[0]);
       assert(VecHintTy);
@@ -4088,11 +4088,11 @@ bool SPIRVToLLVM::transMetadata() {
     }
     // Generate metadata for intel_reqd_sub_group_size
     if (auto *EM = BF->getExecutionMode(ExecutionModeSubgroupSize)) {
-      auto SizeMD = ConstantAsMetadata::get(getUInt32(M, EM->getLiterals()[0]));
+      auto *SizeMD = ConstantAsMetadata::get(getUInt32(M, EM->getLiterals()[0]));
       F->setMetadata(kSPIR2MD::SubgroupSize, MDNode::get(*Context, SizeMD));
     }
     // Generate metadata for max_work_group_size
-    if (auto EM = BF->getExecutionMode(ExecutionModeMaxWorkgroupSizeINTEL)) {
+    if (auto *EM = BF->getExecutionMode(ExecutionModeMaxWorkgroupSizeINTEL)) {
       F->setMetadata(kSPIR2MD::MaxWGSize,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
@@ -4101,17 +4101,17 @@ bool SPIRVToLLVM::transMetadata() {
       F->setMetadata(kSPIR2MD::NoGlobalOffset, MDNode::get(*Context, {}));
     }
     // Generate metadata for max_global_work_dim
-    if (auto EM = BF->getExecutionMode(ExecutionModeMaxWorkDimINTEL)) {
+    if (auto *EM = BF->getExecutionMode(ExecutionModeMaxWorkDimINTEL)) {
       F->setMetadata(kSPIR2MD::MaxWGDim,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
     // Generate metadata for num_simd_work_items
-    if (auto EM = BF->getExecutionMode(ExecutionModeNumSIMDWorkitemsINTEL)) {
+    if (auto *EM = BF->getExecutionMode(ExecutionModeNumSIMDWorkitemsINTEL)) {
       F->setMetadata(kSPIR2MD::NumSIMD,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
     }
     // Generate metadata for scheduler_target_fmax_mhz
-    if (auto EM =
+    if (auto *EM =
             BF->getExecutionMode(ExecutionModeSchedulerTargetFmaxMhzINTEL)) {
       F->setMetadata(kSPIR2MD::FmaxMhz,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
@@ -4370,8 +4370,8 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
           BF->getDecorations(DecorationFunctionDenormModeINTEL);
       IsVCFloatControl = true;
 
-      for (auto DecPtr : DenormModes) {
-        auto DecDenorm =
+      for (const auto *DecPtr : DenormModes) {
+        const auto *DecDenorm =
             static_cast<SPIRVDecorateFunctionDenormModeINTEL const *>(DecPtr);
         VCFloatType FType =
             VCFloatTypeSizeMap::rmap(DecDenorm->getTargetWidth());
@@ -4412,7 +4412,7 @@ bool SPIRVToLLVM::transVectorComputeMetadata(SPIRVFunction *BF) {
     F->addFnAttr(Attr);
   }
 
-  if (auto EM = BF->getExecutionMode(ExecutionModeSharedLocalMemorySizeINTEL)) {
+  if (auto *EM = BF->getExecutionMode(ExecutionModeSharedLocalMemorySizeINTEL)) {
     unsigned int SLMSize = EM->getLiterals()[0];
     Attribute Attr = Attribute::get(*Context, kVCMetadata::VCSLMSize,
                                     std::to_string(SLMSize));
@@ -4483,13 +4483,13 @@ bool SPIRVToLLVM::transFPGAFunctionMetadata(SPIRVFunction *BF, Function *F) {
 }
 
 bool SPIRVToLLVM::transAlign(SPIRVValue *BV, Value *V) {
-  if (auto AL = dyn_cast<AllocaInst>(V)) {
+  if (auto *AL = dyn_cast<AllocaInst>(V)) {
     SPIRVWord Align = 0;
     if (BV->hasAlignment(&Align))
       AL->setAlignment(llvm::Align(Align));
     return true;
   }
-  if (auto GV = dyn_cast<GlobalVariable>(V)) {
+  if (auto *GV = dyn_cast<GlobalVariable>(V)) {
     SPIRVWord Align = 0;
     if (BV->hasAlignment(&Align))
       GV->setAlignment(MaybeAlign(Align));

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -376,7 +376,7 @@ bool SPIRVRegularizeLLVMBase::regularize() {
     std::vector<Instruction *> ToErase;
     for (BasicBlock &BB : *F) {
       for (Instruction &II : BB) {
-        if (auto Call = dyn_cast<CallInst>(&II)) {
+        if (auto *Call = dyn_cast<CallInst>(&II)) {
           Call->setTailCall(false);
           Function *CF = Call->getCalledFunction();
           if (CF && CF->isIntrinsic()) {
@@ -409,7 +409,7 @@ bool SPIRVRegularizeLLVMBase::regularize() {
         }
 
         // Remove optimization info not supported by SPIRV
-        if (auto BO = dyn_cast<BinaryOperator>(&II)) {
+        if (auto *BO = dyn_cast<BinaryOperator>(&II)) {
           if (isa<PossiblyExactOperator>(BO) && BO->isExact())
             BO->setIsExact(false);
         }
@@ -435,7 +435,7 @@ bool SPIRVRegularizeLLVMBase::regularize() {
             II.setMetadata(MDName, nullptr);
           }
         }
-        if (auto Cmpxchg = dyn_cast<AtomicCmpXchgInst>(&II)) {
+        if (auto *Cmpxchg = dyn_cast<AtomicCmpXchgInst>(&II)) {
           // Transform:
           // %1 = cmpxchg i32* %ptr, i32 %comparator, i32 %0 seq_cst acquire
           // To:

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -50,7 +50,7 @@ namespace SPIRV {
 
 void SPIRVToOCLBase::visitCallInst(CallInst &CI) {
   LLVM_DEBUG(dbgs() << "[visistCallInst] " << CI << '\n');
-  auto F = CI.getCalledFunction();
+  auto *F = CI.getCalledFunction();
   if (!F)
     return;
 

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -113,7 +113,7 @@ std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed, Type *PET) {
     return "float";
   if (Ty->isDoubleTy())
     return "double";
-  if (auto IntTy = dyn_cast<IntegerType>(Ty)) {
+  if (const auto *IntTy = dyn_cast<IntegerType>(Ty)) {
     std::string SignPrefix;
     std::string Stem;
     if (!Signed)
@@ -137,7 +137,7 @@ std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed, Type *PET) {
     }
     return SignPrefix + Stem;
   }
-  if (auto VecTy = dyn_cast<FixedVectorType>(Ty)) {
+  if (const auto *VecTy = dyn_cast<FixedVectorType>(Ty)) {
     Type *EleTy = VecTy->getElementType();
     unsigned Size = VecTy->getNumElements();
     std::stringstream Ss;
@@ -160,7 +160,7 @@ std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed, Type *PET) {
 }
 
 StructType *getOrCreateOpaqueStructType(Module *M, StringRef Name) {
-  auto OpaqueType = StructType::getTypeByName(M->getContext(), Name);
+  auto *OpaqueType = StructType::getTypeByName(M->getContext(), Name);
   if (!OpaqueType)
     OpaqueType = StructType::create(M->getContext(), Name);
   return OpaqueType;
@@ -268,7 +268,7 @@ Function *getOrCreateFunction(Module *M, Type *RetTy, ArrayRef<Type *> ArgTypes,
     report_fatal_error(llvm::Twine(SS.str()), false);
   }
   if (!F || F->getFunctionType() != FT) {
-    auto NewF =
+    auto *NewF =
         Function::Create(FT, GlobalValue::ExternalLinkage, MangledName, M);
     if (F && TakeName) {
       NewF->takeName(F);
@@ -383,7 +383,7 @@ SPIRVDecorate *mapPostfixToDecorate(StringRef Postfix, SPIRVEntry *Target) {
 SPIRVValue *addDecorations(SPIRVValue *Target,
                            const SmallVectorImpl<std::string> &Decs) {
   for (auto &I : Decs)
-    if (auto Dec = mapPostfixToDecorate(I, Target))
+    if (auto *Dec = mapPostfixToDecorate(I, Target))
       Target->addDecorate(Dec);
   return Target;
 }
@@ -559,7 +559,7 @@ bool containsUnsignedAtomicType(StringRef Name) {
 }
 
 Constant *castToVoidFuncPtr(Function *F) {
-  auto T = getVoidFuncPtrType(F->getParent());
+  auto *T = getVoidFuncPtrType(F->getParent());
   return ConstantExpr::getBitCast(F, T);
 }
 
@@ -914,7 +914,7 @@ CallInst *mutateCallInst(
     InstName = CI->getName().str();
     CI->setName(InstName + ".old");
   }
-  auto NewCI = addCallInst(M, NewName, CI->getType(), Args, Attrs, CI, Mangle,
+  auto *NewCI = addCallInst(M, NewName, CI->getType(), Args, Attrs, CI, Mangle,
                            InstName, TakeFuncName);
   NewCI->setDebugLoc(CI->getDebugLoc());
   LLVM_DEBUG(dbgs() << " => " << *NewCI << '\n');
@@ -935,9 +935,9 @@ Instruction *mutateCallInst(
   Type *RetTy = CI->getType();
   auto NewName = ArgMutate(CI, Args, RetTy);
   StringRef InstName = CI->getName();
-  auto NewCI = addCallInst(M, NewName, RetTy, Args, Attrs, CI, Mangle, InstName,
+  auto *NewCI = addCallInst(M, NewName, RetTy, Args, Attrs, CI, Mangle, InstName,
                            TakeFuncName);
-  auto NewI = RetMutate(NewCI);
+  auto *NewI = RetMutate(NewCI);
   NewI->takeName(CI);
   NewI->setDebugLoc(CI->getDebugLoc());
   LLVM_DEBUG(dbgs() << " => " << *NewI << '\n');
@@ -951,9 +951,9 @@ void mutateFunction(
     Function *F,
     std::function<std::string(CallInst *, std::vector<Value *> &)> ArgMutate,
     BuiltinFuncMangleInfo *Mangle, AttributeList *Attrs, bool TakeFuncName) {
-  auto M = F->getParent();
+  auto *M = F->getParent();
   for (auto I = F->user_begin(), E = F->user_end(); I != E;) {
-    if (auto CI = dyn_cast<CallInst>(*I++))
+    if (auto *CI = dyn_cast<CallInst>(*I++))
       mutateCallInst(M, CI, ArgMutate, Mangle, Attrs, TakeFuncName);
   }
   if (F->use_empty())
@@ -980,10 +980,10 @@ CallInst *addCallInst(Module *M, StringRef FuncName, Type *RetTy,
                       Instruction *Pos, BuiltinFuncMangleInfo *Mangle,
                       StringRef InstName, bool TakeFuncName) {
 
-  auto F = getOrCreateFunction(M, RetTy, getTypes(Args), FuncName, Mangle,
+  auto *F = getOrCreateFunction(M, RetTy, getTypes(Args), FuncName, Mangle,
                                Attrs, TakeFuncName);
   // Cannot assign a Name to void typed values
-  auto CI = CallInst::Create(F, Args, RetTy->isVoidTy() ? "" : InstName, Pos);
+  auto *CI = CallInst::Create(F, Args, RetTy->isVoidTy() ? "" : InstName, Pos);
   CI->setCallingConv(F->getCallingConv());
   CI->setAttributes(F->getAttributes());
   return CI;
@@ -1012,7 +1012,7 @@ Value *addVector(Instruction *InsPos, ValueVecRange Range) {
     return *Range.first;
   assert(isValidVectorSize(VecSize) && "Invalid vector size");
   IRBuilder<> Builder(InsPos);
-  auto Vec = Builder.CreateVectorSplat(VecSize, *Range.first);
+  auto *Vec = Builder.CreateVectorSplat(VecSize, *Range.first);
   unsigned Index = 1;
   for (++Range.first; Range.first != Range.second; ++Range.first, ++Index)
     Vec = Builder.CreateInsertElement(
@@ -1023,7 +1023,7 @@ Value *addVector(Instruction *InsPos, ValueVecRange Range) {
 
 void makeVector(Instruction *InsPos, std::vector<Value *> &Ops,
                 ValueVecRange Range) {
-  auto Vec = addVector(InsPos, Range);
+  auto *Vec = addVector(InsPos, Range);
   Ops.erase(Range.first, Range.second);
   Ops.push_back(Vec);
 }
@@ -1376,7 +1376,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
     if (isa<FunctionType>(ET)) {
       assert(isVoidFuncTy(cast<FunctionType>(ET)) && "Not supported");
       EPT = new SPIR::BlockType;
-    } else if (auto StructTy = dyn_cast<StructType>(ET)) {
+    } else if (auto *StructTy = dyn_cast<StructType>(ET)) {
       LLVM_DEBUG(dbgs() << "ptr to struct: " << *Ty << '\n');
       auto TyName = StructTy->getStructName();
       if (TyName.startswith(kSPR2TypeName::OCLPrefix)) {
@@ -1390,13 +1390,13 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
       auto Prim = getOCLTypePrimitiveEnum(TyName);
       if (StructTy->isOpaque()) {
         if (TyName == "opencl.block") {
-          auto BlockTy = new SPIR::BlockType;
+          auto *BlockTy = new SPIR::BlockType;
           // Handle block with local memory arguments according to OpenCL 2.0
           // spec.
           if (Info.IsLocalArgBlock) {
             SPIR::RefParamType VoidTyRef(
                 new SPIR::PrimitiveType(SPIR::PRIMITIVE_VOID));
-            auto VoidPtrTy = new SPIR::PointerType(VoidTyRef);
+            auto *VoidPtrTy = new SPIR::PointerType(VoidTyRef);
             VoidPtrTy->setAddressSpace(SPIR::ATTR_LOCAL);
             // "__local void *"
             BlockTy->setParam(0, SPIR::RefParamType(VoidPtrTy));
@@ -1409,7 +1409,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
           if (Prim == SPIR::PRIMITIVE_PIPE_RO_T ||
               Prim == SPIR::PRIMITIVE_PIPE_WO_T) {
             SPIR::RefParamType OpaqueTyRef(new SPIR::PrimitiveType(Prim));
-            auto OpaquePtrTy = new SPIR::PointerType(OpaqueTyRef);
+            auto *OpaquePtrTy = new SPIR::PointerType(OpaqueTyRef);
             OpaquePtrTy->setAddressSpace(getOCLOpaqueTypeAddrSpace(Prim));
             EPT = OpaquePtrTy;
           } else {
@@ -1465,9 +1465,9 @@ Value *getScalarOrArray(Value *V, unsigned Size, Instruction *Pos) {
 }
 
 Constant *getScalarOrVectorConstantInt(Type *T, uint64_t V, bool IsSigned) {
-  if (auto IT = dyn_cast<IntegerType>(T))
+  if (auto *IT = dyn_cast<IntegerType>(T))
     return ConstantInt::get(IT, V);
-  if (auto VT = dyn_cast<FixedVectorType>(T)) {
+  if (auto *VT = dyn_cast<FixedVectorType>(T)) {
     std::vector<Constant *> EV(
         VT->getNumElements(),
         getScalarOrVectorConstantInt(VT->getElementType(), V, IsSigned));
@@ -1479,7 +1479,7 @@ Constant *getScalarOrVectorConstantInt(Type *T, uint64_t V, bool IsSigned) {
 
 Value *getScalarOrArrayConstantInt(Instruction *Pos, Type *T, unsigned Len,
                                    uint64_t V, bool IsSigned) {
-  if (auto IT = dyn_cast<IntegerType>(T)) {
+  if (auto *IT = dyn_cast<IntegerType>(T)) {
     assert(Len == 1 && "Invalid length");
     return ConstantInt::get(IT, V, IsSigned);
   }
@@ -1487,23 +1487,23 @@ Value *getScalarOrArrayConstantInt(Instruction *Pos, Type *T, unsigned Len,
     unsigned PointerSize =
         Pos->getModule()->getDataLayout().getPointerTypeSizeInBits(T);
     auto *ET = Type::getIntNTy(T->getContext(), PointerSize);
-    auto AT = ArrayType::get(ET, Len);
+    auto *AT = ArrayType::get(ET, Len);
     std::vector<Constant *> EV(Len, ConstantInt::get(ET, V, IsSigned));
-    auto CA = ConstantArray::get(AT, EV);
-    auto Alloca = new AllocaInst(AT, 0, "", Pos);
+    auto *CA = ConstantArray::get(AT, EV);
+    auto *Alloca = new AllocaInst(AT, 0, "", Pos);
     new StoreInst(CA, Alloca, Pos);
-    auto Zero = ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
+    auto *Zero = ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
     Value *Index[] = {Zero, Zero};
     auto *Ret = GetElementPtrInst::CreateInBounds(AT, Alloca, Index, "", Pos);
     LLVM_DEBUG(dbgs() << "[getScalarOrArrayConstantInt] Alloca: " << *Alloca
                       << ", Return: " << *Ret << '\n');
     return Ret;
   }
-  if (auto AT = dyn_cast<ArrayType>(T)) {
-    auto ET = AT->getArrayElementType();
+  if (auto *AT = dyn_cast<ArrayType>(T)) {
+    auto *ET = AT->getArrayElementType();
     assert(AT->getArrayNumElements() == Len);
     std::vector<Constant *> EV(Len, ConstantInt::get(ET, V, IsSigned));
-    auto Ret = ConstantArray::get(AT, EV);
+    auto *Ret = ConstantArray::get(AT, EV);
     LLVM_DEBUG(dbgs() << "[getScalarOrArrayConstantInt] Array type: " << *AT
                       << ", Return: " << *Ret << '\n');
     return Ret;
@@ -1652,8 +1652,8 @@ bool eraseIfNoUse(Function *F) {
 
   dumpUsers(F, "[eraseIfNoUse] ");
   for (auto UI = F->user_begin(), UE = F->user_end(); UI != UE;) {
-    auto U = *UI++;
-    if (auto CE = dyn_cast<ConstantExpr>(U)) {
+    auto *U = *UI++;
+    if (auto *CE = dyn_cast<ConstantExpr>(U)) {
       if (CE->use_empty()) {
         CE->dropAllReferences();
         Changed = true;
@@ -1728,7 +1728,7 @@ std::string mangleBuiltin(StringRef UniqName, ArrayRef<Type *> ArgTypes,
     for (unsigned I = 0, E = BIVarArgNegative ? ArgTypes.size()
                                               : (unsigned)BtnInfo->getVarArg();
          I != E; ++I) {
-      auto T = ArgTypes[I];
+      auto *T = ArgTypes[I];
       auto MangleInfo = BtnInfo->getTypeMangleInfo(I);
       if (MangleInfo.PointerTy && T->isPointerTy()) {
         T = MangleInfo.PointerTy;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -385,7 +385,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
   }
 
   if (T->isStructTy() && !T->isSized()) {
-    auto ST = dyn_cast<StructType>(T);
+    auto *ST = dyn_cast<StructType>(T);
     (void)ST; // Silence warning
     assert(!ST->getName().startswith(kSPR2TypeName::PipeRO));
     assert(!ST->getName().startswith(kSPR2TypeName::PipeWO));
@@ -393,7 +393,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
     return mapType(T, BM->addOpaqueType(T->getStructName().str()));
   }
 
-  if (auto ST = dyn_cast<StructType>(T)) {
+  if (auto *ST = dyn_cast<StructType>(T)) {
     assert(ST->isSized());
 
     StringRef Name;
@@ -675,7 +675,7 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(StringRef STName,
   if (TN == kSPIRVTypeName::Pipe) {
     assert(AddrSpace == SPIRAS_Global);
     assert(Postfixes.size() == 1 && "Invalid pipe type ops");
-    auto PipeT = BM->addPipeType();
+    auto *PipeT = BM->addPipeType();
     PipeT->setPipeAcessQualifier(
         static_cast<spv::AccessQualifier>(atoi(Postfixes[0].c_str())));
     return SaveType(PipeT);
@@ -683,7 +683,7 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(StringRef STName,
     assert(AddrSpace == SPIRAS_Global);
     // The sampled type needs to be translated through LLVM type to guarantee
     // uniqueness.
-    auto SampledT = transType(
+    auto *SampledT = transType(
         getLLVMTypeForSPIRVImageSampledTypePostfix(Postfixes[0], *Ctx));
     SmallVector<int, 7> Ops;
     for (unsigned I = 1; I < 8; ++I)
@@ -763,7 +763,7 @@ LLVMToSPIRVBase::getSPIRVFunctionType(SPIRVType *RT,
 }
 
 SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
-  if (auto BF = getTranslatedValue(F))
+  if (auto *BF = getTranslatedValue(F))
     return static_cast<SPIRVFunction *>(BF);
 
   if (F->isIntrinsic() && (!BM->isSPIRVAllowUnknownIntrinsicsEnabled() ||
@@ -902,7 +902,7 @@ void LLVMToSPIRVBase::transVectorComputeMetadata(Function *F) {
   using namespace VectorComputeUtil;
   if (!BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
     return;
-  auto BF = static_cast<SPIRVFunction *>(getTranslatedValue(F));
+  auto *BF = static_cast<SPIRVFunction *>(getTranslatedValue(F));
   assert(BF && "The SPIRVFunction pointer shouldn't be nullptr");
   auto Attrs = F->getAttributes();
 
@@ -1170,7 +1170,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
   if (isa<ConstantTargetNone>(V))
     return BM->addNullConstant(ExpectedType);
 
-  if (auto CAZero = dyn_cast<ConstantAggregateZero>(V)) {
+  if (auto *CAZero = dyn_cast<ConstantAggregateZero>(V)) {
     Type *AggType = CAZero->getType();
     if (const StructType *ST = dyn_cast<StructType>(AggType))
       if (ST->hasName() &&
@@ -1180,7 +1180,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     return BM->addNullConstant(transType(AggType));
   }
 
-  if (auto ConstI = dyn_cast<ConstantInt>(V)) {
+  if (auto *ConstI = dyn_cast<ConstantInt>(V)) {
     unsigned BitWidth = ConstI->getType()->getBitWidth();
     if (BitWidth > 64) {
       BM->getErrorLog().checkError(
@@ -1192,13 +1192,13 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     return BM->addConstant(ExpectedType, ConstI->getZExtValue());
   }
 
-  if (auto ConstFP = dyn_cast<ConstantFP>(V)) {
+  if (auto *ConstFP = dyn_cast<ConstantFP>(V)) {
     auto *BT = static_cast<SPIRVType *>(ExpectedType);
     return BM->addConstant(
         BT, ConstFP->getValueAPF().bitcastToAPInt().getZExtValue());
   }
 
-  if (auto ConstDA = dyn_cast<ConstantDataArray>(V)) {
+  if (auto *ConstDA = dyn_cast<ConstantDataArray>(V)) {
     SPIRVType *InnerTy = ExpectedType->getArrayElementType();
     std::vector<SPIRVValue *> BV;
     for (unsigned I = 0, E = ConstDA->getNumElements(); I != E; ++I)
@@ -1206,7 +1206,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
-  if (auto ConstA = dyn_cast<ConstantArray>(V)) {
+  if (auto *ConstA = dyn_cast<ConstantArray>(V)) {
     SPIRVType *InnerTy = ExpectedType->getArrayElementType();
     std::vector<SPIRVValue *> BV;
     for (auto I = ConstA->op_begin(), E = ConstA->op_end(); I != E; ++I)
@@ -1214,7 +1214,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
-  if (auto ConstDV = dyn_cast<ConstantDataVector>(V)) {
+  if (auto *ConstDV = dyn_cast<ConstantDataVector>(V)) {
     SPIRVType *InnerTy = ExpectedType->getScalarType();
     std::vector<SPIRVValue *> BV;
     for (unsigned I = 0, E = ConstDV->getNumElements(); I != E; ++I)
@@ -1222,7 +1222,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
-  if (auto ConstV = dyn_cast<ConstantVector>(V)) {
+  if (auto *ConstV = dyn_cast<ConstantVector>(V)) {
     SPIRVType *InnerTy = ExpectedType->getScalarType();
     std::vector<SPIRVValue *> BV;
     for (auto I = ConstV->op_begin(), E = ConstV->op_end(); I != E; ++I)
@@ -1272,11 +1272,11 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
-  if (auto ConstUE = dyn_cast<ConstantExpr>(V)) {
-    auto Inst = ConstUE->getAsInstruction();
+  if (auto *ConstUE = dyn_cast<ConstantExpr>(V)) {
+    auto *Inst = ConstUE->getAsInstruction();
     SPIRVDBG(dbgs() << "ConstantExpr: " << *ConstUE << '\n';
              dbgs() << "Instruction: " << *Inst << '\n';)
-    auto BI = transValue(Inst, nullptr, false);
+    auto *BI = transValue(Inst, nullptr, false);
     Inst->dropAllReferences();
     UnboundInst.push_back(Inst);
     return BI;
@@ -1312,7 +1312,7 @@ SPIRVValue *LLVMToSPIRVBase::transValue(Value *V, SPIRVBasicBlock *BB,
           isa<BinaryOperator>(V) || BB) &&
          "Invalid SPIRV BB");
 
-  auto BV = transValueWithoutDecoration(V, BB, CreateForward, FuncTrans);
+  auto *BV = transValueWithoutDecoration(V, BB, CreateForward, FuncTrans);
   if (!BV || !transDecoration(V, BV))
     return nullptr;
   StringRef Name = V->getName();
@@ -1324,7 +1324,7 @@ SPIRVValue *LLVMToSPIRVBase::transValue(Value *V, SPIRVBasicBlock *BB,
 SPIRVInstruction *LLVMToSPIRVBase::transBinaryInst(BinaryOperator *B,
                                                    SPIRVBasicBlock *BB) {
   unsigned LLVMOC = B->getOpcode();
-  auto Op0 = transValue(B->getOperand(0), BB);
+  auto *Op0 = transValue(B->getOperand(0), BB);
   SPIRVInstruction *BI = BM->addBinaryInst(
       transBoolOpCode(Op0, OpCodeMap::map(LLVMOC)), transType(B->getType()),
       Op0, transValue(B->getOperand(1), BB), BB);
@@ -1374,7 +1374,7 @@ SPIRVValue *LLVMToSPIRVBase::transUnaryInst(UnaryInstruction *U,
   }
 
   Op BOC = OpNop;
-  if (auto Cast = dyn_cast<AddrSpaceCastInst>(U)) {
+  if (auto *Cast = dyn_cast<AddrSpaceCastInst>(U)) {
     const auto SrcAddrSpace = Cast->getSrcTy()->getPointerAddressSpace();
     const auto DestAddrSpace = Cast->getDestTy()->getPointerAddressSpace();
     if (DestAddrSpace == SPIRAS_Generic) {
@@ -1430,7 +1430,7 @@ SPIRVValue *LLVMToSPIRVBase::transUnaryInst(UnaryInstruction *U,
     BOC = OpCodeMap::map(OpCode);
   }
 
-  auto Op = transValue(U->getOperand(0), BB, true, FuncTransMode::Pointer);
+  auto *Op = transValue(U->getOperand(0), BB, true, FuncTransMode::Pointer);
   SPIRVType *TransTy = transScavengedType(U);
   return BM->addUnaryInst(transBoolOpCode(Op, BOC), TransTy, Op, BB);
 }
@@ -1782,8 +1782,8 @@ SPIRVValue *
 LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                                              bool CreateForward,
                                              FuncTransMode FuncTrans) {
-  if (auto LBB = dyn_cast<BasicBlock>(V)) {
-    auto BF =
+  if (auto *LBB = dyn_cast<BasicBlock>(V)) {
+    auto *BF =
         static_cast<SPIRVFunction *>(getTranslatedValue(LBB->getParent()));
     assert(BF && "Function not translated");
     BB = static_cast<SPIRVBasicBlock *>(mapValue(V, BM->addBasicBlock(BF)));
@@ -1802,7 +1802,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
         static_cast<SPIRVFunction *>(transValue(F, nullptr)));
   }
 
-  if (auto GV = dyn_cast<GlobalVariable>(V)) {
+  if (auto *GV = dyn_cast<GlobalVariable>(V)) {
     llvm::Type *Ty = Scavenger->getScavengedType(GV);
     // Though variables with common linkage type are initialized by 0,
     // they can be represented in SPIR-V as uninitialized variables with
@@ -1813,7 +1813,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     SPIRVValue *BVarInit = nullptr;
     StructType *ST = Init ? dyn_cast<StructType>(Init->getType()) : nullptr;
     if (ST && ST->hasName() && isSPIRVConstantName(ST->getName())) {
-      auto BV = transConstant(Init);
+      auto *BV = transConstant(Init);
       assert(BV);
       return mapValue(V, BV);
     }
@@ -1834,7 +1834,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     } else if (Init && !isa<UndefValue>(Init)) {
       if (!BM->isAllowedToUseExtension(
               ExtensionID::SPV_INTEL_long_constant_composite)) {
-        if (auto ArrTy = dyn_cast_or_null<ArrayType>(Init->getType())) {
+        if (auto *ArrTy = dyn_cast_or_null<ArrayType>(Init->getType())) {
           // First 3 words of OpConstantComposite encode: 1) word count &
           // opcode, 2) Result Type and 3) Result Id. Max length of SPIRV
           // instruction = 65535 words.
@@ -1878,7 +1878,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     }
 
     SPIRVType *TranslatedTy = transType(Ty);
-    auto BVar = static_cast<SPIRVVariable *>(
+    auto *BVar = static_cast<SPIRVVariable *>(
         BM->addVariable(TranslatedTy, GV->isConstant(), transLinkageType(GV),
                         BVarInit, GV->getName().str(), StorageClass, nullptr));
 
@@ -1921,7 +1921,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
   }
 
   if (isa<Constant>(V)) {
-    auto BV = transConstant(V);
+    auto *BV = transConstant(V);
     assert(BV);
     // Don't store pointer constants in the map -- they are opaque and thus we
     // might reuse the wrong type (Example: a null value) if we do so.
@@ -1930,7 +1930,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     return mapValue(V, BV);
   }
 
-  if (auto Arg = dyn_cast<Argument>(V)) {
+  if (auto *Arg = dyn_cast<Argument>(V)) {
     unsigned ArgNo = Arg->getArgNo();
     SPIRVFunction *BF = BB->getParent();
     // assert(BF->existArgument(ArgNo));
@@ -2002,8 +2002,8 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
   if (dyn_cast<UnreachableInst>(V))
     return mapValue(V, BM->addUnreachableInst(BB));
 
-  if (auto RI = dyn_cast<ReturnInst>(V)) {
-    if (auto RV = RI->getReturnValue())
+  if (auto *RI = dyn_cast<ReturnInst>(V)) {
+    if (auto *RV = RI->getReturnValue())
       return mapValue(V, BM->addReturnValueInst(transValue(RV, BB), BB));
     return mapValue(V, BM->addReturnInst(BB));
   }
@@ -2046,7 +2046,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
 
   if (auto *Switch = dyn_cast<SwitchInst>(V)) {
     std::vector<SPIRVSwitch::PairTy> Pairs;
-    auto Select = transValue(Switch->getCondition(), BB);
+    auto *Select = transValue(Switch->getCondition(), BB);
 
     for (auto I = Switch->case_begin(), E = Switch->case_end(); I != E; ++I) {
       SPIRVSwitch::LiteralTy Lit;
@@ -2144,7 +2144,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                                         SuccessorTrue, SuccessorFalse, BB));
   }
 
-  if (auto Phi = dyn_cast<PHINode>(V)) {
+  if (auto *Phi = dyn_cast<PHINode>(V)) {
     std::vector<SPIRVValue *> IncomingPairs;
 
     for (size_t I = 0, E = Phi->getNumIncomingValues(); I != E; ++I) {
@@ -2156,14 +2156,14 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                     BM->addPhiInst(transScavengedType(Phi), IncomingPairs, BB));
   }
 
-  if (auto Ext = dyn_cast<ExtractValueInst>(V)) {
+  if (auto *Ext = dyn_cast<ExtractValueInst>(V)) {
     return mapValue(V, BM->addCompositeExtractInst(
                            transScavengedType(Ext),
                            transValue(Ext->getAggregateOperand(), BB),
                            Ext->getIndices(), BB));
   }
 
-  if (auto Ins = dyn_cast<InsertValueInst>(V)) {
+  if (auto *Ins = dyn_cast<InsertValueInst>(V)) {
     return mapValue(V, BM->addCompositeInsertInst(
                            transValue(Ins->getInsertedValueOperand(), BB),
                            transValue(Ins->getAggregateOperand(), BB),
@@ -2171,7 +2171,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
   }
 
   if (UnaryInstruction *U = dyn_cast<UnaryInstruction>(V)) {
-    auto UI = transUnaryInst(U, BB);
+    auto *UI = transUnaryInst(U, BB);
     return mapValue(V, UI ? UI : transValue(U->getOperand(0), BB));
   }
 
@@ -2226,9 +2226,9 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                                               Indices, BB, GEP->isInBounds()));
   }
 
-  if (auto Ext = dyn_cast<ExtractElementInst>(V)) {
-    auto Index = Ext->getIndexOperand();
-    if (auto Const = dyn_cast<ConstantInt>(Index))
+  if (auto *Ext = dyn_cast<ExtractElementInst>(V)) {
+    auto *Index = Ext->getIndexOperand();
+    if (auto *Const = dyn_cast<ConstantInt>(Index))
       return mapValue(V, BM->addCompositeExtractInst(
                              transScavengedType(Ext),
                              transValue(Ext->getVectorOperand(), BB),
@@ -2240,9 +2240,9 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                              transValue(Index, BB), BB));
   }
 
-  if (auto Ins = dyn_cast<InsertElementInst>(V)) {
-    auto Index = Ins->getOperand(2);
-    if (auto Const = dyn_cast<ConstantInt>(Index)) {
+  if (auto *Ins = dyn_cast<InsertElementInst>(V)) {
+    auto *Index = Ins->getOperand(2);
+    if (auto *Const = dyn_cast<ConstantInt>(Index)) {
       return mapValue(
           V,
           BM->addCompositeInsertInst(
@@ -2256,7 +2256,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                                             transValue(Index, BB), BB));
   }
 
-  if (auto SF = dyn_cast<ShuffleVectorInst>(V)) {
+  if (auto *SF = dyn_cast<ShuffleVectorInst>(V)) {
     std::vector<SPIRVWord> Comp;
     for (auto &I : SF->getShuffleMask())
       Comp.push_back(I);
@@ -2322,7 +2322,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       return mapValue(V, transAsmINTEL(IA));
 
   if (CallInst *CI = dyn_cast<CallInst>(V)) {
-    if (auto Alias =
+    if (auto *Alias =
             dyn_cast_or_null<llvm::GlobalAlias>(CI->getCalledOperand())) {
       CI->setCalledFunction(cast<Function>(Alias->getAliasee()));
     }
@@ -2355,7 +2355,7 @@ SPIRVValue *LLVMToSPIRVBase::mapValue(Value *V, SPIRVValue *BV) {
       return BV;
     assert(Loc->second->isForward() &&
            "LLVM Value is mapped to different SPIRV Values");
-    auto Forward = static_cast<SPIRVForward *>(Loc->second);
+    auto *Forward = static_cast<SPIRVForward *>(Loc->second);
     BM->replaceForward(Forward, BV);
   }
   ValueMap[V] = BV;
@@ -2648,7 +2648,7 @@ bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
       (isa<AtomicRMWInst>(V) && cast<AtomicRMWInst>(V)->isVolatile()))
     BV->setVolatile(true);
 
-  if (auto BVO = dyn_cast_or_null<OverflowingBinaryOperator>(V)) {
+  if (auto *BVO = dyn_cast_or_null<OverflowingBinaryOperator>(V)) {
     if (BVO->hasNoSignedWrap()) {
       BV->setNoIntegerDecorationWrap<DecorationNoSignedWrap>(true);
     }
@@ -2657,7 +2657,7 @@ bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
     }
   }
 
-  if (auto BVF = dyn_cast_or_null<FPMathOperator>(V)) {
+  if (auto *BVF = dyn_cast_or_null<FPMathOperator>(V)) {
     auto Opcode = BVF->getOpcode();
     if (Opcode == Instruction::FAdd || Opcode == Instruction::FSub ||
         Opcode == Instruction::FMul || Opcode == Instruction::FDiv ||
@@ -2714,11 +2714,11 @@ bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
 }
 
 bool LLVMToSPIRVBase::transAlign(Value *V, SPIRVValue *BV) {
-  if (auto AL = dyn_cast<AllocaInst>(V)) {
+  if (auto *AL = dyn_cast<AllocaInst>(V)) {
     BM->setAlignment(BV, AL->getAlign().value());
     return true;
   }
-  if (auto GV = dyn_cast<GlobalVariable>(V)) {
+  if (auto *GV = dyn_cast<GlobalVariable>(V)) {
     BM->setAlignment(BV, GV->getAlignment());
     return true;
   }
@@ -2778,7 +2778,7 @@ bool LLVMToSPIRVBase::transBuiltinSet() {
 SPIRVValue *LLVMToSPIRVBase::oclTransSpvcCastSampler(CallInst *CI,
                                                      SPIRVBasicBlock *BB) {
   assert(CI->getCalledFunction() && "Unexpected indirect call");
-  auto Arg = CI->getArgOperand(0);
+  auto *Arg = CI->getArgOperand(0);
   auto *TransRT = transType(getSPIRVType(OpTypeSampler));
 
   auto GetSamplerConstant = [&](uint64_t SamplerValue) {
@@ -2789,23 +2789,23 @@ SPIRVValue *LLVMToSPIRVBase::oclTransSpvcCastSampler(CallInst *CI,
     return BV;
   };
 
-  if (auto Const = dyn_cast<ConstantInt>(Arg)) {
+  if (auto *Const = dyn_cast<ConstantInt>(Arg)) {
     // Sampler is declared as a kernel scope constant
     return GetSamplerConstant(Const->getZExtValue());
-  } else if (auto Load = dyn_cast<LoadInst>(Arg)) {
+  } else if (auto *Load = dyn_cast<LoadInst>(Arg)) {
     // If value of the sampler is loaded from a global constant, use its
     // initializer for initialization of the sampler.
-    auto Op = Load->getPointerOperand();
+    auto *Op = Load->getPointerOperand();
     assert(isa<GlobalVariable>(Op) && "Unknown sampler pattern!");
-    auto GV = cast<GlobalVariable>(Op);
+    auto *GV = cast<GlobalVariable>(Op);
     assert(GV->isConstant() ||
            GV->getType()->getPointerAddressSpace() == SPIRAS_Constant);
-    auto Initializer = GV->getInitializer();
+    auto *Initializer = GV->getInitializer();
     assert(isa<ConstantInt>(Initializer) && "sampler not constant int?");
     return GetSamplerConstant(cast<ConstantInt>(Initializer)->getZExtValue());
   }
   // Sampler is a function argument
-  auto BV = transValue(Arg, BB);
+  auto *BV = transValue(Arg, BB);
   assert(BV && BV->getType() == TransRT);
   return BV;
 }
@@ -3577,7 +3577,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     if (DestAlignVal) {
       Align AlignVal = *DestAlignVal;
       MemoryAccess[0] |= MemoryAccessAlignedMask;
-      if (auto MTI = dyn_cast<MemTransferInst>(MI)) {
+      if (auto *MTI = dyn_cast<MemTransferInst>(MI)) {
         MaybeAlign SourceAlignVal = MTI->getSourceAlign();
         assert(SourceAlignVal && "Missed Source alignment!");
 
@@ -3727,31 +3727,31 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     return Value;
   }
   case Intrinsic::experimental_constrained_fadd: {
-    auto BI = BM->addBinaryInst(OpFAdd, transType(II->getType()),
+    auto *BI = BM->addBinaryInst(OpFAdd, transType(II->getType()),
                                 transValue(II->getArgOperand(0), BB),
                                 transValue(II->getArgOperand(1), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(2), BI);
   }
   case Intrinsic::experimental_constrained_fsub: {
-    auto BI = BM->addBinaryInst(OpFSub, transType(II->getType()),
+    auto *BI = BM->addBinaryInst(OpFSub, transType(II->getType()),
                                 transValue(II->getArgOperand(0), BB),
                                 transValue(II->getArgOperand(1), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(2), BI);
   }
   case Intrinsic::experimental_constrained_fmul: {
-    auto BI = BM->addBinaryInst(OpFMul, transType(II->getType()),
+    auto *BI = BM->addBinaryInst(OpFMul, transType(II->getType()),
                                 transValue(II->getArgOperand(0), BB),
                                 transValue(II->getArgOperand(1), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(2), BI);
   }
   case Intrinsic::experimental_constrained_fdiv: {
-    auto BI = BM->addBinaryInst(OpFDiv, transType(II->getType()),
+    auto *BI = BM->addBinaryInst(OpFDiv, transType(II->getType()),
                                 transValue(II->getArgOperand(0), BB),
                                 transValue(II->getArgOperand(1), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(2), BI);
   }
   case Intrinsic::experimental_constrained_frem: {
-    auto BI = BM->addBinaryInst(OpFRem, transType(II->getType()),
+    auto *BI = BM->addBinaryInst(OpFRem, transType(II->getType()),
                                 transValue(II->getArgOperand(0), BB),
                                 transValue(II->getArgOperand(1), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(2), BI);
@@ -3760,7 +3760,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     std::vector<SPIRVValue *> Args{transValue(II->getArgOperand(0), BB),
                                    transValue(II->getArgOperand(1), BB),
                                    transValue(II->getArgOperand(2), BB)};
-    auto BI = BM->addExtInst(transType(II->getType()),
+    auto *BI = BM->addExtInst(transType(II->getType()),
                              BM->getExtInstSetId(SPIRVEIS_OpenCL),
                              OpenCLLIB::Fma, Args, BB);
     return applyRoundingModeConstraint(II->getOperand(3), BI);
@@ -3774,12 +3774,12 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
                             transValue(II->getArgOperand(0), BB), BB);
   }
   case Intrinsic::experimental_constrained_uitofp: {
-    auto BI = BM->addUnaryInst(OpConvertUToF, transType(II->getType()),
+    auto *BI = BM->addUnaryInst(OpConvertUToF, transType(II->getType()),
                                transValue(II->getArgOperand(0), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(1), BI);
   }
   case Intrinsic::experimental_constrained_sitofp: {
-    auto BI = BM->addUnaryInst(OpConvertSToF, transType(II->getType()),
+    auto *BI = BM->addUnaryInst(OpConvertSToF, transType(II->getType()),
                                transValue(II->getArgOperand(0), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(1), BI);
   }
@@ -3788,13 +3788,13 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
                             transValue(II->getArgOperand(0), BB), BB);
   }
   case Intrinsic::experimental_constrained_fptrunc: {
-    auto BI = BM->addUnaryInst(OpFConvert, transType(II->getType()),
+    auto *BI = BM->addUnaryInst(OpFConvert, transType(II->getType()),
                                transValue(II->getArgOperand(0), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(1), BI);
   }
   case Intrinsic::experimental_constrained_fcmp:
   case Intrinsic::experimental_constrained_fcmps: {
-    auto MetaMod = cast<MetadataAsValue>(II->getOperand(2))->getMetadata();
+    auto *MetaMod = cast<MetadataAsValue>(II->getOperand(2))->getMetadata();
     Op CmpTypeOp = StringSwitch<Op>(cast<MDString>(MetaMod)->getString())
                        .Case("oeq", OpFOrdEqual)
                        .Case("ogt", OpFOrdGreaterThan)
@@ -3821,7 +3821,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     SPIRVValue *Mul =
         BM->addBinaryInst(OpFMul, Ty, transValue(II->getArgOperand(0), BB),
                           transValue(II->getArgOperand(1), BB), BB);
-    auto BI = BM->addBinaryInst(OpFAdd, Ty, Mul,
+    auto *BI = BM->addBinaryInst(OpFAdd, Ty, Mul,
                                 transValue(II->getArgOperand(2), BB), BB);
     return applyRoundingModeConstraint(II->getOperand(3), BI);
   }
@@ -4459,9 +4459,9 @@ SPIRVValue *LLVMToSPIRVBase::transDirectCallInst(CallInst *CI,
 
   if (oclIsBuiltin(MangledName, DemangledName) ||
       isDecoratedSPIRVFunc(F, DemangledName)) {
-    if (auto BV = transBuiltinToConstant(DemangledName, CI))
+    if (auto *BV = transBuiltinToConstant(DemangledName, CI))
       return BV;
-    if (auto BV = transBuiltinToInst(DemangledName, CI, BB))
+    if (auto *BV = transBuiltinToInst(DemangledName, CI, BB))
       return BV;
   }
 
@@ -4537,9 +4537,9 @@ SPIRVValue *LLVMToSPIRVBase::transAsmINTEL(InlineAsm *IA) {
   //       but in fact spir-64 is substituted as triple when translator works
   //       eventually we need to fix it (not urgent)
   StringRef TripleStr(M->getTargetTriple());
-  auto AsmTarget = static_cast<SPIRVAsmTargetINTEL *>(
+  auto *AsmTarget = static_cast<SPIRVAsmTargetINTEL *>(
       BM->getOrAddAsmTargetINTEL(TripleStr.str()));
-  auto SIA = BM->addAsmINTEL(
+  auto *SIA = BM->addAsmINTEL(
       static_cast<SPIRVTypeFunction *>(transType(IA->getFunctionType())),
       AsmTarget, IA->getAsmString(), IA->getConstraintString());
   if (IA->hasSideEffects())
@@ -4550,7 +4550,7 @@ SPIRVValue *LLVMToSPIRVBase::transAsmINTEL(InlineAsm *IA) {
 SPIRVValue *LLVMToSPIRVBase::transAsmCallINTEL(CallInst *CI,
                                                SPIRVBasicBlock *BB) {
   assert(CI);
-  auto IA = cast<InlineAsm>(CI->getCalledOperand());
+  auto *IA = cast<InlineAsm>(CI->getCalledOperand());
   return BM->addAsmCallINTELInst(
       static_cast<SPIRVAsmINTEL *>(transValue(IA, BB, false)),
       transArguments(CI, BB, SPIRVEntry::createUnique(OpAsmCallINTEL).get()),
@@ -4774,18 +4774,18 @@ void LLVMToSPIRVBase::mutateFuncArgType(
     const std::map<unsigned, Type *> &ChangedType, Function *F) {
   for (auto &I : ChangedType) {
     for (auto UI = F->user_begin(), UE = F->user_end(); UI != UE; ++UI) {
-      auto Call = dyn_cast<CallInst>(*UI);
+      auto *Call = dyn_cast<CallInst>(*UI);
       if (!Call)
         continue;
-      auto Arg = Call->getArgOperand(I.first);
-      auto OrigTy = Arg->getType();
+      auto *Arg = Call->getArgOperand(I.first);
+      auto *OrigTy = Arg->getType();
       if (OrigTy == I.second)
         continue;
       SPIRVDBG(dbgs() << "[mutate arg type] " << *Call << ", " << *Arg << '\n');
       auto CastF = M->getOrInsertFunction(SPCV_CAST, I.second, OrigTy);
       std::vector<Value *> Args;
       Args.push_back(Arg);
-      auto Cast = CallInst::Create(CastF, Args, "", Call);
+      auto *Cast = CallInst::Create(CastF, Args, "", Call);
       Call->replaceUsesOfWith(Arg, Cast);
       SPIRVDBG(dbgs() << "[mutate arg type] -> " << *Cast << '\n');
     }
@@ -5004,7 +5004,7 @@ bool LLVMToSPIRVBase::translate() {
     return false;
 
   for (auto &F : *M) {
-    auto FT = F.getFunctionType();
+    auto *FT = F.getFunctionType();
     std::map<unsigned, Type *> ChangedType;
     oclGetMutatedArgumentTypesByBuiltin(FT, ChangedType, &F);
     mutateFuncArgType(ChangedType, &F);
@@ -5024,9 +5024,9 @@ bool LLVMToSPIRVBase::translate() {
     else
       Defs.push_back(&F);
   }
-  for (auto I : Decls)
+  for (auto *I : Decls)
     transFunctionDecl(I);
-  for (auto I : Defs)
+  for (auto *I : Defs)
     transFunction(I);
 
   if (!transMetadata())
@@ -5120,7 +5120,7 @@ SPIRVInstruction *LLVMToSPIRVBase::transBuiltinToInst(StringRef DemangledName,
             "without enabled SPV_INTEL_arbitrary_precision_floating_point "
             "extension!\n");
 
-  auto Inst = transBuiltinToInstWithoutDecoration(OC, CI, BB);
+  auto *Inst = transBuiltinToInstWithoutDecoration(OC, CI, BB);
   addDecorations(Inst, Dec);
   return Inst;
 }
@@ -5728,13 +5728,13 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       return BM->addUnaryInst(OC, transScavengedType(CI),
                               transValue(CI->getArgOperand(0), BB), BB);
     } else if (isCmpOpCode(OC) || isUnaryPredicateOpCode(OC)) {
-      auto ResultTy = CI->getType();
+      auto *ResultTy = CI->getType();
       Type *BoolTy = IntegerType::getInt1Ty(M->getContext());
       auto IsVector = ResultTy->isVectorTy();
       if (IsVector)
         BoolTy = FixedVectorType::get(
             BoolTy, cast<FixedVectorType>(ResultTy)->getNumElements());
-      auto BBT = transType(BoolTy);
+      auto *BBT = transType(BoolTy);
       SPIRVInstruction *Res;
       if (isCmpOpCode(OC)) {
         assert(CI && CI->arg_size() == 2 && "Invalid call inst");
@@ -5749,8 +5749,8 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       if (ResultTy == BoolTy)
         return Res;
       assert(IsVector || (!IsVector && ResultTy->isIntegerTy(32)));
-      auto Zero = transValue(Constant::getNullValue(ResultTy), BB);
-      auto One = transValue(
+      auto *Zero = transValue(Constant::getNullValue(ResultTy), BB);
+      auto *One = transValue(
           IsVector ? Constant::getAllOnesValue(ResultTy) : getInt32(M, 1), BB);
       return BM->addSelectInst(Res, One, Zero, BB);
     } else if (isBinaryOpCode(OC)) {
@@ -5766,7 +5766,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
       auto Args = getArguments(CI);
       SPIRVType *SPRetTy = nullptr;
       Type *RetTy = CI->getType();
-      auto F = CI->getCalledFunction();
+      auto *F = CI->getCalledFunction();
       if (!RetTy->isVoidTy()) {
         SPRetTy = transScavengedType(CI);
       } else if (Args.size() > 0 && F->arg_begin()->hasStructRetAttr()) {

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -243,7 +243,7 @@ void SPIRVGroupDecorateGeneric::decode(std::istream &I) {
 
 void SPIRVGroupDecorate::decorateTargets() {
   for (auto &I : Targets) {
-    auto Target = getOrCreate(I);
+    auto *Target = getOrCreate(I);
     for (auto &Dec : DecorationGroup->getDecorations()) {
       assert(Dec->isDecorate());
       Target->addDecorate(static_cast<SPIRVDecorate *>(Dec));
@@ -253,7 +253,7 @@ void SPIRVGroupDecorate::decorateTargets() {
 
 void SPIRVGroupMemberDecorate::decorateTargets() {
   for (auto &I : Targets) {
-    auto Target = getOrCreate(I);
+    auto *Target = getOrCreate(I);
     for (auto &Dec : DecorationGroup->getDecorations()) {
       assert(Dec->isMemberDecorate());
       Target->addMemberDecorate(static_cast<SPIRVMemberDecorate *>(Dec));

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -267,7 +267,7 @@ SPIRVEntry::getValueTypes(const std::vector<SPIRVId> &IdVec) const {
 std::vector<SPIRVId>
 SPIRVEntry::getIds(const std::vector<SPIRVValue *> ValueVec) const {
   std::vector<SPIRVId> IdVec;
-  for (auto I : ValueVec)
+  for (auto *I : ValueVec)
     IdVec.push_back(I->getId());
   return IdVec;
 }

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -102,7 +102,7 @@ void SPIRVFunction::decode(std::istream &I) {
 
     switch (Decoder.OpCode) {
     case OpFunctionParameter: {
-      auto Param = static_cast<SPIRVFunctionParameter *>(Decoder.getEntry());
+      auto *Param = static_cast<SPIRVFunctionParameter *>(Decoder.getEntry());
       assert(Param);
       Module->add(Param);
       Param->setParent(this);

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -545,7 +545,7 @@ private:
 };
 
 SPIRVModuleImpl::~SPIRVModuleImpl() {
-  for (auto I : EntryNoId)
+  for (auto *I : EntryNoId)
     delete I;
 
   for (auto I : IdEntryMap)
@@ -689,8 +689,8 @@ SPIRVConstant *SPIRVModuleImpl::getLiteralAsConstant(unsigned Literal) {
   auto Loc = LiteralMap.find(Literal);
   if (Loc != LiteralMap.end())
     return Loc->second;
-  auto Ty = addIntegerType(32);
-  auto V = new SPIRVConstant(this, Ty, getId(), static_cast<uint64_t>(Literal));
+  auto *Ty = addIntegerType(32);
+  auto *V = new SPIRVConstant(this, Ty, getId(), static_cast<uint64_t>(Literal));
   LiteralMap[Literal] = V;
   addConstant(V);
   return V;
@@ -707,7 +707,7 @@ void SPIRVModuleImpl::layoutEntry(SPIRVEntry *E) {
     addTo(MemberNameVec, E);
     break;
   case OpVariable: {
-    auto BV = static_cast<SPIRVVariable *>(E);
+    auto *BV = static_cast<SPIRVVariable *>(E);
     if (!BV->getParent())
       addTo(VariableVec, E);
   } break;
@@ -900,7 +900,7 @@ void SPIRVModuleImpl::resolveUnknownStructFields() {
       unsigned I = Indices.first;
       SPIRVId ID = Indices.second;
 
-      auto Ty = static_cast<SPIRVType *>(getEntry(ID));
+      auto *Ty = static_cast<SPIRVType *>(getEntry(ID));
       Struct->setMemberType(I, Ty);
     }
   }
@@ -931,7 +931,7 @@ SPIRVTypeInt *SPIRVModuleImpl::addIntegerType(unsigned BitWidth) {
   auto Loc = IntTypeMap.find(BitWidth);
   if (Loc != IntTypeMap.end())
     return Loc->second;
-  auto Ty = new SPIRVTypeInt(this, getId(), BitWidth, false);
+  auto *Ty = new SPIRVTypeInt(this, getId(), BitWidth, false);
   IntTypeMap[BitWidth] = Ty;
   return addType(Ty);
 }
@@ -960,7 +960,7 @@ SPIRVTypeOpaque *SPIRVModuleImpl::addOpaqueType(const std::string &Name) {
 
 SPIRVTypeStruct *SPIRVModuleImpl::openStructType(unsigned NumMembers,
                                                  const std::string &Name) {
-  auto T = new SPIRVTypeStruct(this, getId(), NumMembers, Name);
+  auto *T = new SPIRVTypeStruct(this, getId(), NumMembers, Name);
   return T;
 }
 
@@ -1191,7 +1191,7 @@ SPIRVValue *SPIRVModuleImpl::addCompositeConstant(
     End = ((Elements.end() - End) > MaxNumElements) ? End + MaxNumElements
                                                     : Elements.end();
     Slice.assign(Start, End);
-    auto Continued = static_cast<SPIRVConstantComposite::ContinuedInstType>(
+    auto *Continued = static_cast<SPIRVConstantComposite::ContinuedInstType>(
         addCompositeConstantContinuedINTEL(Slice));
     Res->addContinuedInstruction(Continued);
   }
@@ -1227,7 +1227,7 @@ SPIRVValue *SPIRVModuleImpl::addSpecConstantComposite(
     End = ((Elements.end() - End) > MaxNumElements) ? End + MaxNumElements
                                                     : Elements.end();
     Slice.assign(Start, End);
-    auto Continued = static_cast<SPIRVSpecConstantComposite::ContinuedInstType>(
+    auto *Continued = static_cast<SPIRVSpecConstantComposite::ContinuedInstType>(
         addSpecConstantCompositeContinuedINTEL(Slice));
     Res->addContinuedInstruction(Continued);
   }
@@ -1439,7 +1439,7 @@ SPIRVValue *SPIRVModuleImpl::addAsmINTEL(SPIRVTypeFunction *TheType,
                                          SPIRVAsmTargetINTEL *TheTarget,
                                          const std::string &TheInstructions,
                                          const std::string &TheConstraints) {
-  auto Asm = new SPIRVAsmINTEL(this, TheType, getId(), TheTarget,
+  auto *Asm = new SPIRVAsmINTEL(this, TheType, getId(), TheTarget,
                                TheInstructions, TheConstraints);
   return add(Asm);
 }
@@ -2026,14 +2026,14 @@ SPIRVModuleImpl::addGroupDecorateGeneric(SPIRVGroupDecorateGeneric *GDec) {
 SPIRVGroupDecorate *
 SPIRVModuleImpl::addGroupDecorate(SPIRVDecorationGroup *Group,
                                   const std::vector<SPIRVEntry *> &Targets) {
-  auto GD = new SPIRVGroupDecorate(Group, getIds(Targets));
+  auto *GD = new SPIRVGroupDecorate(Group, getIds(Targets));
   addGroupDecorateGeneric(GD);
   return GD;
 }
 
 SPIRVGroupMemberDecorate *SPIRVModuleImpl::addGroupMemberDecorate(
     SPIRVDecorationGroup *Group, const std::vector<SPIRVEntry *> &Targets) {
-  auto GMD = new SPIRVGroupMemberDecorate(Group, getIds(Targets));
+  auto *GMD = new SPIRVGroupMemberDecorate(Group, getIds(Targets));
   addGroupDecorateGeneric(GMD);
   return GMD;
 }
@@ -2042,7 +2042,7 @@ SPIRVString *SPIRVModuleImpl::getString(const std::string &Str) {
   auto Loc = StrMap.find(Str);
   if (Loc != StrMap.end())
     return Loc->second;
-  auto S = add(new SPIRVString(this, getId(), Str));
+  auto *S = add(new SPIRVString(this, getId(), Str));
   StrMap[Str] = S;
   return S;
 }
@@ -2187,7 +2187,7 @@ SPIRVModuleImpl::getValueTypes(const std::vector<SPIRVId> &IdVec) const {
 std::vector<SPIRVId>
 SPIRVModuleImpl::getIds(const std::vector<SPIRVEntry *> &ValueVec) const {
   std::vector<SPIRVId> IdVec;
-  for (auto I : ValueVec)
+  for (auto *I : ValueVec)
     IdVec.push_back(I->getId());
   return IdVec;
 }
@@ -2195,7 +2195,7 @@ SPIRVModuleImpl::getIds(const std::vector<SPIRVEntry *> &ValueVec) const {
 std::vector<SPIRVId>
 SPIRVModuleImpl::getIds(const std::vector<SPIRVValue *> &ValueVec) const {
   std::vector<SPIRVId> IdVec;
-  for (auto I : ValueVec)
+  for (auto *I : ValueVec)
     IdVec.push_back(I->getId());
   return IdVec;
 }
@@ -2204,7 +2204,7 @@ SPIRVInstTemplateBase *
 SPIRVModuleImpl::addInstTemplate(Op OC, SPIRVBasicBlock *BB, SPIRVType *Ty) {
   assert(!Ty || !Ty->isTypeVoid());
   SPIRVId Id = Ty ? getId() : SPIRVID_INVALID;
-  auto Ins = SPIRVInstTemplateBase::create(OC, Ty, Id, BB, this);
+  auto *Ins = SPIRVInstTemplateBase::create(OC, Ty, Id, BB, this);
   BB->addInstruction(Ins);
   return Ins;
 }
@@ -2214,7 +2214,7 @@ SPIRVModuleImpl::addInstTemplate(Op OC, const std::vector<SPIRVWord> &Ops,
                                  SPIRVBasicBlock *BB, SPIRVType *Ty) {
   assert(!Ty || !Ty->isTypeVoid());
   SPIRVId Id = Ty ? getId() : SPIRVID_INVALID;
-  auto Ins = SPIRVInstTemplateBase::create(OC, Ty, Id, Ops, BB, this);
+  auto *Ins = SPIRVInstTemplateBase::create(OC, Ty, Id, Ops, BB, this);
   BB->addInstruction(Ins);
   return Ins;
 }
@@ -2239,7 +2239,7 @@ SPIRVId SPIRVModuleImpl::getExtInstSetId(SPIRVExtInstSetKind Kind) const {
 bool isSpirvBinary(const std::string &Img) {
   if (Img.size() < sizeof(unsigned))
     return false;
-  auto Magic = reinterpret_cast<const unsigned *>(Img.data());
+  const auto *Magic = reinterpret_cast<const unsigned *>(Img.data());
   return *Magic == MagicNumber;
 }
 


### PR DESCRIPTION
Change `auto` to `auto *` when the type is a pointer.  This makes the code comply with the clang-tidy `llvm-qualified-auto` check.  That check is already enabled, but the code base wasn't fully compliant yet.