### PR TITLE
Add emulation of {s/u)_(add/sub)_sat intrinsics if needed

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -193,6 +193,14 @@ public:
     ReplaceLLVMFmulAddWithOpenCLMad = Value;
   }
 
+  void setUseOpenCLExtInstructionsForLLVMIntrinsic(bool Value) noexcept {
+    UseOpenCLExtInstructionsForLLVMIntrinsic = Value;
+  }
+
+  bool shouldUseOpenCLExtInstructionsForLLVMIntrinsic() const noexcept {
+    return UseOpenCLExtInstructionsForLLVMIntrinsic;
+  }
+
   bool shouldPreserveOCLKernelArgTypeMetadataThroughString() const noexcept {
     return PreserveOCLKernelArgTypeMetadataThroughString;
   }
@@ -242,6 +250,11 @@ private:
   // Controls whether llvm.fmuladd.* should be replaced with mad from OpenCL
   // extended instruction set or with a simple fmul + fadd
   bool ReplaceLLVMFmulAddWithOpenCLMad = true;
+
+  // Controls whether llvm math intrinsics should be replaced with instructions
+  // from OpenCL extended instruction set or emulated by native SPIR-V
+  // instructions
+  bool UseOpenCLExtInstructionsForLLVMIntrinsic = true;
 
   // Add a workaround to preserve OpenCL kernel_arg_type and
   // kernel_arg_type_qual metadata through OpString

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -534,6 +534,10 @@ public:
     return TranslationOpts.shouldReplaceLLVMFmulAddWithOpenCLMad();
   }
 
+  bool shouldUseOpenCLExtInstructionsForLLVMIntrinsic() const noexcept {
+    return TranslationOpts.shouldUseOpenCLExtInstructionsForLLVMIntrinsic();
+  }
+
   bool shouldPreserveOCLKernelArgTypeMetadataThroughString() const noexcept {
     return TranslationOpts
         .shouldPreserveOCLKernelArgTypeMetadataThroughString();

--- a/test/llvm-intrinsics/add_sub.sat.ll
+++ b/test/llvm-intrinsics/add_sub.sat.ll
@@ -1,6 +1,16 @@
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,OPENCL
+; RUN: spirv-val %t.spv
+
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-use-ocl-math-for-llvm-intrinsic=true -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,OPENCL
+; RUN: spirv-val %t.spv
+
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-use-ocl-math-for-llvm-intrinsic=false -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,EMULATION
 ; RUN: spirv-val %t.spv
 
 ; Test checks that saturation addition and substraction llvm intrinsics
@@ -9,17 +19,25 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"
 
-; CHECK: ExtInstImport [[ext:[0-9]+]] "OpenCL.std"
+; COMMON: ExtInstImport [[ext:[0-9]+]] "OpenCL.std"
 
-; CHECK: Name [[test_uadd:[0-9]+]] "test_uadd"
-; CHECK: Name [[test_usub:[0-9]+]] "test_usub"
-; CHECK: Name [[test_sadd:[0-9]+]] "test_sadd"
-; CHECK: Name [[test_ssub:[0-9]+]] "test_ssub"
-; CHECK: Name [[test_vectors:[0-9]+]] "test_vectors"
+; COMMON: Name [[test_uadd:[0-9]+]] "test_uadd"
+; COMMON: Name [[test_usub:[0-9]+]] "test_usub"
+; COMMON: Name [[test_sadd:[0-9]+]] "test_sadd"
+; COMMON: Name [[test_ssub:[0-9]+]] "test_ssub"
+; COMMON: Name [[test_vectors:[0-9]+]] "test_vectors"
 
-; CHECK-DAG: TypeInt [[int:[0-9]+]] 32 0
-; CHECK-DAG: TypeVoid [[void:[0-9]+]]
-; CHECK: TypeVector [[vector:[0-9]+]] [[int]] 4
+; COMMON-DAG: TypeInt [[int:[0-9]+]] 32 0
+; COMMON-DAG: TypeVoid [[void:[0-9]+]]
+; COMMON-DAG: TypeVector [[vector:[0-9]+]] [[int]] 4
+
+; EMULATION-DAG: TypeBool [[bool:[0-9]+]]
+; EMULATION-DAG: TypeVector [[vector_bool:[0-9]+]] [[bool]] 4
+; EMULATION-DAG: Constant [[int]] [[uint_max:[0-9]+]] 4294967295
+; EMULATION-DAG: Constant [[int]] [[zero:[0-9]+]] 0
+; EMULATION-DAG: Constant [[int]] [[int_max:[0-9]+]] 2147483647
+; EMULATION-DAG: Constant [[int]] [[int_min:[0-9]+]] 2147483648
+; EMULATION-DAG: ConstantComposite [[vector]] [[vector_uint_max:[0-9]+]] [[uint_max]] [[uint_max]] [[uint_max]] [[uint_max]]
 
 define spir_func void @test_uadd(i32 %a, i32 %b) {
 entry:
@@ -27,13 +45,16 @@ entry:
   ret void
 }
 
-; CHECK: Function [[void]] [[test_uadd]]
-; CHECK-NEXT: FunctionParameter [[int]] [[lhs:[0-9]+]]
-; CHECK-NEXT: FunctionParameter [[int]] [[rhs:[0-9]+]]
-; CHECK-EMPTY:
-; CHECK-NEXT: Label
-; CHECK-NEXT: ExtInst [[int]] {{[0-9]+}} [[ext]] u_add_sat [[lhs]] [[rhs]]
-; CHECK-NEXT: Return
+; COMMON: Function [[void]] [[test_uadd]]
+; COMMON-NEXT: FunctionParameter [[int]] [[lhs:[0-9]+]]
+; COMMON-NEXT: FunctionParameter [[int]] [[rhs:[0-9]+]]
+; COMMON-EMPTY:
+; COMMON-NEXT: Label
+; OPENCL-NEXT: ExtInst [[int]] {{[0-9]+}} [[ext]] u_add_sat [[lhs]] [[rhs]]
+; EMULATION-NEXT: IAdd [[int]] [[add:[0-9]+]] [[lhs]] [[rhs]]
+; EMULATION-NEXT: UGreaterThan [[bool]] [[greater:[0-9]+]] [[add]] [[lhs]]
+; EMULATION-NEXT: Select [[int]] {{[0-9]+}} [[greater]] [[add]] [[uint_max]]
+; COMMON-NEXT: Return
 
 define spir_func void @test_usub(i32 %a, i32 %b) {
 entry:
@@ -41,13 +62,16 @@ entry:
   ret void
 }
 
-; CHECK: Function [[void]] [[test_usub]]
-; CHECK-NEXT: FunctionParameter [[int]] [[lhs:[0-9]+]]
-; CHECK-NEXT: FunctionParameter [[int]] [[rhs:[0-9]+]]
-; CHECK-EMPTY:
-; CHECK-NEXT: Label
-; CHECK-NEXT: ExtInst [[int]] {{[0-9]+}} [[ext]] u_sub_sat [[lhs]] [[rhs]]
-; CHECK-NEXT: Return
+; COMMON: Function [[void]] [[test_usub]]
+; COMMON-NEXT: FunctionParameter [[int]] [[lhs:[0-9]+]]
+; COMMON-NEXT: FunctionParameter [[int]] [[rhs:[0-9]+]]
+; COMMON-EMPTY:
+; COMMON-NEXT: Label
+; OPENCL-NEXT: ExtInst [[int]] {{[0-9]+}} [[ext]] u_sub_sat [[lhs]] [[rhs]]
+; EMULATION-NEXT: ISub [[int]] [[sub:[0-9]+]] [[lhs]] [[rhs]]
+; EMULATION-NEXT: UGreaterThan [[bool]] [[greater:[0-9]+]] [[lhs]] [[rhs]]
+; EMULATION-NEXT: Select [[int]] {{[0-9]+}} [[greater]] [[sub]] [[zero]]
+; COMMON-NEXT: Return
 
 define spir_func void @test_sadd(i32 %a, i32 %b) {
 entry:
@@ -55,13 +79,24 @@ entry:
   ret void
 }
 
-; CHECK: Function [[void]] [[test_sadd]]
-; CHECK-NEXT: FunctionParameter [[int]] [[lhs:[0-9]+]]
-; CHECK-NEXT: FunctionParameter [[int]] [[rhs:[0-9]+]]
-; CHECK-EMPTY:
-; CHECK-NEXT: Label
-; CHECK-NEXT: ExtInst [[int]] {{[0-9]+}} [[ext]] s_add_sat [[lhs]] [[rhs]]
-; CHECK-NEXT: Return
+; COMMON: Function [[void]] [[test_sadd]]
+; COMMON-NEXT: FunctionParameter [[int]] [[lhs:[0-9]+]]
+; COMMON-NEXT: FunctionParameter [[int]] [[rhs:[0-9]+]]
+; COMMON-EMPTY:
+; COMMON-NEXT: Label
+; OPENCL-NEXT: ExtInst [[int]] {{[0-9]+}} [[ext]] s_add_sat [[lhs]] [[rhs]]
+; EMULATION-NEXT: SGreaterThan [[bool]] [[greater1:[0-9]+]] [[rhs]] [[zero]]
+; EMULATION-NEXT: SLessThan [[bool]] [[less:[0-9]+]] [[rhs]] [[zero]]
+; EMULATION-NEXT: IAdd [[int]] [[add:[0-9]+]] [[lhs]] [[rhs]]
+; EMULATION-NEXT: ISub [[int]] [[sub1:[0-9]+]] [[int_max]] [[rhs]]
+; EMULATION-NEXT: SGreaterThan [[bool]] [[greater2:[0-9]+]] [[lhs]] [[sub1]]
+; EMULATION-NEXT: LogicalAnd [[bool]] [[and1:[0-9]+]] [[greater2]] [[greater1]]
+; EMULATION-NEXT: ISub [[int]] [[sub2:[0-9]+]] [[int_min]] [[rhs]]
+; EMULATION-NEXT: SGreaterThan [[bool]] [[greater3:[0-9]+]] [[sub2]] [[lhs]]
+; EMULATION-NEXT: LogicalAnd [[bool]] [[and2:[0-9]+]] [[greater3]] [[less]]
+; EMULATION-NEXT: Select [[int]] [[select:[0-9]+]] [[and1]] [[int_max]] [[add]]
+; EMULATION-NEXT: Select [[int]] {{[0-9]+}} [[and2]] [[int_min]] [[select]]
+; COMMON-NEXT: Return
 
 define spir_func void @test_ssub(i32 %a, i32 %b) {
 entry:
@@ -69,13 +104,24 @@ entry:
   ret void
 }
 
-; CHECK: Function [[void]] [[test_ssub]]
-; CHECK-NEXT: FunctionParameter [[int]] [[lhs:[0-9]+]]
-; CHECK-NEXT: FunctionParameter [[int]] [[rhs:[0-9]+]]
-; CHECK-EMPTY:
-; CHECK-NEXT: Label
-; CHECK-NEXT: ExtInst [[int]] {{[0-9]+}} [[ext]] s_sub_sat [[lhs]] [[rhs]]
-; CHECK-NEXT: Return
+; COMMON: Function [[void]] [[test_ssub]]
+; COMMON-NEXT: FunctionParameter [[int]] [[lhs:[0-9]+]]
+; COMMON-NEXT: FunctionParameter [[int]] [[rhs:[0-9]+]]
+; COMMON-EMPTY:
+; COMMON-NEXT: Label
+; OPENCL-NEXT: ExtInst [[int]] {{[0-9]+}} [[ext]] s_sub_sat [[lhs]] [[rhs]]
+; EMULATION-NEXT: SGreaterThan [[bool]] [[greater1:[0-9]+]] [[rhs]] [[zero]]
+; EMULATION-NEXT: SLessThan [[bool]] [[less:[0-9]+]] [[rhs]] [[zero]]
+; EMULATION-NEXT: ISub [[int]] [[sub1:[0-9]+]] [[lhs]] [[rhs]]
+; EMULATION-NEXT: IAdd [[int]] [[add1:[0-9]+]] [[int_min]] [[rhs]]
+; EMULATION-NEXT: SGreaterThan [[bool]] [[greater2:[0-9]+]] [[add1]] [[lhs]]
+; EMULATION-NEXT: LogicalAnd [[bool]] [[and1:[0-9]+]] [[greater2]] [[greater1]]
+; EMULATION-NEXT: IAdd [[int]] [[add2:[0-9]+]] [[int_max]] [[rhs]]
+; EMULATION-NEXT: SGreaterThan [[bool]] [[greater3:[0-9]+]] [[lhs]] [[add2]]
+; EMULATION-NEXT: LogicalAnd [[bool]] [[and2:[0-9]+]] [[greater3]] [[less]]
+; EMULATION-NEXT: Select [[int]] [[select:[0-9]+]] [[and2]] [[int_max]] [[sub1]]
+; EMULATION-NEXT: Select [[int]] {{[0-9]+}} [[and1]] [[int_min]] [[select]]
+; COMMON-NEXT: Return
 
 define spir_func void @test_vectors(<4 x i32> %a, <4 x i32> %b) {
 entry:
@@ -83,13 +129,16 @@ entry:
   ret void
 }
 
-; CHECK: Function [[void]] [[test_vectors]]
-; CHECK-NEXT: FunctionParameter [[vector]] [[lhs:[0-9]+]]
-; CHECK-NEXT: FunctionParameter [[vector]] [[rhs:[0-9]+]]
-; CHECK-EMPTY:
-; CHECK-NEXT: Label
-; CHECK-NEXT: ExtInst [[vector]] {{[0-9]+}} [[ext]] u_add_sat [[lhs]] [[rhs]]
-; CHECK-NEXT: Return
+; COMMON: Function [[void]] [[test_vectors]]
+; COMMON-NEXT: FunctionParameter [[vector]] [[lhs:[0-9]+]]
+; COMMON-NEXT: FunctionParameter [[vector]] [[rhs:[0-9]+]]
+; COMMON-EMPTY:
+; COMMON-NEXT: Label
+; OPENCL-NEXT: ExtInst [[vector]] {{[0-9]+}} [[ext]] u_add_sat [[lhs]] [[rhs]]
+; EMULATION-NEXT: IAdd [[vector]] [[add:[0-9]+]] [[lhs]] [[rhs]]
+; EMULATION-NEXT: UGreaterThan [[vector_bool]] [[greater:[0-9]+]] [[add]] [[lhs]]
+; EMULATION-NEXT: Select [[vector]] {{[0-9]+}} [[greater]] [[add]] [[vector_uint_max]]
+; COMMON-NEXT: Return
 
 declare i32 @llvm.uadd.sat.i32(i32, i32);
 declare i32 @llvm.usub.sat.i32(i32, i32);

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -258,6 +258,12 @@ static cl::opt<SPIRV::BuiltinFormat> SPIRVBuiltinFormat(
         clEnumValN(SPIRV::BuiltinFormat::Global, "global",
                    "Use globals to represent SPIR-V builtin variables")));
 
+static cl::opt<bool> SPIRVUseOpenCLExtInstructionsForLLVMIntrinsic(
+    "spirv-use-ocl-math-for-llvm-intrinsic", cl::init(true),
+    cl::desc("Allow to use OpenCL.ExtendedInstructionSet.100 to translate "
+             "LLVM math intrinsics. Otherwise use emulation for these "
+             "intrinsics)"));
+
 static std::string removeExt(const std::string &FileName) {
   size_t Pos = FileName.find_last_of(".");
   if (Pos != std::string::npos)
@@ -754,6 +760,16 @@ int main(int Ac, char **Av) {
     } else {
       Opts.setReplaceLLVMFmulAddWithOpenCLMad(
           SPIRVReplaceLLVMFmulAddWithOpenCLMad);
+    }
+  }
+
+  if (SPIRVUseOpenCLExtInstructionsForLLVMIntrinsic.getNumOccurrences() != 0) {
+    if (IsReverse) {
+      errs() << "Note: --spirv-use-ocl-math-for-llvm-intrinsic option ignored "
+                "as it only affects translation from LLVM IR to SPIR-V";
+    } else {
+      Opts.setUseOpenCLExtInstructionsForLLVMIntrinsic(
+          SPIRVUseOpenCLExtInstructionsForLLVMIntrinsic);
     }
   }
 


### PR DESCRIPTION
While the translator was built around OpenCL - other targets that support SPIR-V and don't support OpenCL might use it.

This patch adds --spirv-use-ocl-math-for-llvm-intrinsic option to control whether we should translate them as math intrinsics to OpenCL ext math instructions or emulate. Default is true aka translate as math instructions.

I don't really want to end up implementing Quake's sqrt algorithm, but it's a possible scenario as well.

Plans are:
1. merge existing --spirv-replace-fmuladd-with-ocl-mad with the new option;
2. optionally introduce InstCombine pass in reverse translation.