### PR TITLE
[NFC] Update stacksave and stackrestore after 25bc999d

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1703,16 +1703,17 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpRestoreMemoryINTEL: {
+    IRBuilder<> Builder(BB);
     auto *Restore = static_cast<SPIRVRestoreMemoryINTEL *>(BV);
     llvm::Value *Ptr = transValue(Restore->getOperand(0), F, BB);
-    Function *StackRestore =
-        Intrinsic::getDeclaration(M, Intrinsic::stackrestore);
-    return mapValue(BV, CallInst::Create(StackRestore, {Ptr}, "", BB));
+    auto *StackRestore = Builder.CreateStackRestore(Ptr);
+    return mapValue(BV, StackRestore);
   }
 
   case OpSaveMemoryINTEL: {
-    Function *StackSave = Intrinsic::getDeclaration(M, Intrinsic::stacksave);
-    return mapValue(BV, CallInst::Create(StackSave, "", BB));
+    IRBuilder<> Builder(BB);
+    auto *StackSave = Builder.CreateStackSave();
+    return mapValue(BV, StackSave);
   }
 
   case OpBranch: {

--- a/test/create-placeholders-for-phi-operands.ll
+++ b/test/create-placeholders-for-phi-operands.ll
@@ -7,10 +7,10 @@
 ; CHECK-LLVM: phi ptr [ [[savedstack:%.*]], {{.*}} ], [ [[savedstack_us:%.*]], {{.*}} ]
 
 ; CHECK-LLVM: BB.{{[0-9]+}}:
-; CHECK-LLVM: [[savedstack]] = call ptr @llvm.stacksave()
+; CHECK-LLVM: [[savedstack]] = call ptr @llvm.stacksave.p0()
 
 ; CHECK-LLVM: BB.{{[0-9]+}}:
-; CHECK-LLVM: [[savedstack_us]] = call ptr @llvm.stacksave()
+; CHECK-LLVM: [[savedstack_us]] = call ptr @llvm.stacksave.p0()
 
 ; ModuleID = 's.bc'
 source_filename = "llvm-link"
@@ -32,7 +32,7 @@ BB.0:
 
 BB.1:                                             ; preds = %BB.12.loopexit, %BB.11.loopexit
   %savedstack.sink = phi i8* [ %savedstack, %BB.12.loopexit ], [ %savedstack.us, %BB.11.loopexit ]
-  call void @llvm.stackrestore(i8* %savedstack.sink), !llvm.access.group !9
+  call void @llvm.stackrestore.p0(i8* %savedstack.sink), !llvm.access.group !9
   br label %BB.2
 
 BB.2:                                             ; preds = %BB.3, %BB.1, %BB.0
@@ -50,7 +50,7 @@ BB.4:                                             ; preds = %BB.3
   br i1 %4, label %BB.5, label %BB.6
 
 BB.5:                                             ; preds = %BB.4
-  %savedstack = call i8* @llvm.stacksave(), !llvm.access.group !9
+  %savedstack = call i8* @llvm.stacksave.p0(), !llvm.access.group !9
   br label %BB.12
 
 BB.6:                                             ; preds = %BB.4
@@ -58,7 +58,7 @@ BB.6:                                             ; preds = %BB.4
   %umax = select i1 %5, i32 %div.i, i32 1
   %arrayidx4812.us = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 %2
   %arrayidx5113.us = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %2
-  %savedstack.us = call i8* @llvm.stacksave(), !llvm.access.group !9
+  %savedstack.us = call i8* @llvm.stacksave.p0(), !llvm.access.group !9
   br label %BB.9
 
 BB.7:                                             ; preds = %BB.8
@@ -108,10 +108,10 @@ BB.12.loopexit:
 declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare i8* @llvm.stacksave() #1
+declare i8* @llvm.stacksave.p0() #1
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.stackrestore(i8*) #1
+declare void @llvm.stackrestore.p0(i8*) #1
 
 attributes #0 = { noinline nounwind mustprogress "contains-openmp-target"="true" "denormal-fp-math"="preserve-sign,preserve-sign" "denormal-fp-math-f32"="ieee,ieee" "frame-pointer"="all" "may-have-openmp-directive"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="true" "no-nans-fp-math"="true" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target.declare"="true" "unsafe-fp-math"="true" }
 attributes #1 = { nofree nosync nounwind willreturn }

--- a/test/extensions/INTEL/SPV_INTEL_variable_length_array/basic.ll
+++ b/test/extensions/INTEL/SPV_INTEL_variable_length_array/basic.ll
@@ -45,8 +45,8 @@ entry:
   %0 = bitcast [42 x i32]* %qqq to i8*
   call void @llvm.lifetime.start.p0i8(i64 168, i8* nonnull %0) #2
 
-; CHECK-LLVM: %[[#SavedMem:]] = call ptr @llvm.stacksave()
-  %1 = call i8* @llvm.stacksave()
+; CHECK-LLVM: %[[#SavedMem:]] = call ptr @llvm.stacksave.p0()
+  %1 = call i8* @llvm.stacksave.p0()
 
 ; CHECK-LLVM: alloca i32, i64 %a, align 16
   %vla = alloca i32, i64 %a, align 16
@@ -54,11 +54,11 @@ entry:
   %arrayidx = getelementptr inbounds i32, i32* %vla, i64 %b
   %2 = load i32, i32* %arrayidx, align 4
 
-; CHECK-LLVM: call void @llvm.stackrestore(ptr %[[#SavedMem]])
-  call void @llvm.stackrestore(i8* %1)
+; CHECK-LLVM: call void @llvm.stackrestore.p0(ptr %[[#SavedMem]])
+  call void @llvm.stackrestore.p0(i8* %1)
 
-; CHECK-LLVM: %[[#SavedMem:]] = call ptr @llvm.stacksave()
-  %3 = call i8* @llvm.stacksave()
+; CHECK-LLVM: %[[#SavedMem:]] = call ptr @llvm.stacksave.p0()
+  %3 = call i8* @llvm.stacksave.p0()
 
 ; CHECK-LLVM: alloca i32, i64 %a, align 16
   %vla2 = alloca i32, i64 %a, align 16
@@ -70,8 +70,8 @@ entry:
   %5 = load i32, i32* %arrayidx4, align 4
   %add5 = add nsw i32 %add, %5
 
-; CHECK-LLVM: call void @llvm.stackrestore(ptr %[[#SavedMem]])
-  call void @llvm.stackrestore(i8* %3)
+; CHECK-LLVM: call void @llvm.stackrestore.p0(ptr %[[#SavedMem]])
+  call void @llvm.stackrestore.p0(i8* %3)
 
   call void @llvm.lifetime.end.p0i8(i64 168, i8* nonnull %0) #2
   ret i32 %add5
@@ -79,9 +79,9 @@ entry:
 
 declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
 
-declare i8* @llvm.stacksave() #2
+declare i8* @llvm.stacksave.p0() #2
 
-declare void @llvm.stackrestore(i8*) #2
+declare void @llvm.stackrestore.p0(i8*) #2
 
 declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
 

--- a/test/extensions/INTEL/SPV_INTEL_variable_length_array/negative.ll
+++ b/test/extensions/INTEL/SPV_INTEL_variable_length_array/negative.ll
@@ -4,7 +4,7 @@
 
 ; CHECK-INTRINSIC: InvalidFunctionCall: Unexpected llvm intrinsic:
 ; CHECK-INTRINSIC-NEXT: Translation of llvm.stacksave intrinsic requires SPV_INTEL_variable_length_array extension or -spirv-allow-unknown-intrinsics option.
-; CHECK-INTRINSIC-NEXT: call ptr @llvm.stacksave()
+; CHECK-INTRINSIC-NEXT: call ptr @llvm.stacksave.p0()
 
 ; CHECK-ALLOCA: InvalidInstruction: Can't translate llvm instruction:
 ; CHECK-ALLOCA-NEXT: %vla = alloca i32, i64 %a
@@ -31,19 +31,19 @@ target triple = "spir"
 
 define dso_local i32 @_Z3fooll(i64 %a, i64 %b) local_unnamed_addr #0 {
 entry:
-  %0 = call ptr @llvm.stacksave()
+  %0 = call ptr @llvm.stacksave.p0()
   %vla = alloca i32, i64 %a, align 16
   %arrayidx = getelementptr inbounds i32, ptr %vla, i64 %b
   %1 = load i32, ptr %arrayidx, align 4
-  call void @llvm.stackrestore(ptr %0)
+  call void @llvm.stackrestore.p0(ptr %0)
   %call = call i32 @_Z3barv()
   %add = add nsw i32 %call, %1
   ret i32 %add
 }
 
-declare ptr @llvm.stacksave() #1
+declare ptr @llvm.stacksave.p0() #1
 
-declare void @llvm.stackrestore(ptr) #1
+declare void @llvm.stackrestore.p0(ptr) #1
 
 declare dso_local i32 @_Z3barv() local_unnamed_addr #2
 

--- a/test/extensions/INTEL/SPV_INTEL_variable_length_array/vla_spec_const.ll
+++ b/test/extensions/INTEL/SPV_INTEL_variable_length_array/vla_spec_const.ll
@@ -93,8 +93,8 @@ entry:
   %0 = getelementptr inbounds %"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon", %"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon" addrspace(4)* %this1, i32 0, i32 0
   %call = call spir_func i64 @_ZNK2cl4sycl12experimental13spec_constantIm13MyUInt64ConstE3getEv(%"class._ZTSN2cl4sycl12experimental13spec_constantIm13MyUInt64ConstEE.cl::sycl::experimental::spec_constant" addrspace(4)* %0)
 ; CHECK-LLVM:  %[[SPEC_CONST:[[:alnum:]]+]] = call spir_func i64 @_ZNK2cl4sycl12experimental13spec_constantIm13MyUInt64ConstE3getEv(
-  %1 = call i8* @llvm.stacksave()
-; CHECK-LLVM: call ptr @llvm.stacksave()
+  %1 = call i8* @llvm.stacksave.p0()
+; CHECK-LLVM: call ptr @llvm.stacksave.p0()
   store i8* %1, i8** %saved_stack, align 8
   %vla = alloca i32, i64 %call, align 4
 ; CHECK-LLVM: alloca i32, i64 %[[SPEC_CONST]], align 4
@@ -102,8 +102,8 @@ entry:
   %ptridx = getelementptr inbounds i32, i32* %vla, i64 0
   store i32 42, i32* %ptridx, align 4, !tbaa !9
   %2 = load i8*, i8** %saved_stack, align 8
-  call void @llvm.stackrestore(i8* %2)
-; CHECK-LLVM: call void @llvm.stackrestore(ptr
+  call void @llvm.stackrestore.p0(i8* %2)
+; CHECK-LLVM: call void @llvm.stackrestore.p0(ptr
   ret void
 }
 
@@ -126,10 +126,10 @@ entry:
 }
 
 ; Function Attrs: nounwind
-declare i8* @llvm.stacksave() #4
+declare i8* @llvm.stacksave.p0() #4
 
 ; Function Attrs: nounwind
-declare void @llvm.stackrestore(i8*) #4
+declare void @llvm.stackrestore.p0(i8*) #4
 
 declare i64 @_Z20__spirv_SpecConstantix(i32, i64)
 


### PR DESCRIPTION
    Intrinsics: Add type overload to stacksave and stackstore

    This allows use with non-0 address space stacks. llvm_ptr_ty should
    never be used. This could use some more percolation up through mlir,
    but this is enough to fix existing tests.

    https://reviews.llvm.org/D156666
