### PR TITLE
Convert tests to opaque pointers

### DIFF
--- a/test/AtomicCompareExchange.ll
+++ b/test/AtomicCompareExchange.ll
@@ -29,16 +29,16 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir"
 
 ; Function Attrs: nounwind
-define dso_local spir_func void @test(i32* %ptr, i32* %value_ptr, i32 %comparator) local_unnamed_addr #0 {
+define dso_local spir_func void @test(ptr %ptr, ptr %value_ptr, i32 %comparator) local_unnamed_addr #0 {
 entry:
-  %0 = load i32, i32* %value_ptr, align 4
-  %1 = cmpxchg i32* %ptr, i32 %comparator, i32 %0 seq_cst acquire
+  %0 = load i32, ptr %value_ptr, align 4
+  %1 = cmpxchg ptr %ptr, i32 %comparator, i32 %0 seq_cst acquire
   %2 = extractvalue { i32, i1 } %1, 1
   br i1 %2, label %cmpxchg.continue, label %cmpxchg.store_expected
 
 cmpxchg.store_expected:                           ; preds = %entry
   %3 = extractvalue { i32, i1 } %1, 0
-  store i32 %3, i32* %value_ptr, align 4
+  store i32 %3, ptr %value_ptr, align 4
   br label %cmpxchg.continue
 
 cmpxchg.continue:                                 ; preds = %cmpxchg.store_expected, %entry
@@ -56,10 +56,10 @@ cmpxchg.continue:                                 ; preds = %cmpxchg.store_expec
 ; CHECK-SPIRV: Store [[Store_ptr]] [[Composite_1]]
 
 ; Function Attrs: nounwind
-define dso_local spir_func void @test2(i32* %ptr, {i32, i1}* %store_ptr) local_unnamed_addr #0 {
+define dso_local spir_func void @test2(ptr %ptr, ptr %store_ptr) local_unnamed_addr #0 {
 entry:
-  %0 = cmpxchg i32* %ptr, i32 128, i32 456 seq_cst acquire
-  store { i32, i1 } %0, { i32, i1 }* %store_ptr, align 4
+  %0 = cmpxchg ptr %ptr, i32 128, i32 456 seq_cst acquire
+  store { i32, i1 } %0, ptr %store_ptr, align 4
   ret void
 }
 

--- a/test/AtomicCompareExchange_cl20.ll
+++ b/test/AtomicCompareExchange_cl20.ll
@@ -18,24 +18,24 @@ target triple = "spir-unknown-unknown"
 ; CHECK: 2 TypeBool [[bool:[0-9]+]]
 
 ; Function Attrs: nounwind
-define spir_func void @test(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #0 {
+define spir_func void @test(ptr addrspace(4) %object, ptr addrspace(4) %expected, i32 %desired) #0 {
 ; CHECK: FunctionParameter [[int_ptr]] [[object:[0-9]+]]
 ; CHECK: FunctionParameter [[int_ptr]] [[expected:[0-9]+]]
 ; CHECK: FunctionParameter [[int]] [[desired:[0-9]+]]
 
 entry:
-  %object.addr = alloca i32 addrspace(4)*, align 4
-  %expected.addr = alloca i32 addrspace(4)*, align 4
+  %object.addr = alloca ptr addrspace(4), align 4
+  %expected.addr = alloca ptr addrspace(4), align 4
   %desired.addr = alloca i32, align 4
   %strong_res = alloca i8, align 1
   %res = alloca i8, align 1
   %weak_res = alloca i8, align 1
-  store i32 addrspace(4)* %object, i32 addrspace(4)** %object.addr, align 4
-  store i32 addrspace(4)* %expected, i32 addrspace(4)** %expected.addr, align 4
-  store i32 %desired, i32* %desired.addr, align 4
-  %0 = load i32 addrspace(4)*, i32 addrspace(4)** %object.addr, align 4
-  %1 = load i32 addrspace(4)*, i32 addrspace(4)** %expected.addr, align 4
-  %2 = load i32, i32* %desired.addr, align 4
+  store ptr addrspace(4) %object, ptr %object.addr, align 4
+  store ptr addrspace(4) %expected, ptr %expected.addr, align 4
+  store i32 %desired, ptr %desired.addr, align 4
+  %0 = load ptr addrspace(4), ptr %object.addr, align 4
+  %1 = load ptr addrspace(4), ptr %expected.addr, align 4
+  %2 = load i32, ptr %desired.addr, align 4
 ; CHECK: Store [[object_addr:[0-9]+]] [[object]]
 ; CHECK: Store [[expected_addr:[0-9]+]] [[expected]]
 ; CHECK: Store [[desired_addr:[0-9]+]] [[desired]]
@@ -44,44 +44,44 @@ entry:
 ; CHECK: Load [[int]] [[Value:[0-9]+]] [[desired_addr]]
 ; CHECK: Load [[int]] [[Comparator:[0-9]+]] [[exp]]
 ; CHECK-NEXT: 9 AtomicCompareExchange [[int]] [[Result:[0-9]+]] [[Pointer]] [[DeviceScope]] [[SequentiallyConsistent_MS]] [[SequentiallyConsistent_MS]] [[Value]] [[Comparator]]
-  %call = call spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)* %0, i32 addrspace(4)* %1, i32 %2)
+  %call = call spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(ptr addrspace(4) %0, ptr addrspace(4) %1, i32 %2)
 ; CHECK-NEXT: Store [[exp]] [[Result]]
 ; CHECK-NEXT: IEqual [[bool]] [[CallRes:[0-9]+]] [[Result]] [[Comparator]]
 ; CHECK-NOT: [[Result]]
   %frombool = zext i1 %call to i8
-  store i8 %frombool, i8* %strong_res, align 1
-  %3 = load i8, i8* %strong_res, align 1
+  store i8 %frombool, ptr %strong_res, align 1
+  %3 = load i8, ptr %strong_res, align 1
   %tobool = trunc i8 %3 to i1
   %lnot = xor i1 %tobool, true
   %frombool1 = zext i1 %lnot to i8
-  store i8 %frombool1, i8* %res, align 1
-  %4 = load i32 addrspace(4)*, i32 addrspace(4)** %object.addr, align 4
-  %5 = load i32 addrspace(4)*, i32 addrspace(4)** %expected.addr, align 4
-  %6 = load i32, i32* %desired.addr, align 4
+  store i8 %frombool1, ptr %res, align 1
+  %4 = load ptr addrspace(4), ptr %object.addr, align 4
+  %5 = load ptr addrspace(4), ptr %expected.addr, align 4
+  %6 = load i32, ptr %desired.addr, align 4
 
 ; CHECK: Load [[int_ptr]] [[Pointer:[0-9]+]] [[object_addr]]
 ; CHECK: Load [[int_ptr]] [[exp:[0-9]+]] [[expected_addr]]
 ; CHECK: Load [[int]] [[Value:[0-9]+]] [[desired_addr]]
 ; CHECK: Load [[int]] [[ComparatorWeak:[0-9]+]] [[exp]]
-  %call2 = call spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)* %4, i32 addrspace(4)* %5, i32 %6)
+  %call2 = call spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(ptr addrspace(4) %4, ptr addrspace(4) %5, i32 %6)
 ; CHECK-NEXT: 9 AtomicCompareExchange [[int]] [[Result:[0-9]+]] [[Pointer]] [[DeviceScope]] [[SequentiallyConsistent_MS]] [[SequentiallyConsistent_MS]] [[Value]] [[ComparatorWeak]]
 ; CHECK-NEXT: Store [[exp]] [[Result]]
 ; CHECK-NEXT: IEqual [[bool]] [[CallRes:[0-9]+]] [[Result]] [[ComparatorWeak]]
 ; CHECK-NOT: [[Result]]
 
   %frombool3 = zext i1 %call2 to i8
-  store i8 %frombool3, i8* %weak_res, align 1
-  %7 = load i8, i8* %weak_res, align 1
+  store i8 %frombool3, ptr %weak_res, align 1
+  %7 = load i8, ptr %weak_res, align 1
   %tobool4 = trunc i8 %7 to i1
   %lnot5 = xor i1 %tobool4, true
   %frombool6 = zext i1 %lnot5 to i8
-  store i8 %frombool6, i8* %res, align 1
+  store i8 %frombool6, ptr %res, align 1
   ret void
 }
 
-declare spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)*, i32 addrspace(4)*, i32) #1
+declare spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(ptr addrspace(4), ptr addrspace(4), i32) #1
 
-declare spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)*, i32 addrspace(4)*, i32) #1
+declare spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(ptr addrspace(4), ptr addrspace(4), i32) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/EnqueueEmptyKernel.ll
+++ b/test/EnqueueEmptyKernel.ll
@@ -36,9 +36,9 @@ target triple = "spir64-unknown-unknown"
 define spir_kernel void @test_enqueue_empty() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
 entry:
   %tmp = alloca %struct.ndrange_t, align 8
-  %call = call spir_func %opencl.queue_t* @_Z17get_default_queuev() #4
-  call spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret(%struct.ndrange_t) %tmp, i64 1) #4
-  %0 = call i32 @__enqueue_kernel_basic_events(%opencl.queue_t* %call, i32 1, %struct.ndrange_t* %tmp, i32 0, %opencl.clk_event_t* addrspace(4)* null, %opencl.clk_event_t* addrspace(4)* null, i8 addrspace(4)* addrspacecast (i8* bitcast (void (i8 addrspace(4)*)* @__test_enqueue_empty_block_invoke_kernel to i8*) to i8 addrspace(4)*), i8 addrspace(4)* addrspacecast (i8 addrspace(1)* bitcast ({ i32, i32 } addrspace(1)* @__block_literal_global to i8 addrspace(1)*) to i8 addrspace(4)*))
+  %call = call spir_func ptr @_Z17get_default_queuev() #4
+  call spir_func void @_Z10ndrange_1Dm(ptr sret(%struct.ndrange_t) %tmp, i64 1) #4
+  %0 = call i32 @__enqueue_kernel_basic_events(ptr %call, i32 1, ptr %tmp, i32 0, ptr addrspace(4) null, ptr addrspace(4) null, ptr addrspace(4) addrspacecast (ptr @__test_enqueue_empty_block_invoke_kernel to ptr addrspace(4)), ptr addrspace(4) addrspacecast (ptr addrspace(1) @__block_literal_global to ptr addrspace(4)))
   ret void
 ; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[GenBlock:[0-9]+]] [[Block]]
 ; CHECK-SPIRV: Bitcast [[Int8PtrGen]] [[Int8PtrGenBlock:[0-9]+]] [[GenBlock]]
@@ -46,28 +46,27 @@ entry:
 }
 
 ; Function Attrs: convergent
-declare spir_func %opencl.queue_t* @_Z17get_default_queuev() #1
+declare spir_func ptr @_Z17get_default_queuev() #1
 
 ; Function Attrs: convergent
-declare spir_func void @_Z10ndrange_1Dm(%struct.ndrange_t* sret(%struct.ndrange_t), i64) #1
+declare spir_func void @_Z10ndrange_1Dm(ptr sret(%struct.ndrange_t), i64) #1
 
 ; Function Attrs: convergent nounwind
-define internal spir_func void @__test_enqueue_empty_block_invoke(i8 addrspace(4)* %.block_descriptor) #2 {
+define internal spir_func void @__test_enqueue_empty_block_invoke(ptr addrspace(4) %.block_descriptor) #2 {
 entry:
-  %.block_descriptor.addr = alloca i8 addrspace(4)*, align 8
-  store i8 addrspace(4)* %.block_descriptor, i8 addrspace(4)** %.block_descriptor.addr, align 8
-  %block = bitcast i8 addrspace(4)* %.block_descriptor to <{ i32, i32 }> addrspace(4)*
+  %.block_descriptor.addr = alloca ptr addrspace(4), align 8
+  store ptr addrspace(4) %.block_descriptor, ptr %.block_descriptor.addr, align 8
   ret void
 }
 
 ; Function Attrs: nounwind
-define internal spir_kernel void @__test_enqueue_empty_block_invoke_kernel(i8 addrspace(4)*) #3 {
+define internal spir_kernel void @__test_enqueue_empty_block_invoke_kernel(ptr addrspace(4)) #3 {
 entry:
-  call void @__test_enqueue_empty_block_invoke(i8 addrspace(4)* %0)
+  call void @__test_enqueue_empty_block_invoke(ptr addrspace(4) %0)
   ret void
 }
 
-declare i32 @__enqueue_kernel_basic_events(%opencl.queue_t*, i32, %struct.ndrange_t*, i32, %opencl.clk_event_t* addrspace(4)*, %opencl.clk_event_t* addrspace(4)*, i8 addrspace(4)*, i8 addrspace(4)*)
+declare i32 @__enqueue_kernel_basic_events(ptr, i32, ptr, i32, ptr addrspace(4), ptr addrspace(4), ptr addrspace(4), ptr addrspace(4))
 
 ; CHECK-SPIRV: Function [[Void]] [[Invoke]] {{[0-9]+}} {{[0-9]+}}
 ; CHECK-SPIRV-NEXT: FunctionParameter [[Int8PtrGen]]  {{[0-9]+}}

--- a/test/ExecutionMode.ll
+++ b/test/ExecutionMode.ll
@@ -26,37 +26,37 @@ target triple = "spir-unknown-unknown"
 ; Function Attrs: nounwind
 define internal spir_func void @__cxx_global_var_init() #0 {
 entry:
-  call spir_func void @_ZNU3AS416global_ctor_dtorC1Ei(%struct.global_ctor_dtor addrspace(4)* addrspacecast (%struct.global_ctor_dtor addrspace(1)* @g to %struct.global_ctor_dtor addrspace(4)*), i32 12)
+  call spir_func void @_ZNU3AS416global_ctor_dtorC1Ei(ptr addrspace(4) addrspacecast (ptr addrspace(1) @g to ptr addrspace(4)), i32 12)
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorC1Ei(%struct.global_ctor_dtor addrspace(4)* %this, i32 %i) unnamed_addr #1 align 2 {
+define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorC1Ei(ptr addrspace(4) %this, i32 %i) unnamed_addr #1 align 2 {
 entry:
-  %this.addr = alloca %struct.global_ctor_dtor addrspace(4)*, align 4
+  %this.addr = alloca ptr addrspace(4), align 4
   %i.addr = alloca i32, align 4
-  store %struct.global_ctor_dtor addrspace(4)* %this, %struct.global_ctor_dtor addrspace(4)** %this.addr, align 4
-  store i32 %i, i32* %i.addr, align 4
-  %this1 = load %struct.global_ctor_dtor addrspace(4)*, %struct.global_ctor_dtor addrspace(4)** %this.addr
-  %0 = load i32, i32* %i.addr, align 4
-  call spir_func void @_ZNU3AS416global_ctor_dtorC2Ei(%struct.global_ctor_dtor addrspace(4)* %this1, i32 %0)
+  store ptr addrspace(4) %this, ptr %this.addr, align 4
+  store i32 %i, ptr %i.addr, align 4
+  %this1 = load ptr addrspace(4), ptr %this.addr
+  %0 = load i32, ptr %i.addr, align 4
+  call spir_func void @_ZNU3AS416global_ctor_dtorC2Ei(ptr addrspace(4) %this1, i32 %0)
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorD1Ev(%struct.global_ctor_dtor addrspace(4)* %this) unnamed_addr #1 align 2 {
+define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorD1Ev(ptr addrspace(4) %this) unnamed_addr #1 align 2 {
 entry:
-  %this.addr = alloca %struct.global_ctor_dtor addrspace(4)*, align 4
-  store %struct.global_ctor_dtor addrspace(4)* %this, %struct.global_ctor_dtor addrspace(4)** %this.addr, align 4
-  %this1 = load %struct.global_ctor_dtor addrspace(4)*, %struct.global_ctor_dtor addrspace(4)** %this.addr
-  call spir_func void @_ZNU3AS416global_ctor_dtorD2Ev(%struct.global_ctor_dtor addrspace(4)* %this1) #0
+  %this.addr = alloca ptr addrspace(4), align 4
+  store ptr addrspace(4) %this, ptr %this.addr, align 4
+  %this1 = load ptr addrspace(4), ptr %this.addr
+  call spir_func void @_ZNU3AS416global_ctor_dtorD2Ev(ptr addrspace(4) %this1) #0
   ret void
 }
 
 ; Function Attrs: nounwind
 define internal spir_func void @__dtor_g() #0 {
 entry:
-  call spir_func void @_ZNU3AS416global_ctor_dtorD1Ev(%struct.global_ctor_dtor addrspace(4)* addrspacecast (%struct.global_ctor_dtor addrspace(1)* @g to %struct.global_ctor_dtor addrspace(4)*))
+  call spir_func void @_ZNU3AS416global_ctor_dtorD1Ev(ptr addrspace(4) addrspacecast (ptr addrspace(1) @g to ptr addrspace(4)))
   ret void
 }
 
@@ -69,27 +69,25 @@ entry:
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorD2Ev(%struct.global_ctor_dtor addrspace(4)* %this) unnamed_addr #1 align 2 {
+define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorD2Ev(ptr addrspace(4) %this) unnamed_addr #1 align 2 {
 entry:
-  %this.addr = alloca %struct.global_ctor_dtor addrspace(4)*, align 4
-  store %struct.global_ctor_dtor addrspace(4)* %this, %struct.global_ctor_dtor addrspace(4)** %this.addr, align 4
-  %this1 = load %struct.global_ctor_dtor addrspace(4)*, %struct.global_ctor_dtor addrspace(4)** %this.addr
-  %a = getelementptr inbounds %struct.global_ctor_dtor, %struct.global_ctor_dtor addrspace(4)* %this1, i32 0, i32 0
-  store i32 0, i32 addrspace(4)* %a, align 4
+  %this.addr = alloca ptr addrspace(4), align 4
+  store ptr addrspace(4) %this, ptr %this.addr, align 4
+  %this1 = load ptr addrspace(4), ptr %this.addr
+  store i32 0, ptr addrspace(4) %this1, align 4
   ret void
 }
 
 ; Function Attrs: nounwind
-define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorC2Ei(%struct.global_ctor_dtor addrspace(4)* %this, i32 %i) unnamed_addr #1 align 2 {
+define linkonce_odr spir_func void @_ZNU3AS416global_ctor_dtorC2Ei(ptr addrspace(4) %this, i32 %i) unnamed_addr #1 align 2 {
 entry:
-  %this.addr = alloca %struct.global_ctor_dtor addrspace(4)*, align 4
+  %this.addr = alloca ptr addrspace(4), align 4
   %i.addr = alloca i32, align 4
-  store %struct.global_ctor_dtor addrspace(4)* %this, %struct.global_ctor_dtor addrspace(4)** %this.addr, align 4
-  store i32 %i, i32* %i.addr, align 4
-  %this1 = load %struct.global_ctor_dtor addrspace(4)*, %struct.global_ctor_dtor addrspace(4)** %this.addr
-  %0 = load i32, i32* %i.addr, align 4
-  %a = getelementptr inbounds %struct.global_ctor_dtor, %struct.global_ctor_dtor addrspace(4)* %this1, i32 0, i32 0
-  store i32 %0, i32 addrspace(4)* %a, align 4
+  store ptr addrspace(4) %this, ptr %this.addr, align 4
+  store i32 %i, ptr %i.addr, align 4
+  %this1 = load ptr addrspace(4), ptr %this.addr
+  %0 = load i32, ptr %i.addr, align 4
+  store i32 %0, ptr addrspace(4) %this1, align 4
   ret void
 }
 
@@ -132,14 +130,14 @@ attributes #2 = { noinline nounwind }
 !llvm.ident = !{!11}
 !spirv.Source = !{!12}
 
-!0 = !{void ()* @worker, i32 30, i32 262149}
-!1 = !{void ()* @worker, i32 18, i32 12, i32 10, i32 1}
-!2 = !{void ()* @worker, i32 17, i32 10, i32 10, i32 10}
-!3 = !{void ()* @worker, i32 36, i32 4}
-!4 = !{void ()* @_SPIRV_GLOBAL__I_45b04794_Test_attr.cl, i32 33}
-!5 = !{void ()* @_SPIRV_GLOBAL__I_45b04794_Test_attr.cl, i32 17, i32 1, i32 1, i32 1}
-!6 = !{void ()* @_SPIRV_GLOBAL__D_45b04794_Test_attr.cl, i32 34}
-!7 = !{void ()* @_SPIRV_GLOBAL__D_45b04794_Test_attr.cl, i32 17, i32 1, i32 1, i32 1}
+!0 = !{ptr @worker, i32 30, i32 262149}
+!1 = !{ptr @worker, i32 18, i32 12, i32 10, i32 1}
+!2 = !{ptr @worker, i32 17, i32 10, i32 10, i32 10}
+!3 = !{ptr @worker, i32 36, i32 4}
+!4 = !{ptr @_SPIRV_GLOBAL__I_45b04794_Test_attr.cl, i32 33}
+!5 = !{ptr @_SPIRV_GLOBAL__I_45b04794_Test_attr.cl, i32 17, i32 1, i32 1, i32 1}
+!6 = !{ptr @_SPIRV_GLOBAL__D_45b04794_Test_attr.cl, i32 34}
+!7 = !{ptr @_SPIRV_GLOBAL__D_45b04794_Test_attr.cl, i32 17, i32 1, i32 1, i32 1}
 !8 = !{i32 1, i32 2}
 !9 = !{i32 2, i32 2}
 !10 = !{}

--- a/test/ExtendBitBoolArg.ll
+++ b/test/ExtendBitBoolArg.ll
@@ -34,13 +34,12 @@ define linkonce_odr dso_local spir_func void @foo(<2 x i1> %vec1, <2 x i1> %vec2
   %3 = addrspacecast ptr %1 to ptr addrspace(4)
   %4 = addrspacecast ptr %2 to ptr addrspace(4)
   %5 = load ptr addrspace(4), ptr addrspace(4) %3, align 8
-  %6 = getelementptr inbounds %"class.ac", ptr addrspace(4) %5, i32 0, i32 0
-  %7 = load i1, ptr addrspace(4) %6, align 1
-  %8 = load i32, ptr addrspace(4) %4, align 4
-  %9 = trunc i32 %8 to i1
-  %10 = lshr i1 %7, %9
-  %11 = zext i1 %10 to i32
-  %12 = and i32 %11, 1
-  %13 = lshr <2 x i1> %vec1, %vec2
+  %6 = load i1, ptr addrspace(4) %5, align 1
+  %7 = load i32, ptr addrspace(4) %4, align 4
+  %8 = trunc i32 %7 to i1
+  %9 = lshr i1 %6, %8
+  %10 = zext i1 %9 to i32
+  %11 = and i32 %10, 1
+  %12 = lshr <2 x i1> %vec1, %vec2
   ret void
 }

--- a/test/RelativeSrcPath.ll
+++ b/test/RelativeSrcPath.ll
@@ -17,20 +17,18 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir"
 
 ; Function Attrs: convergent noinline nounwind optnone
-define spir_kernel void @foo(i32 addrspace(1)* %a, i32 addrspace(1)* %b) #0 !dbg !8 !kernel_arg_addr_space !11 !kernel_arg_access_qual !12 !kernel_arg_type !13 !kernel_arg_base_type !13 !kernel_arg_type_qual !14 {
+define spir_kernel void @foo(ptr addrspace(1) %a, ptr addrspace(1) %b) #0 !dbg !8 !kernel_arg_addr_space !11 !kernel_arg_access_qual !12 !kernel_arg_type !13 !kernel_arg_base_type !13 !kernel_arg_type_qual !14 {
 entry:
-  %a.addr = alloca i32 addrspace(1)*, align 4
-  %b.addr = alloca i32 addrspace(1)*, align 4
-  store i32 addrspace(1)* %a, i32 addrspace(1)** %a.addr, align 4
-  store i32 addrspace(1)* %b, i32 addrspace(1)** %b.addr, align 4
-  %0 = load i32 addrspace(1)*, i32 addrspace(1)** %b.addr, align 4, !dbg !15
-  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %0, i32 0, !dbg !15
-  %1 = load i32, i32 addrspace(1)* %arrayidx, align 4, !dbg !15
-  %2 = load i32 addrspace(1)*, i32 addrspace(1)** %a.addr, align 4, !dbg !15
-  %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %2, i32 0, !dbg !15
-  %3 = load i32, i32 addrspace(1)* %arrayidx1, align 4, !dbg !15
+  %a.addr = alloca ptr addrspace(1), align 4
+  %b.addr = alloca ptr addrspace(1), align 4
+  store ptr addrspace(1) %a, ptr %a.addr, align 4
+  store ptr addrspace(1) %b, ptr %b.addr, align 4
+  %0 = load ptr addrspace(1), ptr %b.addr, align 4, !dbg !15
+  %1 = load i32, ptr addrspace(1) %0, align 4, !dbg !15
+  %2 = load ptr addrspace(1), ptr %a.addr, align 4, !dbg !15
+  %3 = load i32, ptr addrspace(1) %2, align 4, !dbg !15
   %add = add nsw i32 %3, %1, !dbg !15
-  store i32 %add, i32 addrspace(1)* %arrayidx1, align 4, !dbg !15
+  store i32 %add, ptr addrspace(1) %2, align 4, !dbg !15
   ret void, !dbg !16
 }
 

--- a/test/SPIRVVersionAutodetect_1_1.ll
+++ b/test/SPIRVVersionAutodetect_1_1.ll
@@ -28,7 +28,7 @@ attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"=
 !llvm.ident = !{!9}
 !spirv.Source = !{!10}
 
-!0 = !{void ()* @worker, i32 33}
+!0 = !{ptr @worker, i32 33}
 !6 = !{i32 1, i32 2}
 !7 = !{i32 2, i32 2}
 !8 = !{}

--- a/test/SampledImageRetType.ll
+++ b/test/SampledImageRetType.ll
@@ -11,21 +11,21 @@ target triple = "spir64"
 ;CHECK: TypeSampler [[sampler_t:[0-9]+]]
 ;CHECK: TypeSampledImage [[sampled_image_t:[0-9]+]]
 
-declare dso_local spir_func i8 addrspace(4)* @_Z20__spirv_SampledImageI14ocl_image1d_roPvET0_T_11ocl_sampler(%opencl.image1d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*) local_unnamed_addr #2
+declare dso_local spir_func ptr addrspace(4) @_Z20__spirv_SampledImageI14ocl_image1d_roPvET0_T_11ocl_sampler(ptr addrspace(1), ptr addrspace(2)) local_unnamed_addr #2
 
-declare dso_local spir_func <4 x float> @_Z30__spirv_ImageSampleExplicitLodIPvDv4_fiET0_T_T1_if(i8 addrspace(4)*, i32, i32, float) local_unnamed_addr #2
+declare dso_local spir_func <4 x float> @_Z30__spirv_ImageSampleExplicitLodIPvDv4_fiET0_T_T1_if(ptr addrspace(4), i32, i32, float) local_unnamed_addr #2
 
 @__spirv_BuiltInGlobalInvocationId = external dso_local local_unnamed_addr addrspace(2) constant <3 x i64>, align 32
 
-define weak_odr dso_local spir_kernel void @_ZTS17image_kernel_readILi1EE(%opencl.image1d_ro_t addrspace(1)*, %opencl.sampler_t addrspace(2)*) {
+define weak_odr dso_local spir_kernel void @_ZTS17image_kernel_readILi1EE(ptr addrspace(1), ptr addrspace(2)) {
 ;CHECK: Function
 ;CHECK: FunctionParameter [[image1d_t]] [[image:[0-9]+]]
 ;CHECK: FunctionParameter [[sampler_t]] [[sampler:[0-9]+]]
-  %3 = load <3 x i64>, <3 x i64> addrspace(2)* @__spirv_BuiltInGlobalInvocationId, align 32
+  %3 = load <3 x i64>, ptr addrspace(2) @__spirv_BuiltInGlobalInvocationId, align 32
   %4 = extractelement <3 x i64> %3, i64 0
   %5 = trunc i64 %4 to i32
-  %6 = tail call spir_func i8 addrspace(4)* @_Z20__spirv_SampledImageI14ocl_image1d_roPvET0_T_11ocl_sampler(%opencl.image1d_ro_t addrspace(1)* %0, %opencl.sampler_t addrspace(2)* %1)
-  %7 = tail call spir_func <4 x float> @_Z30__spirv_ImageSampleExplicitLodIPvDv4_fiET0_T_T1_if(i8 addrspace(4)* %6, i32 %5, i32 2, float 0.000000e+00)
+  %6 = tail call spir_func ptr addrspace(4) @_Z20__spirv_SampledImageI14ocl_image1d_roPvET0_T_11ocl_sampler(ptr addrspace(1) %0, ptr addrspace(2) %1)
+  %7 = tail call spir_func <4 x float> @_Z30__spirv_ImageSampleExplicitLodIPvDv4_fiET0_T_T1_if(ptr addrspace(4) %6, i32 %5, i32 2, float 0.000000e+00)
 
 ;CHECK: SampledImage [[sampled_image_t]] [[sampled_image:[0-9]+]] [[image]] [[sampler]]
 ;CHECK: ImageSampleExplicitLod {{[0-9]+}} {{[0-9]+}} [[sampled_image]] {{[0-9]+}} {{[0-9]+}} {{[0-9]+}}

--- a/test/appending-linkage-type.ll
+++ b/test/appending-linkage-type.ll
@@ -11,9 +11,9 @@ target triple = "spir64-unknown-unknown"
 %union.int_double = type { i64 }
 
 @_c0 = internal addrspace(1) constant %union.int_double { i64 4607182418800017408 }, align 8 #0
-@._c0.ref = internal constant %union.int_double addrspace(1)* @_c0 #0
+@._c0.ref = internal constant ptr addrspace(1) @_c0 #0
 ; CHECK-LLVM: @llvm.compiler.used = appending global
-@llvm.compiler.used = appending global [1 x i8*] [i8* bitcast (%union.int_double addrspace(1)** @._c0.ref to i8*)] #0
+@llvm.compiler.used = appending global [1 x ptr] [ptr @._c0.ref] #0
 
 attributes #0 = { "VCGlobalVariable" }
 

--- a/test/atomic-load-store.ll
+++ b/test/atomic-load-store.ll
@@ -19,17 +19,17 @@ entry:
   %0 = alloca i32
 
 ; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#Relaxed]] [[#]]
-  store atomic i32 0, i32* %0 monotonic, align 4
+  store atomic i32 0, ptr %0 monotonic, align 4
 ; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#Release]] [[#]]
-  store atomic i32 0, i32* %0 release, align 4
+  store atomic i32 0, ptr %0 release, align 4
 ; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#SequentiallyConsistent]] [[#]]
-  store atomic i32 0, i32* %0 seq_cst, align 4
+  store atomic i32 0, ptr %0 seq_cst, align 4
 
 ; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#Relaxed]]
-  %1 = load atomic i32, i32* %0 monotonic, align 4
+  %1 = load atomic i32, ptr %0 monotonic, align 4
 ; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#Acquire]]
-  %2 = load atomic i32, i32* %0 acquire, align 4
+  %2 = load atomic i32, ptr %0 acquire, align 4
 ; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#SequentiallyConsistent]]
-  %3 = load atomic i32, i32* %0 seq_cst, align 4
+  %3 = load atomic i32, ptr %0 seq_cst, align 4
   ret void
 }

--- a/test/atomicrmw.ll
+++ b/test/atomicrmw.ll
@@ -25,37 +25,37 @@ target triple = "spir64"
 ; Function Attrs: nounwind
 define dso_local spir_func void @test_atomicrmw() local_unnamed_addr #0 {
 entry:
-  %0 = atomicrmw xchg i32 addrspace(1)* @ui, i32 42 acq_rel
+  %0 = atomicrmw xchg ptr addrspace(1) @ui, i32 42 acq_rel
 ; CHECK: AtomicExchange [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_AcquireRelease]] [[Value]]
 
-  %1 = atomicrmw xchg float addrspace(1)* @f, float 42.000000e+00 seq_cst
+  %1 = atomicrmw xchg ptr addrspace(1) @f, float 42.000000e+00 seq_cst
 ; CHECK: AtomicExchange [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[FPValue]]
 
-  %2 = atomicrmw add i32 addrspace(1)* @ui, i32 42 monotonic
+  %2 = atomicrmw add ptr addrspace(1) @ui, i32 42 monotonic
 ; CHECK: AtomicIAdd [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Relaxed]] [[Value]]
 
-  %3 = atomicrmw sub i32 addrspace(1)* @ui, i32 42 acquire
+  %3 = atomicrmw sub ptr addrspace(1) @ui, i32 42 acquire
 ; CHECK: AtomicISub [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Acquire]] [[Value]]
 
-  %4 = atomicrmw or i32 addrspace(1)* @ui, i32 42 release
+  %4 = atomicrmw or ptr addrspace(1) @ui, i32 42 release
 ; CHECK: AtomicOr [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Release]] [[Value]]
 
-  %5 = atomicrmw xor i32 addrspace(1)* @ui, i32 42 acq_rel
+  %5 = atomicrmw xor ptr addrspace(1) @ui, i32 42 acq_rel
 ; CHECK: AtomicXor [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_AcquireRelease]] [[Value]]
 
-  %6 = atomicrmw and i32 addrspace(1)* @ui, i32 42 seq_cst
+  %6 = atomicrmw and ptr addrspace(1) @ui, i32 42 seq_cst
 ; CHECK: AtomicAnd [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[Value]]
 
-  %7 = atomicrmw max i32 addrspace(1)* @ui, i32 42 monotonic
+  %7 = atomicrmw max ptr addrspace(1) @ui, i32 42 monotonic
 ; CHECK: AtomicSMax [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Relaxed]] [[Value]]
 
-  %8 = atomicrmw min i32 addrspace(1)* @ui, i32 42 acquire
+  %8 = atomicrmw min ptr addrspace(1) @ui, i32 42 acquire
 ; CHECK: AtomicSMin [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Acquire]] [[Value]]
 
-  %9 = atomicrmw umax i32 addrspace(1)* @ui, i32 42 release
+  %9 = atomicrmw umax ptr addrspace(1) @ui, i32 42 release
 ; CHECK: AtomicUMax [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Release]] [[Value]]
 
-  %10 = atomicrmw umin i32 addrspace(1)* @ui, i32 42 acq_rel
+  %10 = atomicrmw umin ptr addrspace(1) @ui, i32 42 acq_rel
 ; CHECK: AtomicUMin [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_AcquireRelease]] [[Value]]
 
   ret void

--- a/test/builtin-globals.ll
+++ b/test/builtin-globals.ll
@@ -27,6 +27,6 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: convergent norecurse nounwind
 define weak_odr dso_local spir_kernel void @foo() {
 entry:
-  %0 = load i64, i64 addrspace(1)* getelementptr inbounds (<3 x i64>, <3 x i64> addrspace(1)* @__spirv_BuiltInWorkgroupId, i64 0, i64 0), align 32
+  %0 = load i64, ptr addrspace(1) @__spirv_BuiltInWorkgroupId, align 32
  ret void
 }

--- a/test/builtin-vars-gep.ll
+++ b/test/builtin-vars-gep.ll
@@ -15,15 +15,14 @@ define spir_func void @foo() {
 entry:
   %GroupID = alloca [3 x i64], align 8
   %0 = addrspacecast ptr addrspace(1) @__spirv_BuiltInWorkgroupSize to ptr addrspace(4)
-  %1 = getelementptr <3 x i64>, ptr addrspace(4) %0, i64 0, i64 0
 ; CHECK-LLVM: %[[GLocalSize0:[0-9]+]] = call spir_func i64 @_Z14get_local_sizej(i32 0) #1
-  %2 = addrspacecast ptr addrspace(1) @__spirv_BuiltInWorkgroupSize to ptr addrspace(4)
-  %3 = getelementptr <3 x i64>, ptr addrspace(4) %2, i64 0, i64 2
-  %4 = load i64, ptr addrspace(4) %1, align 32
-  %5 = load i64, ptr addrspace(4) %3, align 8
+  %1 = addrspacecast ptr addrspace(1) @__spirv_BuiltInWorkgroupSize to ptr addrspace(4)
+  %2 = getelementptr <3 x i64>, ptr addrspace(4) %1, i64 0, i64 2
+  %3 = load i64, ptr addrspace(4) %0, align 32
+  %4 = load i64, ptr addrspace(4) %2, align 8
 ; CHECK-LLVM: %[[GLocalSize2:[0-9]+]] = call spir_func i64 @_Z14get_local_sizej(i32 2) #1
 ; CHECK-LLVM:  mul i64 %[[GLocalSize0]], %[[GLocalSize2]]
-  %mul = mul i64 %4, %5
+  %mul = mul i64 %3, %4
   ret void
 }
 
@@ -32,14 +31,13 @@ define spir_func void @foo_i8gep() {
 entry:
   %GroupID = alloca [3 x i64], align 8
   %0 = addrspacecast ptr addrspace(1) @__spirv_BuiltInWorkgroupSize to ptr addrspace(4)
-  %1 = getelementptr i8, ptr addrspace(4) %0, i64 0
 ; CHECK-LLVM: %[[GLocalSize0:[0-9]+]] = call spir_func i64 @_Z14get_local_sizej(i32 0) #1
-  %2 = addrspacecast ptr addrspace(1) @__spirv_BuiltInWorkgroupSize to ptr addrspace(4)
-  %3 = getelementptr i8, ptr addrspace(4) %2, i64 16
-  %4 = load i64, ptr addrspace(4) %1, align 32
-  %5 = load i64, ptr addrspace(4) %3, align 8
+  %1 = addrspacecast ptr addrspace(1) @__spirv_BuiltInWorkgroupSize to ptr addrspace(4)
+  %2 = getelementptr i8, ptr addrspace(4) %1, i64 16
+  %3 = load i64, ptr addrspace(4) %0, align 32
+  %4 = load i64, ptr addrspace(4) %2, align 8
 ; CHECK-LLVM: %[[GLocalSize2:[0-9]+]] = call spir_func i64 @_Z14get_local_sizej(i32 2) #1
 ; CHECK-LLVM:  mul i64 %[[GLocalSize0]], %[[GLocalSize2]]
-  %mul = mul i64 %4, %5
+  %mul = mul i64 %3, %4
   ret void
 }

--- a/test/capability-Int64Atomics-store.ll
+++ b/test/capability-Int64Atomics-store.ll
@@ -17,13 +17,13 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64"
 
 ; Function Attrs: nounwind
-define spir_func void @foo(i64 addrspace(4)* %object, i64 %desired) #0 {
+define spir_func void @foo(ptr addrspace(4) %object, i64 %desired) #0 {
 entry:
-  tail call spir_func void @_Z12atomic_storePVU3AS4U7_Atomicll(i64 addrspace(4)* %object, i64 %desired) #2
+  tail call spir_func void @_Z12atomic_storePVU3AS4U7_Atomicll(ptr addrspace(4) %object, i64 %desired) #2
   ret void
 }
 
-declare spir_func void @_Z12atomic_storePVU3AS4U7_Atomicll(i64 addrspace(4)*, i64) #1
+declare spir_func void @_Z12atomic_storePVU3AS4U7_Atomicll(ptr addrspace(4), i64) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/capability-Int64Atomics.ll
+++ b/test/capability-Int64Atomics.ll
@@ -18,13 +18,13 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64"
 
 ; Function Attrs: nounwind
-define spir_func void @foo(i64 addrspace(4)* %object, i64 %desired) #0 {
+define spir_func void @foo(ptr addrspace(4) %object, i64 %desired) #0 {
 entry:
-  %call = tail call spir_func i64 @_Z16atomic_fetch_xorPVU3AS4U7_Atomicll(i64 addrspace(4)* %object, i64 %desired) #2
+  %call = tail call spir_func i64 @_Z16atomic_fetch_xorPVU3AS4U7_Atomicll(ptr addrspace(4) %object, i64 %desired) #2
   ret void
 }
 
-declare spir_func i64 @_Z16atomic_fetch_xorPVU3AS4U7_Atomicll(i64 addrspace(4)*, i64) #1
+declare spir_func i64 @_Z16atomic_fetch_xorPVU3AS4U7_Atomicll(ptr addrspace(4), i64) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/capbility-kernel.ll
+++ b/test/capbility-kernel.ll
@@ -12,7 +12,7 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-DAG: {{[0-9]*}} Capability Linkage
 ; Function Attrs: nounwind
-define spir_func void @func_export(i32 addrspace(1)* nocapture %a) #0 {
+define spir_func void @func_export(ptr addrspace(1) nocapture %a) #0 {
 entry:
 ; CHECK-DAG: {{[0-9]*}} Capability Int64
   %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #3
@@ -20,7 +20,7 @@ entry:
   br i1 %cmp, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-  store i32 1, i32 addrspace(1)* %a, align 4, !tbaa !9
+  store i32 1, ptr addrspace(1) %a, align 4, !tbaa !9
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
@@ -34,13 +34,13 @@ declare spir_func i64 @_Z13get_global_idj(i32) #1
 ; CHECK-NOT: {{[0-9]*}} Capability Shader
 ; CHECK-NOT: {{[0-9]*}} Capability Float64
 ; Function Attrs: nounwind
-define spir_kernel void @func_kernel(i32 addrspace(1)* %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
+define spir_kernel void @func_kernel(ptr addrspace(1) %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
 entry:
-  tail call spir_func void @func_import(i32 addrspace(1)* %a) #4
+  tail call spir_func void @func_import(ptr addrspace(1) %a) #4
   ret void
 }
 
-declare spir_func void @func_import(i32 addrspace(1)*) #2
+declare spir_func void @func_import(ptr addrspace(1)) #2
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/complex-constexpr.ll
+++ b/test/complex-constexpr.ll
@@ -34,8 +34,8 @@ entry:
 ; CHECK-LLVM:  %[[UToPtr:[0-9]+]] = inttoptr i64 -1 to ptr addrspace(4)
 ; CHECK-LLVM:  %[[Sel:[0-9]+]] = select i1 %[[IEq]], ptr addrspace(4) %[[UToPtr]], ptr addrspace(4) %[[Cast]]
 ; CHECK-LLVM:  call spir_func void @bar(ptr addrspace(4) %[[Cast]], ptr addrspace(4) %[[Sel]]) #0
-  %0 = select i1 icmp eq (ptr addrspace(4) getelementptr inbounds ([1 x i8], ptr addrspace(4) addrspacecast (ptr addrspace(1) @.str.1 to ptr addrspace(4)), i64 0, i64 0), ptr addrspace(4) null), ptr addrspace(4) inttoptr (i64 -1 to ptr addrspace(4)), ptr addrspace(4) getelementptr inbounds ([1 x i8], ptr addrspace(4) addrspacecast (ptr addrspace(1) @.str.1 to ptr addrspace(4)), i64 0, i64 0)
-  call spir_func void @bar(ptr addrspace(4) getelementptr inbounds ([1 x i8], ptr addrspace(4) addrspacecast (ptr addrspace(1) @.str.1 to ptr addrspace(4)), i64 0, i64 0), ptr addrspace(4) %0)
+  %0 = select i1 icmp eq (ptr addrspace(4) addrspacecast (ptr addrspace(1) @.str.1 to ptr addrspace(4)), ptr addrspace(4) null), ptr addrspace(4) inttoptr (i64 -1 to ptr addrspace(4)), ptr addrspace(4) addrspacecast (ptr addrspace(1) @.str.1 to ptr addrspace(4))
+  call spir_func void @bar(ptr addrspace(4) addrspacecast (ptr addrspace(1) @.str.1 to ptr addrspace(4)), ptr addrspace(4) %0)
   ret void
 }
 

--- a/test/constexpr_phi.ll
+++ b/test/constexpr_phi.ll
@@ -41,17 +41,17 @@ define dso_local i32 @_Z2f2i(i32 %0) {
   ret i32 %2
 }
 
-define dso_local i64 @_Z3runiiPi(i32 %0, i32 %1, i32* nocapture %2) local_unnamed_addr {
+define dso_local i64 @_Z3runiiPi(i32 %0, i32 %1, ptr nocapture %2) local_unnamed_addr {
   %4 = icmp slt i32 %0, 10
   br i1 %4, label %5, label %7
 
 5:
   %6 = add nsw i32 %1, 2
-  store i32 %6, i32* %2, align 4
+  store i32 %6, ptr %2, align 4
   br label %7
 
 7:
-  %8 = phi <2 x i64> [ <i64 ptrtoint (i32 (i32)* @_Z2f2i to i64), i64 ptrtoint (i32 (i32)* @_Z2f2i to i64)>, %5 ], [ <i64 ptrtoint (i32 (i32)* @_Z2f2i to i64), i64 ptrtoint (i32 (i32)* @_Z2f1i to i64)>, %3 ]
+  %8 = phi <2 x i64> [ <i64 ptrtoint (ptr @_Z2f2i to i64), i64 ptrtoint (ptr @_Z2f2i to i64)>, %5 ], [ <i64 ptrtoint (ptr @_Z2f2i to i64), i64 ptrtoint (ptr @_Z2f1i to i64)>, %3 ]
   %9 = extractelement <2 x i64> %8, i64 0
   %10 = extractelement <2 x i64> %8, i64 1
   %11 = add nsw i64 %9, %10

--- a/test/constexpr_vector.ll
+++ b/test/constexpr_vector.ll
@@ -81,27 +81,27 @@ define dllexport void @vadd() {
 entry:
   %Funcs = alloca <16 x i8>, align 16
   store <16 x i8> <
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 0),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 1),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 2),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 3),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 4),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 5),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 6),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 7),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 0),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 1),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 2),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 3),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 4),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 5),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 6),
-    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 7)
-    >, <16 x i8>* %Funcs, align 16
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 0),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 1),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 2),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 3),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 4),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 5),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 6),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 7),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 0),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 1),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 2),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 3),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 4),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 5),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 6),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 7)
+    >, ptr %Funcs, align 16
   %Funcs1 = alloca <2 x i64>, align 16
   store <2 x i64> <
-    i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64),
-    i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64)
-    >, <2 x i64>* %Funcs1, align 16
+    i64 ptrtoint (ptr @_Z2f1u2CMvb32_j to i64),
+    i64 ptrtoint (ptr @_Z2f2u2CMvb32_j to i64)
+    >, ptr %Funcs1, align 16
   ret void
 }

--- a/test/create-placeholders-for-phi-operands.ll
+++ b/test/create-placeholders-for-phi-operands.ll
@@ -18,7 +18,7 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64"
 
 ; Function Attrs: noinline nounwind mustprogress
-define weak dso_local spir_kernel void @Kernel(i32 addrspace(1)* %0, i32 addrspace(1)* %1, i64 %.omp.lb.ascast.val109.zext, i64 %.omp.ub.ascast.val.zext, i64 %.capture_expr.0.ascast.val.zext, i64 %length_.ascast.val.zext) local_unnamed_addr #0 {
+define weak dso_local spir_kernel void @Kernel(ptr addrspace(1) %0, ptr addrspace(1) %1, i64 %.omp.lb.ascast.val109.zext, i64 %.omp.ub.ascast.val.zext, i64 %.capture_expr.0.ascast.val.zext, i64 %length_.ascast.val.zext) local_unnamed_addr #0 {
 BB.0:
   %dmt.i = alloca [624 x i32], align 4
   %length_.ascast.val.zext.trunc = trunc i64 %length_.ascast.val.zext to i32
@@ -31,8 +31,8 @@ BB.0:
   br i1 %or.cond, label %BB.2, label %BB.3
 
 BB.1:                                             ; preds = %BB.12.loopexit, %BB.11.loopexit
-  %savedstack.sink = phi i8* [ %savedstack, %BB.12.loopexit ], [ %savedstack.us, %BB.11.loopexit ]
-  call void @llvm.stackrestore.p0(i8* %savedstack.sink), !llvm.access.group !9
+  %savedstack.sink = phi ptr [ %savedstack, %BB.12.loopexit ], [ %savedstack.us, %BB.11.loopexit ]
+  call void @llvm.stackrestore.p0(ptr %savedstack.sink), !llvm.access.group !9
   br label %BB.2
 
 BB.2:                                             ; preds = %BB.3, %BB.1, %BB.0
@@ -50,15 +50,15 @@ BB.4:                                             ; preds = %BB.3
   br i1 %4, label %BB.5, label %BB.6
 
 BB.5:                                             ; preds = %BB.4
-  %savedstack = call i8* @llvm.stacksave.p0(), !llvm.access.group !9
+  %savedstack = call ptr @llvm.stacksave.p0(), !llvm.access.group !9
   br label %BB.12
 
 BB.6:                                             ; preds = %BB.4
   %5 = icmp ugt i32 %div.i, 1
   %umax = select i1 %5, i32 %div.i, i32 1
-  %arrayidx4812.us = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 %2
-  %arrayidx5113.us = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %2
-  %savedstack.us = call i8* @llvm.stacksave.p0(), !llvm.access.group !9
+  %arrayidx4812.us = getelementptr inbounds i32, ptr addrspace(1) %0, i64 %2
+  %arrayidx5113.us = getelementptr inbounds i32, ptr addrspace(1) %1, i64 %2
+  %savedstack.us = call ptr @llvm.stacksave.p0(), !llvm.access.group !9
   br label %BB.9
 
 BB.7:                                             ; preds = %BB.8
@@ -72,8 +72,8 @@ BB.11.loopexit:
 BB.8:                                             ; preds = %BB.11, %BB.8
   %indvars.iv22 = phi i64 [ 0, %BB.11 ], [ %indvars.iv.next23, %BB.8 ]
   %j.0.i17.us = phi i32 [ 0, %BB.11 ], [ %add.i.us, %BB.8 ]
-  %arrayidx1276.i.us = getelementptr inbounds [624 x i32], [624 x i32]* %dmt.i, i64 0, i64 %indvars.iv22
-  %6 = load i32, i32* %arrayidx1276.i.us, align 4, !alias.scope !14, !noalias !19, !llvm.access.group !9
+  %arrayidx1276.i.us = getelementptr inbounds [624 x i32], ptr %dmt.i, i64 0, i64 %indvars.iv22
+  %6 = load i32, ptr %arrayidx1276.i.us, align 4, !alias.scope !14, !noalias !19, !llvm.access.group !9
   %and.i.us = and i32 %6, -2147483648
   %indvars.iv.next23 = add nuw nsw i64 %indvars.iv22, 1
   %add.i.us = add nuw nsw i32 %j.0.i17.us, 1
@@ -108,10 +108,10 @@ BB.12.loopexit:
 declare spir_func i64 @_Z13get_global_idj(i32) local_unnamed_addr
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare i8* @llvm.stacksave.p0() #1
+declare ptr @llvm.stacksave.p0() #1
 
 ; Function Attrs: nofree nosync nounwind willreturn
-declare void @llvm.stackrestore.p0(i8*) #1
+declare void @llvm.stackrestore.p0(ptr) #1
 
 attributes #0 = { noinline nounwind mustprogress "contains-openmp-target"="true" "denormal-fp-math"="preserve-sign,preserve-sign" "denormal-fp-math-f32"="ieee,ieee" "frame-pointer"="all" "may-have-openmp-directive"="false" "min-legal-vector-width"="0" "no-infs-fp-math"="true" "no-nans-fp-math"="true" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target.declare"="true" "unsafe-fp-math"="true" }
 attributes #1 = { nofree nosync nounwind willreturn }

--- a/test/custom_class.ll
+++ b/test/custom_class.ll
@@ -35,45 +35,40 @@ target triple = "spir64-unknown-linux"
 
 $"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10SYCLCustom" = comdat any
 
-@_ZN11CustomClassC1Ei = dso_local unnamed_addr alias void (%class._ZTS11CustomClass.CustomClass addrspace(4)*, i32), void (%class._ZTS11CustomClass.CustomClass addrspace(4)*, i32)* @_ZN11CustomClassC2Ei
+@_ZN11CustomClassC1Ei = dso_local unnamed_addr alias void (ptr addrspace(4), i32), ptr @_ZN11CustomClassC2Ei
 
 ; Function Attrs: norecurse
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10SYCLCustom"() #0 comdat !kernel_arg_addr_space !4 !kernel_arg_access_qual !4 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !4 {
 entry:
   %0 = alloca %"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon", align 1
-  %1 = bitcast %"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon"* %0 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 1, i8* %1) #4
-  %2 = addrspacecast %"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon"* %0 to %"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon" addrspace(4)*
-  call spir_func void @"_ZZZ4mainENK3$_0clERN2cl4sycl7handlerEENKUlvE_clEv"(%"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon" addrspace(4)* %2)
-  %3 = bitcast %"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon"* %0 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 1, i8* %3) #4
+  call void @llvm.lifetime.start.p0(i64 1, ptr %0) #4
+  %1 = addrspacecast ptr %0 to ptr addrspace(4)
+  call spir_func void @"_ZZZ4mainENK3$_0clERN2cl4sycl7handlerEENKUlvE_clEv"(ptr addrspace(4) %1)
+  call void @llvm.lifetime.end.p0(i64 1, ptr %0) #4
   ret void
 }
 
 ; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #1
 
 ; Function Attrs: inlinehint norecurse
-define internal spir_func void @"_ZZZ4mainENK3$_0clERN2cl4sycl7handlerEENKUlvE_clEv"(%"class._ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEEUlvE_.anon" addrspace(4)* %this) #2 align 2 {
+define internal spir_func void @"_ZZZ4mainENK3$_0clERN2cl4sycl7handlerEENKUlvE_clEv"(ptr addrspace(4) %this) #2 align 2 {
 entry:
   %dummyClass = alloca %class._ZTS11CustomClass.CustomClass, align 4
-  %0 = bitcast %class._ZTS11CustomClass.CustomClass* %dummyClass to i8*
-  call void @llvm.lifetime.start.p0i8(i64 4, i8* %0) #4
-  %1 = addrspacecast %class._ZTS11CustomClass.CustomClass* %dummyClass to %class._ZTS11CustomClass.CustomClass addrspace(4)*
-  call spir_func void @_ZN11CustomClassC1Ei(%class._ZTS11CustomClass.CustomClass addrspace(4)* %1, i32 1)
-  %2 = bitcast %class._ZTS11CustomClass.CustomClass* %dummyClass to i8*
-  call void @llvm.lifetime.end.p0i8(i64 4, i8* %2) #4
+  call void @llvm.lifetime.start.p0(i64 4, ptr %dummyClass) #4
+  %0 = addrspacecast ptr %dummyClass to ptr addrspace(4)
+  call spir_func void @_ZN11CustomClassC1Ei(ptr addrspace(4) %0, i32 1)
+  call void @llvm.lifetime.end.p0(i64 4, ptr %dummyClass) #4
   ret void
 }
 
 ; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
 
 ; Function Attrs: norecurse nounwind
-define dso_local spir_func void @_ZN11CustomClassC2Ei(%class._ZTS11CustomClass.CustomClass addrspace(4)* %this, i32 %value) unnamed_addr #3 align 2 {
+define dso_local spir_func void @_ZN11CustomClassC2Ei(ptr addrspace(4) %this, i32 %value) unnamed_addr #3 align 2 {
 entry:
-  %data = getelementptr inbounds %class._ZTS11CustomClass.CustomClass, %class._ZTS11CustomClass.CustomClass addrspace(4)* %this, i32 0, i32 0
-  store i32 %value, i32 addrspace(4)* %data, align 4, !tbaa !5
+  store i32 %value, ptr addrspace(4) %this, align 4, !tbaa !5
   ret void
 }
 

--- a/test/debug-label-skip.ll
+++ b/test/debug-label-skip.ll
@@ -12,21 +12,21 @@ entry:
   %a.addr = alloca i32, align 4
   %b.addr = alloca i32, align 4
   %sum = alloca i32, align 4
-  store i32 %a, i32* %a.addr, align 4
-  store i32 %b, i32* %b.addr, align 4
+  store i32 %a, ptr %a.addr, align 4
+  store i32 %b, ptr %b.addr, align 4
   br label %top
 
 top:                                              ; preds = %entry
   call void @llvm.dbg.label(metadata !9), !dbg !10
-  %0 = load i32, i32* %a.addr, align 4
-  %1 = load i32, i32* %b.addr, align 4
+  %0 = load i32, ptr %a.addr, align 4
+  %1 = load i32, ptr %b.addr, align 4
   %add = add nsw i32 %0, %1
-  store i32 %add, i32* %sum, align 4
+  store i32 %add, ptr %sum, align 4
   br label %done
 
 done:                                             ; preds = %top
   call void @llvm.dbg.label(metadata !11), !dbg !12
-  %2 = load i32, i32* %sum, align 4
+  %2 = load i32, ptr %sum, align 4
   ret i32 %2
 }
 

--- a/test/dominator-order.ll
+++ b/test/dominator-order.ll
@@ -20,7 +20,7 @@ source_filename = "reproducer.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
-define spir_kernel void @test(i8 addrspace(1)* %arg) local_unnamed_addr #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !4 {
+define spir_kernel void @test(ptr addrspace(1) %arg) local_unnamed_addr #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !4 {
 entry:
   br label %for.body
 

--- a/test/empty.ll
+++ b/test/empty.ll
@@ -9,10 +9,10 @@ target triple = "spir-unknown-unknown"
 ; Function Attrs: nounwind
 ; CHECK: Capability Addresses
 ; CHECK: "foo"
-define spir_kernel void @foo(i32 addrspace(1)* %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @foo(ptr addrspace(1) %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
-  %a.addr = alloca i32 addrspace(1)*, align 4
-  store i32 addrspace(1)* %a, i32 addrspace(1)** %a.addr, align 4
+  %a.addr = alloca ptr addrspace(1), align 4
+  store ptr addrspace(1) %a, ptr %a.addr, align 4
   ret void
 }
 

--- a/test/entry-point-interfaces.ll
+++ b/test/entry-point-interfaces.ll
@@ -28,8 +28,8 @@ target triple = "spir"
 ; Function Attrs: convergent noinline norecurse nounwind optnone
 define dso_local spir_kernel void @test() #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !2 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !2 !kernel_arg_host_accessible !2 !kernel_arg_pipe_depth !2 !kernel_arg_pipe_io !2 !kernel_arg_buffer_location !2 {
 entry:
-  %0 = load i32, i32 addrspace(2)* @var.const, align 4
-  %1 = load i32, i32 addrspace(2)* @var2.const, align 4
+  %0 = load i32, ptr addrspace(2) @var.const, align 4
+  %1 = load i32, ptr addrspace(2) @var2.const, align 4
   %mul = mul nsw i32 %0, %1
   %mul1 = mul nsw i32 %mul, 2
   ret void

--- a/test/half_extension.ll
+++ b/test/half_extension.ll
@@ -25,17 +25,17 @@ define spir_func half @test() #0 {
 entry:
   %x = alloca half, align 2
   %y = alloca half, align 2
-  store half 0xH2E66, half* %x, align 2
-  %0 = load half, half* %x, align 2
+  store half 0xH2E66, ptr %x, align 2
+  %0 = load half, ptr %x, align 2
   %conv = fpext half %0 to float
   %add = fadd float %conv, 2.000000e+00
   %conv1 = fptrunc float %add to half
-  store half %conv1, half* %x, align 2
-  %1 = load half, half* %x, align 2
-  %2 = load half, half* %x, align 2
+  store half %conv1, ptr %x, align 2
+  %1 = load half, ptr %x, align 2
+  %2 = load half, ptr %x, align 2
   %add2 = fadd half %1, %2
-  store half %add2, half* %y, align 2
-  %3 = load half, half* %y, align 2
+  store half %add2, ptr %y, align 2
+  %3 = load half, ptr %y, align 2
   ret half %3
 }
 

--- a/test/image-user-sampler-args.ll
+++ b/test/image-user-sampler-args.ll
@@ -14,7 +14,7 @@ entry:
 
 declare spir_func <4 x float> @_Z11read_imagef14ocl_image2d_ro11ocl_samplerDv2_f(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), target("spirv.Sampler"), <2 x float>) local_unnamed_addr
 
-define hidden spir_kernel void @kernel_fn(float addrspace(1)* %0, target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %1, target("spirv.Sampler") %2, i32 %3, i32 %4) local_unnamed_addr {
+define hidden spir_kernel void @kernel_fn(ptr addrspace(1) %0, target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %1, target("spirv.Sampler") %2, i32 %3, i32 %4) local_unnamed_addr {
 entry:
   %5 = call spir_func <4 x float> @user_fn(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %1, target("spirv.Sampler") %2, <2 x float> undef)
   %add16 = add nsw i32 undef, undef

--- a/test/image.ll
+++ b/test/image.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-unknown"
 %opencl.image2d_t = type opaque
 
 ; Function Attrs: nounwind
-define spir_kernel void @image_copy(%opencl.image2d_t addrspace(1)* readnone %image1, %opencl.image2d_t addrspace(1)* %image2) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
+define spir_kernel void @image_copy(ptr addrspace(1) readnone %image1, ptr addrspace(1) %image2) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
 entry:
   %call = tail call spir_func i64 @_Z13get_global_idj(i32 0) #3
   %conv = trunc i64 %call to i32
@@ -30,8 +30,8 @@ entry:
   %conv2 = trunc i64 %call1 to i32
   %vecinit = insertelement <2 x i32> undef, i32 %conv, i32 0
   %vecinit3 = insertelement <2 x i32> %vecinit, i32 %conv2, i32 1
-  %call4 = tail call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(%opencl.image2d_t addrspace(1)* %image1, i32 20, <2 x i32> %vecinit3) #3
-  tail call spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f(%opencl.image2d_t addrspace(1)* %image2, <2 x i32> %vecinit3, <4 x float> %call4) #4
+  %call4 = tail call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1) %image1, i32 20, <2 x i32> %vecinit3) #3
+  tail call spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f(ptr addrspace(1) %image2, <2 x i32> %vecinit3, <4 x float> %call4) #4
 ; CHECK-LLVM: call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(ptr addrspace(1) %image2, <2 x i32> %vecinit3, <4 x float> %call4) #0
 ; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_f(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %image2, <2 x i32> %vecinit3, <4 x float> %call4) #0
   ret void
@@ -41,9 +41,9 @@ entry:
 declare spir_func i64 @_Z13get_global_idj(i32) #1
 
 ; Function Attrs: nounwind readnone
-declare spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(%opencl.image2d_t addrspace(1)*, i32, <2 x i32>) #1
+declare spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(ptr addrspace(1), i32, <2 x i32>) #1
 
-declare spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f(%opencl.image2d_t addrspace(1)*, <2 x i32>, <4 x float>) #2
+declare spir_func void @_Z12write_imagef11ocl_image2dDv2_iDv4_f(ptr addrspace(1), <2 x i32>, <4 x float>) #2
 ; CHECK-LLVM: declare spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(ptr addrspace(1), <2 x i32>, <4 x float>)
 ; CHECK-SPV-IR: declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDv4_f(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, <4 x float>)
 

--- a/test/layout.ll
+++ b/test/layout.ll
@@ -123,29 +123,29 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir"
 
 @v = addrspace(1) global [2 x i32] [i32 1, i32 2], align 4
-@s = addrspace(1) global i32 addrspace(1)* getelementptr inbounds ([2 x i32], [2 x i32] addrspace(1)* @v, i32 0, i32 1), align 4
+@s = addrspace(1) global ptr addrspace(1) getelementptr inbounds ([2 x i32], ptr addrspace(1) @v, i32 0, i32 1), align 4
 
 %struct.A = type { i32, %struct.C }
 %struct.C = type { i32, %struct.B }
-%struct.B = type { i32, %struct.A addrspace(4)* }
+%struct.B = type { i32, ptr addrspace(4) }
 
 @f = addrspace(2) constant [2 x float] zeroinitializer, align 4
 @b = external addrspace(2) constant <3 x i32>
 @a = common addrspace(1) global %struct.A zeroinitializer, align 4
 
 ; Function Attrs: nounwind
-define spir_kernel void @foo(<3 x i32> addrspace(1)* %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @foo(ptr addrspace(1) %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
-  call spir_func void @bar1(<3 x i32> addrspace(1)* %a)
-  %loadVec4 = load <4 x i32> , <4 x i32> addrspace(2)* bitcast (<3 x i32> addrspace(2)* @b to <4 x i32> addrspace(2)*)
+  call spir_func void @bar1(ptr addrspace(1) %a)
+  %loadVec4 = load <4 x i32> , ptr addrspace(2) @b
   %extractVec = shufflevector <4 x i32> %loadVec4, <4 x i32> undef, <3 x i32> <i32 0, i32 1, i32 2>
-  call spir_func void @bar2(<3 x i32> addrspace(1)* %a, <3 x i32> %extractVec)
+  call spir_func void @bar2(ptr addrspace(1) %a, <3 x i32> %extractVec)
   ret void
 }
 
-declare spir_func void @bar1(<3 x i32> addrspace(1)*) #1
+declare spir_func void @bar1(ptr addrspace(1)) #1
 
-declare spir_func void @bar2(<3 x i32> addrspace(1)*, <3 x i32>) #1
+declare spir_func void @bar2(ptr addrspace(1), <3 x i32>) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
@@ -157,7 +157,7 @@ attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "
 !opencl.used.optional.core.features = !{!8}
 !opencl.compiler.options = !{!8}
 
-!0 = !{void (<3 x i32> addrspace(1)*)* @foo, !1, !2, !3, !4, !5}
+!0 = !{ptr @foo, !1, !2, !3, !4, !5}
 !1 = !{i32 1}
 !2 = !{!"none"}
 !3 = !{!"int3*"}

--- a/test/linkage-types.ll
+++ b/test/linkage-types.ll
@@ -100,16 +100,16 @@ define spir_func void @f() #0 {
 entry:
   %q = alloca i32, align 4
   %r = alloca i32, align 4
-  %0 = load i32, i32 addrspace(1)* @i2, align 4
-  store i32 %0, i32* %q, align 4
-  %1 = load i32, i32 addrspace(1)* @i3, align 4
-  store i32 %1, i32 addrspace(1)* @i5, align 4
-  %2 = load i32, i32 addrspace(1)* @e, align 4
-  store i32 %2, i32* %r, align 4
-  %3 = load i32, i32 addrspace(2)* getelementptr inbounds ([256 x i32], [256 x i32] addrspace(2)* @noise_table, i32 0, i32 0), align 4
-  store i32 %3, i32* %r, align 4
-  %4 = load i32, i32 addrspace(2)* getelementptr inbounds ([2 x i32], [2 x i32] addrspace(2)* @f.color_table, i32 0, i32 0), align 4
-  store i32 %4, i32* %r, align 4
+  %0 = load i32, ptr addrspace(1) @i2, align 4
+  store i32 %0, ptr %q, align 4
+  %1 = load i32, ptr addrspace(1) @i3, align 4
+  store i32 %1, ptr addrspace(1) @i5, align 4
+  %2 = load i32, ptr addrspace(1) @e, align 4
+  store i32 %2, ptr %r, align 4
+  %3 = load i32, ptr addrspace(2) @noise_table, align 4
+  store i32 %3, ptr %r, align 4
+  %4 = load i32, ptr addrspace(2) @f.color_table, align 4
+  store i32 %4, ptr %r, align 4
   %call = call spir_func i32 @g()
   call spir_func void @inline_fun()
   ret void
@@ -130,8 +130,8 @@ entry:
 ; Function Attrs: inlinehint nounwind
 define linkonce_odr spir_func void @inline_fun() #1 {
 entry:
-  %t = alloca i32 addrspace(1)*, align 4
-  store i32 addrspace(1)* @i1, i32 addrspace(1)** %t, align 4
+  %t = alloca ptr addrspace(1), align 4
+  store ptr addrspace(1) @i1, ptr %t, align 4
   ret void
 }
 

--- a/test/literal-struct.ll
+++ b/test/literal-struct.ll
@@ -25,31 +25,30 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"
 
-%struct.__opencl_block_literal_generic = type { i32, i32, i8 addrspace(4)* }
+%struct.__opencl_block_literal_generic = type { i32, i32, ptr addrspace(4) }
 
-@__block_literal_global = internal addrspace(1) constant { i32, i32, i8 addrspace(4)* } { i32 12, i32 4, i8 addrspace(4)* addrspacecast (i8* bitcast (void (i8 addrspace(4)*)* @__foo_block_invoke to i8*) to i8 addrspace(4)*) }, align 4
+@__block_literal_global = internal addrspace(1) constant { i32, i32, ptr addrspace(4) } { i32 12, i32 4, ptr addrspace(4) addrspacecast (ptr @__foo_block_invoke to ptr addrspace(4)) }, align 4
 ; CHECK: ConstantComposite [[StructType]]
 
-@__block_literal_global.1 = internal addrspace(1) constant { i32, i32, i8 addrspace(4)* } zeroinitializer, align 4
+@__block_literal_global.1 = internal addrspace(1) constant { i32, i32, ptr addrspace(4) } zeroinitializer, align 4
 ; CHECK: ConstantNull [[StructType]]
 
 ; Function Attrs: convergent noinline nounwind optnone
 define spir_func void @foo() #0 {
 entry:
-  %myBlock = alloca %struct.__opencl_block_literal_generic addrspace(4)*, align 4
-  store %struct.__opencl_block_literal_generic addrspace(4)* addrspacecast (%struct.__opencl_block_literal_generic addrspace(1)* bitcast ({ i32, i32, i8 addrspace(4)* } addrspace(1)* @__block_literal_global to %struct.__opencl_block_literal_generic addrspace(1)*) to %struct.__opencl_block_literal_generic addrspace(4)*), %struct.__opencl_block_literal_generic addrspace(4)** %myBlock, align 4
-  call spir_func void @__foo_block_invoke(i8 addrspace(4)* addrspacecast (i8 addrspace(1)* bitcast ({ i32, i32, i8 addrspace(4)* } addrspace(1)* @__block_literal_global to i8 addrspace(1)*) to i8 addrspace(4)*)) #1
+  %myBlock = alloca ptr addrspace(4), align 4
+  store ptr addrspace(4) addrspacecast (ptr addrspace(1) @__block_literal_global to ptr addrspace(4)), ptr %myBlock, align 4
+  call spir_func void @__foo_block_invoke(ptr addrspace(4) addrspacecast (ptr addrspace(1) @__block_literal_global to ptr addrspace(4))) #1
   ret void
 }
 
 ; Function Attrs: convergent noinline nounwind optnone
-define internal spir_func void @__foo_block_invoke(i8 addrspace(4)* %.block_descriptor) #0 {
+define internal spir_func void @__foo_block_invoke(ptr addrspace(4) %.block_descriptor) #0 {
 entry:
-  %.block_descriptor.addr = alloca i8 addrspace(4)*, align 4
-  %block.addr = alloca <{ i32, i32, i8 addrspace(4)* }> addrspace(4)*, align 4
-  store i8 addrspace(4)* %.block_descriptor, i8 addrspace(4)** %.block_descriptor.addr, align 4
-  %block = bitcast i8 addrspace(4)* %.block_descriptor to <{ i32, i32, i8 addrspace(4)* }> addrspace(4)*
-  store <{ i32, i32, i8 addrspace(4)* }> addrspace(4)* %block, <{ i32, i32, i8 addrspace(4)* }> addrspace(4)** %block.addr, align 4
+  %.block_descriptor.addr = alloca ptr addrspace(4), align 4
+  %block.addr = alloca ptr addrspace(4), align 4
+  store ptr addrspace(4) %.block_descriptor, ptr %.block_descriptor.addr, align 4
+  store ptr addrspace(4) %.block_descriptor, ptr %block.addr, align 4
   ret void
 }
 

--- a/test/long-type-struct.ll
+++ b/test/long-type-struct.ll
@@ -36,18 +36,17 @@ $"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE4Test" = comdat any
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE4Test"() local_unnamed_addr #0 comdat !kernel_arg_buffer_location !3 {
 entry:
   %agg.tmp.i = alloca %struct._ZTS1A.A, align 8
-  %0 = bitcast ptr %agg.tmp.i to ptr
-  call void @llvm.lifetime.start.p0i8(i64 65600, ptr nonnull %0)
+  call void @llvm.lifetime.start.p0(i64 65600, ptr nonnull %agg.tmp.i)
   tail call spir_func void @_Z3foo1A(ptr nonnull byval(%struct._ZTS1A.A) align 8 %agg.tmp.i) #3
-  call void @llvm.lifetime.end.p0i8(i64 65600, ptr nonnull %0)
+  call void @llvm.lifetime.end.p0(i64 65600, ptr nonnull %agg.tmp.i)
   ret void
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg, ptr nocapture) #1
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg, ptr nocapture) #1
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
 
 ; Function Attrs: convergent
 declare dso_local spir_func void @_Z3foo1A(ptr byval(%struct._ZTS1A.A) align 8) local_unnamed_addr #2

--- a/test/mangled_function.ll
+++ b/test/mangled_function.ll
@@ -25,15 +25,15 @@ target triple = "spir-unknown-unknown"
 %opencl.image2d_ro_t = type opaque
 
 ; Function Attrs: convergent nounwind
-define spir_func void @bar(%opencl.image2d_ro_t addrspace(1)* %srcImage) local_unnamed_addr #0 {
+define spir_func void @bar(ptr addrspace(1) %srcImage) local_unnamed_addr #0 {
 entry:
 ; CHECK-LLVM: call spir_func void @_Z3foo14ocl_image2d_ro(ptr addrspace(1) %srcImage)
-  tail call spir_func void @_Z3foo14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)* %srcImage) #2
+  tail call spir_func void @_Z3foo14ocl_image2d_ro(ptr addrspace(1) %srcImage) #2
   ret void
 }
 
 ; Function Attrs: convergent
-declare spir_func void @_Z3foo14ocl_image2d_ro(%opencl.image2d_ro_t addrspace(1)*) local_unnamed_addr #1
+declare spir_func void @_Z3foo14ocl_image2d_ro(ptr addrspace(1)) local_unnamed_addr #1
 
 attributes #0 = { convergent nounwind "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { convergent "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/multi_md.ll
+++ b/test/multi_md.ll
@@ -20,28 +20,28 @@ define spir_kernel void @__OpenCL_writer_kernel(i8 zeroext %c, i32 %i) #0 !kerne
 entry:
   %c.addr = alloca i8, align 1
   %i.addr = alloca i32, align 4
-  store i8 %c, i8* %c.addr, align 1, !tbaa !14
-  store i32 %i, i32* %i.addr, align 4, !tbaa !17
-  %0 = load i8, i8* %c.addr, align 1, !tbaa !14
-  store i8 %0, i8 addrspace(1)* getelementptr inbounds (%struct.my_struct_t, %struct.my_struct_t addrspace(1)* @var, i32 0, i32 0), align 1, !tbaa !19
-  %1 = load i32, i32* %i.addr, align 4, !tbaa !17
-  store i32 %1, i32 addrspace(1)* getelementptr inbounds (%struct.my_struct_t, %struct.my_struct_t addrspace(1)* @var, i32 0, i32 1), align 4, !tbaa !21
+  store i8 %c, ptr %c.addr, align 1, !tbaa !14
+  store i32 %i, ptr %i.addr, align 4, !tbaa !17
+  %0 = load i8, ptr %c.addr, align 1, !tbaa !14
+  store i8 %0, ptr addrspace(1) @var, align 1, !tbaa !19
+  %1 = load i32, ptr %i.addr, align 4, !tbaa !17
+  store i32 %1, ptr addrspace(1) getelementptr inbounds (%struct.my_struct_t, ptr addrspace(1) @var, i32 0, i32 1), align 4, !tbaa !21
   ret void
 }
 
 ; Function Attrs: nounwind
-define spir_kernel void @__OpenCL_reader_kernel(i8 addrspace(1)* %C, i32 addrspace(1)* %I) #0 !kernel_arg_addr_space !8 !kernel_arg_access_qual !2 !kernel_arg_type !9 !kernel_arg_base_type !10 !kernel_arg_type_qual !5 {
+define spir_kernel void @__OpenCL_reader_kernel(ptr addrspace(1) %C, ptr addrspace(1) %I) #0 !kernel_arg_addr_space !8 !kernel_arg_access_qual !2 !kernel_arg_type !9 !kernel_arg_base_type !10 !kernel_arg_type_qual !5 {
 entry:
-  %C.addr = alloca i8 addrspace(1)*, align 8
-  %I.addr = alloca i32 addrspace(1)*, align 8
-  store i8 addrspace(1)* %C, i8 addrspace(1)** %C.addr, align 8, !tbaa !22
-  store i32 addrspace(1)* %I, i32 addrspace(1)** %I.addr, align 8, !tbaa !22
-  %0 = load i8, i8 addrspace(1)* getelementptr inbounds (%struct.my_struct_t, %struct.my_struct_t addrspace(1)* @var, i32 0, i32 0), align 1, !tbaa !19
-  %1 = load i8 addrspace(1)*, i8 addrspace(1)** %C.addr, align 8, !tbaa !22
-  store i8 %0, i8 addrspace(1)* %1, align 1, !tbaa !14
-  %2 = load i32, i32 addrspace(1)* getelementptr inbounds (%struct.my_struct_t, %struct.my_struct_t addrspace(1)* @var, i32 0, i32 1), align 4, !tbaa !21
-  %3 = load i32 addrspace(1)*, i32 addrspace(1)** %I.addr, align 8, !tbaa !22
-  store i32 %2, i32 addrspace(1)* %3, align 4, !tbaa !17
+  %C.addr = alloca ptr addrspace(1), align 8
+  %I.addr = alloca ptr addrspace(1), align 8
+  store ptr addrspace(1) %C, ptr %C.addr, align 8, !tbaa !22
+  store ptr addrspace(1) %I, ptr %I.addr, align 8, !tbaa !22
+  %0 = load i8, ptr addrspace(1) @var, align 1, !tbaa !19
+  %1 = load ptr addrspace(1), ptr %C.addr, align 8, !tbaa !22
+  store i8 %0, ptr addrspace(1) %1, align 1, !tbaa !14
+  %2 = load i32, ptr addrspace(1) getelementptr inbounds (%struct.my_struct_t, ptr addrspace(1) @var, i32 0, i32 1), align 4, !tbaa !21
+  %3 = load ptr addrspace(1), ptr %I.addr, align 8, !tbaa !22
+  store i32 %2, ptr addrspace(1) %3, align 4, !tbaa !17
   ret void
 }
 

--- a/test/negative/SPV_INTEL_bfloat16_conversion/bf16tof_inval_input_ty.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/bf16tof_inval_input_ty.ll
@@ -12,7 +12,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_func void @_Z1f() {
   %1 = alloca <2 x i16>, align 4
-  %2 = load <2 x i16>, <2 x i16>* %1, align 4
+  %2 = load <2 x i16>, ptr %1, align 4
   %3 = tail call spir_func float @_Z27__spirv_ConvertBF16ToFINTELf(<2 x i16> %2)
   ret void
 }

--- a/test/negative/SPV_INTEL_bfloat16_conversion/bf16tof_inval_output_ty.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/bf16tof_inval_output_ty.ll
@@ -12,11 +12,11 @@ target triple = "spir64-unknown-unknown"
 
 define spir_func void @_Z1f() {
   %1 = alloca [3 x i32], align 4
-  %2 = tail call spir_func float @_Z27__spirv_ConvertBF16ToFINTELf([3 x i32]* %1)
+  %2 = tail call spir_func float @_Z27__spirv_ConvertBF16ToFINTELf(ptr %1)
   ret void
 }
 
-declare spir_func float @_Z27__spirv_ConvertBF16ToFINTELf([3 x i32]*)
+declare spir_func float @_Z27__spirv_ConvertBF16ToFINTELf(ptr)
 
 !opencl.spir.version = !{!0}
 !spirv.Source = !{!1}

--- a/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_input_ty.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_input_ty.ll
@@ -12,7 +12,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_func void @_Z1f() {
   %1 = alloca double, align 8
-  %2 = load double, double* %1, align 8
+  %2 = load double, ptr %1, align 8
   %3 = tail call spir_func zeroext i16 @_Z27__spirv_ConvertFToBF16INTELf(double %2)
   ret void
 }

--- a/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_output_ty_1.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_output_ty_1.ll
@@ -12,7 +12,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_func void @_Z1f() {
   %1 = alloca float, align 4
-  %2 = load float, float* %1, align 4
+  %2 = load float, ptr %1, align 4
   %3 = tail call spir_func zeroext i32 @_Z27__spirv_ConvertFToBF16INTELf(float %2)
   ret void
 }

--- a/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_output_ty_2.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_output_ty_2.ll
@@ -12,7 +12,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_func void @_Z1f() {
   %1 = alloca float, align 4
-  %2 = load float, float* %1, align 4
+  %2 = load float, ptr %1, align 4
   %3 = tail call spir_func <4 x i16> @_Z27__spirv_ConvertFToBF16INTELf(float %2)
   ret void
 }

--- a/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_params.ll
+++ b/test/negative/SPV_INTEL_bfloat16_conversion/f2bf16_inval_params.ll
@@ -12,7 +12,7 @@ target triple = "spir64-unknown-unknown"
 
 define spir_func void @_Z1f() {
   %1 = alloca <4 x float>, align 16
-  %2 = load <4 x float>, <4 x float>* %1, align 16
+  %2 = load <4 x float>, ptr %1, align 16
   %3 = tail call spir_func <8 x i16> @_Z27__spirv_ConvertFToBF16INTELf(<4 x float> %2)
   ret void
 }

--- a/test/negative/invalid-constant-generic-cast.ll
+++ b/test/negative/invalid-constant-generic-cast.ll
@@ -8,9 +8,9 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nofree norecurse nounwind writeonly
-define dso_local spir_func void @_Z10kernel_funPi(i32 addrspace(4)* %ptr) {
+define dso_local spir_func void @_Z10kernel_funPi(ptr addrspace(4) %ptr) {
 entry:
-  %0 = addrspacecast i32 addrspace(4)* %ptr to i32 addrspace(2)*
+  %0 = addrspacecast ptr addrspace(4) %ptr to ptr addrspace(2)
   ret void
 }
 

--- a/test/negative/invalid-device-local-cast.ll
+++ b/test/negative/invalid-device-local-cast.ll
@@ -8,9 +8,9 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nofree norecurse nounwind writeonly
-define dso_local spir_func void @_Z10kernel_funPi(i32 addrspace(5)* %ptr) {
+define dso_local spir_func void @_Z10kernel_funPi(ptr addrspace(5) %ptr) {
 entry:
-  %0 = addrspacecast i32 addrspace(5)* %ptr to i32 addrspace(3)*
+  %0 = addrspacecast ptr addrspace(5) %ptr to ptr addrspace(3)
   ret void
 }
 

--- a/test/negative/invalid-private-global-cast.ll
+++ b/test/negative/invalid-private-global-cast.ll
@@ -8,9 +8,9 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nofree norecurse nounwind writeonly
-define dso_local spir_func void @_Z10kernel_funPi(i32 addrspace(1)* %ptr) {
+define dso_local spir_func void @_Z10kernel_funPi(ptr addrspace(1) %ptr) {
 entry:
-  %0 = addrspacecast i32 addrspace(1)* %ptr to i32*
+  %0 = addrspacecast ptr addrspace(1) %ptr to ptr
   ret void
 }
 

--- a/test/negative/unsup_invoke_instr.ll
+++ b/test/negative/unsup_invoke_instr.ll
@@ -23,7 +23,7 @@ define dso_local i32 @_funcEx() #4 {
 }
 
 ; Function Attrs: noinline norecurse optnone uwtable
-define dso_local i32 @func() #5 personality i8* bitcast (i32 (...)* @__gxx_personality_v0 to i8*) {
+define dso_local i32 @func() #5 personality ptr @__gxx_personality_v0 {
 entry:
   %call = invoke i32 @_funcEx()
           to label %invoke.cont unwind label %lpad
@@ -32,7 +32,7 @@ invoke.cont:
   ret i32 0
 
 lpad:
-  %0 = landingpad { i8*, i32 }
+  %0 = landingpad { ptr, i32 }
           cleanup
   ret i32 0
 }

--- a/test/no_capability_shader.ll
+++ b/test/no_capability_shader.ll
@@ -16,7 +16,7 @@ target triple = "spir64-unknown-unknown"
 %opencl.image1d_buffer_ro_t = type opaque
 
 ; Function Attrs: nounwind
-define spir_kernel void @sample_test(%opencl.image2d_ro_t addrspace(1)* %src, %opencl.image1d_buffer_ro_t addrspace(1)* %buf) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @sample_test(ptr addrspace(1) %src, ptr addrspace(1) %buf) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
   ret void
 }

--- a/test/relationals.ll
+++ b/test/relationals.ll
@@ -34,32 +34,32 @@ define spir_kernel void @k() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qua
 entry:
   %arg1 = alloca <4 x float>, align 16
   %ret = alloca <4 x i8>, align 4
-  %0 = load <4 x float>, <4 x float>* %arg1, align 16
+  %0 = load <4 x float>, ptr %arg1, align 16
   %call1 = call spir_func <4 x i8> @_Z13__spirv_IsNanIDv4_aDv4_fET_T0_(<4 x float> %0)
 ; CHECK-SPIRV: {{[0-9]+}} IsNan [[TBoolVec]] [[IsNanRes:[0-9]+]]
 ; CHECK-SPIRV: {{[0-9]+}} Select {{[0-9]+}} [[SelectRes:[0-9]+]] [[IsNanRes]]
 ; CHECK-SPIRV: {{[0-9]+}} Store {{[0-9]+}} [[SelectRes]]
-  store <4 x i8> %call1, <4 x i8>* %ret, align 4
+  store <4 x i8> %call1, ptr %ret, align 4
   %call2 = call spir_func <4 x i8> @_Z13__spirv_IsInfIDv4_aDv4_fET_T0_(<4 x float> %0)
 ; CHECK-SPIRV: {{[0-9]+}} IsInf [[TBoolVec]] [[IsInfRes:[0-9]+]]
 ; CHECK-SPIRV: {{[0-9]+}} Select {{[0-9]+}} [[Select1Res:[0-9]+]] [[IsInfRes]]
 ; CHECK-SPIRV: {{[0-9]+}} Store {{[0-9]+}} [[Select1Res]]
-  store <4 x i8> %call2, <4 x i8>* %ret, align 4
+  store <4 x i8> %call2, ptr %ret, align 4
   %call3 = call spir_func <4 x i8> @_Z16__spirv_IsFiniteIDv4_aDv4_fET_T0_(<4 x float> %0)
 ; CHECK-SPIRV: {{[0-9]+}} IsFinite [[TBoolVec]] [[IsFiniteRes:[0-9]+]]
 ; CHECK-SPIRV: {{[0-9]+}} Select {{[0-9]+}} [[Select2Res:[0-9]+]] [[IsFiniteRes]]
 ; CHECK-SPIRV: {{[0-9]+}} Store {{[0-9]+}} [[Select2Res]]
-  store <4 x i8> %call3, <4 x i8>* %ret, align 4
+  store <4 x i8> %call3, ptr %ret, align 4
   %call4 = call spir_func <4 x i8> @_Z16__spirv_IsNormalIDv4_aDv4_fET_T0_(<4 x float> %0)
 ; CHECK-SPIRV: {{[0-9]+}} IsNormal [[TBoolVec]] [[IsNormalRes:[0-9]+]]
 ; CHECK-SPIRV: {{[0-9]+}} Select {{[0-9]+}} [[Select3Res:[0-9]+]] [[IsNormalRes]]
 ; CHECK-SPIRV: {{[0-9]+}} Store {{[0-9]+}} [[Select3Res]]
-  store <4 x i8> %call4, <4 x i8>* %ret, align 4
+  store <4 x i8> %call4, ptr %ret, align 4
   %call5 = call spir_func <4 x i8> @_Z18__spirv_SignBitSetIDv4_aDv4_fET_T0_(<4 x float> %0)
 ; CHECK-SPIRV: {{[0-9]+}} SignBitSet [[TBoolVec]] [[SignBitSetRes:[0-9]+]]
 ; CHECK-SPIRV: {{[0-9]+}} Select {{[0-9]+}} [[Select4Res:[0-9]+]] [[SignBitSetRes]]
 ; CHECK-SPIRV: {{[0-9]+}} Store {{[0-9]+}} [[Select4Res]]
-  store <4 x i8> %call5, <4 x i8>* %ret, align 4
+  store <4 x i8> %call5, ptr %ret, align 4
   ret void
 }
 

--- a/test/spec_const_decoration.ll
+++ b/test/spec_const_decoration.ll
@@ -15,26 +15,25 @@ target triple = "spir64-unknown-unknown"
 $_ZTS6kernel = comdat any
 
 ; Function Attrs: convergent norecurse
-define weak_odr dso_local spir_kernel void @_ZTS6kernel(i8 addrspace(1)* %_arg_, %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range"* byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_1, %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range"* byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_2, %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range"* byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_3) local_unnamed_addr #0 comdat !kernel_arg_buffer_location !6 {
+define weak_odr dso_local spir_kernel void @_ZTS6kernel(ptr addrspace(1) %_arg_, ptr byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_1, ptr byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_2, ptr byval(%"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range") align 8 %_arg_3) local_unnamed_addr #0 comdat !kernel_arg_buffer_location !6 {
 entry:
-  %0 = getelementptr inbounds %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range", %"class._ZTSN2cl4sycl5rangeILi1EEE.cl::sycl::range"* %_arg_3, i64 0, i32 0, i32 0, i64 0
-  %1 = addrspacecast i64* %0 to i64 addrspace(4)*
-  %2 = load i64, i64 addrspace(4)* %1, align 8
+  %0 = addrspacecast ptr %_arg_3 to ptr addrspace(4)
+  %1 = load i64, ptr addrspace(4) %0, align 8
   br label %for.cond.i.i
 
 for.cond.i.i:                                     ; preds = %for.body.i.i, %entry
-  %value.0.i.i = phi i8 [ -1, %entry ], [ %3, %for.body.i.i ]
+  %value.0.i.i = phi i8 [ -1, %entry ], [ %2, %for.body.i.i ]
   %cmp.i.i = phi i1 [ true, %entry ], [ false, %for.body.i.i ]
   br i1 %cmp.i.i, label %for.body.i.i, label %_ZZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_ENKUlNS0_14kernel_handlerEE_clES4_.exit
 
 for.body.i.i:                                     ; preds = %for.cond.i.i
-  %3 = call i8 @_Z20__spirv_SpecConstantia(i32 0, i8 70)
+  %2 = call i8 @_Z20__spirv_SpecConstantia(i32 0, i8 70)
   br label %for.cond.i.i, !llvm.loop !7
 
 _ZZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_ENKUlNS0_14kernel_handlerEE_clES4_.exit: ; preds = %for.cond.i.i
-  %add.ptr.i = getelementptr inbounds i8, i8 addrspace(1)* %_arg_, i64 %2
-  %arrayidx.ascast.i.i = addrspacecast i8 addrspace(1)* %add.ptr.i to i8 addrspace(4)*
-  store i8 %value.0.i.i, i8 addrspace(4)* %arrayidx.ascast.i.i, align 1, !tbaa !9
+  %add.ptr.i = getelementptr inbounds i8, ptr addrspace(1) %_arg_, i64 %1
+  %arrayidx.ascast.i.i = addrspacecast ptr addrspace(1) %add.ptr.i to ptr addrspace(4)
+  store i8 %value.0.i.i, ptr addrspace(4) %arrayidx.ascast.i.i, align 1, !tbaa !9
   ret void
 }
 

--- a/test/spirv-extensions-control.ll
+++ b/test/spirv-extensions-control.ll
@@ -27,10 +27,10 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @foo(i32 addrspace(1)* %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @foo(ptr addrspace(1) %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
-  %a.addr = alloca i32 addrspace(1)*, align 4
-  store i32 addrspace(1)* %a, i32 addrspace(1)** %a.addr, align 4
+  %a.addr = alloca ptr addrspace(1), align 4
+  store ptr addrspace(1) %a, ptr %a.addr, align 4
   ret void
 }
 

--- a/test/spirv-load-store.ll
+++ b/test/spirv-load-store.ll
@@ -13,16 +13,16 @@ source_filename = "test.cpp"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-define weak_odr dso_local spir_kernel void @foo(i32 addrspace(1)* %var) {
+define weak_odr dso_local spir_kernel void @foo(ptr addrspace(1) %var) {
 entry:
-  tail call spir_func void @_Z13__spirv_StorePiiii(i32 addrspace(1)* %var, i32 42, i32 3, i32 4)
-  %0 = tail call spir_func double @_Z12__spirv_LoadPi(i32 addrspace(1)* %var)
+  tail call spir_func void @_Z13__spirv_StorePiiii(ptr addrspace(1) %var, i32 42, i32 3, i32 4)
+  %0 = tail call spir_func double @_Z12__spirv_LoadPi(ptr addrspace(1) %var)
   ret void
 }
 
-declare dso_local spir_func double @_Z12__spirv_LoadPi(i32 addrspace(1)*) local_unnamed_addr
+declare dso_local spir_func double @_Z12__spirv_LoadPi(ptr addrspace(1)) local_unnamed_addr
 
-declare dso_local spir_func void @_Z13__spirv_StorePiiii(i32 addrspace(1)*, i32, i32, i32) local_unnamed_addr
+declare dso_local spir_func void @_Z13__spirv_StorePiiii(ptr addrspace(1), i32, i32, i32) local_unnamed_addr
 
 !llvm.module.flags = !{!0, !1}
 !opencl.spir.version = !{!2}

--- a/test/spirv-tools-dis.ll
+++ b/test/spirv-tools-dis.ll
@@ -13,12 +13,12 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @foo(i32 addrspace(1)* %a) !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @foo(ptr addrspace(1) %a) !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
-  %a.addr = alloca i32 addrspace(1)*, align 4
-  store i32 addrspace(1)* %a, i32 addrspace(1)** %a.addr, align 4
-  %0 = load i32 addrspace(1)*, i32 addrspace(1)** %a.addr, align 4
-  store i32 0, i32 addrspace(1)* %0, align 4
+  %a.addr = alloca ptr addrspace(1), align 4
+  store ptr addrspace(1) %a, ptr %a.addr, align 4
+  %0 = load ptr addrspace(1), ptr %a.addr, align 4
+  store i32 0, ptr addrspace(1) %0, align 4
   ret void
 }
 

--- a/test/spirv_param_decorations_quals.ll
+++ b/test/spirv_param_decorations_quals.ll
@@ -10,7 +10,7 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir"
 
 ; Function Attrs: convergent nounwind
-define spir_kernel void @k(i32 addrspace(1)* %a) #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_type_qual !7 !kernel_arg_base_type !6 !spirv.ParameterDecorations !10 {
+define spir_kernel void @k(ptr addrspace(1) %a) #0 !kernel_arg_addr_space !4 !kernel_arg_access_qual !5 !kernel_arg_type !6 !kernel_arg_type_qual !7 !kernel_arg_base_type !6 !spirv.ParameterDecorations !10 {
 entry:
   ret void
 }

--- a/test/store.ll
+++ b/test/store.ll
@@ -8,13 +8,13 @@ target triple = "spir-unknown-unknown"
 
 ; Function Attrs: nounwind
 ; CHECK: "foo"
-define spir_kernel void @foo(i32 addrspace(1)* %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @foo(ptr addrspace(1) %a) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
-  %a.addr = alloca i32 addrspace(1)*, align 4
-  store i32 addrspace(1)* %a, i32 addrspace(1)** %a.addr, align 4
-  %0 = load i32 addrspace(1)*, i32 addrspace(1)** %a.addr, align 4
+  %a.addr = alloca ptr addrspace(1), align 4
+  store ptr addrspace(1) %a, ptr %a.addr, align 4
+  %0 = load ptr addrspace(1), ptr %a.addr, align 4
 ; CHECK: 5 Store {{[0-9]+}} {{[0-9]+}} 2 4
-  store i32 0, i32 addrspace(1)* %0, align 4
+  store i32 0, ptr addrspace(1) %0, align 4
   ret void
 }
 


### PR DESCRIPTION
This completes the initial bulk conversion of tests using the migration script.

There are more tests to be converted; however they will need manual fixups, so leave them out of this bulk conversion.