### PR TITLE
[Backport to 16][OpaquePointers] Handle llvm.memset intrinsic mangling mismatches.

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2885,6 +2885,14 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF) {
   // assuming llvm.memset is supported by the device compiler. If this
   // assumption is not safe, we should have a command line option to control
   // this behavior.
+  if (FuncNameRef.startswith("spirv.llvm_memset_p")) {
+    // We can't guarantee that the name is correctly mangled due to opaque
+    // pointers. Derive the correct name from the function type.
+    FuncName =
+        Intrinsic::getDeclaration(M, Intrinsic::memset,
+                                  {FT->getParamType(0), FT->getParamType(2)})
+            ->getName();
+  }
   if (FuncNameRef.consume_front("spirv.")) {
     FuncNameRef.consume_back(".volatile");
     FuncName = FuncNameRef.str();


### PR DESCRIPTION
Original change:
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/bdd765263a0a7184dbd18fe5396313802f731e25

Non-constant @llvm.memset calls are presently lowered by generating synthetic functions with the mangled name of memset. However, the reader tries to use this name to generate the intrinsic call again. This causes verification issues if the SPIRVWriter and SPIRVReader do not agree on whether or not to use opaque pointers. This change uses the actual type of the function (which will take into account whether or not it is in opaque pointer mode) to generate the LLVM intrinsic name, fixing the mismatch issues.