### PR TITLE
DRAFT: Can apply MemoryINTEL decoration multiple times on same variable

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3480,9 +3480,12 @@ void generateIntelFPGAAnnotation(
     Out << "{register:1}";
 
   SPIRVWord Result = 0;
-  if (E->hasDecorate(DecorationMemoryINTEL))
-    Out << "{memory:"
-        << E->getDecorationStringLiteral(DecorationMemoryINTEL).front() << '}';
+  if (E->hasDecorate(DecorationMemoryINTEL)) {
+    auto Annotations = E->getAllDecorationStringLiterals(DecorationMemoryINTEL);
+    for (size_t I = 0; I != Annotations.size(); ++I) {
+      Out << "{memory:" << Annotations[I].front() << '}';
+    }
+  }
   if (E->hasDecorate(DecorationBankwidthINTEL, 0, &Result))
     Out << "{bankwidth:" << Result << '}';
   if (E->hasDecorate(DecorationNumbanksINTEL, 0, &Result))
@@ -3575,12 +3578,12 @@ void generateIntelFPGAAnnotationForStructMember(
     Out << "{register:1}";
 
   SPIRVWord Result = 0;
-  if (E->hasMemberDecorate(DecorationMemoryINTEL, 0, MemberNumber, &Result))
-    Out << "{memory:"
-        << E->getMemberDecorationStringLiteral(DecorationMemoryINTEL,
-                                               MemberNumber)
-               .front()
-        << '}';
+  if (E->hasMemberDecorate(DecorationMemoryINTEL, 0, MemberNumber, &Result)) {
+    auto Annotations = E->getAllMemberDecorationStringLiterals(DecorationMemoryINTEL, MemberNumber);
+    for (size_t I = 0; I != Annotations.size(); ++I) {
+      Out << "{memory:" << Annotations[I].front() << '}';
+    }
+  }
   if (E->hasMemberDecorate(DecorationBankwidthINTEL, 0, MemberNumber, &Result))
     Out << "{bankwidth:" << Result << '}';
   if (E->hasMemberDecorate(DecorationNumbanksINTEL, 0, MemberNumber, &Result))

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3262,8 +3262,8 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
   for (const auto &I : Decorations) {
     // Such decoration already exists on a type, try to skip it
     if (E->hasDecorate(I.first, /*Index=*/0, /*Result=*/nullptr))
-      // Allow multiple UserSemantic Decorations
-      if (I.first != DecorationUserSemantic)
+      // Allow multiple UserSemantic and MemoryINTEL Decorations
+      if (I.first != DecorationUserSemantic && I.first != DecorationMemoryINTEL)
         continue;
 
     switch (static_cast<size_t>(I.first)) {
@@ -3421,8 +3421,8 @@ void addAnnotationDecorationsForStructMember(SPIRVEntry *E,
     // Such decoration already exists on a type, skip it
     if (E->hasMemberDecorate(I.first, /*Index=*/0, MemberNumber,
                              /*Result=*/nullptr))
-      // Allow multiple UserSemantic Decorations
-      if (I.first != DecorationUserSemantic)
+      // Allow multiple UserSemantic and MemoryINTEL Decorations
+      if (I.first != DecorationUserSemantic && I.first != DecorationMemoryINTEL)
         continue;
 
     switch (I.first) {


### PR DESCRIPTION
According to [SPIRV spec](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_decoration) only one instance of a specific decoration can be on a SPIRV-Id, unless the decoration explicitly allows it.  

`MemoryINTEL` is such a decoration where it does not conflict with other instances of the same decoration. The example below is makes semantic sense. 

```
5 Decorate XX MemoryINTEL "DEFAULT" 
6 Decorate XX MemoryINTEL "BLOCK_RAM"
```