### PR TITLE
[NFC] Fix clang format automation after 68d618f90

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -83,14 +83,7 @@ jobs:
       id: run-clang-format
       run: |
         cat diff-to-inspect.txt | /usr/share/clang/clang-format-${{ env.LLVM_VERSION }}/clang-format-diff.py \
-            -p1 -binary clang-format-${{ env.LLVM_VERSION }} > clang-format.patch
-        if [ -s clang-format.patch ]; then
-          echo "clang-format found incorrectly formatted code:"
-          cat clang-format.patch;
-          exit 1;
-        else
-          rm clang-format.patch # to avoid uploading empty file
-        fi
+            -p1 -binary clang-format-${{ env.LLVM_VERSION }}
 
     - name: Run clang-tidy
       # By some reason, GitHub Actions automatically include "success()"


### PR DESCRIPTION
The patch adds exit(1) in case if the clang-format reports an error and it breaks our pre-commit CI.