### PR TITLE
Convert tests to opaque pointers, preserving metadata

### DIFF
--- a/test/AtomicBuiltinsFloat.ll
+++ b/test/AtomicBuiltinsFloat.ll
@@ -14,51 +14,51 @@ target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:2
 target triple = "spir-unknown-unknown"
 
 ; Function Attrs: convergent norecurse nounwind
-define dso_local spir_kernel void @test_atomic_kernel(float addrspace(3)* %ff) local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
+define dso_local spir_kernel void @test_atomic_kernel(ptr addrspace(3) %ff) local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_base_type !5 !kernel_arg_type_qual !6 {
 entry:
-  %0 = addrspacecast float addrspace(3)* %ff to float addrspace(4)*
-  tail call spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
-  tail call spir_func void @_Z12atomic_storePU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
-  tail call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)* %0, float 1.000000e+00, i32 0) #2
-  tail call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)* %0, float 1.000000e+00, i32 0, i32 1) #2
-  %call = tail call spir_func float @_Z11atomic_loadPU3AS4VU7_Atomicf(float addrspace(4)* %0) #2
-  %call1 = tail call spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order(float addrspace(4)* %0, i32 0) #2
-  %call2 = tail call spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order12memory_scope(float addrspace(4)* %0, i32 0, i32 1) #2
-  %call3 = tail call spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(float addrspace(4)* %0, float 1.000000e+00) #2
-  %call4 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)* %0, float 1.000000e+00, i32 0) #2
-  %call5 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)* %0, float 1.000000e+00, i32 0, i32 1) #2
+  %0 = addrspacecast ptr addrspace(3) %ff to ptr addrspace(4)
+  tail call spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(ptr addrspace(4) %0, float 1.000000e+00) #2
+  tail call spir_func void @_Z12atomic_storePU3AS4VU7_Atomicff(ptr addrspace(4) %0, float 1.000000e+00) #2
+  tail call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order(ptr addrspace(4) %0, float 1.000000e+00, i32 0) #2
+  tail call spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(ptr addrspace(4) %0, float 1.000000e+00, i32 0, i32 1) #2
+  %call = tail call spir_func float @_Z11atomic_loadPU3AS4VU7_Atomicf(ptr addrspace(4) %0) #2
+  %call1 = tail call spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order(ptr addrspace(4) %0, i32 0) #2
+  %call2 = tail call spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order12memory_scope(ptr addrspace(4) %0, i32 0, i32 1) #2
+  %call3 = tail call spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(ptr addrspace(4) %0, float 1.000000e+00) #2
+  %call4 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(ptr addrspace(4) %0, float 1.000000e+00, i32 0) #2
+  %call5 = tail call spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(ptr addrspace(4) %0, float 1.000000e+00, i32 0, i32 1) #2
   ret void
 }
 
 ; Function Attrs: convergent
-declare spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
+declare spir_func void @_Z11atomic_initPU3AS4VU7_Atomicff(ptr addrspace(4), float) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func void @_Z12atomic_storePU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
+declare spir_func void @_Z12atomic_storePU3AS4VU7_Atomicff(ptr addrspace(4), float) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)*, float, i32) local_unnamed_addr #1
+declare spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order(ptr addrspace(4), float, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)*, float, i32, i32) local_unnamed_addr #1
+declare spir_func void @_Z21atomic_store_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(ptr addrspace(4), float, i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func float @_Z11atomic_loadPU3AS4VU7_Atomicf(float addrspace(4)*) local_unnamed_addr #1
+declare spir_func float @_Z11atomic_loadPU3AS4VU7_Atomicf(ptr addrspace(4)) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order(float addrspace(4)*, i32) local_unnamed_addr #1
+declare spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order(ptr addrspace(4), i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order12memory_scope(float addrspace(4)*, i32, i32) local_unnamed_addr #1
+declare spir_func float @_Z20atomic_load_explicitPU3AS4VU7_Atomicf12memory_order12memory_scope(ptr addrspace(4), i32, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(float addrspace(4)*, float) local_unnamed_addr #1
+declare spir_func float @_Z15atomic_exchangePU3AS4VU7_Atomicff(ptr addrspace(4), float) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(float addrspace(4)*, float, i32) local_unnamed_addr #1
+declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order(ptr addrspace(4), float, i32) local_unnamed_addr #1
 
 ; Function Attrs: convergent
-declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(float addrspace(4)*, float, i32, i32) local_unnamed_addr #1
+declare spir_func float @_Z24atomic_exchange_explicitPU3AS4VU7_Atomicff12memory_order12memory_scope(ptr addrspace(4), float, i32, i32) local_unnamed_addr #1
 
 attributes #0 = { convergent norecurse nounwind "frame-pointer"="none" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "uniform-work-group-size"="false" }
 attributes #1 = { convergent "frame-pointer"="none" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }

--- a/test/SamplerArgNonKernel.ll
+++ b/test/SamplerArgNonKernel.ll
@@ -29,14 +29,13 @@ entry:
 declare spir_func <4 x i32> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), i32, <2 x i32>) #1
 
 ; Function Attrs: nounwind
-define spir_kernel void @test2(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %Img, float addrspace(1)* %result) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @test2(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %Img, ptr addrspace(1) %result) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 ;CHECK: Function  {{[0-9]+}} [[KernelId]]
 entry:
   %call = call spir_func float @test(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %Img, i32 0)
-  %arrayidx = getelementptr inbounds float, float addrspace(1)* %result, i32 0
-  %0 = load float, float addrspace(1)* %arrayidx, align 4
+  %0 = load float, ptr addrspace(1) %result, align 4
   %add = fadd float %0, %call
-  store float %add, float addrspace(1)* %arrayidx, align 4
+  store float %add, ptr addrspace(1) %result, align 4
   ret void
 }
 

--- a/test/half_no_extension.ll
+++ b/test/half_no_extension.ll
@@ -19,24 +19,23 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64-unknown-unknown"
 
 ; Function Attrs: nounwind
-define spir_kernel void @test(<4 x float> addrspace(1)* %p, half addrspace(1)* %f) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define spir_kernel void @test(ptr addrspace(1) %p, ptr addrspace(1) %f) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
-  %p.addr = alloca <4 x float> addrspace(1)*, align 8
-  %f.addr = alloca half addrspace(1)*, align 8
+  %p.addr = alloca ptr addrspace(1), align 8
+  %f.addr = alloca ptr addrspace(1), align 8
   %data = alloca <4 x float>, align 16
-  store <4 x float> addrspace(1)* %p, <4 x float> addrspace(1)** %p.addr, align 8
-  store half addrspace(1)* %f, half addrspace(1)** %f.addr, align 8
-  %0 = load <4 x float> addrspace(1)*, <4 x float> addrspace(1)** %p.addr, align 8
-  %arrayidx = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %0, i64 0
-  %1 = load <4 x float>, <4 x float> addrspace(1)* %arrayidx, align 16
-  store <4 x float> %1, <4 x float>* %data, align 16
-  %2 = load <4 x float>, <4 x float>* %data, align 16
-  %3 = load half addrspace(1)*, half addrspace(1)** %f.addr, align 8
-  call spir_func void @_Z17vstorea_half4_rtpDv4_fmPU3AS1Dh(<4 x float> %2, i64 0, half addrspace(1)* %3)
+  store ptr addrspace(1) %p, ptr %p.addr, align 8
+  store ptr addrspace(1) %f, ptr %f.addr, align 8
+  %0 = load ptr addrspace(1), ptr %p.addr, align 8
+  %1 = load <4 x float>, ptr addrspace(1) %0, align 16
+  store <4 x float> %1, ptr %data, align 16
+  %2 = load <4 x float>, ptr %data, align 16
+  %3 = load ptr addrspace(1), ptr %f.addr, align 8
+  call spir_func void @_Z17vstorea_half4_rtpDv4_fmPU3AS1Dh(<4 x float> %2, i64 0, ptr addrspace(1) %3)
   ret void
 }
 
-declare spir_func void @_Z17vstorea_half4_rtpDv4_fmPU3AS1Dh(<4 x float>, i64, half addrspace(1)*) #1
+declare spir_func void @_Z17vstorea_half4_rtpDv4_fmPU3AS1Dh(<4 x float>, i64, ptr addrspace(1)) #1
 
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }

--- a/test/link-attribute.ll
+++ b/test/link-attribute.ll
@@ -13,7 +13,7 @@ target triple = "spir64-unknown-unknown"
 @imageSampler = addrspace(2) constant i32 36, align 4
 
 ; Function Attrs: nounwind
-define spir_kernel void @sample_kernel(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %input, float addrspace(1)* nocapture %xOffsets, float addrspace(1)* nocapture %yOffsets, <4 x float> addrspace(1)* nocapture %results) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
+define spir_kernel void @sample_kernel(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %input, ptr addrspace(1) nocapture %xOffsets, ptr addrspace(1) nocapture %yOffsets, ptr addrspace(1) nocapture %results) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !5 !kernel_arg_type_qual !4 {
   %1 = tail call spir_func i64 @_Z13get_global_idj(i32 0) #1
   %2 = trunc i64 %1 to i32
   %3 = tail call spir_func i64 @_Z13get_global_idj(i32 1) #1
@@ -27,8 +27,8 @@ define spir_kernel void @sample_kernel(target("spirv.Image", void, 1, 0, 0, 0, 0
   %11 = insertelement <2 x float> %9, float %10, i32 1
   %12 = tail call spir_func <4 x float> @_Z11read_imagef11ocl_image2d11ocl_samplerDv2_f(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %input, i32 36, <2 x float> %11) #1
   %13 = sext i32 %7 to i64
-  %14 = getelementptr inbounds <4 x float>, <4 x float> addrspace(1)* %results, i64 %13
-  store <4 x float> %12, <4 x float> addrspace(1)* %14, align 16, !tbaa !11
+  %14 = getelementptr inbounds <4 x float>, ptr addrspace(1) %results, i64 %13
+  store <4 x float> %12, ptr addrspace(1) %14, align 16, !tbaa !11
   ret void
 }
 

--- a/test/simple.ll
+++ b/test/simple.ll
@@ -7,28 +7,25 @@ target triple = "spir64-unknown-unknown"
 ; CHECK: Capability Float64
 ; CHECK: "fun01"
 ; Function Attrs: nounwind
-define spir_kernel void @fun01(i32 addrspace(1)* noalias %a, i32 addrspace(1)* %b, i32 %c) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 !reqd_work_group_size !6 {
+define spir_kernel void @fun01(ptr addrspace(1) noalias %a, ptr addrspace(1) %b, i32 %c) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 !reqd_work_group_size !6 {
 entry:
-  %a.addr = alloca i32 addrspace(1)*, align 8
-  %b.addr = alloca i32 addrspace(1)*, align 8
+  %a.addr = alloca ptr addrspace(1), align 8
+  %b.addr = alloca ptr addrspace(1), align 8
   %c.addr = alloca i32, align 4
-  store i32 addrspace(1)* %a, i32 addrspace(1)** %a.addr, align 8
-  store i32 addrspace(1)* %b, i32 addrspace(1)** %b.addr, align 8
-  store i32 %c, i32* %c.addr, align 4
-  %0 = load i32 addrspace(1)*, i32 addrspace(1)** %b.addr, align 8
-  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %0, i64 0
-  %1 = load i32, i32 addrspace(1)* %arrayidx, align 4
-  %2 = load i32 addrspace(1)*, i32 addrspace(1)** %a.addr, align 8
-  %arrayidx1 = getelementptr inbounds i32, i32 addrspace(1)* %2, i64 0
-  store i32 %1, i32 addrspace(1)* %arrayidx1, align 4
-  %3 = load i32 addrspace(1)*, i32 addrspace(1)** %b.addr, align 8
-  %cmp = icmp ugt i32 addrspace(1)* %3, null
+  store ptr addrspace(1) %a, ptr %a.addr, align 8
+  store ptr addrspace(1) %b, ptr %b.addr, align 8
+  store i32 %c, ptr %c.addr, align 4
+  %0 = load ptr addrspace(1), ptr %b.addr, align 8
+  %1 = load i32, ptr addrspace(1) %0, align 4
+  %2 = load ptr addrspace(1), ptr %a.addr, align 8
+  store i32 %1, ptr addrspace(1) %2, align 4
+  %3 = load ptr addrspace(1), ptr %b.addr, align 8
+  %cmp = icmp ugt ptr addrspace(1) %3, null
   br i1 %cmp, label %if.then, label %if.end
 
 if.then:                                          ; preds = %entry
-  %4 = load i32 addrspace(1)*, i32 addrspace(1)** %a.addr, align 8
-  %arrayidx2 = getelementptr inbounds i32, i32 addrspace(1)* %4, i64 0
-  store i32 2, i32 addrspace(1)* %arrayidx2, align 4
+  %4 = load ptr addrspace(1), ptr %a.addr, align 8
+  store i32 2, ptr addrspace(1) %4, align 4
   br label %if.end
 
 if.end:                                           ; preds = %if.then, %entry
@@ -37,50 +34,50 @@ if.end:                                           ; preds = %if.then, %entry
 
 ; CHECK: "fun02"
 ; Function Attrs: nounwind
-define spir_kernel void @fun02(double addrspace(1)* %a, double addrspace(1)* %b, i32 %c) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !8 !kernel_arg_base_type !9 !kernel_arg_type_qual !10 !vec_type_hint !11 {
+define spir_kernel void @fun02(ptr addrspace(1) %a, ptr addrspace(1) %b, i32 %c) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !8 !kernel_arg_base_type !9 !kernel_arg_type_qual !10 !vec_type_hint !11 {
 entry:
-  %a.addr = alloca double addrspace(1)*, align 8
-  %b.addr = alloca double addrspace(1)*, align 8
+  %a.addr = alloca ptr addrspace(1), align 8
+  %b.addr = alloca ptr addrspace(1), align 8
   %c.addr = alloca i32, align 4
-  store double addrspace(1)* %a, double addrspace(1)** %a.addr, align 8
-  store double addrspace(1)* %b, double addrspace(1)** %b.addr, align 8
-  store i32 %c, i32* %c.addr, align 4
-  %0 = load i32, i32* %c.addr, align 4
+  store ptr addrspace(1) %a, ptr %a.addr, align 8
+  store ptr addrspace(1) %b, ptr %b.addr, align 8
+  store i32 %c, ptr %c.addr, align 4
+  %0 = load i32, ptr %c.addr, align 4
   %idxprom = sext i32 %0 to i64
-  %1 = load double addrspace(1)*, double addrspace(1)** %b.addr, align 8
-  %arrayidx = getelementptr inbounds double, double addrspace(1)* %1, i64 %idxprom
-  %2 = load double, double addrspace(1)* %arrayidx, align 8
-  %3 = load i32, i32* %c.addr, align 4
+  %1 = load ptr addrspace(1), ptr %b.addr, align 8
+  %arrayidx = getelementptr inbounds double, ptr addrspace(1) %1, i64 %idxprom
+  %2 = load double, ptr addrspace(1) %arrayidx, align 8
+  %3 = load i32, ptr %c.addr, align 4
   %idxprom1 = sext i32 %3 to i64
-  %4 = load double addrspace(1)*, double addrspace(1)** %a.addr, align 8
-  %arrayidx2 = getelementptr inbounds double, double addrspace(1)* %4, i64 %idxprom1
-  store double %2, double addrspace(1)* %arrayidx2, align 8
+  %4 = load ptr addrspace(1), ptr %a.addr, align 8
+  %arrayidx2 = getelementptr inbounds double, ptr addrspace(1) %4, i64 %idxprom1
+  store double %2, ptr addrspace(1) %arrayidx2, align 8
   ret void
 }
 
 ; CHECK: "test_builtin"
 ; Function Attrs: nounwind
-define spir_func void @test_builtin(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
+define spir_func void @test_builtin(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 {
 entry:
-  %in.addr = alloca i32 addrspace(1)*, align 8
-  %out.addr = alloca i32 addrspace(1)*, align 8
+  %in.addr = alloca ptr addrspace(1), align 8
+  %out.addr = alloca ptr addrspace(1), align 8
   %n = alloca i32, align 4
-  store i32 addrspace(1)* %in, i32 addrspace(1)** %in.addr, align 8
-  store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 8
+  store ptr addrspace(1) %in, ptr %in.addr, align 8
+  store ptr addrspace(1) %out, ptr %out.addr, align 8
   %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
   %conv = trunc i64 %call to i32
-  store i32 %conv, i32* %n, align 4
-  %0 = load i32, i32* %n, align 4
+  store i32 %conv, ptr %n, align 4
+  %0 = load i32, ptr %n, align 4
   %idxprom = sext i32 %0 to i64
-  %1 = load i32 addrspace(1)*, i32 addrspace(1)** %in.addr, align 8
-  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %idxprom
-  %2 = load i32, i32 addrspace(1)* %arrayidx, align 4
+  %1 = load ptr addrspace(1), ptr %in.addr, align 8
+  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %1, i64 %idxprom
+  %2 = load i32, ptr addrspace(1) %arrayidx, align 4
   %call1 = call spir_func i32 @_Z3absi(i32 %2) #2
-  %3 = load i32, i32* %n, align 4
+  %3 = load i32, ptr %n, align 4
   %idxprom2 = sext i32 %3 to i64
-  %4 = load i32 addrspace(1)*, i32 addrspace(1)** %out.addr, align 8
-  %arrayidx3 = getelementptr inbounds i32, i32 addrspace(1)* %4, i64 %idxprom2
-  store i32 %call1, i32 addrspace(1)* %arrayidx3, align 4
+  %4 = load ptr addrspace(1), ptr %out.addr, align 8
+  %arrayidx3 = getelementptr inbounds i32, ptr addrspace(1) %4, i64 %idxprom2
+  store i32 %call1, ptr addrspace(1) %arrayidx3, align 4
   ret void
 }
 
@@ -97,35 +94,35 @@ declare spir_func i32 @_Z3absi(i32) #1
 define spir_func i32 @myabs(i32 %x) #0 {
 entry:
   %x.addr = alloca i32, align 4
-  store i32 %x, i32* %x.addr, align 4
-  %0 = load i32, i32* %x.addr, align 4
+  store i32 %x, ptr %x.addr, align 4
+  %0 = load i32, ptr %x.addr, align 4
   %call = call spir_func i32 @_Z3absi(i32 %0) #2
   ret i32 %call
 }
 
 ; CHECK: "test_function_call"
 ; Function Attrs: nounwind
-define spir_func void @test_function_call(i32 addrspace(1)* %in, i32 addrspace(1)* %out) #0 {
+define spir_func void @test_function_call(ptr addrspace(1) %in, ptr addrspace(1) %out) #0 {
 entry:
-  %in.addr = alloca i32 addrspace(1)*, align 8
-  %out.addr = alloca i32 addrspace(1)*, align 8
+  %in.addr = alloca ptr addrspace(1), align 8
+  %out.addr = alloca ptr addrspace(1), align 8
   %n = alloca i32, align 4
-  store i32 addrspace(1)* %in, i32 addrspace(1)** %in.addr, align 8
-  store i32 addrspace(1)* %out, i32 addrspace(1)** %out.addr, align 8
+  store ptr addrspace(1) %in, ptr %in.addr, align 8
+  store ptr addrspace(1) %out, ptr %out.addr, align 8
   %call = call spir_func i64 @_Z13get_global_idj(i32 0) #2
   %conv = trunc i64 %call to i32
-  store i32 %conv, i32* %n, align 4
-  %0 = load i32, i32* %n, align 4
+  store i32 %conv, ptr %n, align 4
+  %0 = load i32, ptr %n, align 4
   %idxprom = sext i32 %0 to i64
-  %1 = load i32 addrspace(1)*, i32 addrspace(1)** %in.addr, align 8
-  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %1, i64 %idxprom
-  %2 = load i32, i32 addrspace(1)* %arrayidx, align 4
+  %1 = load ptr addrspace(1), ptr %in.addr, align 8
+  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %1, i64 %idxprom
+  %2 = load i32, ptr addrspace(1) %arrayidx, align 4
   %call1 = call spir_func i32 @myabs(i32 %2)
-  %3 = load i32, i32* %n, align 4
+  %3 = load i32, ptr %n, align 4
   %idxprom2 = sext i32 %3 to i64
-  %4 = load i32 addrspace(1)*, i32 addrspace(1)** %out.addr, align 8
-  %arrayidx3 = getelementptr inbounds i32, i32 addrspace(1)* %4, i64 %idxprom2
-  store i32 %call1, i32 addrspace(1)* %arrayidx3, align 4
+  %4 = load ptr addrspace(1), ptr %out.addr, align 8
+  %arrayidx3 = getelementptr inbounds i32, ptr addrspace(1) %4, i64 %idxprom2
+  store i32 %call1, ptr addrspace(1) %arrayidx3, align 4
   ret void
 }
 

--- a/test/sitofp-with-bool.ll
+++ b/test/sitofp-with-bool.ll
@@ -21,11 +21,11 @@ target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:
 target triple = "spir64"
 
 ; Function Attrs: nofree norecurse nounwind writeonly
-define dso_local spir_kernel void @K(float addrspace(1)* nocapture %A, i32 %B) local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define dso_local spir_kernel void @K(ptr addrspace(1) nocapture %A, i32 %B) local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
   %cmp = icmp sgt i32 %B, 0
   %conv = sitofp i1 %cmp to float
-  store float %conv, float addrspace(1)* %A, align 4
+  store float %conv, ptr addrspace(1) %A, align 4
   ret void
 }
 

--- a/test/uitofp-with-bool.ll
+++ b/test/uitofp-with-bool.ll
@@ -85,7 +85,7 @@ target triple = "spir64"
 ; SPV-DAG: FunctionParameter {{[0-9]+}} [[i1v:[0-9]+]]
 
 ; Function Attrs: nofree norecurse nounwind writeonly
-define dso_local spir_kernel void @K(float addrspace(1)* nocapture %A, i32 %B, i1 %i1s, <2 x i1> %i1v) local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+define dso_local spir_kernel void @K(ptr addrspace(1) nocapture %A, i32 %B, i1 %i1s, <2 x i1> %i1v) local_unnamed_addr #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
 entry:
 
 
@@ -99,7 +99,7 @@ entry:
   %conv = uitofp i1 %cmp to float
 ; SPV-DAG: Store [[A]] [[utof_res]]
 ; LLVM-DAG: store float %conv, ptr addrspace(1) %A, align 4
-  store float %conv, float addrspace(1)* %A, align 4;
+  store float %conv, ptr addrspace(1) %A, align 4;
 
 ; SPV-DAG: Select [[int_8]] [[s1]] [[i1s]] [[mone_8]] [[zero_8]]
 ; LLVM-DAG: %s1 = select i1 %i1s, i8 -1, i8 0


### PR DESCRIPTION
Bulk-convert some of the remaining tests using the migration script, while manually ensuring that kernel argument metadata is left unchanged.  This converts most of the tests that were taken out of #2134 after @vmaksimo noticed that kernel argument metadata was inadvertently changed by the migration script.