### PR TITLE
Fixing Intrinsic::ptr_annotation

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3131,6 +3131,8 @@ AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
 
     std::pair<StringRef, StringRef> Split = AnnotatedDecoration.split(':');
     StringRef Name = Split.first, ValueStr = Split.second;
+    SPIRVDBG(spvdbgs() << "[tryParseAnnotationString]: AnnotationString: "
+                       << Name.str() << "\n");
 
     unsigned DecorationKind = 0;
     if (!Name.getAsInteger(10, DecorationKind)) {
@@ -4281,19 +4283,17 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
   // i8* <ptr> is a pointer on a GV, which can carry optinal variadic
   // clang::annotation attribute expression arguments.
   case Intrinsic::ptr_annotation: {
-    // Strip all bitcast and addrspace casts from the pointer argument:
-    //   llvm annotation intrinsic only takes i8*, so the original pointer
-    //   probably had to loose its addrspace and its original type.
-    Value *AnnotSubj = II->getArgOperand(0);
-    while (isa<BitCastInst>(AnnotSubj) || isa<AddrSpaceCastInst>(AnnotSubj)) {
-      AnnotSubj = cast<CastInst>(AnnotSubj)->getOperand(0);
+    Value *AnnotSubj = nullptr;
+    if (auto *BI = dyn_cast<BitCastInst>(II->getArgOperand(0))) {
+      AnnotSubj = BI->getOperand(0);
+    } else {
+      AnnotSubj = II->getOperand(0);
     }
 
     std::string AnnotationString;
     processAnnotationString(II, AnnotationString);
     AnnotationDecorations Decorations =
         tryParseAnnotationString(BM, AnnotationString);
-
     // Translate FPGARegIntel annotations to OpFPGARegINTEL.
     if (AnnotationString == kOCLBuiltinName::FPGARegIntel) {
       auto *Ty = transScavengedType(II);
@@ -4303,76 +4303,27 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       return transValue(BI, BB);
     }
 
-    // If the pointer is a GEP on a struct, then we have to emit a member
-    // decoration for the GEP-accessed struct, or a memory access decoration
-    // for the GEP itself. There may not be a GEP in this case if the access is
-    // to the first member of the struct; if so, attempt to get a struct type
-    // from an alloca instead.
-    SPIRVType *StructTy = nullptr;
-    [[maybe_unused]] SPIRVValue *ResPtr = nullptr;
-    [[maybe_unused]] SPIRVWord MemberNumber = 0;
-    if (auto *const GI = dyn_cast<GetElementPtrInst>(AnnotSubj)) {
-      if (auto *const STy = dyn_cast<StructType>(GI->getSourceElementType())) {
-        StructTy = transType(STy);
-        ResPtr = transValue(GI, BB);
-        MemberNumber = dyn_cast<ConstantInt>(GI->getOperand(2))->getZExtValue();
-      }
-    } else if (auto *const AI = dyn_cast<AllocaInst>(AnnotSubj)) {
-      if (auto *const STy = dyn_cast<StructType>(AI->getAllocatedType())) {
-        StructTy = transType(STy);
-        ResPtr = transValue(AI, BB);
-        MemberNumber = 0;
-      }
-    }
-    if (StructTy) {
-
-      // If we didn't find any IntelFPGA-specific decorations, let's add the
-      // whole annotation string as UserSemantic Decoration
-      if (Decorations.empty()) {
-        // TODO: Is there a way to detect that the annotation belongs solely
-        // to struct member memory atributes or struct member memory access
-        // controls? This would allow emitting just the necessary decoration.
-        StructTy->addMemberDecorate(new SPIRVMemberDecorateUserSemanticAttr(
-            StructTy, MemberNumber, AnnotationString.c_str()));
-        ResPtr->addDecorate(new SPIRVDecorateUserSemanticAttr(
-            ResPtr, AnnotationString.c_str()));
-      } else {
-        addAnnotationDecorationsForStructMember(
-            StructTy, MemberNumber, Decorations.MemoryAttributesVec);
-        // Apply the LSU parameter decoration to the pointer result of a GEP
-        // to the given struct member (InBoundsPtrAccessChain in SPIR-V).
-        // Decorating the member itself with a MemberDecoration is not feasible,
-        // because multiple accesses to the struct-held memory can require
-        // different LSU parameters.
-        addAnnotationDecorations(ResPtr, Decorations.MemoryAccessesVec);
-        if (allowDecorateWithBufferLocationOrLatencyControlINTEL(II)) {
-          addAnnotationDecorations(ResPtr, Decorations.BufferLocationVec);
-          addAnnotationDecorations(ResPtr, Decorations.LatencyControlVec);
-        }
-      }
-      II->replaceAllUsesWith(II->getOperand(0));
+    SPIRVValue *DecSubj = transValue(AnnotSubj, BB);
+    if (Decorations.empty()) {
+      DecSubj->addDecorate(
+          new SPIRVDecorateUserSemanticAttr(DecSubj, AnnotationString.c_str()));
     } else {
-      // Memory accesses to a standalone pointer variable
-      auto *DecSubj = transValue(II->getArgOperand(0), BB);
-      if (Decorations.empty())
-        DecSubj->addDecorate(new SPIRVDecorateUserSemanticAttr(
-            DecSubj, AnnotationString.c_str()));
-      else {
-        // Apply the LSU parameter decoration to the pointer result of an
-        // instruction. Note it's the address to the accessed memory that's
-        // loaded from the original pointer variable, and not the value
-        // accessed by the latter.
-        addAnnotationDecorations(DecSubj, Decorations.MemoryAccessesVec);
-        if (allowDecorateWithBufferLocationOrLatencyControlINTEL(II)) {
-          addAnnotationDecorations(DecSubj, Decorations.BufferLocationVec);
-          addAnnotationDecorations(DecSubj, Decorations.LatencyControlVec);
-        }
-
-        addAnnotationDecorations(DecSubj, Decorations.CacheControlVec);
+      SPIRVDBG(spvdbgs() << "Artem: [transIntrinsicInst]: !Decorations.empty()" << "\n");
+      addAnnotationDecorations(DecSubj, Decorations.MemoryAttributesVec);
+      // Apply the LSU parameter decoration to the pointer result of a GEP
+      // to the given struct member (InBoundsPtrAccessChain in SPIR-V).
+      // Decorating the member itself with a MemberDecoration is not feasible,
+      // because multiple accesses to the struct-held memory can require
+      // different LSU parameters.
+      addAnnotationDecorations(DecSubj, Decorations.MemoryAccessesVec);
+      addAnnotationDecorations(DecSubj, Decorations.CacheControlVec);
+      if (allowDecorateWithBufferLocationOrLatencyControlINTEL(II)) {
+        addAnnotationDecorations(DecSubj, Decorations.BufferLocationVec);
+        addAnnotationDecorations(DecSubj, Decorations.LatencyControlVec);
       }
-      II->replaceAllUsesWith(II->getOperand(0));
     }
-    return nullptr;
+    II->replaceAllUsesWith(II->getOperand(0));
+    return DecSubj;
   }
   case Intrinsic::stacksave: {
     if (BM->isAllowedToUseExtension(

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4308,7 +4308,6 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       DecSubj->addDecorate(
           new SPIRVDecorateUserSemanticAttr(DecSubj, AnnotationString.c_str()));
     } else {
-      SPIRVDBG(spvdbgs() << "Artem: [transIntrinsicInst]: !Decorations.empty()" << "\n");
       addAnnotationDecorations(DecSubj, Decorations.MemoryAttributesVec);
       // Apply the LSU parameter decoration to the pointer result of a GEP
       // to the given struct member (InBoundsPtrAccessChain in SPIR-V).

--- a/test/extensions/INTEL/SPV_INTEL_fpga_memory_accesses/IntelFPGAMemoryAccesses.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_memory_accesses/IntelFPGAMemoryAccesses.ll
@@ -204,9 +204,9 @@ entry:
   %15 = bitcast double addrspace(4)** %t to i8*
   call void @llvm.lifetime.start.p0i8(i64 8, i8* %15) #5
 ; CHECK-LLVM: %[[FLOAT_FUNC_PARAM_LOAD:[[:alnum:].]+]] = load ptr addrspace(4), ptr %[[FLOAT_FUNC_PARAM]]
-; CHECK-LLVM: %[[BITCAST_FLOAT_TO_DOUBLE:[[:alnum:].]+]] = bitcast ptr addrspace(4) %[[FLOAT_FUNC_PARAM_LOAD]] to ptr addrspace(4)
-; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %[[BITCAST_FLOAT_TO_DOUBLE]], ptr [[PARAM_3_CACHE_0]]
-; CHECK-LLVM: store ptr addrspace(4) %[[INTRINSIC_CALL]], ptr %[[DOUBLE_VAR]]
+; CHECK-LLVM: %[[INTRINSIC_CALL:[[:alnum:].]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %[[FLOAT_FUNC_PARAM_LOAD]], ptr [[PARAM_3_CACHE_0]]
+; CHECK-LLVM: %[[BITCAST_FLOAT_TO_DOUBLE:[[:alnum:].]+]] = bitcast ptr addrspace(4) %[[INTRINSIC_CALL]] to ptr addrspace(4)
+; CHECK-LLVM: store ptr addrspace(4) %[[BITCAST_FLOAT_TO_DOUBLE]], ptr %[[DOUBLE_VAR]]
   %16 = load float addrspace(4)*, float addrspace(4)** %A.addr, align 8, !tbaa !5
   %17 = bitcast float addrspace(4)* %16 to double addrspace(4)*
   %18 = call double addrspace(4)* @llvm.ptr.annotation.p4f64(double addrspace(4)* %17, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str, i32 0, i32 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str.1, i32 0, i32 0), i32 0, i8* null) #6

--- a/test/extensions/INTEL/SPV_INTEL_fpga_memory_accesses/intel_fpga_lsu_optimized.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_memory_accesses/intel_fpga_lsu_optimized.ll
@@ -90,38 +90,38 @@ entry:
   ; CHECK-LLVM: [[PTR_i27:[%0-9a-z.]+]] = getelementptr inbounds i32, ptr addrspace(1) {{[%0-9a-z._]+}}, i64 {{[%0-9a-z.]+}}
   ; CHECK-LLVM: [[PTR_i:[%0-9a-z.]+]] = getelementptr inbounds i32, ptr addrspace(1) {{[%0-9a-z._]+}}, i64 {{[%0-9a-z.]+}}
   ; CHECK-LLVM: [[PTR_i27_AS_CAST:[%0-9a-z.]+]] = addrspacecast ptr addrspace(1) [[PTR_i27]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_i27_BIT_CAST:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_i27_AS_CAST]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_ANNOT_CALL:[%0-9a-z.]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) [[PTR_i27_BIT_CAST]], ptr [[PTR_i27_ANNOT_STR]]
+  ; CHECK-LLVM: [[PTR_ANNOT_CALL:[%0-9a-z.]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) [[PTR_i27_AS_CAST]], ptr [[PTR_i27_ANNOT_STR]]
   ; CHECK-LLVM: [[PTR_ANNOT_CALL_BC:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_ANNOT_CALL]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_RESULT_LOAD:[%0-9a-z.]+]] = load i32, ptr addrspace(4) [[PTR_ANNOT_CALL_BC]]
+  ; CHECK-LLVM: [[PTR_ANNOT_CALL_BC2:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_ANNOT_CALL_BC]] to ptr addrspace(4)
+  ; CHECK-LLVM: [[PTR_RESULT_LOAD:[%0-9a-z.]+]] = load i32, ptr addrspace(4) [[PTR_ANNOT_CALL_BC2]]
   %add.ptr.i15.i = getelementptr inbounds i32, i32 addrspace(1)* %add.ptr.i27, i64 1
   %7 = addrspacecast i32 addrspace(1)* %add.ptr.i15.i to i32 addrspace(4)*
   %8 = tail call dereferenceable(4) i32 addrspace(4)* @llvm.ptr.annotation.p4i32(i32 addrspace(4)* %7, i8* getelementptr inbounds ([28 x i8], [28 x i8]* @.str.2, i64 0, i64 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str.1, i64 0, i64 0), i32 0, i8* null) #2
   %9 = load i32, i32 addrspace(4)* %8, align 4, !tbaa !9
   ; CHECK-LLVM: [[PTR_i15_i:[%0-9a-z.]+]] = getelementptr inbounds i32, ptr addrspace(1) {{[%0-9a-z._]+}}, i64 {{[%0-9a-z.]+}}
   ; CHECK-LLVM: [[PTR_i15_i_AS_CAST:[%0-9a-z.]+]] = addrspacecast ptr addrspace(1) [[PTR_i15_i]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_i15_i_BIT_CAST:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_i15_i_AS_CAST]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_ANNOT_CALL:[%0-9a-z.]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) [[PTR_i15_i_BIT_CAST]], ptr [[PTR_i15_i_ANNOT_STR]]
+  ; CHECK-LLVM: [[PTR_ANNOT_CALL:[%0-9a-z.]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) [[PTR_i15_i_AS_CAST]], ptr [[PTR_i15_i_ANNOT_STR]]
   ; CHECK-LLVM: [[PTR_ANNOT_CALL_BC:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_ANNOT_CALL]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_RESULT_LOAD_1:[%0-9a-z.]+]] = load i32, ptr addrspace(4) [[PTR_ANNOT_CALL_BC]]
+  ; CHECK-LLVM: [[PTR_ANNOT_CALL_BC2:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_ANNOT_CALL_BC]] to ptr addrspace(4)
+  ; CHECK-LLVM: [[PTR_RESULT_LOAD_1:[%0-9a-z.]+]] = load i32, ptr addrspace(4) [[PTR_ANNOT_CALL_BC2]]
   %10 = addrspacecast i32 addrspace(1)* %add.ptr.i to i32 addrspace(4)*
   %11 = tail call i32 addrspace(4)* @llvm.ptr.annotation.p4i32(i32 addrspace(4)* %10, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.3, i64 0, i64 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str.1, i64 0, i64 0), i32 0, i8* null) #2
   store i32 %6, i32 addrspace(4)* %11, align 4, !tbaa !9
   ; CHECK-LLVM: [[PTR_i_AS_CAST:[%0-9a-z.]+]] = addrspacecast ptr addrspace(1) [[PTR_i]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_i_BIT_CAST:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_i_AS_CAST]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_ANNOT_CALL:[%0-9a-z.]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) [[PTR_i_BIT_CAST]], ptr [[PTR_i_ANNOT_STR]]
+  ; CHECK-LLVM: [[PTR_ANNOT_CALL:[%0-9a-z.]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) [[PTR_i_AS_CAST]], ptr [[PTR_i_ANNOT_STR]]
   ; CHECK-LLVM: [[PTR_ANNOT_CALL_BC:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_ANNOT_CALL]] to ptr addrspace(4)
-  ; CHECK-LLVM: store i32 [[PTR_RESULT_LOAD]], ptr addrspace(4) [[PTR_ANNOT_CALL_BC]]
+  ; CHECK-LLVM: [[PTR_ANNOT_CALL_BC2:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_ANNOT_CALL_BC]] to ptr addrspace(4)
+  ; CHECK-LLVM: store i32 [[PTR_RESULT_LOAD]], ptr addrspace(4) [[PTR_ANNOT_CALL_BC2]]
   %add.ptr.i.i = getelementptr inbounds i32, i32 addrspace(1)* %add.ptr.i, i64 1
   %12 = addrspacecast i32 addrspace(1)* %add.ptr.i.i to i32 addrspace(4)*
   %13 = tail call i32 addrspace(4)* @llvm.ptr.annotation.p4i32(i32 addrspace(4)* %12, i8* getelementptr inbounds ([25 x i8], [25 x i8]* @.str.4, i64 0, i64 0), i8* getelementptr inbounds ([14 x i8], [14 x i8]* @.str.1, i64 0, i64 0), i32 0, i8* null) #2
   store i32 %9, i32 addrspace(4)* %13, align 4, !tbaa !9
   ; CHECK-LLVM: [[PTR_i_i:[%0-9a-z.]+]] = getelementptr inbounds i32, ptr addrspace(1) {{[%0-9a-z._]+}}, i64 {{[%0-9a-z.]+}}
   ; CHECK-LLVM: [[PTR_i_i_AS_CAST:[%0-9a-z.]+]] = addrspacecast ptr addrspace(1) [[PTR_i_i]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_i_i_BIT_CAST:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_i_i_AS_CAST]] to ptr addrspace(4)
-  ; CHECK-LLVM: [[PTR_ANNOT_CALL:[%0-9a-z.]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) [[PTR_i_i_BIT_CAST]], ptr [[PTR_i_i_ANNOT_STR]]
+  ; CHECK-LLVM: [[PTR_ANNOT_CALL:[%0-9a-z.]+]] = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) [[PTR_i_i_AS_CAST]], ptr [[PTR_i_i_ANNOT_STR]]
   ; CHECK-LLVM: [[PTR_ANNOT_CALL_BC:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_ANNOT_CALL]] to ptr addrspace(4)
-  ; CHECK-LLVM: store i32 [[PTR_RESULT_LOAD_1]], ptr addrspace(4) [[PTR_ANNOT_CALL_BC]]
+  ; CHECK-LLVM: [[PTR_ANNOT_CALL_BC2:[%0-9a-z.]+]] = bitcast ptr addrspace(4) [[PTR_ANNOT_CALL_BC]] to ptr addrspace(4)
+  ; CHECK-LLVM: store i32 [[PTR_RESULT_LOAD_1]], ptr addrspace(4) [[PTR_ANNOT_CALL_BC2]]
   ret void
 }
 

--- a/test/extensions/INTEL/SPV_INTEL_fpga_memory_attributes/IntelFPGAMemoryAttributesForStruct.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_memory_attributes/IntelFPGAMemoryAttributesForStruct.ll
@@ -10,96 +10,67 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV: Capability FPGAMemoryAttributesINTEL
 ; CHECK-SPIRV: Extension "SPV_INTEL_fpga_memory_attributes"
 ; CHECK-SPIRV: Name [[#REGISTER_FUNC_NAME:]] "test_fpga_register_attr"
-; CHECK-SPIRV: Name [[#REGISTER_TYPE:]] "register_type"
 ; CHECK-SPIRV: Name [[#MEMORY_FUNC_NAME:]] "test_fpga_memory_attr"
-; CHECK-SPIRV: Name [[#MEMORY_TYPE:]] "memory_type"
 ; CHECK-SPIRV: Name [[#NUMBANKS_FUNC_NAME:]] "test_fpga_numbanks_attr"
-; CHECK-SPIRV: Name [[#NUMBANKS_TYPE:]] "numbanks_type"
 ; CHECK-SPIRV: Name [[#BANKWIDTH_FUNC_NAME:]] "test_fpga_bankwidth_attr"
-; CHECK-SPIRV: Name [[#BANKWIDTH_TYPE:]] "bankwidth_type"
 ; CHECK-SPIRV: Name [[#MAX_PRIVATE_COPIES_FUNC_NAME:]] "test_fpga_max_private_copies_attr"
-; CHECK-SPIRV: Name [[#MAX_PRIVATE_COPIES_TYPE:]] "max_private_copies_type"
 ; CHECK-SPIRV: Name [[#SINGLEPUMP_FUNC_NAME:]] "test_fpga_singlepump_attr"
-; CHECK-SPIRV: Name [[#SINGLEPUMP_TYPE:]] "singlepump_type"
 ; CHECK-SPIRV: Name [[#DOUBLEPUMP_FUNC_NAME:]] "test_fpga_doublepump_attr"
-; CHECK-SPIRV: Name [[#DOUBLEPUMP_TYPE:]] "doublepump_type"
 ; CHECK-SPIRV: Name [[#MAX_REPLICATES_FUNC_NAME:]] "test_fpga_max_replicates_attr"
-; CHECK-SPIRV: Name [[#MAX_REPLICATES_TYPE:]] "max_replicates_type"
 ; CHECK-SPIRV: Name [[#SIMPLE_DUAL_PORT_FUNC_NAME:]] "test_fpga_simple_dual_port_attr"
-; CHECK-SPIRV: Name [[#SIMPLE_DUAL_PORT_TYPE:]] "simple_dual_port_type"
 ; CHECK-SPIRV: Name [[#MERGE_FUNC_NAME:]] "test_fpga_merge_attr"
-; CHECK-SPIRV: Name [[#MERGE_TYPE:]] "merge_type"
 ; CHECK-SPIRV: Name [[#BANKBITS_FUNC_NAME:]] "test_fpga_bankbits_attr"
-; CHECK-SPIRV: Name [[#BANKBITS_TYPE:]] "bankbits_type"
 ; CHECK-SPIRV: Name [[#FORCE_POW_2_DEPTH_FUNC_NAME:]] "test_fpga_force_pow_2_depth_attr"
-; CHECK-SPIRV: Name [[#FORCE_POW_2_DEPTH_TYPE:]] "force_pow_2_depth_type"
 ; CHECK-SPIRV: Name [[#STRIDESIZE_FUNC_NAME:]] "test_fpga_stride_size_attr"
-; CHECK-SPIRV: Name [[#STRIDESIZE_TYPE:]] "stride_size_type"
 ; CHECK-SPIRV: Name [[#WORDSIZE_FUNC_NAME:]] "test_fpga_word_size_attr"
-; CHECK-SPIRV: Name [[#WORDSIZE_TYPE:]] "word_size_type"
 ; CHECK-SPIRV: Name [[#TRUE_DUAL_PORT_FUNC_NAME:]] "test_fpga_true_dual_port_attr"
-; CHECK-SPIRV: Name [[#TRUE_DUAL_PORT_TYPE:]] "true_dual_port_type"
 
 ; CHECK-SPIRV: Decorate [[#REGISTER_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#REGISTER:]]
-; CHECK-SPIRV: MemberDecorate [[#REGISTER_TYPE]] 0 RegisterINTEL
+; CHECK-SPIRV: Decorate [[#REGISTER:]] RegisterINTEL
 ; CHECK-SPIRV: Decorate [[#MEMORY_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#MEMORY:]]
-; CHECK-SPIRV: MemberDecorate [[#MEMORY_TYPE]] 0 MemoryINTEL "DEFAULT"
+; CHECK-SPIRV: Decorate [[#MEMORY:]] MemoryINTEL "DEFAULT"
 ; CHECK-SPIRV: Decorate [[#NUMBANKS_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#NUMBANKS:]]
-; CHECK-SPIRV: MemberDecorate [[#NUMBANKS_TYPE]] 0 NumbanksINTEL 4
+; CHECK-SPIRV: Decorate [[#NUMBANKS:]] NumbanksINTEL 4
 ; CHECK-SPIRV: Decorate [[#BANKWIDTH_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#BANKWIDTH:]]
-; CHECK-SPIRV: MemberDecorate [[#BANKWIDTH_TYPE]] 0 BankwidthINTEL 4
+; CHECK-SPIRV: Decorate [[#BANKWIDTH:]] BankwidthINTEL 4
 ; CHECK-SPIRV: Decorate [[#MAX_PRIVATE_COPIES_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#MAX_PRIVATE_COPIES:]]
-; CHECK-SPIRV: MemberDecorate [[#MAX_PRIVATE_COPIES_TYPE]] 0 MaxPrivateCopiesINTEL 1
+; CHECK-SPIRV: Decorate [[#MAX_PRIVATE_COPIES:]] MaxPrivateCopiesINTEL 1
 ; CHECK-SPIRV: Decorate [[#SINGLEPUMP_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#SINGLEPUMP:]]
-; CHECK-SPIRV: MemberDecorate [[#SINGLEPUMP_TYPE]] 0 SinglepumpINTEL
+; CHECK-SPIRV: Decorate [[#SINGLEPUMP:]] SinglepumpINTEL
 ; CHECK-SPIRV: Decorate [[#DOUBLEPUMP_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#DOUBLEPUMP:]]
-; CHECK-SPIRV: MemberDecorate [[#DOUBLEPUMP_TYPE]] 0 DoublepumpINTEL
+; CHECK-SPIRV: Decorate [[#DOUBLEPUMP:]] DoublepumpINTEL
 ; CHECK-SPIRV: Decorate [[#MAX_REPLICATES_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#MAX_REPLICATES:]]
-; CHECK-SPIRV: MemberDecorate [[#MAX_REPLICATES_TYPE]] 0 MaxReplicatesINTEL 2
+; CHECK-SPIRV: Decorate [[#MAX_REPLICATES:]] MaxReplicatesINTEL 2
 ; CHECK-SPIRV: Decorate [[#SIMPLE_DUAL_PORT_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#SIMPLE_DUAL_PORT:]]
-; CHECK-SPIRV: MemberDecorate [[#SIMPLE_DUAL_PORT_TYPE]] 0 SimpleDualPortINTEL
+; CHECK-SPIRV: Decorate [[#SIMPLE_DUAL_PORT:]] SimpleDualPortINTEL
 ; CHECK-SPIRV: Decorate [[#MERGE_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#MERGE:]]
-; CHECK-SPIRV: MemberDecorate [[#MERGE_TYPE]] 0 MergeINTEL "key" "type"
+; CHECK-SPIRV: Decorate [[#MERGE:]] MergeINTEL "key" "type"
 ; CHECK-SPIRV: Decorate [[#BANKBITS_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#BANKBITS:]]
-; CHECK-SPIRV: MemberDecorate [[#BANKBITS_TYPE]] 0 BankBitsINTEL 2
+; CHECK-SPIRV: Decorate [[#BANKBITS:]] BankBitsINTEL 2
 ; CHECK-SPIRV: Decorate [[#FORCE_POW_2_DEPTH_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#FORCE_POW_2_DEPTH:]]
-; CHECK-SPIRV: MemberDecorate [[#FORCE_POW_2_DEPTH_TYPE]] 0 ForcePow2DepthINTEL 2
+; CHECK-SPIRV: Decorate [[#FORCE_POW_2_DEPTH:]] ForcePow2DepthINTEL 2
 ; CHECK-SPIRV: Decorate [[#STRIDESIZE_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#STRIDESIZE:]]
-; CHECK-SPIRV: MemberDecorate [[#STRIDESIZE_TYPE]] 0 StridesizeINTEL 4
+; CHECK-SPIRV: Decorate [[#STRIDESIZE:]] StridesizeINTEL 4
 ; CHECK-SPIRV: Decorate [[#WORDSIZE_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#WORDSIZE:]]
-; CHECK-SPIRV: MemberDecorate [[#WORDSIZE_TYPE]] 0 WordsizeINTEL 8
+; CHECK-SPIRV: Decorate [[#WORDSIZE:]] WordsizeINTEL 8
 ; CHECK-SPIRV: Decorate [[#TRUE_DUAL_PORT_FUNC_NAME]] LinkageAttributes
-; CHECK-SPIRV: Decorate [[#TRUE_DUAL_PORT:]]
-; CHECK-SPIRV: MemberDecorate [[#TRUE_DUAL_PORT_TYPE]] 0 TrueDualPortINTEL
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#REGISTER]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#MEMORY]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#NUMBANKS]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#BANKWIDTH]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#MAX_PRIVATE_COPIES]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#SINGLEPUMP]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#DOUBLEPUMP]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#MAX_REPLICATES]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#SIMPLE_DUAL_PORT]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#MERGE]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#BANKBITS]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#FORCE_POW_2_DEPTH]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#STRIDESIZE]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#WORDSIZE]] {{[0-9]+}}
-; CHECK-SPIRV: Variable {{[0-9]+}} [[#TRUE_DUAL_PORT]] {{[0-9]+}}
+; CHECK-SPIRV: Decorate [[#TRUE_DUAL_PORT:]] TrueDualPortINTEL
+
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#REGISTER]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#MEMORY]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#NUMBANKS]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#BANKWIDTH]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#MAX_PRIVATE_COPIES]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#SINGLEPUMP]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#DOUBLEPUMP]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#MAX_REPLICATES]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#SIMPLE_DUAL_PORT]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#MERGE]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#BANKBITS]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#FORCE_POW_2_DEPTH]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#STRIDESIZE]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#WORDSIZE]] {{[0-9]+}}
+; CHECK-SPIRV: PtrCastToGeneric {{[0-9]+}} [[#TRUE_DUAL_PORT]] {{[0-9]+}}
 
 ; CHECK-LLVM: [[REGISTER:@[0-9_.]+]] = {{.*}}{register:1}
 ; CHECK-LLVM: [[MEMORY:@[0-9_.]+]] = {{.*}}{memory:DEFAULT}
@@ -116,21 +87,22 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-LLVM: [[STRIDESIZE:@[0-9_.]+]] = {{.*}}{stride_size:4}
 ; CHECK-LLVM: [[WORDSIZE:@[0-9_.]+]] = {{.*}}{word_size:8}
 ; CHECK-LLVM: [[TRUE_DUAL_PORT:@[0-9_.]+]] = {{.*}}{true_dual_port}
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[REGISTER]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[MEMORY]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[NUMBANKS]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[BANKWIDTH]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[MAX_PRIVATE_COPIES]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[SINGLEPUMP]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[DOUBLEPUMP]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[MAX_REPLICATES]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[SIMPLE_DUAL_PORT]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[MERGE]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[BANK_BITS]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[FORCE_POW_2_DEPTH]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[STRIDESIZE]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[WORDSIZE]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %{{[a-zA-Z0-9_]+}}, ptr [[TRUE_DUAL_PORT]], ptr undef, i32 undef, ptr undef)
+
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[REGISTER]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[MEMORY]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[NUMBANKS]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[BANKWIDTH]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[MAX_PRIVATE_COPIES]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[SINGLEPUMP]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[DOUBLEPUMP]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[MAX_REPLICATES]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[SIMPLE_DUAL_PORT]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[MERGE]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[BANK_BITS]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[FORCE_POW_2_DEPTH]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[STRIDESIZE]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[WORDSIZE]]
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr {{.*}}, ptr [[TRUE_DUAL_PORT]]
 
 %"register_type" = type { i32 }
 %"memory_type" = type { i32 }

--- a/test/transcoding/annotate_attribute.ll
+++ b/test/transcoding/annotate_attribute.ll
@@ -17,15 +17,15 @@
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "bar"
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "{FOO}"
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "my_custom_annotations: 30, 60"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 1 UserSemantic "128"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 2 UserSemantic "qux"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "{baz}"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 3 UserSemantic "my_custom_annotations: 20, 60, 80"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "annotation_with_zerointializer: 0, 0, 0"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "annotation_with_false: 0"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "annotation_mixed: 0, 1, 0"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "abc: 1, 2, 3"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 UserSemantic "annotation_with_true: 1"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "128"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "qux"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "{baz}"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "my_custom_annotations: 20, 60, 80"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "annotation_with_zerointializer: 0, 0, 0"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "annotation_with_false: 0"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "annotation_mixed: 0, 1, 0"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "abc: 1, 2, 3"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "annotation_with_true: 1"
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
@@ -211,8 +211,8 @@ define weak_odr dso_local spir_kernel void @_ZTSZ11TestKernelAvE4MyIP(ptr addrsp
   %3 = addrspacecast ptr %2 to ptr addrspace(4)
   %4 = call ptr addrspace(4) @llvm.ptr.annotation.p4.p0(ptr addrspace(4) %3, ptr @.str.11, ptr @.str.1.12, i32 13, ptr @.args)
   ; CHECK-LLVM: %[[ALLOCA:.*]] = alloca %struct.MyIP, align 8
-  ; CHECK-LLVM: %[[GEP:.*]] = getelementptr inbounds %struct.MyIP, ptr %[[ALLOCA]], i32 0, i32 0
-  ; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %[[GEP]], ptr [[STR12]], ptr undef, i32 undef, ptr undef)
+  ; CHECK-LLVM: %[[ASCAST:.*]] = addrspacecast ptr %[[ALLOCA]] to ptr addrspace(4)
+  ; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr addrspace(4) %[[ASCAST]], ptr [[STR12]], ptr undef, i32 undef, ptr undef)
   %5 = addrspacecast ptr addrspace(1) %0 to ptr addrspace(4)
   store ptr addrspace(4) %5, ptr addrspace(4) %4, align 8, !tbaa !17
   %6 = load ptr addrspace(4), ptr addrspace(4) %4, align 8, !tbaa !17

--- a/test/transcoding/annotation_generic_decoration.ll
+++ b/test/transcoding/annotation_generic_decoration.ll
@@ -23,17 +23,17 @@ define dso_local noundef i32 @main() {
 
 declare ptr @llvm.ptr.annotation.p0(ptr, ptr, ptr, i32, ptr)
 
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 RegisterINTEL
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 MemoryINTEL "testmem"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 BankwidthINTEL 42
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 NumbanksINTEL 41
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 MaxPrivateCopiesINTEL 3
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 DoublepumpINTEL
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 SinglepumpINTEL
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 MaxReplicatesINTEL 2
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 MergeINTEL "str1" "str2"
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 BankBitsINTEL 1 3 2
-; CHECK-SPIRV-DAG: MemberDecorate {{[0-9]+}} 0 ForcePow2DepthINTEL 24
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} RegisterINTEL
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} MemoryINTEL "testmem"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} BankwidthINTEL 42
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} NumbanksINTEL 41
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} MaxPrivateCopiesINTEL 3
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} DoublepumpINTEL
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} SinglepumpINTEL
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} MaxReplicatesINTEL 2
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} MergeINTEL "str1" "str2"
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} BankBitsINTEL 1 3 2
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} ForcePow2DepthINTEL 24
 
 ; CHECK-LLVM: @{{.*}} = private unnamed_addr constant [163 x i8] c"
 ; CHECK-LLVM-DAG: {register:1}

--- a/test/transcoding/multiple_user_semantic.ll
+++ b/test/transcoding/multiple_user_semantic.ll
@@ -10,31 +10,24 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_accesses,+SPV_INTEL_fpga_memory_attributes -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; CHECK-SPIRV-DAG: Name [[#ClassMember:]] "class.Sample"
 ; CHECK-SPIRV-DAG: Decorate [[#Var:]] UserSemantic "var_annotation_a"
 ; CHECK-SPIRV-DAG: Decorate [[#Var]] UserSemantic "var_annotation_b2"
-; CHECK-SPIRV-DAG: MemberDecorate [[#ClassMember]] 0 UserSemantic "class_annotation_a"
-; CHECK-SPIRV-DAG: MemberDecorate [[#ClassMember]] 0 UserSemantic "class_annotation_b2"
+; CHECK-SPIRV-DAG: Decorate [[#Gep:]] UserSemantic "class_annotation_a"
+; CHECK-SPIRV-DAG: Decorate [[#Gep]] UserSemantic "class_annotation_b2"
 ; CHECK-SPIRV: Variable [[#]] [[#Var]] [[#]]
+; CHECK-SPIRV: InBoundsPtrAccessChain [[#]] [[#Gep]] [[#]]
 
-; CHECK-LLVM: @[[StrStructA:[0-9_.]+]] = {{.*}}"class_annotation_a\00"
-; CHECK-LLVM: @[[StrStructB:[0-9_.]+]] = {{.*}}"class_annotation_b2\00"
-; CHECK-LLVM: @[[StrA:[0-9_.]+]] = {{.*}}"var_annotation_a\00"
-; CHECK-LLVM: @[[StrB:[0-9_.]+]] = {{.*}}"var_annotation_b2\00"
+; CHECK-LLVM-DAG: @[[StrStructA:[0-9_.]+]] = {{.*}}"class_annotation_a\00"
+; CHECK-LLVM-DAG: @[[StrStructB:[0-9_.]+]] = {{.*}}"class_annotation_b2\00"
+; CHECK-LLVM-DAG: @[[StrA:[0-9_.]+]] = {{.*}}"var_annotation_a\00"
+; CHECK-LLVM-DAG: @[[StrB:[0-9_.]+]] = {{.*}}"var_annotation_b2\00"
 ; CHECK-LLVM: %[[#StructMember:]] = alloca %class.Sample, align 4
-; CHECK-LLVM: %[[#GEP1:]] = getelementptr inbounds %class.Sample, ptr %[[#StructMember]], i32 0, i32 0
-; CHECK-LLVM: %[[#PtrAnn1:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#GEP1:]], ptr @[[StrStructA]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: %[[#PtrAnn2:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#PtrAnn1]], ptr @[[StrStructB]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: [[#Var:]] = alloca i32, align 4
-; CHECK-LLVM: call void @llvm.var.annotation.p0.p0(ptr %[[#Var]], ptr @[[StrA]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call void @llvm.var.annotation.p0.p0(ptr %[[#Var]], ptr @[[StrB]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: [[#Bitcast3:]] = bitcast ptr %[[#PtrAnn2]] to ptr
-; CHECK-LLVM: [[#Bitcast4:]] = bitcast ptr %[[#Bitcast3]] to ptr
-; CHECK-LLVM: [[#Load1:]] = load i32, ptr %[[#Bitcast4]], align 4
-; CHECK-LLVM: call spir_func void @_Z3fooi(i32 %[[#Load1]])
-; CHECK-LLVM: [[#Load2:]] = load i32, ptr %[[#Var]], align 4
-; CHECK-LLVM: call spir_func void @_Z3fooi(i32 %[[#Load2]])
-
+; CHECK-LLVM: %[[#Var:]] = alloca i32, align 4
+; CHECK-LLVM-DAG: %[[#GEP1:]] = getelementptr inbounds %class.Sample, ptr %[[#StructMember]], i32 0, i32 0
+; CHECK-LLVM-DAG: %[[#PtrAnn1:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#GEP1:]], ptr @[[StrStructA]], ptr undef, i32 undef, ptr undef)
+; CHECK-LLVM-DAG: %[[#PtrAnn2:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#PtrAnn1]], ptr @[[StrStructB]], ptr undef, i32 undef, ptr undef)
+; CHECK-LLVM-DAG: call void @llvm.var.annotation.p0.p0(ptr %[[#Var]], ptr @[[StrA]], ptr undef, i32 undef, ptr undef)
+; CHECK-LLVM-DAG: call void @llvm.var.annotation.p0.p0(ptr %[[#Var]], ptr @[[StrB]], ptr undef, i32 undef, ptr undef)
 
 source_filename = "llvm-link"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/test/transcoding/multiple_user_semantic_nonopaque.ll
+++ b/test/transcoding/multiple_user_semantic_nonopaque.ll
@@ -10,23 +10,23 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_accesses,+SPV_INTEL_fpga_memory_attributes -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; CHECK-SPIRV: Name [[#ClassMember:]] "class.Sample"
 ; CHECK-SPIRV: Decorate [[#Var:]] UserSemantic "var_annotation_a"
 ; CHECK-SPIRV: Decorate [[#Var]] UserSemantic "var_annotation_b"
-; CHECK-SPIRV: MemberDecorate [[#ClassMember]] 0 UserSemantic "class_annotation_a"
-; CHECK-SPIRV: MemberDecorate [[#ClassMember]] 0 UserSemantic "class_annotation_b"
-; CHECK-SPIRV: Variable [[#]] [[#Var]] [[#]]
+; CHECK-SPIRV: Decorate [[#Var2:]] UserSemantic "class_annotation_a"
+; CHECK-SPIRV: Decorate [[#Var2]] UserSemantic "class_annotation_b"
+; CHECK-SPIRV-DAG: Variable [[#]] [[#Var]] [[#]]
+; CHECK-SPIRV-DAG: Variable [[#]] [[#Var2]] [[#]]
 
 ; CHECK-LLVM-DAG: @[[StrA:[0-9_.]+]] = {{.*}}"var_annotation_a\00"
 ; CHECK-LLVM-DAG: @[[StrB:[0-9_.]+]] = {{.*}}"var_annotation_b\00"
 ; CHECK-LLVM-DAG: @[[StrStructA:[0-9_.]+]] = {{.*}}"class_annotation_a\00"
 ; CHECK-LLVM-DAG: @[[StrStructB:[0-9_.]+]] = {{.*}}"class_annotation_b\00"
 ; CHECK-LLVM: [[#Var:]] = alloca i32, align 4
-; CHECK-LLVM: call void @llvm.var.annotation.p0.p0(ptr %[[#Var]], ptr @[[StrA]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call void @llvm.var.annotation.p0.p0(ptr %[[#Var]], ptr @[[StrB]], ptr undef, i32 undef, ptr undef)
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr %[[#Var]], ptr @[[StrA]], ptr undef, i32 undef, ptr undef)
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr %[[#Var]], ptr @[[StrB]], ptr undef, i32 undef, ptr undef)
 ; CHECK-LLVM: %[[#StructMember:]] = alloca %class.Sample, align 4
-; CHECK-LLVM: %[[#PtrAnn:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#GEP1:]], ptr @[[StrStructA]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#PtrAnn]], ptr @[[StrStructB]], ptr undef, i32 undef, ptr undef)
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr %[[#StructMember]], ptr @[[StrStructA]], ptr undef, i32 undef, ptr undef)
+; CHECK-LLVM: call void @llvm.var.annotation{{.*}}(ptr %[[#StructMember]], ptr @[[StrStructB]], ptr undef, i32 undef, ptr undef)
 
 
 source_filename = "llvm-link"

--- a/test/transcoding/multiple_user_semantic_on_struct.ll
+++ b/test/transcoding/multiple_user_semantic_on_struct.ll
@@ -25,7 +25,6 @@
 ;     return 0;
 ; }
 
-
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
@@ -38,79 +37,20 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_accesses,+SPV_INTEL_fpga_memory_attributes -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; CHECK-SPIRV: Name [[#ClassA:]] "class.A"
-; CHECK-SPIRV: Name [[#ClassB:]] "class.B"
-; CHECK-SPIRV: MemberDecorate [[#ClassA]] 0 UserSemantic "ClassA"
-; CHECK-SPIRV: MemberDecorate [[#ClassA]] 0 UserSemantic "ClassA"
-; CHECK-SPIRV: MemberDecorate [[#ClassA]] 1 UserSemantic "Dec1"
-; CHECK-SPIRV: MemberDecorate [[#ClassA]] 1 UserSemantic "Dec2"
-; CHECK-SPIRV: MemberDecorate [[#ClassA]] 1 UserSemantic "Dec3"
-; CHECK-SPIRV: MemberDecorate [[#ClassA]] 2 UserSemantic "ClassAfieldB"
-; CHECK-SPIRV: MemberDecorate [[#ClassB]] 0 UserSemantic "ClassB"
-; CHECK-SPIRV: MemberDecorate [[#ClassB]] 0 UserSemantic "ClassB"
-
-; CHECK-LLVM: @[[#StrStructA:]] = {{.*}}"ClassA\00"
-; CHECK-LLVM: @[[#StrStructA2:]] = {{.*}}"ClassA\00"
-; CHECK-LLVM: @[[#Dec1:]] = {{.*}}"Dec1\00"
-; CHECK-LLVM: @[[#Dec2:]] = {{.*}}"Dec2\00"
-; CHECK-LLVM: @[[#Dec3:]] = {{.*}}"Dec3\00"
-; CHECK-LLVM: @[[#StrAfieldB:]] = {{.*}}"ClassAfieldB\00"
-; CHECK-LLVM: @[[#StrStructB:]] = {{.*}}"ClassB\00"
-; CHECK-LLVM: @[[#StrStructB2:]] = {{.*}}"ClassB\00"
-; CHECK-LLVM: @[[#StrObj2StructA:]] = {{.*}}"ClassA\00"
-; CHECK-LLVM: @[[#StrObj2StructA2:]] = {{.*}}"ClassA\00"
-
-; CHECK-LLVM: %[[#ObjClassA:]] = alloca %class.A, align 4
-; CHECK-LLVM: %[[#GepClassAVal:]] = getelementptr inbounds %class.A, ptr %[[#ObjClassA]], i32 0, i32 0
-; CHECK-LLVM: %[[#PtrAnnClassAVal:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#GepClassAVal]], ptr @[[#StrStructA]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: %[[#PtrAnn2ClassAVal:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#PtrAnnClassAVal]], ptr @[[#StrStructA2]], ptr undef, i32 undef, ptr undef)
-
-; CHECK-LLVM: %[[#GepMultiDec:]] = getelementptr inbounds %class.A, ptr %[[#ObjClassA]], i32 0, i32 1
-; CHECK-LLVM: %[[#PtrAnnMultiDec:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#GepMultiDec]], ptr @[[#Dec1]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: %[[#PtrAnn2MultiDec:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#PtrAnnMultiDec]], ptr @[[#Dec2]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: %[[#PtrAnn3MultiDec:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#PtrAnn2MultiDec]], ptr @[[#Dec3]], ptr undef, i32 undef, ptr undef)
-
-; CHECK-LLVM: %[[#GepClassAFieldB:]] = getelementptr inbounds %class.A, ptr %[[#ObjClassA]], i32 0, i32 2
-; CHECK-LLVM: %[[#PtrAnnClassAFieldB:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#GepClassAFieldB]], ptr @[[#StrAfieldB]], ptr undef, i32 undef, ptr undef)
-
-; CHECK-LLVM: %[[#ObjClassB:]] = alloca %class.B, align 4
-; CHECK-LLVM: %[[#GEPClassB:]] = getelementptr inbounds %class.B, ptr %[[#ObjClassB]], i32 0, i32 0
-; CHECK-LLVM: %[[#PtrAnnClassB:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#GEPClassB]], ptr @[[#StrStructB]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: %[[#PtrAnn2ClassB:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#PtrAnnClassB]], ptr @[[#StrStructB2]], ptr undef, i32 undef, ptr undef)
-
-; CHECK-LLVM: %[[#Obj2ClassA:]] = alloca %class.A, align 4
-; CHECK-LLVM: %[[#GepObj2ClassA:]] = getelementptr inbounds %class.A, ptr %[[#Obj2ClassA]], i32 0, i32 0
-; CHECK-LLVM: %[[#PtrAnnObj2ClassA:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#GepObj2ClassA]], ptr @[[#StrObj2StructA]], ptr undef, i32 undef, ptr undef)
-; CHECK-LLVM: %[[#PtrAnn2Obj2ClassA:]] = call ptr @llvm.ptr.annotation.p0.p0(ptr %[[#PtrAnnObj2ClassA]], ptr @[[#StrObj2StructA2]], ptr undef, i32 undef, ptr undef)
-
-
-; CHECK-LLVM: %[[#CastClassAVal:]] = bitcast ptr %[[#PtrAnn2ClassAVal]] to ptr
-; CHECK-LLVM: %[[#LoadClassAVal:]] = bitcast ptr %[[#CastClassAVal]] to ptr
-; CHECK-LLVM: %[[#CallClassA:]] = load i32, ptr %[[#LoadClassAVal]], align 4
-; CHECK-LLVM: call spir_func void @_Z3fooi(i32 %[[#CallClassA]])
-
-; CHECK-LLVM: %[[#CastObj2ClassA:]] = bitcast ptr %[[#PtrAnn2Obj2ClassA]] to ptr
-; CHECK-LLVM: %[[#LoadObj2ClassA:]] = bitcast ptr %[[#CastObj2ClassA]] to ptr
-; CHECK-LLVM: %[[#CallObj2ClassA:]] = load i32, ptr %[[#LoadObj2ClassA]], align 4
-; CHECK-LLVM: call spir_func void @_Z3fooi(i32 %[[#CallObj2ClassA]])
-
-; CHECK-LLVM: %[[#CastMultiDec:]] = bitcast ptr %[[#PtrAnn3MultiDec]] to ptr
-; CHECK-LLVM: %[[#LoadMultiDec:]] = bitcast ptr %[[#CastMultiDec]] to ptr
-; CHECK-LLVM: %[[#CallClassAMultiDec:]] = load i32, ptr %[[#LoadMultiDec]], align 4
-; CHECK-LLVM: call spir_func void @_Z3fooi(i32 %[[#CallClassAMultiDec]])
-
-; CHECK-LLVM: %[[#CastClassAFieldB:]] = bitcast ptr %[[#PtrAnnClassAFieldB]] to ptr
-; CHECK-LLVM: %[[#Cast2ClassAFieldB:]] = bitcast ptr %[[#CastClassAFieldB]] to ptr
-; CHECK-LLVM: %[[#GEPClassB:]] = getelementptr inbounds %class.B, ptr %[[#Cast2ClassAFieldB]], i32 0, i32 0
-; CHECK-LLVM: %[[#CastClassB:]] = bitcast ptr %[[#GEPClassB]] to ptr
-; CHECK-LLVM: %[[#Cast2ClassB:]] = bitcast ptr %[[#CastClassB]] to ptr
-; CHECK-LLVM: %[[#CallClassAFieldB:]] = load i32, ptr %[[#Cast2ClassB]], align 4
-; CHECK-LLVM: call spir_func void @_Z3fooi(i32 %[[#CallClassAFieldB]])
-
-; CHECK-LLVM: %[[#CastClassB:]] = bitcast ptr %[[#PtrAnn2ClassB]] to ptr
-; CHECK-LLVM: %[[#Cast2ClassB:]] = bitcast ptr %[[#CastClassB]] to ptr
-; CHECK-LLVM: %[[#CallClassB:]] = load i32, ptr %[[#Cast2ClassB]], align 4
-; CHECK-LLVM: call spir_func void @_Z3fooi(i32 %[[#CallClassB]])
+; CHECK-SPIRV: Decorate [[#GEP1:]] UserSemantic "ClassA"
+; CHECK-SPIRV: Decorate [[#GEP2:]] UserSemantic "ClassA"
+; CHECK-SPIRV: Decorate [[#GEP3:]] UserSemantic "Dec1"
+; CHECK-SPIRV: Decorate [[#GEP3]] UserSemantic "Dec2"
+; CHECK-SPIRV: Decorate [[#GEP3]] UserSemantic "Dec3"
+; CHECK-SPIRV: Decorate [[#GEP4:]] UserSemantic "ClassAfieldB"
+; CHECK-SPIRV: Decorate [[#GEP5:]] UserSemantic "ClassB"
+; CHECK-SPIRV: Decorate [[#GEP6:]] UserSemantic "ClassB"
+; CHECK-SPIRV: InBoundsPtrAccessChain [[#]] [[#GEP1]] [[#]]
+; CHECK-SPIRV: InBoundsPtrAccessChain [[#]] [[#GEP2]] [[#]]
+; CHECK-SPIRV: InBoundsPtrAccessChain [[#]] [[#GEP3]] [[#]]
+; CHECK-SPIRV: InBoundsPtrAccessChain [[#]] [[#GEP4]] [[#]]
+; CHECK-SPIRV: InBoundsPtrAccessChain [[#]] [[#GEP5]] [[#]]
+; CHECK-SPIRV: InBoundsPtrAccessChain [[#]] [[#GEP6]] [[#]]
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64"
@@ -126,35 +66,77 @@ target triple = "spir64"
 @.str.5 = private unnamed_addr constant [13 x i8] c"ClassAfieldB\00", section "llvm.metadata"
 @.str.6 = private unnamed_addr constant [7 x i8] c"ClassB\00", section "llvm.metadata"
 
+; CHECK-LLVM-DAG: @[[#StrStructA:]] = {{.*}}"ClassA\00"
+; CHECK-LLVM-DAG: @[[#Dec1:]] = {{.*}}"Dec1\00"
+; CHECK-LLVM-DAG: @[[#Dec2:]] = {{.*}}"Dec2\00"
+; CHECK-LLVM-DAG: @[[#Dec3:]] = {{.*}}"Dec3\00"
+; CHECK-LLVM-DAG: @[[#StrAfieldB:]] = {{.*}}"ClassAfieldB\00"
+; CHECK-LLVM-DAG: @[[#StrStructB:]] = {{.*}}"ClassB\00"
+
 define dso_local noundef i32 @main() #0 {
   %1 = alloca i32, align 4
   %2 = alloca %class.A, align 4
   %3 = alloca %class.B, align 4
   %4 = alloca %class.A, align 4
+; CHECK-LLVM: %[[#ObjClassA:]] = alloca %class.A, align 4
+; CHECK-LLVM: %[[#ObjClassB:]] = alloca %class.B, align 4
+; CHECK-LLVM: %[[#Obj2ClassA:]] = alloca %class.A, align 4
+
   store i32 0, ptr %1, align 4
   %5 = getelementptr inbounds %class.A, ptr %2, i32 0, i32 0
   %6 = call ptr @llvm.ptr.annotation.p0.p0(ptr %5, ptr @.str, ptr @.str.1, i32 11, ptr null)
+  ; CHECK-LLVM: %[[#GepClassAVal:]] = getelementptr inbounds %class.A, ptr %[[#ObjClassA]], i32 0, i32 0
+  ; CHECK-LLVM: %[[#PtrAnnClassAVal:]] = call ptr @llvm.ptr.annotation{{.*}}(ptr %[[#GepClassAVal]], ptr @[[#StrStructA]]
   %7 = load i32, ptr %6, align 4
+ ; CHECK-LLVM: %[[#LoadClassAVal:]] = bitcast ptr %[[#PtrAnnClassAVal]] to ptr
+  ; CHECK-LLVM: %[[#LoadClassAVal2:]] = bitcast ptr %[[#LoadClassAVal]] to ptr
+  ; CHECK-LLVM: %[[#CallClassA:]] = load i32, ptr %[[#LoadClassAVal2]], align 4
   call void @_Z3fooi(i32 noundef %7)
   %8 = getelementptr inbounds %class.A, ptr %4, i32 0, i32 0
   %9 = call ptr @llvm.ptr.annotation.p0.p0(ptr %8, ptr @.str, ptr @.str.1, i32 11, ptr null)
+  ; CHECK-LLVM: %[[#GepObj2ClassA:]] = getelementptr inbounds %class.A, ptr %[[#Obj2ClassA]], i32 0, i32 0
+  ; CHECK-LLVM: %[[#PtrAnnObj2ClassA:]] = call ptr @llvm.ptr.annotation{{.*}}(ptr %[[#GepObj2ClassA]], ptr @[[#StrStructA]]
   %10 = load i32, ptr %9, align 4
+  ; CHECK-LLVM: %[[#LoadObj2ClassA:]] = bitcast ptr %[[#PtrAnnObj2ClassA]] to ptr
+  ; CHECK-LLVM: %[[#LoadObj2ClassA2:]] = bitcast ptr %[[#LoadObj2ClassA]] to ptr
+  ; CHECK-LLVM: %[[#CallObj2ClassA:]] = load i32, ptr %[[#LoadObj2ClassA2]], align 4
   call void @_Z3fooi(i32 noundef %10)
   %11 = getelementptr inbounds %class.A, ptr %2, i32 0, i32 1
   %12 = call ptr @llvm.ptr.annotation.p0.p0(ptr %11, ptr @.str.2, ptr @.str.1, i32 12, ptr null)
   %13 = call ptr @llvm.ptr.annotation.p0.p0(ptr %12, ptr @.str.3, ptr @.str.1, i32 12, ptr null)
   %14 = call ptr @llvm.ptr.annotation.p0.p0(ptr %13, ptr @.str.4, ptr @.str.1, i32 12, ptr null)
+  ; CHECK-LLVM: %[[#GepMultiDec:]] = getelementptr inbounds %class.A, ptr %[[#ObjClassA]], i32 0, i32 1
+  ; CHECK-LLVM: %[[#PtrAnnMultiDec:]] = call ptr @llvm.ptr.annotation{{.*}}(ptr %[[#GepMultiDec]], ptr @[[#Dec1]]
+  ; CHECK-LLVM: %[[#PtrAnn2MultiDec:]] = call ptr @llvm.ptr.annotation{{.*}}(ptr %[[#PtrAnnMultiDec]], ptr @[[#Dec2]]
+  ; CHECK-LLVM: %[[#PtrAnn3MultiDec:]] = call ptr @llvm.ptr.annotation{{.*}}(ptr %[[#PtrAnnMultiDec]], ptr @[[#Dec3]]
   %15 = load i32, ptr %14, align 4
+  ; CHECK-LLVM: %[[#LoadMultiDec:]] = bitcast ptr %[[#PtrAnnMultiDec]] to ptr
+  ; CHECK-LLVM: %[[#LoadMultiDec2:]] = bitcast ptr %[[#LoadMultiDec]] to ptr
+  ; CHECK-LLVM: %[[#CallClassAMultiDec:]] = load i32, ptr %[[#LoadMultiDec2]], align 4
   call void @_Z3fooi(i32 noundef %15)
   %16 = getelementptr inbounds %class.A, ptr %2, i32 0, i32 2
   %17 = call ptr @llvm.ptr.annotation.p0.p0(ptr %16, ptr @.str.5, ptr @.str.1, i32 13, ptr null)
+  ; CHECK-LLVM: %[[#GepClassAFieldB:]] = getelementptr inbounds %class.A, ptr %[[#ObjClassA]], i32 0, i32 2
+  ; CHECK-LLVM: %[[#PtrAnnClassAFieldB:]] = call ptr @llvm.ptr.annotation{{.*}}(ptr %[[#GepClassAFieldB]], ptr @[[#StrAfieldB]]
   %18 = getelementptr inbounds %class.B, ptr %17, i32 0, i32 0
   %19 = call ptr @llvm.ptr.annotation.p0.p0(ptr %18, ptr @.str.6, ptr @.str.1, i32 5, ptr null)
+  ; CHECK-LLVM: %[[#CastGepClassAFieldB:]] = bitcast ptr %[[#GepClassAFieldB]] to ptr
+  ; CHECK-LLVM: %[[#CastGepClassAFieldB2:]] = bitcast ptr %[[#CastGepClassAFieldB]] to ptr
+  ; CHECK-LLVM: %[[#GEPClassB:]] = getelementptr inbounds %class.B, ptr %[[#CastGepClassAFieldB2]], i32 0, i32 0
+  ; CHECK-LLVM: %[[#PtrAnnClassB:]] = call ptr @llvm.ptr.annotation{{.*}}(ptr %[[#GEPClassB]], ptr @[[#StrStructB]]
   %20 = load i32, ptr %19, align 4
+  ; CHECK-LLVM: %[[#Cast2ClassB:]] = bitcast ptr %[[#PtrAnnClassB]] to ptr
+  ; CHECK-LLVM: %[[#Cast2ClassB2:]] = bitcast ptr %[[#Cast2ClassB]] to ptr
+  ; CHECK-LLVM: %[[#CallClassAFieldB:]] = load i32, ptr %[[#Cast2ClassB2]], align 4
   call void @_Z3fooi(i32 noundef %20)
   %21 = getelementptr inbounds %class.B, ptr %3, i32 0, i32 0
   %22 = call ptr @llvm.ptr.annotation.p0.p0(ptr %21, ptr @.str.6, ptr @.str.1, i32 5, ptr null)
+  ; CHECK-LLVM: %[[#GEP2ClassB:]] = getelementptr inbounds %class.B, ptr %[[#ObjClassB]], i32 0, i32 0
+  ; CHECK-LLVM: %[[#PtrAnn2ClassB:]] = call ptr @llvm.ptr.annotation{{.*}}(ptr %[[#GEP2ClassB]], ptr @[[#StrStructB]]
   %23 = load i32, ptr %22, align 4
+  ; CHECK-LLVM: %[[#Cast2ClassB:]] = bitcast ptr %[[#PtrAnn2ClassB]] to ptr
+  ; CHECK-LLVM: %[[#Cast2ClassB2:]] = bitcast ptr %[[#Cast2ClassB]] to ptr
+  ; CHECK-LLVM: %[[#CallClassB:]] = load i32, ptr %[[#Cast2ClassB2]], align 4
   call void @_Z3fooi(i32 noundef %23)
   ret i32 0
 }


### PR DESCRIPTION
There is a fundamental misalignment between when translating llvm.ptr.annotation to [SPIRV's OpMemberDecorate](https://registry.khronos.org/SPIR-V/specs/1.0/SPIRV.html#OpMemberDecorate).

llvm.ptr.annotation is applied onto a pointer.

OpMemberDecorate is applied on a type, which means that all variables of this type will have this Decoration.

This change fixes this misalignment by translating llvm.ptr.annotation to [SPIRV's OpDecorate](https://registry.khronos.org/SPIR-V/specs/1.0/SPIRV.html#OpDecorate) instead, which instead places the decoration onto the pointer.