### PR TITLE
Added support for StallFreeINTEL

### DIFF
--- a/include/LLVMSPIRVExtensions.inc
+++ b/include/LLVMSPIRVExtensions.inc
@@ -42,7 +42,6 @@ EXT(SPV_INTEL_arbitrary_precision_floating_point)
 EXT(SPV_INTEL_variable_length_array)
 EXT(SPV_INTEL_fp_fast_math_mode)
 EXT(SPV_INTEL_fpga_cluster_attributes)
-EXT(SPV_INTEL_fpga_cluster_attributesV2)
 EXT(SPV_INTEL_loop_fuse)
 EXT(SPV_INTEL_long_constant_composite) // TODO: rename to
                                        // SPV_INTEL_long_composites later

--- a/include/LLVMSPIRVExtensions.inc
+++ b/include/LLVMSPIRVExtensions.inc
@@ -42,6 +42,7 @@ EXT(SPV_INTEL_arbitrary_precision_floating_point)
 EXT(SPV_INTEL_variable_length_array)
 EXT(SPV_INTEL_fp_fast_math_mode)
 EXT(SPV_INTEL_fpga_cluster_attributes)
+EXT(SPV_INTEL_fpga_cluster_attributesV2)
 EXT(SPV_INTEL_loop_fuse)
 EXT(SPV_INTEL_long_constant_composite) // TODO: rename to
                                        // SPV_INTEL_long_composites later

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -406,6 +406,7 @@ const static char NoGlobalOffset[] = "no_global_work_offset";
 const static char MaxWGDim[] = "max_global_work_dim";
 const static char NumSIMD[] = "num_simd_work_items";
 const static char StallEnable[] = "stall_enable";
+const static char StallFree[] = "stall_free";
 const static char FmaxMhz[] = "scheduler_target_fmax_mhz";
 const static char LoopFuse[] = "loop_fuse";
 const static char PreferDSP[] = "prefer_dsp";

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4535,6 +4535,11 @@ bool SPIRVToLLVM::transFPGAFunctionMetadata(SPIRVFunction *BF, Function *F) {
     MetadataVec.push_back(ConstantAsMetadata::get(getInt32(M, 1)));
     F->setMetadata(kSPIR2MD::StallEnable, MDNode::get(*Context, MetadataVec));
   }
+  if (BF->hasDecorate(DecorationStallFreeINTEL)) {
+    std::vector<Metadata *> MetadataVec;
+    MetadataVec.push_back(ConstantAsMetadata::get(getInt32(M, 1)));
+    F->setMetadata(kSPIR2MD::StallFree, MDNode::get(*Context, MetadataVec));
+  }
   if (BF->hasDecorate(DecorationFuseLoopsInFunctionINTEL)) {
     std::vector<Metadata *> MetadataVec;
     auto Literals =

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -998,6 +998,13 @@ void LLVMToSPIRVBase::transFPGAFunctionMetadata(SPIRVFunction *BF,
         BF->addDecorate(new SPIRVDecorateStallEnableINTEL(BF));
     }
   }
+  if (MDNode *StallFree = F->getMetadata(kSPIR2MD::StallFree)) {
+    if (BM->isAllowedToUseExtension(
+            ExtensionID::SPV_INTEL_fpga_cluster_attributesV2)) {
+      if (getMDOperandAsInt(StallFree, 0))
+        BF->addDecorate(new SPIRVDecorateStallFreeINTEL(BF));
+    }
+  }
   if (MDNode *LoopFuse = F->getMetadata(kSPIR2MD::LoopFuse)) {
     if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_loop_fuse)) {
       size_t Depth = getMDOperandAsInt(LoopFuse, 0);
@@ -2572,6 +2579,10 @@ static void transMetadataDecorations(Metadata *MD, SPIRVEntry *Target) {
     }
     case DecorationStallEnableINTEL: {
       Target->addDecorate(new SPIRVDecorateStallEnableINTEL(Target));
+      break;
+    }
+    case DecorationStallFreeINTEL: {
+      Target->addDecorate(new SPIRVDecorateStallFreeINTEL(Target));      
       break;
     }
     case DecorationMergeINTEL: {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1002,7 +1002,6 @@ void LLVMToSPIRVBase::transFPGAFunctionMetadata(SPIRVFunction *BF,
     if (BM->isAllowedToUseExtension(
             ExtensionID::SPV_INTEL_fpga_cluster_attributes)) {
       if (getMDOperandAsInt(StallFree, 0)) {
-        BM->addCapability(spv::CapabilityFPGAClusterAttributesV2INTEL);
         BF->addDecorate(new SPIRVDecorateStallFreeINTEL(BF));
       }
     }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1000,7 +1000,8 @@ void LLVMToSPIRVBase::transFPGAFunctionMetadata(SPIRVFunction *BF,
   }
   if (MDNode *StallFree = F->getMetadata(kSPIR2MD::StallFree)) {
     if (BM->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_fpga_cluster_attributesV2)) {
+            ExtensionID::SPV_INTEL_fpga_cluster_attributes) &&
+        BM->hasCapability(spv::CapabilityFPGAClusterAttributesV2INTEL)) {
       if (getMDOperandAsInt(StallFree, 0))
         BF->addDecorate(new SPIRVDecorateStallFreeINTEL(BF));
     }
@@ -2582,7 +2583,7 @@ static void transMetadataDecorations(Metadata *MD, SPIRVEntry *Target) {
       break;
     }
     case DecorationStallFreeINTEL: {
-      Target->addDecorate(new SPIRVDecorateStallFreeINTEL(Target));      
+      Target->addDecorate(new SPIRVDecorateStallFreeINTEL(Target));
       break;
     }
     case DecorationMergeINTEL: {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1000,10 +1000,11 @@ void LLVMToSPIRVBase::transFPGAFunctionMetadata(SPIRVFunction *BF,
   }
   if (MDNode *StallFree = F->getMetadata(kSPIR2MD::StallFree)) {
     if (BM->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_fpga_cluster_attributes) &&
-        BM->hasCapability(spv::CapabilityFPGAClusterAttributesV2INTEL)) {
-      if (getMDOperandAsInt(StallFree, 0))
+            ExtensionID::SPV_INTEL_fpga_cluster_attributes)) {
+      if (getMDOperandAsInt(StallFree, 0)) {
+        BM->addCapability(spv::CapabilityFPGAClusterAttributesV2INTEL);
         BF->addDecorate(new SPIRVDecorateStallFreeINTEL(BF));
+      }
     }
   }
   if (MDNode *LoopFuse = F->getMetadata(kSPIR2MD::LoopFuse)) {

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -174,7 +174,7 @@ public:
     case DecorationStallEnableINTEL:
       return ExtensionID::SPV_INTEL_fpga_cluster_attributes;
     case DecorationStallFreeINTEL:
-      return ExtensionID::SPV_INTEL_fpga_cluster_attributesV2;
+      return ExtensionID::SPV_INTEL_fpga_cluster_attributes;
     case DecorationFuseLoopsInFunctionINTEL:
       return ExtensionID::SPV_INTEL_loop_fuse;
     case internal::DecorationCallableFunctionINTEL:

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -173,6 +173,8 @@ public:
       return ExtensionID::SPV_INTEL_float_controls2;
     case DecorationStallEnableINTEL:
       return ExtensionID::SPV_INTEL_fpga_cluster_attributes;
+    case DecorationStallFreeINTEL:
+      return ExtensionID::SPV_INTEL_fpga_cluster_attributesV2;
     case DecorationFuseLoopsInFunctionINTEL:
       return ExtensionID::SPV_INTEL_loop_fuse;
     case internal::DecorationCallableFunctionINTEL:
@@ -682,6 +684,12 @@ public:
   // Complete constructor for SPIRVDecorateStallEnableINTEL
   SPIRVDecorateStallEnableINTEL(SPIRVEntry *TheTarget)
       : SPIRVDecorate(spv::DecorationStallEnableINTEL, TheTarget) {}
+};
+
+class SPIRVDecorateStallFreeINTEL : public SPIRVDecorate {
+public:
+  SPIRVDecorateStallFreeINTEL(SPIRVEntry *TheTarget)
+      : SPIRVDecorate(spv::DecorationStallFreeINTEL, TheTarget) {}
 };
 
 class SPIRVDecorateFuseLoopsInFunctionINTEL : public SPIRVDecorate {

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -462,7 +462,8 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationMediaBlockIOINTEL, {CapabilityVectorComputeINTEL});
   ADD_VEC_INIT(DecorationStallEnableINTEL,
                {CapabilityFPGAClusterAttributesINTEL});
-  ADD_VEC_INIT(DecorationStallFreeINTEL, {CapabilityFPGAClusterAttributesV2INTEL})
+  ADD_VEC_INIT(DecorationStallFreeINTEL,
+               {CapabilityFPGAClusterAttributesV2INTEL});
   ADD_VEC_INIT(DecorationFuseLoopsInFunctionINTEL, {CapabilityLoopFuseINTEL});
   ADD_VEC_INIT(DecorationMathOpDSPModeINTEL, {CapabilityFPGADSPControlINTEL});
   ADD_VEC_INIT(DecorationInitiationIntervalINTEL,

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -462,6 +462,7 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationMediaBlockIOINTEL, {CapabilityVectorComputeINTEL});
   ADD_VEC_INIT(DecorationStallEnableINTEL,
                {CapabilityFPGAClusterAttributesINTEL});
+  ADD_VEC_INIT(DecorationStallFreeINTEL, {CapabilityFPGAClusterAttributesV2INTEL})
   ADD_VEC_INIT(DecorationFuseLoopsInFunctionINTEL, {CapabilityLoopFuseINTEL});
   ADD_VEC_INIT(DecorationMathOpDSPModeINTEL, {CapabilityFPGADSPControlINTEL});
   ADD_VEC_INIT(DecorationInitiationIntervalINTEL,

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -169,6 +169,7 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationDontStaticallyCoalesceINTEL, "DontStaticallyCoalesceINTEL");
   add(DecorationPrefetchINTEL, "PrefetchINTEL");
   add(DecorationStallEnableINTEL, "StallEnableINTEL");
+  add(DecorationStallFreeINTEL, "StallFreeINTEL");
   add(DecorationFuseLoopsInFunctionINTEL, "FuseLoopsInFunctionINTEL");
   add(DecorationAliasScopeINTEL, "AliasScopeINTEL");
   add(DecorationNoAliasINTEL, "NoAliasINTEL");
@@ -594,6 +595,7 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(CapabilityFPGAKernelAttributesv2INTEL, "FPGAKernelAttributesv2INTEL");
   add(CapabilityFPGAMemoryAccessesINTEL, "FPGAMemoryAccessesINTEL");
   add(CapabilityFPGAClusterAttributesINTEL, "FPGAClusterAttributesINTEL");
+  add(CapabilityFPGAClusterAttributesV2INTEL, "FPGAClusterAttributesV2INTEL");
   add(CapabilityLoopFuseINTEL, "LoopFuseINTEL");
   add(CapabilityMemoryAccessAliasingINTEL, "MemoryAccessAliasingINTEL");
   add(CapabilityFPGABufferLocationINTEL, "FPGABufferLocationINTEL");

--- a/test/extensions/INTEL/SPV_INTEL_fpga_cluster_attributes/function_attributes.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fpga_cluster_attributes/function_attributes.ll
@@ -1,0 +1,33 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_fpga_cluster_attributes -spirv-text -o - %t.bc | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_fpga_cluster_attributes %t.bc -o %t.spv
+; spirv-val %t.spv
+; RUN: llvm-spirv -r --spirv-ext=+SPV_INTEL_fpga_cluster_attributes %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s 
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-DAG: Capability FPGAClusterAttributesINTEL
+; CHECK-SPIRV-DAG: Capability FPGAClusterAttributesV2INTEL
+; CHECK-SPIRV-DAG: Extension "SPV_INTEL_fpga_cluster_attributes"
+; CHECK-SPIRV-DAG: Decorate [[#STALLENABLE_DEC:]] StallEnableINTEL
+; CHECK-SPIRV-DAG: Decorate [[#STALLFREE_DEC:]] StallFreeINTEL
+; CHECK-SPIRV: Function {{[0-9]+}} [[#STALLENABLE_DEC]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-SPIRV: Function {{[0-9]+}} [[#STALLFREE_DEC]] {{[0-9]+}} {{[0-9]+}}
+; CHECK-LLVM: define spir_func void @test_fpga_stallenable_attr() {{.*}} !stall_enable [[STALL_MD:![0-9]+]]
+; CHECK-LLVM: define spir_func void @test_fpga_stallfree_attr() {{.*}} !stall_free [[STALL_MD]]
+; CHECK-LLVM: [[STALL_MD]] = !{i32 1}
+
+
+define spir_func void @test_fpga_stallenable_attr() !stall_enable !0 {
+entry:
+  ret void
+}
+
+define spir_func void @test_fpga_stallfree_attr() !stall_free !1 {
+entry:
+  ret void
+}
+
+!0 = !{ i32 1 }
+!1 = !{ i32 1 }


### PR DESCRIPTION
Commit also adds new extension capability FPGAClusterAttributesV2INTEL. 
Specification:
https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/INTEL/SPV_INTEL_fpga_cluster_attributes.asciidoc