### PR TITLE
Update after getInt8PtrTy LLVM API removal

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -567,7 +567,7 @@ void SPIRVToOCLBase::visitCallSPIRVPipeBuiltin(CallInst *CI, Op OC) {
     Mutator.mapArg(Mutator.arg_size() - 3, [](IRBuilder<> &Builder, Value *P) {
       Type *T = P->getType();
       assert(isa<PointerType>(T));
-      auto *NewTy = Builder.getInt8PtrTy(SPIRAS_Generic);
+      auto *NewTy = Builder.getPtrTy(SPIRAS_Generic);
       if (T != NewTy) {
         P = Builder.CreatePointerBitCastOrAddrSpaceCast(P, NewTy);
       }

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -259,7 +259,7 @@ void SPIRVToOCL20Base::visitCallSPIRVEnqueueKernel(CallInst *CI, Op OC) {
   auto Mutator = mutateCallInst(CI, FName.str());
   Mutator.mapArg(6, [=](IRBuilder<> &Builder, Value *Invoke) {
     Value *Replace = CastInst::CreatePointerBitCastOrAddrSpaceCast(
-        Invoke, Builder.getInt8PtrTy(SPIRAS_Generic), "", CI);
+        Invoke, Builder.getPtrTy(SPIRAS_Generic), "", CI);
     return std::make_pair(
         Replace, TypedPointerType::get(Builder.getInt8Ty(), SPIRAS_Generic));
   });


### PR DESCRIPTION
Replace instances of `getInt8PtrTy` after llvm commit llvm/llvm-project@6cd7500ae690 ("[llvm][IR] Remove method IRBuilderBase::getInt8PtrTy (#74096)", 2023-12-01).