### PR TITLE
Memory leak fix in SPIRVFunction::decodeBB

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -153,6 +153,7 @@ bool SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
                                           std::to_string(Entry->getOpCode()))) {
       // Bail out if the opcode is not implemented.
       Module->setInvalid();
+      delete Entry;
       return false;
     }
 
@@ -164,6 +165,7 @@ bool SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
                                SPIRVDebug::DebugNoLine) ||
                Inst->isExtInst(SPIRVEIS_NonSemantic_Shader_DebugInfo_200,
                                SPIRVDebug::DebugNoLine)) {
+      delete Entry;
       continue;
     } else if (Inst->isExtInst(SPIRVEIS_NonSemantic_Shader_DebugInfo_100,
                                SPIRVDebug::DebugLine) ||


### PR DESCRIPTION
SPIRVEntry is created by function getEntry() but not deleted in a few frame ending branches. Fixes some ASan errors from #2233.