### PR TITLE
Fix warning with variadic macro

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -3834,7 +3834,7 @@ protected:
                    " 64-bit type or two element vector of 32-bit type\n");
   }
 };
-#define _SPIRV_OP(x, ...) typedef SPIRVReadClockKHRInstBase<Op##x> SPIRV##x;
+#define _SPIRV_OP(x) typedef SPIRVReadClockKHRInstBase<Op##x> SPIRV##x;
 _SPIRV_OP(ReadClockKHR)
 #undef _SPIRV_OP
 


### PR DESCRIPTION
The following warning used to appear:
SPIRVInstruction.h:3745:23: warning: ISO C++11 requires at least one argument for the "..." in a variadic macro _SPIRV_OP(ReadClockKHR)