### PR TITLE
[NFC] Remove unnecessary prefix check in LLVMToSPIRVBase::getFPBuiltinType

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4518,9 +4518,8 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
 LLVMToSPIRVBase::FPBuiltinType
 LLVMToSPIRVBase::getFPBuiltinType(IntrinsicInst *II, StringRef &OpName) {
   StringRef Name = II->getCalledFunction()->getName();
-  if (!Name.startswith("llvm.fpbuiltin"))
+  if (!Name.consume_front("llvm.fpbuiltin."))
     return FPBuiltinType::UNKNOWN;
-  Name.consume_front("llvm.fpbuiltin.");
   OpName = Name.split('.').first;
   FPBuiltinType Type =
       StringSwitch<FPBuiltinType>(OpName)


### PR DESCRIPTION
Definition of StringRef.consume_front also performs prefix check. It makes additional check redundant.