### PR TITLE
[CI] Upgrade to actions/checkout@v3 (#1888)

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # In order to gather diff from PR we need to fetch not only the latest
         # commit. Depth of 2 is enough, because GitHub Actions supply us with

--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -61,13 +61,13 @@ jobs:
           # pre-installed. Make sure to override these with the relevant version.
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
       - name: Checkout LLVM sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: llvm/llvm-project
           ref: release/14.x
           path: llvm-project
       - name:  Checkout the translator sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: llvm-project/llvm/projects/SPIRV-LLVM-Translator
       - name:  Get tag for SPIR-V Headers
@@ -75,7 +75,7 @@ jobs:
         run: |
           echo "spirv_headers_tag=$(cat llvm-project/llvm/projects/SPIRV-LLVM-Translator/spirv-headers-tag.conf)" >> $GITHUB_ENV
       - name:  Checkout SPIR-V Headers
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: KhronosGroup/SPIRV-Headers
           ref: ${{ env.spirv_headers_tag }}
@@ -116,13 +116,13 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout LLVM sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: llvm/llvm-project
           ref: release/14.x
           path: llvm-project
       - name:  Checkout the translator sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: llvm-project\\llvm\\projects\\SPIRV-LLVM-Translator
       - name:  Get tag for SPIR-V Headers
@@ -130,7 +130,7 @@ jobs:
         run: |
           echo "spirv_headers_tag=$(type llvm-project\\llvm\\projects\\SPIRV-LLVM-Translator\\spirv-headers-tag.conf)" >> $GITHUB_ENV
       - name:  Checkout SPIR-V Headers
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: KhronosGroup/SPIRV-Headers
           ref: ${{ env.spirv_headers_tag }}
@@ -168,13 +168,13 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout LLVM sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: llvm/llvm-project
           ref: release/14.x
           path: llvm-project
       - name:  Checkout the translator sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: llvm-project/llvm/projects/SPIRV-LLVM-Translator
       - name:  Get tag for SPIR-V Headers
@@ -182,7 +182,7 @@ jobs:
         run: |
           echo "spirv_headers_tag=$(cat llvm-project/llvm/projects/SPIRV-LLVM-Translator/spirv-headers-tag.conf)" >> $GITHUB_ENV
       - name:  Checkout SPIR-V Headers
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: KhronosGroup/SPIRV-Headers
           ref: ${{ env.spirv_headers_tag }}

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -57,7 +57,7 @@ jobs:
           # pre-installed. Make sure to override these with the relevant version.
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
       - name:  Checkout the translator sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: SPIRV-LLVM-Translator
       - name:  Get tag for SPIR-V Headers
@@ -65,7 +65,7 @@ jobs:
         run: |
           echo "spirv_headers_tag=$(cat SPIRV-LLVM-Translator/spirv-headers-tag.conf)" >> $GITHUB_ENV
       - name:  Checkout SPIR-V Headers
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: KhronosGroup/SPIRV-Headers
           ref: ${{ env.spirv_headers_tag }}


### PR DESCRIPTION
Node.js 12 actions are deprecated, so update to v3 which uses Node 16.

(cherry picked from commit fed835227f84fd902c68c2437caac141ce6b6ec5)