### PR TITLE
Update for StringRef::{starts,ends}with deprecation

### DIFF
--- a/lib/SPIRV/LLVMSPIRVOpts.cpp
+++ b/lib/SPIRV/LLVMSPIRVOpts.cpp
@@ -54,7 +54,7 @@ bool TranslatorOpts::isUnknownIntrinsicAllowed(IntrinsicInst *II) const
   const auto &IntrinsicPrefixList = SPIRVAllowUnknownIntrinsics.value();
   StringRef IntrinsicName = II->getCalledOperand()->getName();
   for (const auto &Prefix : IntrinsicPrefixList) {
-    if (IntrinsicName.startswith(Prefix)) // Also true if `Prefix` is empty
+    if (IntrinsicName.starts_with(Prefix)) // Also true if `Prefix` is empty
       return true;
   }
   return false;

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -90,8 +90,8 @@ static Type *getBlockStructType(Value *Parameter) {
 /// for a demangled function name, or 0 if the function does not return an
 /// integer type (e.g. read_imagef).
 static unsigned getImageSignZeroExt(StringRef DemangledName) {
-  bool IsSigned = !DemangledName.endswith("ui") && DemangledName.back() == 'i';
-  bool IsUnsigned = DemangledName.endswith("ui");
+  bool IsSigned = !DemangledName.ends_with("ui") && DemangledName.back() == 'i';
+  bool IsUnsigned = DemangledName.ends_with("ui");
 
   if (IsSigned)
     return ImageOperandsMask::ImageOperandsSignExtendMask;
@@ -327,8 +327,8 @@ void OCLToSPIRVBase::visitCallInst(CallInst &CI) {
   }
   if (DemangledName == kOCLBuiltinName::Dot ||
       DemangledName == kOCLBuiltinName::DotAccSat ||
-      DemangledName.startswith(kOCLBuiltinName::Dot4x8PackedPrefix) ||
-      DemangledName.startswith(kOCLBuiltinName::DotAccSat4x8PackedPrefix)) {
+      DemangledName.starts_with(kOCLBuiltinName::Dot4x8PackedPrefix) ||
+      DemangledName.starts_with(kOCLBuiltinName::DotAccSat4x8PackedPrefix)) {
     if (CI.getOperand(0)->getType()->isVectorTy()) {
       auto *VT = (VectorType *)(CI.getOperand(0)->getType());
       if (!isa<llvm::IntegerType>(VT->getElementType())) {
@@ -554,9 +554,9 @@ void OCLToSPIRVBase::transMemoryBarrier(CallInst *CI,
 void OCLToSPIRVBase::visitCallAtomicLegacy(CallInst *CI, StringRef MangledName,
                                            StringRef DemangledName) {
   StringRef Stem = DemangledName;
-  if (Stem.startswith("atom_"))
+  if (Stem.starts_with("atom_"))
     Stem = Stem.drop_front(strlen("atom_"));
-  else if (Stem.startswith("atomic_"))
+  else if (Stem.starts_with("atomic_"))
     Stem = Stem.drop_front(strlen("atomic_"));
   else
     return;
@@ -586,7 +586,7 @@ void OCLToSPIRVBase::visitCallAtomicLegacy(CallInst *CI, StringRef MangledName,
   Info.UniqName = "atomic_" + Prefix + Sign + Stem.str() + Postfix;
   std::vector<int> PostOps;
   PostOps.push_back(OCLLegacyAtomicMemOrder);
-  if (Stem.startswith("compare_exchange"))
+  if (Stem.starts_with("compare_exchange"))
     PostOps.push_back(OCLLegacyAtomicMemOrder);
   PostOps.push_back(OCLLegacyAtomicMemScope);
 
@@ -601,24 +601,24 @@ void OCLToSPIRVBase::visitCallAtomicLegacy(CallInst *CI, StringRef MangledName,
 void OCLToSPIRVBase::visitCallAtomicCpp11(CallInst *CI, StringRef MangledName,
                                           StringRef DemangledName) {
   StringRef Stem = DemangledName;
-  if (Stem.startswith("atomic_"))
+  if (Stem.starts_with("atomic_"))
     Stem = Stem.drop_front(strlen("atomic_"));
   else
     return;
 
   std::string NewStem(Stem);
   std::vector<int> PostOps;
-  if (Stem.startswith("store") || Stem.startswith("load") ||
-      Stem.startswith("exchange") || Stem.startswith("compare_exchange") ||
-      Stem.startswith("fetch") || Stem.startswith("flag")) {
-    if ((Stem.startswith("fetch_min") || Stem.startswith("fetch_max")) &&
+  if (Stem.starts_with("store") || Stem.starts_with("load") ||
+      Stem.starts_with("exchange") || Stem.starts_with("compare_exchange") ||
+      Stem.starts_with("fetch") || Stem.starts_with("flag")) {
+    if ((Stem.starts_with("fetch_min") || Stem.starts_with("fetch_max")) &&
         containsUnsignedAtomicType(MangledName))
       NewStem.insert(NewStem.begin() + strlen("fetch_"), 'u');
 
-    if (!Stem.endswith("_explicit")) {
+    if (!Stem.ends_with("_explicit")) {
       NewStem = NewStem + "_explicit";
       PostOps.push_back(OCLMO_seq_cst);
-      if (Stem.startswith("compare_exchange"))
+      if (Stem.starts_with("compare_exchange"))
         PostOps.push_back(OCLMO_seq_cst);
       PostOps.push_back(OCLMS_device);
     } else {
@@ -793,7 +793,7 @@ void OCLToSPIRVBase::visitCallGroupBuiltin(CallInst *CI,
     FuncName = FuncName.drop_front(strlen(kSPIRVName::GroupPrefix));
     SPIRSPIRVGroupOperationMap::foreachConditional(
         [&](const std::string &S, SPIRVGroupOperationKind G) {
-          if (!FuncName.startswith(S))
+          if (!FuncName.starts_with(S))
             return true; // continue
           PreOps.push_back(G);
           StringRef Op =
@@ -887,7 +887,7 @@ void OCLToSPIRVBase::transBuiltin(CallInst *CI, OCLBuiltinTransInfo &Info) {
   Op OC = OpNop;
   unsigned ExtOp = ~0U;
   SPIRVBuiltinVariableKind BVKind = BuiltInMax;
-  if (StringRef(Info.UniqName).startswith(kSPIRVName::Prefix))
+  if (StringRef(Info.UniqName).starts_with(kSPIRVName::Prefix))
     return;
   if (OCLSPIRVBuiltinMap::find(Info.UniqName, &OC)) {
     if (OC == OpImageRead) {
@@ -1222,7 +1222,7 @@ void OCLToSPIRVBase::visitCallDot(CallInst *CI, StringRef MangledName,
       // dot(short2, ushort2) _Z3dotDv2_sDv2_t
       // dot(ushort2, short2) _Z3dotDv2_tDv2_s
       // dot(ushort2, ushort2) _Z3dotDv2_tS_
-      assert(MangledName.startswith("_Z3dotDv"));
+      assert(MangledName.starts_with("_Z3dotDv"));
       if (MangledName[MangledName.size() - 1] == '_') {
         IsFirstSigned = ((MangledName[MangledName.size() - 3] == 'c') ||
                          (MangledName[MangledName.size() - 3] == 's'));
@@ -1243,7 +1243,7 @@ void OCLToSPIRVBase::visitCallDot(CallInst *CI, StringRef MangledName,
       // dot_acc_sat(short2, ushort2, int) _Z11dot_acc_satDv4_sDv4_ti
       // dot_acc_sat(ushort2, short2, int) _Z11dot_acc_satDv4_tDv4_si
       // dot_acc_sat(ushort2, ushort2, uint) _Z11dot_acc_satDv4_tS_j
-      assert(MangledName.startswith("_Z11dot_acc_satDv"));
+      assert(MangledName.starts_with("_Z11dot_acc_satDv"));
       IsFirstSigned = ((MangledName[19] == 'c') || (MangledName[19] == 's'));
       IsSecondSigned = (MangledName[20] == 'S'
                             ? IsFirstSigned
@@ -1265,10 +1265,10 @@ void OCLToSPIRVBase::visitCallDot(CallInst *CI, StringRef MangledName,
     // _Z28dot_acc_sat_4x8packed_us_intjji
     // dot_acc_sat_4x8packed_uu_uint(uint, uint, uint)
     // _Z29dot_acc_sat_4x8packed_uu_uintjjj
-    assert(MangledName.startswith("_Z20dot_4x8packed") ||
-           MangledName.startswith("_Z21dot_4x8packed") ||
-           MangledName.startswith("_Z28dot_acc_sat_4x8packed") ||
-           MangledName.startswith("_Z29dot_acc_sat_4x8packed"));
+    assert(MangledName.starts_with("_Z20dot_4x8packed") ||
+           MangledName.starts_with("_Z21dot_4x8packed") ||
+           MangledName.starts_with("_Z28dot_acc_sat_4x8packed") ||
+           MangledName.starts_with("_Z29dot_acc_sat_4x8packed"));
     size_t SignIndex = IsAccSat
                            ? strlen(kOCLBuiltinName::DotAccSat4x8PackedPrefix)
                            : strlen(kOCLBuiltinName::Dot4x8PackedPrefix);
@@ -1582,7 +1582,7 @@ static const char *getSubgroupAVCIntelTyKind(StringRef MangledName) {
   // We're looking for the type name of the last parameter, which will be at the
   // very end of the mangled name. Since we only care about the ending of the
   // name, we don't need to be any more clever than this.
-  return MangledName.endswith("_payload_t") ? "payload" : "result";
+  return MangledName.ends_with("_payload_t") ? "payload" : "result";
 }
 
 static Type *getSubgroupAVCIntelMCEType(Module *M, std::string &TName) {

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -223,7 +223,7 @@ void OCLTypeToSPIRVBase::adaptFunctionArguments(Function *F) {
       auto STName = NewTy->getStructName();
       if (!hasAccessQualifiedName(STName))
         continue;
-      if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
+      if (STName.starts_with(kSPR2TypeName::ImagePrefix)) {
         auto Ty = STName.str();
         auto Acc = getAccessQualifier(Ty);
         auto Desc = getImageDescriptor(ParamTys[I]);
@@ -251,7 +251,7 @@ void OCLTypeToSPIRVBase::adaptArgumentsByMetadata(Function *F) {
     if (OCLTyStr == OCL_TYPE_NAME_SAMPLER_T) {
       addAdaptedType(&(*Arg), getSPIRVType(OpTypeSampler));
       Changed = true;
-    } else if (OCLTyStr.startswith("image") && OCLTyStr.endswith("_t")) {
+    } else if (OCLTyStr.starts_with("image") && OCLTyStr.ends_with("_t")) {
       auto Ty = (Twine("opencl.") + OCLTyStr).str();
       if (auto *STy = StructType::getTypeByName(F->getContext(), Ty)) {
         auto *ImageTy = TypedPointerType::get(STy, SPIRAS_Global);

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -676,7 +676,7 @@ AtomicWorkItemFenceLiterals getAtomicWorkItemFenceLiterals(CallInst *CI) {
 }
 
 size_t getAtomicBuiltinNumMemoryOrderArgs(StringRef Name) {
-  if (Name.startswith("atomic_compare_exchange"))
+  if (Name.starts_with("atomic_compare_exchange"))
     return 2;
   return 1;
 }
@@ -691,8 +691,8 @@ size_t getSPIRVAtomicBuiltinNumMemoryOrderArgs(Op OC) {
 // max]_explicit functions declared in clang headers should be translated
 // to corresponding FP-typed Atomic Instructions
 bool isComputeAtomicOCLBuiltin(StringRef DemangledName) {
-  if (!DemangledName.startswith(kOCLBuiltinName::AtomicPrefix) &&
-      !DemangledName.startswith(kOCLBuiltinName::AtomPrefix))
+  if (!DemangledName.starts_with(kOCLBuiltinName::AtomicPrefix) &&
+      !DemangledName.starts_with(kOCLBuiltinName::AtomPrefix))
     return false;
 
   return llvm::StringSwitch<bool>(DemangledName)
@@ -1027,12 +1027,12 @@ public:
       NameRef = StringRef(TempStorage);
     };
 
-    if (NameRef.startswith("async_work_group")) {
+    if (NameRef.starts_with("async_work_group")) {
       addUnsignedArg(-1);
       setArgAttr(1, SPIR::ATTR_CONST);
-    } else if (NameRef.startswith("printf"))
+    } else if (NameRef.starts_with("printf"))
       setVarArg(1);
-    else if (NameRef.startswith("write_imageui"))
+    else if (NameRef.starts_with("write_imageui"))
       addUnsignedArg(2);
     else if (NameRef.equals("prefetch")) {
       addUnsignedArg(1);
@@ -1045,13 +1045,13 @@ public:
       FunctionType *InvokeTy = getBlockInvokeTy(F, BlockArgIdx);
       if (InvokeTy->getNumParams() > 1)
         setLocalArgBlock(BlockArgIdx);
-    } else if (NameRef.startswith("__enqueue_kernel")) {
+    } else if (NameRef.starts_with("__enqueue_kernel")) {
       // clang doesn't mangle enqueue_kernel builtins
       setAsDontMangle();
-    } else if (NameRef.startswith("get_") || NameRef.equals("nan") ||
-               NameRef.equals("mem_fence") || NameRef.startswith("shuffle")) {
+    } else if (NameRef.starts_with("get_") || NameRef.equals("nan") ||
+               NameRef.equals("mem_fence") || NameRef.starts_with("shuffle")) {
       addUnsignedArg(-1);
-      if (NameRef.startswith(kOCLBuiltinName::GetFence)) {
+      if (NameRef.starts_with(kOCLBuiltinName::GetFence)) {
         setArgAttr(0, SPIR::ATTR_CONST);
         addVoidPtrArg(0);
       }
@@ -1062,18 +1062,18 @@ public:
           NameRef.equals("intel_work_group_barrier_arrive") ||
           NameRef.equals("intel_work_group_barrier_wait"))
         setEnumArg(1, SPIR::PRIMITIVE_MEMORY_SCOPE);
-    } else if (NameRef.startswith("atomic_work_item_fence")) {
+    } else if (NameRef.starts_with("atomic_work_item_fence")) {
       addUnsignedArg(0);
       setEnumArg(1, SPIR::PRIMITIVE_MEMORY_ORDER);
       setEnumArg(2, SPIR::PRIMITIVE_MEMORY_SCOPE);
-    } else if (NameRef.startswith("atom_")) {
+    } else if (NameRef.starts_with("atom_")) {
       setArgAttr(0, SPIR::ATTR_VOLATILE);
-      if (NameRef.endswith("_umax") || NameRef.endswith("_umin")) {
+      if (NameRef.ends_with("_umax") || NameRef.ends_with("_umin")) {
         addUnsignedArg(-1);
         // We need to remove u to match OpenCL C built-in function name
         EraseSymbol(5);
       }
-    } else if (NameRef.startswith("atomic")) {
+    } else if (NameRef.starts_with("atomic")) {
       setArgAttr(0, SPIR::ATTR_VOLATILE);
       if (NameRef.contains("_umax") || NameRef.contains("_umin")) {
         addUnsignedArg(-1);
@@ -1085,41 +1085,41 @@ public:
       }
       if (NameRef.contains("store_explicit") ||
           NameRef.contains("exchange_explicit") ||
-          (NameRef.startswith("atomic_fetch") &&
+          (NameRef.starts_with("atomic_fetch") &&
            NameRef.contains("explicit"))) {
         setEnumArg(2, SPIR::PRIMITIVE_MEMORY_ORDER);
         setEnumArg(3, SPIR::PRIMITIVE_MEMORY_SCOPE);
       } else if (NameRef.contains("load_explicit") ||
-                 (NameRef.startswith("atomic_flag") &&
+                 (NameRef.starts_with("atomic_flag") &&
                   NameRef.contains("explicit"))) {
         setEnumArg(1, SPIR::PRIMITIVE_MEMORY_ORDER);
         setEnumArg(2, SPIR::PRIMITIVE_MEMORY_SCOPE);
-      } else if (NameRef.endswith("compare_exchange_strong_explicit") ||
-                 NameRef.endswith("compare_exchange_weak_explicit")) {
+      } else if (NameRef.ends_with("compare_exchange_strong_explicit") ||
+                 NameRef.ends_with("compare_exchange_weak_explicit")) {
         setEnumArg(3, SPIR::PRIMITIVE_MEMORY_ORDER);
         setEnumArg(4, SPIR::PRIMITIVE_MEMORY_ORDER);
         setEnumArg(5, SPIR::PRIMITIVE_MEMORY_SCOPE);
       }
       // Don't set atomic property to the first argument of 1.2 atomic
       // built-ins.
-      if (!NameRef.endswith("xchg") && // covers _cmpxchg too
+      if (!NameRef.ends_with("xchg") && // covers _cmpxchg too
           (NameRef.contains("fetch") ||
-           !(NameRef.endswith("_add") || NameRef.endswith("_sub") ||
-             NameRef.endswith("_inc") || NameRef.endswith("_dec") ||
-             NameRef.endswith("_min") || NameRef.endswith("_max") ||
-             NameRef.endswith("_and") || NameRef.endswith("_or") ||
-             NameRef.endswith("_xor")))) {
+           !(NameRef.ends_with("_add") || NameRef.ends_with("_sub") ||
+             NameRef.ends_with("_inc") || NameRef.ends_with("_dec") ||
+             NameRef.ends_with("_min") || NameRef.ends_with("_max") ||
+             NameRef.ends_with("_and") || NameRef.ends_with("_or") ||
+             NameRef.ends_with("_xor")))) {
         addAtomicArg(0);
       }
-    } else if (NameRef.startswith("uconvert_")) {
+    } else if (NameRef.starts_with("uconvert_")) {
       addUnsignedArg(0);
       NameRef = NameRef.drop_front(1);
       UnmangledName.erase(0, 1);
-    } else if (NameRef.startswith("s_")) {
+    } else if (NameRef.starts_with("s_")) {
       if (NameRef.equals("s_upsample"))
         addUnsignedArg(1);
       NameRef = NameRef.drop_front(2);
-    } else if (NameRef.startswith("u_")) {
+    } else if (NameRef.starts_with("u_")) {
       addUnsignedArg(-1);
       NameRef = NameRef.drop_front(2);
     } else if (NameRef.equals("fclamp")) {
@@ -1170,12 +1170,12 @@ public:
     } else if (NameRef.equals("enqueue_marker")) {
       setArgAttr(2, SPIR::ATTR_CONST);
       addUnsignedArg(1);
-    } else if (NameRef.startswith("vload")) {
+    } else if (NameRef.starts_with("vload")) {
       addUnsignedArg(0);
       setArgAttr(1, SPIR::ATTR_CONST);
-    } else if (NameRef.startswith("vstore")) {
+    } else if (NameRef.starts_with("vstore")) {
       addUnsignedArg(1);
-    } else if (NameRef.startswith("ndrange_")) {
+    } else if (NameRef.starts_with("ndrange_")) {
       addUnsignedArgs(0, 2);
       if (NameRef[8] == '2' || NameRef[8] == '3') {
         setArgAttr(0, SPIR::ATTR_CONST);
@@ -1190,7 +1190,7 @@ public:
       EraseSymbol(NameRef.find("umin"));
     } else if (NameRef.contains("broadcast")) {
       addUnsignedArg(-1);
-    } else if (NameRef.startswith(kOCLBuiltinName::SampledReadImage)) {
+    } else if (NameRef.starts_with(kOCLBuiltinName::SampledReadImage)) {
       if (!NameRef.consume_front(kOCLBuiltinName::Sampled))
         report_fatal_error(llvm::Twine("Builtin name illformed"));
       addSamplerArg(1);
@@ -1282,12 +1282,12 @@ public:
         else if (NameRef.contains("chroma_mode_cost_function"))
           addUnsignedArg(0);
       }
-    } else if (NameRef.startswith("intel_sub_group_shuffle")) {
-      if (NameRef.endswith("_down") || NameRef.endswith("_up"))
+    } else if (NameRef.starts_with("intel_sub_group_shuffle")) {
+      if (NameRef.ends_with("_down") || NameRef.ends_with("_up"))
         addUnsignedArg(2);
       else
         addUnsignedArg(1);
-    } else if (NameRef.startswith("intel_sub_group_block_write")) {
+    } else if (NameRef.starts_with("intel_sub_group_block_write")) {
       // distinguish write to image and other data types based on number of
       // arguments--images have one more argument.
       if (F->getFunctionType()->getNumParams() == 2) {
@@ -1296,16 +1296,16 @@ public:
       } else {
         addUnsignedArg(2);
       }
-    } else if (NameRef.startswith("intel_sub_group_block_read")) {
+    } else if (NameRef.starts_with("intel_sub_group_block_read")) {
       // distinguish read from image and other data types based on number of
       // arguments--images have one more argument.
       if (F->getFunctionType()->getNumParams() == 1) {
         setArgAttr(0, SPIR::ATTR_CONST);
         addUnsignedArg(0);
       }
-    } else if (NameRef.startswith("intel_sub_group_media_block_write")) {
+    } else if (NameRef.starts_with("intel_sub_group_media_block_write")) {
       addUnsignedArg(3);
-    } else if (NameRef.startswith(kOCLBuiltinName::SubGroupPrefix)) {
+    } else if (NameRef.starts_with(kOCLBuiltinName::SubGroupPrefix)) {
       if (NameRef.contains("ballot")) {
         if (NameRef.contains("inverse") || NameRef.contains("bit_count") ||
             NameRef.contains("inclusive_scan") ||
@@ -1315,14 +1315,14 @@ public:
         else if (NameRef.contains("bit_extract")) {
           addUnsignedArgs(0, 1);
         }
-      } else if (NameRef.startswith("sub_group_clustered_rotate")) {
+      } else if (NameRef.starts_with("sub_group_clustered_rotate")) {
         addUnsignedArg(2);
       } else if (NameRef.contains("shuffle") || NameRef.contains("clustered"))
         addUnsignedArg(1);
-    } else if (NameRef.startswith("bitfield_insert")) {
+    } else if (NameRef.starts_with("bitfield_insert")) {
       addUnsignedArgs(2, 3);
-    } else if (NameRef.startswith("bitfield_extract_signed") ||
-               NameRef.startswith("bitfield_extract_unsigned")) {
+    } else if (NameRef.starts_with("bitfield_extract_signed") ||
+               NameRef.starts_with("bitfield_extract_unsigned")) {
       addUnsignedArgs(1, 2);
     }
 

--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -365,7 +365,7 @@ void BuiltinCallHelper::initialize(llvm::Module &M) {
     if (!Ty->isOpaque() || !Ty->hasName())
       continue;
     StringRef Name = Ty->getName();
-    if (Name.startswith("opencl.") || Name.startswith("spirv.")) {
+    if (Name.starts_with("opencl.") || Name.starts_with("spirv.")) {
       UseTargetTypes = false;
     }
   }

--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.cpp
@@ -67,11 +67,11 @@ void SPIRVLowerSaddWithOverflowBase::visitIntrinsicInst(CallInst &I) {
   assert(IntrinsicFunc && "Missing function");
   StringRef IntrinsicName = IntrinsicFunc->getName();
   std::string FuncName = "llvm_sadd_with_overflow_i";
-  if (IntrinsicName.endswith(".i16"))
+  if (IntrinsicName.ends_with(".i16"))
     FuncName += "16";
-  else if (IntrinsicName.endswith(".i32"))
+  else if (IntrinsicName.ends_with(".i32"))
     FuncName += "32";
-  else if (IntrinsicName.endswith(".i64"))
+  else if (IntrinsicName.ends_with(".i64"))
     FuncName += "64";
   else {
     assert(false &&

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1167,7 +1167,7 @@ Value *SPIRVToLLVM::mapValue(SPIRVValue *BV, Value *V) {
     auto *LD = dyn_cast<LoadInst>(Loc->second);
     auto *Placeholder = dyn_cast<GlobalVariable>(LD->getPointerOperand());
     assert(LD && Placeholder &&
-           Placeholder->getName().startswith(KPlaceholderPrefix) &&
+           Placeholder->getName().starts_with(KPlaceholderPrefix) &&
            "A value is translated twice");
     // Replaces placeholders for PHI nodes
     LD->replaceAllUsesWith(V);
@@ -3038,7 +3038,7 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF) {
   // assuming llvm.memset is supported by the device compiler. If this
   // assumption is not safe, we should have a command line option to control
   // this behavior.
-  if (FuncNameRef.startswith("spirv.llvm_memset_p")) {
+  if (FuncNameRef.starts_with("spirv.llvm_memset_p")) {
     // We can't guarantee that the name is correctly mangled due to opaque
     // pointers. Derive the correct name from the function type.
     FuncName =

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -294,7 +294,7 @@ void SPIRVRegularizeLLVMBase::expandSYCLTypeUsing(Module *M) {
   std::vector<Function *> ToExpandVIDWithSYCLTypeByValComp;
 
   for (auto &F : *M) {
-    if (F.getName().startswith("_Z28__spirv_VectorExtractDynamic") &&
+    if (F.getName().starts_with("_Z28__spirv_VectorExtractDynamic") &&
         F.hasStructRetAttr()) {
       auto *SRetTy = F.getParamStructRetType(0);
       if (isSYCLHalfType(SRetTy) || isSYCLBfloat16Type(SRetTy))
@@ -304,7 +304,7 @@ void SPIRVRegularizeLLVMBase::expandSYCLTypeUsing(Module *M) {
                          "instruction cannot be a structure other than SYCL "
                          "half.");
     }
-    if (F.getName().startswith("_Z27__spirv_VectorInsertDynamic") &&
+    if (F.getName().starts_with("_Z27__spirv_VectorInsertDynamic") &&
         F.getArg(1)->getType()->isPointerTy()) {
       auto *ET = F.getParamByValType(1);
       if (isSYCLHalfType(ET) || isSYCLBfloat16Type(ET))

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -1066,7 +1066,7 @@ void SPIRVToOCLBase::translateOpaqueTypes() {
   for (auto *S : M->getIdentifiedStructTypes()) {
     StringRef STName = S->getStructName();
     bool IsSPIRVOpaque =
-        S->isOpaque() && STName.startswith(kSPIRVTypeName::PrefixAndDelim);
+        S->isOpaque() && STName.starts_with(kSPIRVTypeName::PrefixAndDelim);
 
     if (!IsSPIRVOpaque)
       continue;
@@ -1076,7 +1076,7 @@ void SPIRVToOCLBase::translateOpaqueTypes() {
 }
 
 std::string SPIRVToOCLBase::translateOpaqueType(StringRef STName) {
-  if (!STName.startswith(kSPIRVTypeName::PrefixAndDelim))
+  if (!STName.starts_with(kSPIRVTypeName::PrefixAndDelim))
     return STName.str();
 
   SmallVector<std::string, 8> Postfixes;

--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -557,7 +557,7 @@ bool SPIRVTypeScavenger::typeIntrinsicCall(
     default:
       return false;
     }
-  } else if (TargetFn->getName().startswith("_Z18__spirv_ocl_printf")) {
+  } else if (TargetFn->getName().starts_with("_Z18__spirv_ocl_printf")) {
     Type *Int8Ty = Type::getInt8Ty(Ctx);
     // The first argument is a string pointer. Subsequent arguments may include
     // pointer-valued arguments, corresponding to %s or %p parameters.
@@ -727,8 +727,8 @@ void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
   // existing code can propagate types to the parameters.
   // TODO: Investigate if target extension types and the specially-handled
   // SPIR-V intrinsics renders this code unnecessary.
-  if (F.isDeclaration() && F.getName().startswith("_Z")) {
-    if (F.getName().startswith("_Z")) {
+  if (F.isDeclaration() && F.getName().starts_with("_Z")) {
+    if (F.getName().starts_with("_Z")) {
       SmallVector<Type *, 8> ParamTypes;
       if (getParameterTypes(&F, ParamTypes)) {
         for (Argument *Arg : PointerArgs) {

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -206,7 +206,7 @@ bool isSPIRVStructType(llvm::Type *Ty, StringRef BaseTyName,
         std::string(kSPIRVTypeName::PrefixAndDelim) + BaseTyName.str();
     if (FullName != N)
       N = N + kSPIRVTypeName::Delimiter;
-    if (FullName.startswith(N)) {
+    if (FullName.starts_with(N)) {
       if (Postfix)
         *Postfix = FullName.drop_front(N.size());
       return true;
@@ -222,9 +222,9 @@ bool isSYCLHalfType(llvm::Type *Ty) {
     StringRef Name = ST->getName();
     if (!Name.consume_front("class."))
       return false;
-    if ((Name.startswith("sycl::") || Name.startswith("cl::sycl::") ||
-         Name.startswith("__sycl_internal::")) &&
-        Name.endswith("::half")) {
+    if ((Name.starts_with("sycl::") || Name.starts_with("cl::sycl::") ||
+         Name.starts_with("__sycl_internal::")) &&
+        Name.ends_with("::half")) {
       return true;
     }
   }
@@ -238,9 +238,9 @@ bool isSYCLBfloat16Type(llvm::Type *Ty) {
     StringRef Name = ST->getName();
     if (!Name.consume_front("class."))
       return false;
-    if ((Name.startswith("sycl::") || Name.startswith("cl::sycl::") ||
-         Name.startswith("__sycl_internal::")) &&
-        Name.endswith("::bfloat16")) {
+    if ((Name.starts_with("sycl::") || Name.starts_with("cl::sycl::") ||
+         Name.starts_with("__sycl_internal::")) &&
+        Name.ends_with("::bfloat16")) {
       return true;
     }
   }
@@ -330,7 +330,7 @@ std::string prefixSPIRVName(const std::string &S) {
 
 StringRef dePrefixSPIRVName(StringRef R, SmallVectorImpl<StringRef> &Postfix) {
   const size_t Start = strlen(kSPIRVName::Prefix);
-  if (!R.startswith(kSPIRVName::Prefix))
+  if (!R.starts_with(kSPIRVName::Prefix))
     return R;
   R = R.drop_front(Start);
   R.split(Postfix, "_", -1, false);
@@ -373,7 +373,7 @@ SPIRVDecorate *mapPostfixToDecorate(StringRef Postfix, SPIRVEntry *Target) {
   if (Postfix == kSPIRVPostfix::Sat)
     return new SPIRVDecorate(spv::DecorationSaturatedConversion, Target);
 
-  if (Postfix.startswith(kSPIRVPostfix::Rt))
+  if (Postfix.starts_with(kSPIRVPostfix::Rt))
     return new SPIRVDecorate(spv::DecorationFPRoundingMode, Target,
                              map<SPIRVFPRoundingModeKind>(Postfix.str()));
 
@@ -413,7 +413,7 @@ std::string getPostfixForReturnType(const Type *PRetTy, bool IsSigned,
 // Enqueue kernel, kernel query, pipe and address space cast built-ins
 // are not mangled.
 bool isNonMangledOCLBuiltin(StringRef Name) {
-  if (!Name.startswith("__"))
+  if (!Name.starts_with("__"))
     return false;
 
   return isEnqueueKernelBI(Name) || isKernelQueryBI(Name) ||
@@ -427,7 +427,7 @@ Op getSPIRVFuncOC(StringRef S, SmallVectorImpl<std::string> *Dec) {
   if (!oclIsBuiltin(S, Name))
     Name = S;
   StringRef R(Name);
-  if ((!Name.startswith(kSPIRVName::Prefix) && !isNonMangledOCLBuiltin(S)) ||
+  if ((!Name.starts_with(kSPIRVName::Prefix) && !isNonMangledOCLBuiltin(S)) ||
       !getByName(dePrefixSPIRVName(R, Postfix).str(), OC)) {
     return OpNop;
   }
@@ -457,13 +457,13 @@ bool oclIsBuiltin(StringRef Name, StringRef &DemangledName, bool IsCpp) {
     DemangledName = Name.drop_front(2);
     return true;
   }
-  if (!Name.startswith("_Z"))
+  if (!Name.starts_with("_Z"))
     return false;
   // OpenCL C++ built-ins are declared in cl namespace.
   // TODO: consider using 'St' abbriviation for cl namespace mangling.
   // Similar to ::std:: in C++.
   if (IsCpp) {
-    if (!Name.startswith("_ZN"))
+    if (!Name.starts_with("_ZN"))
       return false;
     // Skip CV and ref qualifiers.
     size_t NameSpaceStart = Name.find_first_not_of("rVKRO", 3);
@@ -576,7 +576,7 @@ bool hasArrayArg(Function *F) {
 /// Convert a struct name from the name given to it in Itanium name mangling to
 /// the name given to it as an LLVM opaque struct.
 static std::string demangleBuiltinOpenCLTypeName(StringRef MangledStructName) {
-  assert(MangledStructName.startswith("ocl_") &&
+  assert(MangledStructName.starts_with("ocl_") &&
          "Not a valid builtin OpenCL mangled name");
   // Bare structure type that starts with ocl_ is a builtin opencl type.
   // See clang/lib/CodeGen/CGOpenCLRuntime for how these map to LLVM types
@@ -595,7 +595,7 @@ static std::string demangleBuiltinOpenCLTypeName(StringRef MangledStructName) {
   if (LlvmStructName.empty()) {
     LlvmStructName = "opencl.";
     LlvmStructName += MangledStructName.substr(4); // Strip off ocl_
-    if (!MangledStructName.endswith("_t"))
+    if (!MangledStructName.ends_with("_t"))
       LlvmStructName += "_t";
   }
   return LlvmStructName;
@@ -700,7 +700,7 @@ parseNode(Module *M, const llvm::itanium_demangle::Node *ParamType,
     // pointer element types, the only relevant names are those corresponding
     // to the OpenCL special types (which all begin with "ocl_").
     StringRef Arg(stringify(Name));
-    if (Arg.startswith("ocl_")) {
+    if (Arg.starts_with("ocl_")) {
       const std::string StructName = demangleBuiltinOpenCLTypeName(Arg);
       PointeeTy = GetStructType(StructName);
     } else if (Arg.consume_front("__spirv_")) {
@@ -749,9 +749,9 @@ parseNode(Module *M, const llvm::itanium_demangle::Node *ParamType,
           StructName += NameSuffixPair.second;
         }
         PointeeTy = GetStructType(StructName);
-      } else if (MangledStructName.startswith("opencl.")) {
+      } else if (MangledStructName.starts_with("opencl.")) {
         PointeeTy = GetStructType(MangledStructName);
-      } else if (MangledStructName.startswith("ocl_")) {
+      } else if (MangledStructName.starts_with("ocl_")) {
         const std::string StructName =
             demangleBuiltinOpenCLTypeName(MangledStructName);
         PointeeTy = TypedPointerType::get(GetStructType(StructName), 0);
@@ -794,8 +794,8 @@ bool getParameterTypes(Function *F, SmallVectorImpl<Type *> &ArgTys,
   // If there's no mangled name, we can't do anything. Also, if there's no
   // parameters, do nothing.
   StringRef Name = F->getName();
-  if (!Name.startswith("_Z") || F->arg_empty())
-    return Name.startswith("_Z");
+  if (!Name.starts_with("_Z") || F->arg_empty())
+    return Name.starts_with("_Z");
 
   Module *M = F->getParent();
   auto GetStructType = [&](StringRef Name) {
@@ -1169,7 +1169,7 @@ ConstantInt *mapSInt(Module *M, ConstantInt *I, std::function<int(int)> F) {
 }
 
 bool isDecoratedSPIRVFunc(const Function *F, StringRef &UndecoratedName) {
-  if (!F->hasName() || !F->getName().startswith(kSPIRVName::Prefix))
+  if (!F->hasName() || !F->getName().starts_with(kSPIRVName::Prefix))
     return false;
   UndecoratedName = F->getName();
   return true;
@@ -1322,9 +1322,9 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
     auto Name = Ty->getStructName();
     std::string Tmp;
 
-    if (Name.startswith(kLLVMTypeName::StructPrefix))
+    if (Name.starts_with(kLLVMTypeName::StructPrefix))
       Name = Name.drop_front(strlen(kLLVMTypeName::StructPrefix));
-    if (Name.startswith(kSPIRVTypeName::PrefixAndDelim)) {
+    if (Name.starts_with(kSPIRVTypeName::PrefixAndDelim)) {
       Name = Name.substr(sizeof(kSPIRVTypeName::PrefixAndDelim) - 1);
       Tmp = Name.str();
       auto Pos = Tmp.find(kSPIRVTypeName::Delimiter); // first dot
@@ -1379,7 +1379,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
     } else if (auto *StructTy = dyn_cast<StructType>(ET)) {
       LLVM_DEBUG(dbgs() << "ptr to struct: " << *Ty << '\n');
       auto TyName = StructTy->getStructName();
-      if (TyName.startswith(kSPR2TypeName::OCLPrefix)) {
+      if (TyName.starts_with(kSPR2TypeName::OCLPrefix)) {
         auto DelimPos = TyName.find_first_of(kSPR2TypeName::Delimiter,
                                              strlen(kSPR2TypeName::OCLPrefix));
         if (DelimPos != StringRef::npos)
@@ -1616,7 +1616,7 @@ std::string getImageBaseTypeName(StringRef Name) {
   SmallVector<StringRef, 4> SubStrs;
   const char Delims[] = {kSPR2TypeName::Delimiter, 0};
   Name.split(SubStrs, Delims);
-  if (Name.startswith(kSPR2TypeName::OCLPrefix)) {
+  if (Name.starts_with(kSPR2TypeName::OCLPrefix)) {
     Name = SubStrs[1];
   } else {
     Name = SubStrs[0];
@@ -1812,7 +1812,7 @@ bool isSPIRVOCLExtInst(const CallInst *CI, OCLExtOpKind *ExtOp) {
   if (!oclIsBuiltin(CI->getCalledFunction()->getName(), DemangledName))
     return false;
   StringRef S = DemangledName;
-  if (!S.startswith(kSPIRVName::Prefix))
+  if (!S.starts_with(kSPIRVName::Prefix))
     return false;
   S = S.drop_front(strlen(kSPIRVName::Prefix));
   auto Loc = S.find(kSPIRVPostfix::Divider);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -234,7 +234,7 @@ bool LLVMToSPIRVBase::isBuiltinTransToExtInst(
   LLVM_DEBUG(dbgs() << "[oclIsBuiltinTransToExtInst] CallInst: demangled name: "
                     << DemangledName << '\n');
   StringRef S = DemangledName;
-  if (!S.startswith(kSPIRVName::Prefix))
+  if (!S.starts_with(kSPIRVName::Prefix))
     return false;
   S = S.drop_front(strlen(kSPIRVName::Prefix));
   auto Loc = S.find(kSPIRVPostfix::Divider);
@@ -406,9 +406,9 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
   if (T->isStructTy() && !T->isSized()) {
     auto *ST = dyn_cast<StructType>(T);
     (void)ST; // Silence warning
-    assert(!ST->getName().startswith(kSPR2TypeName::PipeRO));
-    assert(!ST->getName().startswith(kSPR2TypeName::PipeWO));
-    assert(!ST->getName().startswith(kSPR2TypeName::ImagePrefix));
+    assert(!ST->getName().starts_with(kSPR2TypeName::PipeRO));
+    assert(!ST->getName().starts_with(kSPR2TypeName::PipeWO));
+    assert(!ST->getName().starts_with(kSPR2TypeName::ImagePrefix));
     return mapType(T, BM->addOpaqueType(T->getStructName().str()));
   }
 
@@ -603,15 +603,15 @@ SPIRVType *LLVMToSPIRVBase::transPointerType(Type *ET, unsigned AddrSpc) {
       return MappedTy;
     };
 
-    if (STName.startswith(kSPR2TypeName::PipeRO) ||
-        STName.startswith(kSPR2TypeName::PipeWO)) {
+    if (STName.starts_with(kSPR2TypeName::PipeRO) ||
+        STName.starts_with(kSPR2TypeName::PipeWO)) {
       auto *PipeT = BM->addPipeType();
-      PipeT->setPipeAcessQualifier(STName.startswith(kSPR2TypeName::PipeRO)
+      PipeT->setPipeAcessQualifier(STName.starts_with(kSPR2TypeName::PipeRO)
                                        ? AccessQualifierReadOnly
                                        : AccessQualifierWriteOnly);
       return SaveType(PipeT);
     }
-    if (STName.startswith(kSPR2TypeName::ImagePrefix)) {
+    if (STName.starts_with(kSPR2TypeName::ImagePrefix)) {
       assert(AddrSpc == SPIRAS_Global);
       Type *ImageTy =
           adjustImageType(TypedPointerType::get(ST, AddrSpc),
@@ -620,10 +620,10 @@ SPIRVType *LLVMToSPIRVBase::transPointerType(Type *ET, unsigned AddrSpc) {
     }
     if (STName == kSPR2TypeName::Sampler)
       return SaveType(transType(getSPIRVType(OpTypeSampler)));
-    if (STName.startswith(kSPIRVTypeName::PrefixAndDelim))
+    if (STName.starts_with(kSPIRVTypeName::PrefixAndDelim))
       return transSPIRVOpaqueType(STName, AddrSpc);
 
-    if (STName.startswith(kOCLSubgroupsAVCIntel::TypePrefix))
+    if (STName.starts_with(kOCLSubgroupsAVCIntel::TypePrefix))
       return SaveType(BM->addSubgroupAvcINTELType(
           OCLSubgroupINTELTypeOpCodeMap::map(ST->getName().str())));
 
@@ -632,7 +632,7 @@ SPIRVType *LLVMToSPIRVBase::transPointerType(Type *ET, unsigned AddrSpc) {
       return SaveType(transType(RealType));
     }
     if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute)) {
-      if (STName.startswith(kVCType::VCBufferSurface)) {
+      if (STName.starts_with(kVCType::VCBufferSurface)) {
         // VCBufferSurface always have Access Qualifier
         auto Access = getAccessQualifier(STName);
         return SaveType(BM->addBufferSurfaceINTELType(Access));
@@ -687,7 +687,7 @@ SPIRVType *LLVMToSPIRVBase::transSPIRVOpaqueType(StringRef STName,
   };
   StructType *ST = StructType::getTypeByName(M->getContext(), STName);
 
-  assert(STName.startswith(kSPIRVTypeName::PrefixAndDelim) &&
+  assert(STName.starts_with(kSPIRVTypeName::PrefixAndDelim) &&
          "Invalid SPIR-V opaque type name");
   SmallVector<std::string, 8> Postfixes;
   auto TN = decodeSPIRVTypeName(STName, Postfixes);
@@ -3631,7 +3631,7 @@ SPIRVInstruction *addFPBuiltinDecoration(SPIRVModule *BM, IntrinsicInst *II,
                                          SPIRVInstruction *I) {
   const bool AllowFPMaxError =
       BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fp_max_error);
-  assert(II->getCalledFunction()->getName().startswith("llvm.fpbuiltin"));
+  assert(II->getCalledFunction()->getName().starts_with("llvm.fpbuiltin"));
   // Add a new decoration for llvm.builtin intrinsics, if needed
   if (AllowFPMaxError)
     if (II->getAttributes().hasFnAttr("fpbuiltin-max-error")) {
@@ -3653,13 +3653,13 @@ SPIRVInstruction *
 LLVMToSPIRVBase::applyRoundingModeConstraint(Value *V, SPIRVInstruction *I) {
   StringRef RMode =
       cast<MDString>(cast<MetadataAsValue>(V)->getMetadata())->getString();
-  if (RMode.endswith("tonearest"))
+  if (RMode.ends_with("tonearest"))
     I->addFPRoundingMode(FPRoundingModeRTE);
-  else if (RMode.endswith("towardzero"))
+  else if (RMode.ends_with("towardzero"))
     I->addFPRoundingMode(FPRoundingModeRTZ);
-  else if (RMode.endswith("upward"))
+  else if (RMode.ends_with("upward"))
     I->addFPRoundingMode(FPRoundingModeRTP);
-  else if (RMode.endswith("downward"))
+  else if (RMode.ends_with("downward"))
     I->addFPRoundingMode(FPRoundingModeRTN);
   return I;
 }
@@ -4908,7 +4908,7 @@ SPIRVValue *LLVMToSPIRVBase::transDirectCallInst(CallInst *CI,
   auto MangledName = F->getName();
   StringRef DemangledName;
 
-  if (MangledName.startswith(SPCV_CAST) || MangledName == SAMPLER_INIT)
+  if (MangledName.starts_with(SPCV_CAST) || MangledName == SAMPLER_INIT)
     return oclTransSpvcCastSampler(CI, BB);
 
   if (oclIsBuiltin(MangledName, DemangledName) ||
@@ -5469,9 +5469,9 @@ bool LLVMToSPIRVBase::translate() {
   std::vector<Function *> Decls, Defs;
   for (auto &F : *M) {
     if (isBuiltinTransToInst(&F) || isBuiltinTransToExtInst(&F) ||
-        F.getName().startswith(SPCV_CAST) ||
-        F.getName().startswith(LLVM_MEMCPY) ||
-        F.getName().startswith(SAMPLER_INIT))
+        F.getName().starts_with(SPCV_CAST) ||
+        F.getName().starts_with(LLVM_MEMCPY) ||
+        F.getName().starts_with(SAMPLER_INIT))
       continue;
     if (F.isDeclaration())
       Decls.push_back(&F);


### PR DESCRIPTION
Replace with the `{starts,ends}_with` variants, after LLVM commit llvm/llvm-project@5ac12951b4e9 ("[ADT] Deprecate StringRef::{starts,ends}with (#75491)", 2023-12-17).

This is a mechanical change applied using:

```
  git grep -l startswith | xargs sed -i -e 's/startswith/starts_with/g'
  git grep -l endswith | xargs sed -i -e 's/endswith/ends_with/g'
```