### PR TITLE
Fix check for (neg) zero for fpclass emulation

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4432,14 +4432,14 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
             GetNegPosInstTest(TestIsSubnormal, FPClass & fcNegSubnormal)));
     }
     if (FPClass & fcZero) {
-      // Create zero integer constant and check for equality with bitcasted to
+      // Create zero integer constant and check for equality with converted to
       // int float value
-      auto *BitCastToInt =
-          BM->addUnaryInst(OpBitcast, OpSPIRVTy, InputFloat, BB);
+      auto *Convert =
+          BM->addUnaryInst(OpConvertFToU, OpSPIRVTy, InputFloat, BB);
       auto *ZeroConst = transValue(
           Constant::getIntegerValue(IntOpLLVMTy, APInt::getZero(BitSize)), BB);
       auto *TestIsZero =
-          BM->addCmpInst(OpIEqual, ResTy, BitCastToInt, ZeroConst, BB);
+          BM->addCmpInst(OpIEqual, ResTy, Convert, ZeroConst, BB);
       if (FPClass & fcPosZero && FPClass & fcNegZero)
         ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsZero));
       else

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4434,8 +4434,8 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     if (FPClass & fcZero) {
       // Create zero integer constant and check for equality with bitcasted to
       // int float value
-      auto SetUpCMPToZero = [&](SPIRVValue *BitCastToInt, bool IsPositive)
-        -> SPIRVValue * {
+      auto SetUpCMPToZero = [&](SPIRVValue *BitCastToInt,
+                                bool IsPositive) -> SPIRVValue * {
         APInt ZeroInt = APInt::getZero(BitSize);
         if (IsPositive) {
           auto *ZeroConst =

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4437,20 +4437,19 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       auto *BitCastToInt =
           BM->addUnaryInst(OpBitcast, OpSPIRVTy, InputFloat, BB);
       APInt ZeroInt = APInt::getZero(BitSize);
-      auto *ZeroConst = transValue(
-          Constant::getIntegerValue(IntOpLLVMTy, ZeroInt), BB);
+      auto *ZeroConst =
+          transValue(Constant::getIntegerValue(IntOpLLVMTy, ZeroInt), BB);
       ZeroInt.setSignBit();
-      auto *NegZeroConst = transValue(
-          Constant::getIntegerValue(IntOpLLVMTy, ZeroInt), BB);
+      auto *NegZeroConst =
+          transValue(Constant::getIntegerValue(IntOpLLVMTy, ZeroInt), BB);
       if (FPClass & fcPosZero && FPClass & fcNegZero) {
         auto *TestIsPosZero =
             BM->addCmpInst(OpIEqual, ResTy, BitCastToInt, ZeroConst, BB);
         auto *TestIsNegZero =
             BM->addCmpInst(OpIEqual, ResTy, BitCastToInt, NegZeroConst, BB);
-        auto *TestIsZero =
-            BM->addInstTemplate(OpLogicalOr, {TestIsPosZero->getId(),
-                                              TestIsNegZero->getId()}, BB,
-                                              ResTy);
+        auto *TestIsZero = BM->addInstTemplate(
+            OpLogicalOr, {TestIsPosZero->getId(), TestIsNegZero->getId()}, BB,
+            ResTy);
         ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsZero));
       } else if (FPClass & fcPosZero) {
         auto *TestIsPosZero =

--- a/test/llvm-intrinsics/fpclass.ll
+++ b/test/llvm-intrinsics/fpclass.ll
@@ -306,7 +306,7 @@ define i1 @test_class_zero(float %arg) {
 ; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
 ; CHECK-SPIRV-EMPTY:
 ; CHECK-SPIRV-NEXT: Label
-; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast:]] [[#Val]]
+; CHECK-SPIRV-NEXT: ConvertFToU [[#Int32Ty]] [[#BitCast:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast]] [[#ZeroConst]] 
 ; CHECK-SPIRV-NEXT: ReturnValue [[#Equal]]
   %val = call i1 @llvm.is.fpclass.f32(float %arg, i32 96)
@@ -319,8 +319,8 @@ define i1 @test_class_poszero(float %arg) {
 ; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
 ; CHECK-SPIRV-EMPTY:
 ; CHECK-SPIRV-NEXT: Label
-; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast:]] [[#Val]]
-; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast]] [[#ZeroConst]] 
+; CHECK-SPIRV-NEXT: ConvertFToU [[#Int32Ty]] [[#BitCast:]] [[#Val]]
+; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast]] [[#ZeroConst]]
 ; CHECK-SPIRV-NEXT: SignBitSet [[#BoolTy]] [[#Sign:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: LogicalNot [[#BoolTy]] [[#Not:]] [[#Sign]]
 ; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#And:]] [[#Not]] [[#Equal]]
@@ -335,7 +335,7 @@ define i1 @test_class_negzero(float %arg) {
 ; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
 ; CHECK-SPIRV-EMPTY:
 ; CHECK-SPIRV-NEXT: Label
-; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast:]] [[#Val]]
+; CHECK-SPIRV-NEXT: ConvertFToU [[#Int32Ty]] [[#BitCast:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast]] [[#ZeroConst]] 
 ; CHECK-SPIRV-NEXT: SignBitSet [[#BoolTy]] [[#Sign:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#And:]] [[#Sign]] [[#Equal]]
@@ -381,7 +381,7 @@ define i1 @test_class_neginf_posnormal_negsubnormal_poszero_snan_f64(double %arg
 ; CHECK-SPIRV-NEXT: ISub [[#Int64Ty]] [[#Sub:]] [[#BitCast2]] [[#MantissaConst64]]
 ; CHECK-SPIRV-NEXT: ULessThan [[#BoolTy]] [[#Less:]] [[#Sub]] [[#MantissaConst64]]
 ; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#And4:]] [[#Sign]] [[#Less]]
-; CHECK-SPIRV-NEXT: Bitcast [[#Int64Ty]] [[#BitCast3:]] [[#Val]]
+; CHECK-SPIRV-NEXT: ConvertFToU [[#Int64Ty]] [[#BitCast3:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast3]] [[#ZeroConst64]]
 ; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#And5:]] [[#Not2]] [[#Equal]]
 ; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or1:]] [[#And1]] [[#And2]]
@@ -414,7 +414,7 @@ define <2 x i1> @test_class_neginf_posnormal_negsubnormal_poszero_snan_v2f16(<2 
 ; CHECK-SPIRV-NEXT: ISub [[#Int16VecTy]] [[#Sub:]] [[#BitCast2]] [[#MantissaConstVec16]]
 ; CHECK-SPIRV-NEXT: ULessThan [[#VecBoolTy]] [[#Less:]] [[#Sub]] [[#MantissaConstVec16]]
 ; CHECK-SPIRV-NEXT: LogicalAnd [[#VecBoolTy]] [[#And4:]] [[#Sign]] [[#Less]]
-; CHECK-SPIRV-NEXT: Bitcast [[#Int16VecTy]] [[#BitCast3:]] [[#Val]]
+; CHECK-SPIRV-NEXT: ConvertFToU [[#Int16VecTy]] [[#BitCast3:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: IEqual [[#VecBoolTy]] [[#Equal:]] [[#BitCast3]] [[#ZeroConst16]]
 ; CHECK-SPIRV-NEXT: LogicalAnd [[#VecBoolTy]] [[#And5:]] [[#Not2]] [[#Equal]]
 ; CHECK-SPIRV-NEXT: LogicalOr [[#VecBoolTy]] [[#Or1:]] [[#And1]] [[#And2]]

--- a/test/llvm-intrinsics/fpclass.ll
+++ b/test/llvm-intrinsics/fpclass.ll
@@ -21,6 +21,7 @@
 ; CHECK-SPIRV-DAG: Constant [[#Int32Ty]] [[#QNanBitConst:]] 2143289344
 ; CHECK-SPIRV-DAG: Constant [[#Int32Ty]] [[#MantissaConst:]] 8388607
 ; CHECK-SPIRV-DAG: Constant [[#Int32Ty]] [[#ZeroConst:]] 0
+; CHECK-SPIRV-DAG: Constant [[#Int32Ty]] [[#NegatedZeroConst:]] 2147483648
 ; CHECK-SPIRV-DAG: Constant [[#Int64Ty]] [[#QNanBitConst64:]] 0 2146959360
 ; CHECK-SPIRV-DAG: Constant [[#Int64Ty]] [[#MantissaConst64:]] 4294967295 1048575
 ; CHECK-SPIRV-DAG: Constant [[#Int64Ty]] [[#ZeroConst64:]] 0 0
@@ -306,9 +307,11 @@ define i1 @test_class_zero(float %arg) {
 ; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
 ; CHECK-SPIRV-EMPTY:
 ; CHECK-SPIRV-NEXT: Label
-; CHECK-SPIRV-NEXT: ConvertFToU [[#Int32Ty]] [[#BitCast:]] [[#Val]]
-; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast]] [[#ZeroConst]] 
-; CHECK-SPIRV-NEXT: ReturnValue [[#Equal]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast:]] [[#Val]]
+; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#EqualPos:]] [[#BitCast]] [[#ZeroConst]]
+; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#EqualNeg:]] [[#BitCast]] [[#NegatedZeroConst]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Result:]] [[#EqualPos]] [[#EqualNeg]]
+; CHECK-SPIRV-NEXT: ReturnValue [[#Result]]
   %val = call i1 @llvm.is.fpclass.f32(float %arg, i32 96)
   ret i1 %val
 }
@@ -319,12 +322,9 @@ define i1 @test_class_poszero(float %arg) {
 ; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
 ; CHECK-SPIRV-EMPTY:
 ; CHECK-SPIRV-NEXT: Label
-; CHECK-SPIRV-NEXT: ConvertFToU [[#Int32Ty]] [[#BitCast:]] [[#Val]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast]] [[#ZeroConst]]
-; CHECK-SPIRV-NEXT: SignBitSet [[#BoolTy]] [[#Sign:]] [[#Val]]
-; CHECK-SPIRV-NEXT: LogicalNot [[#BoolTy]] [[#Not:]] [[#Sign]]
-; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#And:]] [[#Not]] [[#Equal]]
-; CHECK-SPIRV-NEXT: ReturnValue [[#And]]
+; CHECK-SPIRV-NEXT: ReturnValue [[#Equal]]
   %val = call i1 @llvm.is.fpclass.f32(float %arg, i32 64)
   ret i1 %val
 }
@@ -335,11 +335,9 @@ define i1 @test_class_negzero(float %arg) {
 ; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
 ; CHECK-SPIRV-EMPTY:
 ; CHECK-SPIRV-NEXT: Label
-; CHECK-SPIRV-NEXT: ConvertFToU [[#Int32Ty]] [[#BitCast:]] [[#Val]]
-; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast]] [[#ZeroConst]] 
-; CHECK-SPIRV-NEXT: SignBitSet [[#BoolTy]] [[#Sign:]] [[#Val]]
-; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#And:]] [[#Sign]] [[#Equal]]
-; CHECK-SPIRV-NEXT: ReturnValue [[#And]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast:]] [[#Val]]
+; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast]] [[#NegatedZeroConst]]
+; CHECK-SPIRV-NEXT: ReturnValue [[#Equal]]
   %val = call i1 @llvm.is.fpclass.f32(float %arg, i32 32)
   ret i1 %val
 }
@@ -381,13 +379,12 @@ define i1 @test_class_neginf_posnormal_negsubnormal_poszero_snan_f64(double %arg
 ; CHECK-SPIRV-NEXT: ISub [[#Int64Ty]] [[#Sub:]] [[#BitCast2]] [[#MantissaConst64]]
 ; CHECK-SPIRV-NEXT: ULessThan [[#BoolTy]] [[#Less:]] [[#Sub]] [[#MantissaConst64]]
 ; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#And4:]] [[#Sign]] [[#Less]]
-; CHECK-SPIRV-NEXT: ConvertFToU [[#Int64Ty]] [[#BitCast3:]] [[#Val]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int64Ty]] [[#BitCast3:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#Equal:]] [[#BitCast3]] [[#ZeroConst64]]
-; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#And5:]] [[#Not2]] [[#Equal]]
 ; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or1:]] [[#And1]] [[#And2]]
 ; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or2:]] [[#Or1]] [[#And3]]
 ; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or3:]] [[#Or2]] [[#And4]]
-; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or4:]] [[#Or3]] [[#And5]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or4:]] [[#Or3]] [[#Equal]]
 ; CHECK-SPIRV-NEXT: ReturnValue [[#Or4]]
   %val = call i1 @llvm.is.fpclass.f64(double %arg, i32 341)
   ret i1 %val
@@ -414,13 +411,12 @@ define <2 x i1> @test_class_neginf_posnormal_negsubnormal_poszero_snan_v2f16(<2 
 ; CHECK-SPIRV-NEXT: ISub [[#Int16VecTy]] [[#Sub:]] [[#BitCast2]] [[#MantissaConstVec16]]
 ; CHECK-SPIRV-NEXT: ULessThan [[#VecBoolTy]] [[#Less:]] [[#Sub]] [[#MantissaConstVec16]]
 ; CHECK-SPIRV-NEXT: LogicalAnd [[#VecBoolTy]] [[#And4:]] [[#Sign]] [[#Less]]
-; CHECK-SPIRV-NEXT: ConvertFToU [[#Int16VecTy]] [[#BitCast3:]] [[#Val]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int16VecTy]] [[#BitCast3:]] [[#Val]]
 ; CHECK-SPIRV-NEXT: IEqual [[#VecBoolTy]] [[#Equal:]] [[#BitCast3]] [[#ZeroConst16]]
-; CHECK-SPIRV-NEXT: LogicalAnd [[#VecBoolTy]] [[#And5:]] [[#Not2]] [[#Equal]]
 ; CHECK-SPIRV-NEXT: LogicalOr [[#VecBoolTy]] [[#Or1:]] [[#And1]] [[#And2]]
 ; CHECK-SPIRV-NEXT: LogicalOr [[#VecBoolTy]] [[#Or2:]] [[#Or1]] [[#And3]]
 ; CHECK-SPIRV-NEXT: LogicalOr [[#VecBoolTy]] [[#Or3:]] [[#Or2]] [[#And4]]
-; CHECK-SPIRV-NEXT: LogicalOr [[#VecBoolTy]] [[#Or4:]] [[#Or3]] [[#And5]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#VecBoolTy]] [[#Or4:]] [[#Or3]] [[#Equal]]
 ; CHECK-SPIRV-NEXT: ReturnValue [[#Or4]]
   %val = call <2 x i1> @llvm.is.fpclass.v2f16(<2 x half> %arg, i32 341)
   ret <2 x i1> %val


### PR DESCRIPTION
We should compare not only to zero integer, but also 'negated' zero.