### PR TITLE
Only require Shader capability if unavoidable

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3615,7 +3615,9 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     return nullptr;
   }
   case Intrinsic::bitreverse: {
-    BM->addCapability(CapabilityShader);
+    if (!BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_bit_instructions)) {
+      BM->addCapability(CapabilityShader);
+    }
     SPIRVType *Ty = transType(II->getType());
     SPIRVValue *Op = transValue(II->getArgOperand(0), BB);
     return BM->addUnaryInst(OpBitReverse, Ty, Op, BB);

--- a/test/extensions/KHR/SPV_KHR_bit_instructions/capabilities.ll
+++ b/test/extensions/KHR/SPV_KHR_bit_instructions/capabilities.ll
@@ -1,0 +1,42 @@
+; RUN: llvm-as %s -o %t.bc
+
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=-SPV_KHR_bit_instructions -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-COMMON,CHECK-WITHOUT-EXT
+
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_KHR_bit_instructions -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-COMMON,CHECK-WITH-EXT
+
+; CHECK-WITHOUT-EXT: Capability Shader
+
+; CHECK-WITH-EXT-NOT: Capability Shader
+; CHECK-WITH-EXT: Capability BitInstructions
+; CHECK-WITH-EXT-NOT: Capability Shader
+; CHECK-WITH-EXT: Extension "SPV_KHR_bit_instructions"
+
+; CHECK-COMMON: 4 BitReverse
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @TestSatPacked(i32 %0, i32 %1) #0 {
+  %3 = call i32 @llvm.bitreverse.i32(i32 %0)
+  ret void
+}
+
+declare i32 @llvm.bitreverse.i32(i32) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+
+!spirv.MemoryModel = !{!0}
+!spirv.Source = !{!1}
+!opencl.spir.version = !{!2}
+!opencl.ocl.version = !{!2}
+!opencl.used.extensions = !{!3}
+!opencl.used.optional.core.features = !{!3}
+
+!0 = !{i32 2, i32 2}
+!1 = !{i32 3, i32 102000}
+!2 = !{i32 1, i32 2}
+!3 = !{}


### PR DESCRIPTION
Requiring the `Shader` capability for any module that uses `llvm.bitreverse` is problematic for OpenCL execution environments. Only require the `Shader` capability if we cannot use the `BitInstructions` capability.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2139