### PR TITLE
Mark all passes as required in LLVM new pass manager

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.h
+++ b/lib/SPIRV/OCLToSPIRV.h
@@ -304,6 +304,8 @@ class OCLToSPIRVPass : public OCLToSPIRVBase,
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
+
+  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/PreprocessMetadata.h
+++ b/lib/SPIRV/PreprocessMetadata.h
@@ -83,6 +83,8 @@ class PreprocessMetadataPass
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
+
+  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.h
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.h
@@ -51,6 +51,8 @@ public:
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &FAM);
 
+  static bool isRequired() { return true; }
+
 private:
   SPIRV::TranslatorOpts Opts;
 };

--- a/lib/SPIRV/SPIRVLowerBool.h
+++ b/lib/SPIRV/SPIRVLowerBool.h
@@ -70,6 +70,8 @@ class SPIRVLowerBoolPass : public llvm::PassInfoMixin<SPIRVLowerBoolPass>,
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
+
+  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerBoolLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerConstExpr.h
+++ b/lib/SPIRV/SPIRVLowerConstExpr.h
@@ -40,6 +40,8 @@ public:
     return runLowerConstExpr(M) ? llvm::PreservedAnalyses::none()
                                 : llvm::PreservedAnalyses::all();
   }
+
+  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVLowerMemmove.h
+++ b/lib/SPIRV/SPIRVLowerMemmove.h
@@ -63,6 +63,8 @@ class SPIRVLowerMemmovePass : public llvm::PassInfoMixin<SPIRVLowerMemmovePass>,
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
+
+  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerMemmoveLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerOCLBlocks.h
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.h
@@ -53,6 +53,8 @@ class SPIRVLowerOCLBlocksPass
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
+
+  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerOCLBlocksLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerSaddWithOverflow.h
+++ b/lib/SPIRV/SPIRVLowerSaddWithOverflow.h
@@ -62,6 +62,8 @@ class SPIRVLowerSaddWithOverflowPass
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
+
+  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerSaddWithOverflowLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -122,6 +122,8 @@ public:
     return runRegularizeLLVM(M) ? llvm::PreservedAnalyses::none()
                                 : llvm::PreservedAnalyses::all();
   }
+
+  static bool isRequired() { return true; }
 };
 
 class SPIRVRegularizeLLVMLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -380,6 +380,8 @@ public:
     return runSPIRVToOCL(M) ? llvm::PreservedAnalyses::none()
                             : llvm::PreservedAnalyses::all();
   }
+
+  static bool isRequired() { return true; }
 };
 
 class SPIRVToOCL12Legacy : public SPIRVToOCL12Base, public SPIRVToOCLLegacy {
@@ -451,6 +453,8 @@ public:
     return runSPIRVToOCL(M) ? llvm::PreservedAnalyses::none()
                             : llvm::PreservedAnalyses::all();
   }
+
+  static bool isRequired() { return true; }
 };
 
 class SPIRVToOCL20Legacy : public SPIRVToOCLLegacy, public SPIRVToOCL20Base {

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -273,6 +273,8 @@ public:
                                           : llvm::PreservedAnalyses::all();
   }
 
+  static bool isRequired() { return true; }
+
 private:
   SPIRVModule *SMod;
 };


### PR DESCRIPTION
When these passes are used in LLVM new pass manager, they can't be
skipped since they are not optimization passes which are optional.

Before this PR I'm seeing crash in compiler when bisecting pass manager.