### PR TITLE
README.md: State Kernel capability restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![In-tree build & tests](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/actions/workflows/check-in-tree-build.yml/badge.svg?branch=main&event=schedule)](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/actions?query=workflow%3A%22In-tree+build+%26+tests%22+event%3Aschedule)
 
 This repository contains source code for the LLVM/SPIR-V Bi-Directional Translator, a library and tool for translation between LLVM IR and [SPIR-V](https://www.khronos.org/registry/spir-v/).
+This project currently only supports the OpenCL/compute "flavour" of SPIR-V: it consumes and produces SPIR-V modules that declare the `Kernel` capability.
 
 The LLVM/SPIR-V Bi-Directional Translator is open source software. You may freely distribute it under the terms of the license agreement found in LICENSE.txt.
 


### PR DESCRIPTION
Mention explicitly in the README that only SPIR-V modules that declare the `Kernel` capability are supported.  This is a key restriction for anyone looking to translate between (arbitrary) SPIR-V and LLVM IR, so mention it at the top of the README.

This came up in the OpenCL Tooling TSG call of Dec 14th; tagging @asudarsa, @bashbaug, @keryell.