### PR TITLE
Document contract between LLVM IR producer and the translator wrt. global variable declarations

### DIFF
--- a/docs/SPIRVRepresentationInLLVM.rst
+++ b/docs/SPIRVRepresentationInLLVM.rst
@@ -398,9 +398,9 @@ Global variables
 A global variable resides in an address space, and the default address space
 in LLVM is zero. The SPIR-V storage class represented by the zero LLVM IR
 address spaces is Function. However, SPIR-V global variable declarations are
-``OpVariable`` instructions whose Storage Class is not ``Function``. This
-means that global variable declarations are not permitted to have no address
-space or ``addrspace(0)``.
+``OpVariable`` instructions whose Storage Class cannot be ``Function``. This
+means that global variable declarations must always have an address space
+specified and that address space cannot be ``0``.
 
 Function metadata
 -----------------

--- a/docs/SPIRVRepresentationInLLVM.rst
+++ b/docs/SPIRVRepresentationInLLVM.rst
@@ -392,6 +392,16 @@ Calling convention
 A function with ``spir_kernel`` calling convention will be translated as an entry
 point of the SPIR-V module.
 
+Global variables
+----------------
+
+A global variable resides in an address space, and the default address space
+in LLVM is zero. The SPIR-V storage class represented by the zero LLVM IR
+address spaces is Function. However, SPIR-V global variable declarations are
+``OpVariable`` instructions whose Storage Class is not ``Function``. This
+means that global variable declarations are not permitted to have no address
+space or ``addrspace(0)``.
+
 Function metadata
 -----------------
 


### PR DESCRIPTION
Global variable declarations are not permitted to have no address space or ``addrspace(0)``. This PR is to document this contract.