### PR TITLE
Access out of scope fix in OCLToSPIRVBase::visitCallReadWriteImage

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -1078,8 +1078,9 @@ void OCLToSPIRVBase::visitCallReadWriteImage(CallInst *CI,
     Info.UniqName = kOCLBuiltinName::ReadImage;
     unsigned ImgOpMask = getImageSignZeroExt(DemangledName);
     if (ImgOpMask) {
-      Info.PostProc = [&](BuiltinCallMutator &Mutator) {
-        Mutator.appendArg(getInt32(M, ImgOpMask));
+      Module *Mod = M;
+      Info.PostProc = [ImgOpMask, Mod](BuiltinCallMutator &Mutator) {
+        Mutator.appendArg(getInt32(Mod, ImgOpMask));
       };
     }
   }


### PR DESCRIPTION
ImageOpMask pointer was passed to closure as reference. Closure is executed outside of original stack frame which renders reference invalid. Fixes some ASan errors from issue #2233.