### PR TITLE
[NFC][DebugInfo] Remove unused code

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -804,9 +804,6 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgSubrangeType(const DISubrange *ST) {
       case CountIdx:
         IntNode = ST->getCount().get<ConstantInt *>();
         break;
-      case StrideIdx:
-        IntNode = ST->getStride().get<ConstantInt *>();
-        break;
       }
       Ops[Idx] = IntNode ? SPIRVWriter->transValue(IntNode, nullptr)->getId()
                          : getDebugInfoNoneId();


### PR DESCRIPTION
`TransOperand` is never called for StrideIdx (3), because the loop below ends at MinOperandCount (3).