### PR TITLE
add support for the 'fcmp false' instruction

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2045,6 +2045,8 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
   }
 
   if (CmpInst *Cmp = dyn_cast<CmpInst>(V)) {
+    if(Cmp->getPredicate() == CmpInst::Predicate::FCMP_FALSE)
+      return mapValue(V, BM->addConstant(BM->addBoolType(), 0));
     SPIRVInstruction *BI = transCmpInst(Cmp, BB);
     return mapValue(V, BI);
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2045,8 +2045,13 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
   }
 
   if (CmpInst *Cmp = dyn_cast<CmpInst>(V)) {
-    if (Cmp->getPredicate() == CmpInst::Predicate::FCMP_FALSE)
-      return mapValue(V, BM->addConstant(BM->addBoolType(), 0));
+    if (Cmp->getPredicate() == CmpInst::Predicate::FCMP_FALSE) {
+      auto CmpTy = Cmp->getType();
+      SPIRVValue *FalseValue = CmpTy->isVectorTy()
+                                   ? BM->addNullConstant(transType(CmpTy))
+                                   : BM->addConstant(BM->addBoolType(), 0);
+      return mapValue(V, FalseValue);
+    }
     SPIRVInstruction *BI = transCmpInst(Cmp, BB);
     return mapValue(V, BI);
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2045,7 +2045,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
   }
 
   if (CmpInst *Cmp = dyn_cast<CmpInst>(V)) {
-    if(Cmp->getPredicate() == CmpInst::Predicate::FCMP_FALSE)
+    if (Cmp->getPredicate() == CmpInst::Predicate::FCMP_FALSE)
       return mapValue(V, BM->addConstant(BM->addBoolType(), 0));
     SPIRVInstruction *BI = transCmpInst(Cmp, BB);
     return mapValue(V, BI);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2046,7 +2046,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
 
   if (CmpInst *Cmp = dyn_cast<CmpInst>(V)) {
     if (Cmp->getPredicate() == CmpInst::Predicate::FCMP_FALSE) {
-      auto CmpTy = Cmp->getType();
+      auto *CmpTy = Cmp->getType();
       SPIRVValue *FalseValue = CmpTy->isVectorTy()
                                    ? BM->addNullConstant(transType(CmpTy))
                                    : BM->addConstant(BM->addBoolType(), 0);

--- a/test/FCmpFalse.ll
+++ b/test/FCmpFalse.ll
@@ -1,0 +1,16 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+; CHECK-SPIRV: ConstantFalse [[#]] [[#FalseVal:]]
+; CHECK-SPIRV: ReturnValue [[#FalseVal]]
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+define spir_func i1 @f(float %0) {
+ %2 = fcmp false float %0, %0
+ ret i1 %2
+}

--- a/test/FCmpFalse_Vec.ll
+++ b/test/FCmpFalse_Vec.ll
@@ -1,0 +1,18 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+; CHECK-SPIRV: TypeBool [[#BoolTy:]]
+; CHECK-SPIRV: TypeVector [[#VecTy:]] [[#BoolTy]] 4
+; CHECK-SPIRV: ConstantNull [[#VecTy]] [[#VecNullVal:]]
+; CHECK-SPIRV: ReturnValue [[#VecNullVal]]
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+define spir_func <4 x i1> @f(<4 x float> %0) {
+ %2 = fcmp false <4 x float> %0, %0
+ ret <4 x i1> %2
+}


### PR DESCRIPTION
There is no direct equivalent for "fcmp false" in the specification [https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_relational_and_logical_instructions], but we may return ConstantFalse in this case instead of reporting error.

This patch depends on https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2216