### PR TITLE
Ignore llvm.ubsantrap intrinsic

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3484,6 +3484,7 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::invariant_end:
   case Intrinsic::dbg_label:
   case Intrinsic::trap:
+  case Intrinsic::ubsantrap:
   case Intrinsic::arithmetic_fence:
   case Intrinsic::masked_gather:
   case Intrinsic::masked_scatter:
@@ -4212,6 +4213,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
   // llvm.trap intrinsic is not implemented. But for now don't crash. This
   // change is pending the trap/abort intrinsic implementation.
   case Intrinsic::trap:
+  case Intrinsic::ubsantrap:
   // llvm.instrprof.* intrinsics are not supported
   case Intrinsic::instrprof_increment:
   case Intrinsic::instrprof_increment_step:

--- a/test/llvm-intrinsics/ubsantrap.ll
+++ b/test/llvm-intrinsics/ubsantrap.ll
@@ -1,0 +1,13 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target triple = "spir64-unknown-unknown"
+
+define spir_func void @test_ubsantrap() {
+entry:
+  call void @llvm.ubsantrap(i8 16)
+  ret void
+}
+
+declare void @llvm.ubsantrap(i8)


### PR DESCRIPTION
It's the similar case as llvm.trap intrinsic - the preferred way is to ignore it in the translator.