### PR TITLE
[SPIRV-V Extension] fpbuiltin-max-error w/o extension

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -305,12 +305,16 @@ static bool recursiveType(const StructType *ST, const Type *Ty) {
 // Add decoration if needed
 void addFPBuiltinDecoration(SPIRVModule *BM, Instruction *Inst,
                             SPIRVInstruction *I) {
-  if (!BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fp_max_error))
-    return;
+  bool Allow_fp_max_error =
+      BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fp_max_error);
+
   auto *II = dyn_cast_or_null<IntrinsicInst>(Inst);
   if (II && II->getCalledFunction()->getName().starts_with("llvm.fpbuiltin")) {
     // Add a new decoration for llvm.builtin intrinsics, if needed
     if (II->getAttributes().hasFnAttr("fpbuiltin-max-error")) {
+      BM->getErrorLog().checkError(Allow_fp_max_error,
+                                   SPIRVEC_RequiresExtension,
+                                   "SPV_INTEL_fp_max_error\n");
       double F = 0.0;
       II->getAttributes()
           .getFnAttr("fpbuiltin-max-error")
@@ -320,6 +324,8 @@ void addFPBuiltinDecoration(SPIRVModule *BM, Instruction *Inst,
                      convertFloatToSPIRVWord(F));
     }
   } else if (auto *MD = Inst->getMetadata("fpmath")) {
+    if (!Allow_fp_max_error)
+      return;
     auto *MDVal = mdconst::dyn_extract<ConstantFP>(MD->getOperand(0));
     double ValAsDouble = MDVal->getValue().convertToFloat();
     I->addDecorate(DecorationFPMaxErrorDecorationINTEL,

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -305,15 +305,14 @@ static bool recursiveType(const StructType *ST, const Type *Ty) {
 // Add decoration if needed
 void addFPBuiltinDecoration(SPIRVModule *BM, Instruction *Inst,
                             SPIRVInstruction *I) {
-  bool Allow_fp_max_error =
+  bool AllowFPMaxError =
       BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fp_max_error);
 
   auto *II = dyn_cast_or_null<IntrinsicInst>(Inst);
   if (II && II->getCalledFunction()->getName().starts_with("llvm.fpbuiltin")) {
     // Add a new decoration for llvm.builtin intrinsics, if needed
     if (II->getAttributes().hasFnAttr("fpbuiltin-max-error")) {
-      BM->getErrorLog().checkError(Allow_fp_max_error,
-                                   SPIRVEC_RequiresExtension,
+      BM->getErrorLog().checkError(AllowFPMaxError, SPIRVEC_RequiresExtension,
                                    "SPV_INTEL_fp_max_error\n");
       double F = 0.0;
       II->getAttributes()
@@ -324,7 +323,7 @@ void addFPBuiltinDecoration(SPIRVModule *BM, Instruction *Inst,
                      convertFloatToSPIRVWord(F));
     }
   } else if (auto *MD = Inst->getMetadata("fpmath")) {
-    if (!Allow_fp_max_error)
+    if (!AllowFPMaxError)
       return;
     auto *MDVal = mdconst::dyn_extract<ConstantFP>(MD->getOperand(0));
     double ValAsDouble = MDVal->getValue().convertToFloat();

--- a/test/extensions/INTEL/SPV_INTEL_fp_max_error/IntelFPMaxError.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fp_max_error/IntelFPMaxError.ll
@@ -1,4 +1,12 @@
 ; RUN: llvm-as %s -o %t.bc
+
+;; Check that an error is reported if a fpbuiltin-max-error attribute is encountered without the SPV_INTEL_fp_max_error
+;; extension.
+; RUN: not llvm-spirv %t.bc --spirv-allow-unknown-intrinsics=llvm.fpbuiltin -o %t.spv 2>&1  | FileCheck %s --check-prefix=CHECK_NO_CAPABILITY_ERROR
+; CHECK_NO_CAPABILITY_ERROR: RequiresExtension: Feature requires the following SPIR-V extension:
+; CHECK_NO_CAPABILITY_ERROR-NEXT: SPV_INTEL_fp_max_error
+
+;; Check that fpbuiltin-max-error is translated and reverse-translated properly
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fp_max_error --spirv-allow-unknown-intrinsics=llvm.fpbuiltin -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV


### PR DESCRIPTION
Report an error if fpbuiltin-max-error found without extension enabled