### PR TITLE
Memory leak fix in SPIRVDecoder::getSourceContinuedInstructions

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -357,6 +357,7 @@ std::vector<SPIRVEntry *> SPIRVDecoder::getSourceContinuedInstructions() {
     SPIRVExtInst *Inst = static_cast<SPIRVExtInst *>(Entry);
     if (Inst->getExtOp() != SPIRVDebug::Instruction::SourceContinued) {
       IS.seekg(Pos); // restore position
+      delete Entry;
       return ContinuedInst;
     }
     M.add(Entry);


### PR DESCRIPTION
SPIRVEntry created in function getEntry isn't deleted when it is ExtOp and isn't SourceContinued. Fixes most of ASan errors in issue #2233.