### PR TITLE
Access out of scope fix in OCLToSPIRVBase::visitCallAtomicCmpXchg

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -485,11 +485,12 @@ CallInst *OCLToSPIRVBase::visitCallAtomicCmpXchg(CallInst *CI) {
     Mutator.mapArg(1, [=](IRBuilder<> &Builder, Value *V) {
       return Builder.CreateLoad(MemTy, V, "exp");
     });
-    Mutator.changeReturnType(MemTy, [&](IRBuilder<> &Builder, CallInst *NCI) {
-      NewCI = NCI;
-      Builder.CreateStore(NCI, Expected);
-      return Builder.CreateICmpEQ(NCI, NCI->getArgOperand(1));
-    });
+    Mutator.changeReturnType(
+        MemTy, [Expected, &NewCI](IRBuilder<> &Builder, CallInst *NCI) {
+          NewCI = NCI;
+          Builder.CreateStore(NCI, Expected);
+          return Builder.CreateICmpEQ(NCI, NCI->getArgOperand(1));
+        });
   }
   return NewCI;
 }


### PR DESCRIPTION
Pointer named Expected was taken by reference to closure to be executed later by Mutator. Mutator executes the closure in his destructor which happens after the destruction of Expected pointer stack frame. This fix clears some ASan errors from #2233.