### PR TITLE
[SPV->LLVM] Fix global c/dtors type if SPV is from opaque type LLVM

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3816,7 +3816,7 @@ static GlobalVariable *mutateGlobalCtorDtors(GlobalVariable *GV) {
 }
 
 void SPIRVToLLVM::transGlobalCtorDtors(SPIRVVariable *BV) {
-  GlobalVariable *V = cast<GlobalVariable>(transValue(BV, nullptr, nullptr));
+  auto *V = cast<GlobalVariable>(transValue(BV, nullptr, nullptr));
   V = mutateGlobalCtorDtors(V);
   V->setLinkage(GlobalVariable::AppendingLinkage);
 }

--- a/test/transcoding/SPV_INTEL_function_pointers/global_ctor_dtor_opaque.spt
+++ b/test/transcoding/SPV_INTEL_function_pointers/global_ctor_dtor_opaque.spt
@@ -1,0 +1,54 @@
+119734787 65792 393230 22 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+2 Capability Int64
+2 Capability Int8
+2 Capability FunctionPointersINTEL
+8 Extension "SPV_INTEL_function_pointers"
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 2 2
+3 Source 0 0
+7 Name 14 "asan.module_ctor"
+7 Name 15 "asan.module_ctor"
+7 Name 20 "llvm.global_ctors"
+
+9 Decorate 20 LinkageAttributes "llvm.global_ctors" Export
+4 TypeInt 3 32 0
+4 TypeInt 4 8 0
+4 TypeInt 6 64 0
+5 Constant 6 7 1 0
+4 Constant 3 10 1
+4 TypePointer 5 7 4
+5 TypeStruct 2 3 5 5
+
+4 TypeArray 8 2 7
+4 TypePointer 9 7 8
+2 TypeVoid 11
+3 TypeFunction 12 11
+4 TypePointer 13 7 12
+4 ConstantFunctionPointerINTEL 13 15 14
+5 SpecConstantOp 5 16 124 15
+3 ConstantNull 5 17
+6 ConstantComposite 2 18 10 16 17
+
+4 ConstantComposite 8 19 18
+
+5 Variable 9 20 7 19
+
+
+
+5 Function 11 14 0 12
+
+2 Label 21
+1 Return
+
+1 FunctionEnd
+
+; RUN: llvm-spirv %s --to-binary -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck --input-file=%t.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: [[TY:%.*]] = type { i32, void ()*, i8* }
+; CHECK-LLVM: @llvm.global_ctors = appending global [1 x [[TY]]] [[[TY]] { i32 1, void ()* @asan.module_ctor, i8* null }]


### PR DESCRIPTION
When SPV is generated from LLVM IR with opaque pointer enabled, ctor
function in global ctors has opaque pointer type rather than function
type. When translating the SPV back to LLVM IR with typed pointer like
in LLVM 14, ctor function type is casted to i8* pointer in the global
ctors initializer. This results in error in LLVM verifier.
This PR fixes the issue by removing the cast.