### PR TITLE
Report disallowed extensions in metadata

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5400,6 +5400,10 @@ bool LLVMToSPIRVBase::transExtension() {
       std::string S;
       N.nextOp().get(S);
       assert(!S.empty() && "Invalid extension");
+      ExtensionID ExtID = SPIRVMap<ExtensionID, std::string>::rmap(S);
+      if (!BM->getErrorLog().checkError(BM->isAllowedToUseExtension(ExtID),
+                                        SPIRVEC_RequiresExtension, S))
+        return false;
       BM->getExtension().insert(S);
     }
   }

--- a/test/negative/extension_from_metadata.ll
+++ b/test/negative/extension_from_metadata.ll
@@ -1,0 +1,32 @@
+; Check whether the translator reports an error for a module with !spirv.Extension
+; metadata containing an extension that is disabled by --spirv-ext
+
+; RUN: llvm-as < %s -o %t.bc
+; RUN: not llvm-spirv --spirv-ext=-SPV_KHR_bit_instructions %t.bc 2>&1 | FileCheck %s
+
+; CHECK: RequiresExtension: Feature requires the following SPIR-V extension:
+; CHECK-NEXT: SPV_KHR_bit_instructions
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @foo() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!spirv.MemoryModel = !{!0}
+!spirv.Source = !{!1}
+!spirv.Extension = !{!3}
+!opencl.spir.version = !{!0}
+!opencl.ocl.version = !{!0}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!2}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 3, i32 102000}
+!2 = !{}
+!3 = !{!"SPV_KHR_bit_instructions"}


### PR DESCRIPTION
When translating the `spirv.Extension` metadata of an LLVM Module, report an error when encountering an extension that has been explicitly disabled.