### PR TITLE
Manually convert tests to opaque pointers

### DIFF
--- a/test/DebugInfo/Generic/c-and-cpp-mixed.ll
+++ b/test/DebugInfo/Generic/c-and-cpp-mixed.ll
@@ -70,18 +70,18 @@ target triple = "spir64-unknown-unknown"
 
 define void @foo() nounwind !dbg !5 {
 entry:
-  %puts = tail call i32 @puts(i8* getelementptr inbounds ([4 x i8], [4 x i8]* @str, i32 0, i32 0)), !dbg !23
+  %puts = tail call i32 @puts(ptr @str), !dbg !23
   ret void, !dbg !25
 }
 
-declare i32 @puts(i8* nocapture) nounwind
+declare i32 @puts(ptr nocapture) nounwind
 
-define i32 @main(i32 %argc, i8** nocapture %argv) nounwind !dbg !12 {
+define i32 @main(i32 %argc, ptr nocapture %argv) nounwind !dbg !12 {
 entry:
   tail call void @llvm.dbg.value(metadata i32 %argc, metadata !21, metadata !DIExpression()), !dbg !26
   ; Avoid talking about the pointer size in debug info because that's target dependent
-  tail call void @llvm.dbg.value(metadata i8** %argv, metadata !22, metadata !DIExpression(DW_OP_deref, DW_OP_deref)), !dbg !27
-  %puts = tail call i32 @puts(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @str1, i32 0, i32 0)), !dbg !28
+  tail call void @llvm.dbg.value(metadata ptr %argv, metadata !22, metadata !DIExpression(DW_OP_deref, DW_OP_deref)), !dbg !27
+  %puts = tail call i32 @puts(ptr @str1), !dbg !28
   tail call void @foo() nounwind, !dbg !30
   ret i32 0, !dbg !31
 }

--- a/test/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space/non-constant-printf.ll
+++ b/test/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space/non-constant-printf.ll
@@ -45,28 +45,28 @@ target triple = "spir-unknown-unknown"
 
 ; Function Attrs: nounwind
 define spir_kernel void @test() #0 !kernel_arg_addr_space !3 !kernel_arg_access_qual !3 !kernel_arg_type !3 !kernel_arg_type_qual !3 !kernel_arg_base_type !3 {
-  %1 = getelementptr inbounds [6 x i8], [6 x i8]* @0, i32 0, i32 0
-  %2 = call spir_func i32 @_Z18__spirv_ocl_printfPc(i8* %1) #0
-  %3 = getelementptr inbounds [6 x i8], [6 x i8] addrspace(1)* @1, i32 0, i32 0
-  %4 = call spir_func i32 @_Z18__spirv_ocl_printfPU3AS1c(i8 addrspace(1)* %3) #0
-  %5 = getelementptr inbounds [6 x i8], [6 x i8] addrspace(3)* @2, i32 0, i32 0
-  %6 = call spir_func i32 @_Z18__spirv_ocl_printfPU3AS3c(i8 addrspace(3)* %5) #0
-  %7 = getelementptr inbounds [6 x i8], [6 x i8] addrspace(4)* @3, i32 0, i32 0
-  %8 = call spir_func i32 @_Z18__spirv_ocl_printfPU3AS4c(i8 addrspace(4)* %7) #0
+  %1 = getelementptr inbounds [6 x i8], ptr @0, i32 0, i32 0
+  %2 = call spir_func i32 @_Z18__spirv_ocl_printfPc(ptr %1) #0
+  %3 = getelementptr inbounds [6 x i8], ptr addrspace(1) @1, i32 0, i32 0
+  %4 = call spir_func i32 @_Z18__spirv_ocl_printfPU3AS1c(ptr addrspace(1) %3) #0
+  %5 = getelementptr inbounds [6 x i8], ptr addrspace(3) @2, i32 0, i32 0
+  %6 = call spir_func i32 @_Z18__spirv_ocl_printfPU3AS3c(ptr addrspace(3) %5) #0
+  %7 = getelementptr inbounds [6 x i8], ptr addrspace(4) @3, i32 0, i32 0
+  %8 = call spir_func i32 @_Z18__spirv_ocl_printfPU3AS4c(ptr addrspace(4) %7) #0
   ret void
 }
 
 ; Function Attrs: nounwind
-declare spir_func i32 @_Z18__spirv_ocl_printfPc(i8*) #0
+declare spir_func i32 @_Z18__spirv_ocl_printfPc(ptr) #0
 
 ; Function Attrs: nounwind
-declare spir_func i32 @_Z18__spirv_ocl_printfPU3AS1c(i8 addrspace(1)*) #0
+declare spir_func i32 @_Z18__spirv_ocl_printfPU3AS1c(ptr addrspace(1)) #0
 
 ; Function Attrs: nounwind
-declare spir_func i32 @_Z18__spirv_ocl_printfPU3AS3c(i8 addrspace(3)*) #0
+declare spir_func i32 @_Z18__spirv_ocl_printfPU3AS3c(ptr addrspace(3)) #0
 
 ; Function Attrs: nounwind
-declare spir_func i32 @_Z18__spirv_ocl_printfPU3AS4c(i8 addrspace(4)*) #0
+declare spir_func i32 @_Z18__spirv_ocl_printfPU3AS4c(ptr addrspace(4)) #0
 
 attributes #0 = { nounwind }
 

--- a/test/transcoding/global-constant-expression.ll
+++ b/test/transcoding/global-constant-expression.ll
@@ -10,7 +10,7 @@ target triple = "spir-unknown-unknown"
 ; CHECK-LLVM: @k_var = addrspace(1) global [2 x ptr addrspace(1)] [ptr addrspace(1) getelementptr inbounds ([2 x i8], ptr addrspace(1) @a_var, i32 0, i64 1), ptr addrspace(1) @a_var], align 4
 
 @a_var = addrspace(1) global [2 x i8] c"\96\96", align 1
-@k_var = addrspace(1) global [2 x i8 addrspace(1)*] [i8 addrspace(1)* getelementptr inbounds ([2 x i8], [2 x i8] addrspace(1)* @a_var, i32 0, i64 1), i8 addrspace(1)* getelementptr inbounds ([2 x i8], [2 x i8] addrspace(1)* @a_var, i32 0, i32 0)], align 4
+@k_var = addrspace(1) global [2 x ptr addrspace(1)] [ptr addrspace(1) getelementptr inbounds ([2 x i8], ptr addrspace(1) @a_var, i32 0, i64 1), ptr addrspace(1) getelementptr inbounds ([2 x i8], ptr addrspace(1) @a_var, i32 0, i32 0)], align 4
 
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.spir.version = !{!0}

--- a/test/transcoding/spirv-private-array-initialization.ll
+++ b/test/transcoding/spirv-private-array-initialization.ll
@@ -43,15 +43,15 @@ define spir_func void @test() #0 {
 entry:
   %arr = alloca [3 x i32], align 4
   %arr2 = alloca [3 x i32], align 4
-  %0 = bitcast [3 x i32]* %arr to i8*
-  call void @llvm.memcpy.p0i8.p2i8.i32(i8* align 4 %0, i8 addrspace(2)* align 4 bitcast ([3 x i32] addrspace(2)* @__const.test.arr to i8 addrspace(2)*), i32 12, i1 false)
-  %1 = bitcast [3 x i32]* %arr2 to i8*
-  call void @llvm.memcpy.p0i8.p2i8.i32(i8* align 4 %1, i8 addrspace(2)* align 4 bitcast ([3 x i32] addrspace(2)* @__const.test.arr2 to i8 addrspace(2)*), i32 12, i1 false)
+  %0 = bitcast ptr %arr to ptr
+  call void @llvm.memcpy.p0.p2.i32(ptr align 4 %0, ptr addrspace(2) align 4 bitcast (ptr addrspace(2) @__const.test.arr to ptr addrspace(2)), i32 12, i1 false)
+  %1 = bitcast ptr %arr2 to ptr
+  call void @llvm.memcpy.p0.p2.i32(ptr align 4 %1, ptr addrspace(2) align 4 bitcast (ptr addrspace(2) @__const.test.arr2 to ptr addrspace(2)), i32 12, i1 false)
   ret void
 }
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p2i8.i32(i8* nocapture writeonly, i8 addrspace(2)* nocapture readonly, i32, i1) #1
+declare void @llvm.memcpy.p0.p2.i32(ptr nocapture writeonly, ptr addrspace(2) nocapture readonly, i32, i1) #1
 
 attributes #0 = { convergent noinline nounwind optnone "correctly-rounded-divide-sqrt-fp-math"="false" "denorms-are-zero"="false" "disable-tail-calls"="false" "less-precise-fpmad"="false" "min-legal-vector-width"="0" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-jump-tables"="false" "no-nans-fp-math"="false" "no-signed-zeros-fp-math"="false" "no-trapping-math"="false" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { argmemonly nounwind }


### PR DESCRIPTION
Manually convert some tests to opaque pointers that the migration script did not handle correctly.