### PR TITLE
[NFC] Align FortranArray.ll test

### DIFF
--- a/test/DebugInfo/NonSemantic/Shader200/FortranArray.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranArray.ll
@@ -8,10 +8,10 @@
 
 ; CHECK-SPIRV: [[#CompUnit:]] [[#]] DebugCompilationUnit
 ; CHECK-SPIRV: [[#None:]] [[#]] DebugInfoNone
-; CHECK-SPIRV: [[#EntryFunc:]] [[#]] DebugFunction
 ; CHECK-SPIRV: [[#BaseTy:]] [[#]] DebugTypeBasic
 ; CHECK-SPIRV: [[#Subrange:]] [[#]] DebugTypeSubrange
 ; CHECK-SPIRV: DebugTypeArrayDynamic [[#BaseTy]] [[#]] [[#]] [[#None]] [[#None]] [[#Subrange]]
+; CHECK-SPIRV-DAG: [[#EntryFunc:]] [[#]] DebugFunction
 ; CHECK-SPIRV: DebugEntryPoint [[#EntryFunc]] [[#CompUnit]] [[#]] [[#]] {{$}}
 
 ; CHECK-LLVM: !DICompileUnit(language: DW_LANG_Fortran95


### PR DESCRIPTION
Added -DAG to CHECK for DebugFunction. It's better not to relax order of checks for debug info instructions, but in this case it should be OK as the main purpose of the test is not about DebugFunction.