### PR TITLE
[DebugInfo] Preserve DIExpression in DIGlobalVariableExpression

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1184,9 +1184,8 @@ LLVMToSPIRVDbgTran::transDbgGlobalVariable(const DIGlobalVariable *GV) {
   Ops[FlagsIdx] = transDebugFlags(GV);
 
   // Check if GV is the definition of previously declared static member
-  DIDerivedType *StaticMember = GV->getStaticDataMemberDeclaration();
-  Ops.push_back(StaticMember ? transDbgEntry(StaticMember)->getId()
-                             : getDebugInfoNoneId());
+  if (DIDerivedType *StaticMember = GV->getStaticDataMemberDeclaration())
+    Ops.push_back(transDbgEntry(StaticMember)->getId());
 
   // Check if Ops[VariableIdx] has no information
   if (Ops[VariableIdx] == getDebugInfoNoneId()) {

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1185,11 +1185,11 @@ LLVMToSPIRVDbgTran::transDbgGlobalVariable(const DIGlobalVariable *GV) {
 
   // Check if GV is the definition of previously declared static member
   DIDerivedType *StaticMember = GV->getStaticDataMemberDeclaration();
-  Ops.push_back(StaticMember ? transDbgEntry(StaticMember)->getId() :
-                getDebugInfoNoneId());
+  Ops.push_back(StaticMember ? transDbgEntry(StaticMember)->getId()
+                             : getDebugInfoNoneId());
 
   for (const DIGlobalVariableExpression *G : DIF.global_variables()) {
-    if (G->getVariable()==GV) {
+    if (G->getVariable() == GV) {
       Ops.push_back(transDbgExpression(G->getExpression())->getId());
       break;
     }

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1188,12 +1188,14 @@ LLVMToSPIRVDbgTran::transDbgGlobalVariable(const DIGlobalVariable *GV) {
   Ops.push_back(StaticMember ? transDbgEntry(StaticMember)->getId()
                              : getDebugInfoNoneId());
 
-  for (const DIGlobalVariableExpression *G : DIF.global_variables()) {
-    if (G->getVariable() == GV) {
-      Ops.push_back(transDbgExpression(G->getExpression())->getId());
-      break;
+  if (BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200)
+    // Check if GV has an associated GVE with a DIExpression
+    for (const DIGlobalVariableExpression *GVE : DIF.global_variables()) {
+      if (GVE->getVariable() == GV) {
+        Ops.push_back(transDbgExpression(GVE->getExpression())->getId());
+        break;
+      }
     }
-  }
 
   if (isNonSemanticDebugInfo())
     transformToConstant(Ops, {LineIdx, ColumnIdx, FlagsIdx});

--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1184,8 +1184,16 @@ LLVMToSPIRVDbgTran::transDbgGlobalVariable(const DIGlobalVariable *GV) {
   Ops[FlagsIdx] = transDebugFlags(GV);
 
   // Check if GV is the definition of previously declared static member
-  if (DIDerivedType *StaticMember = GV->getStaticDataMemberDeclaration())
-    Ops.push_back(transDbgEntry(StaticMember)->getId());
+  DIDerivedType *StaticMember = GV->getStaticDataMemberDeclaration();
+  Ops.push_back(StaticMember ? transDbgEntry(StaticMember)->getId() :
+                getDebugInfoNoneId());
+
+  for (const DIGlobalVariableExpression *G : DIF.global_variables()) {
+    if (G->getVariable()==GV) {
+      Ops.push_back(transDbgExpression(G->getExpression())->getId());
+      break;
+    }
+  }
 
   if (isNonSemanticDebugInfo())
     transformToConstant(Ops, {LineIdx, ColumnIdx, FlagsIdx});

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1131,7 +1131,8 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
   }
 
   DIExpression *DIExpr = nullptr;
-  if (Ops.size() > DIExpressionIdx)
+  if (DebugInst->getExtSetKind() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200 &&
+      Ops.size() > DIExpressionIdx)
     DIExpr = transDebugInst<DIExpression>(
         BM->get<SPIRVExtInst>(Ops[DIExpressionIdx]));
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1124,8 +1124,7 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
   StringRef LinkageName = getString(Ops[LinkageNameIdx]);
 
   DIDerivedType *StaticMemberDecl = nullptr;
-  if (Ops.size() > MinOperandCount &&
-      !getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[StaticMemberDeclarationIdx])) {
+  if (Ops.size() > MinOperandCount) {
     StaticMemberDecl = transDebugInst<DIDerivedType>(
         BM->get<SPIRVExtInst>(Ops[StaticMemberDeclarationIdx]));
   }

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1132,7 +1132,8 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
 
   DIExpression *DIExpr = nullptr;
   if (Ops.size() > DIExpressionIdx)
-    DIExpr = transDebugInst<DIExpression>(BM->get<SPIRVExtInst>(Ops[DIExpressionIdx]));
+    DIExpr = transDebugInst<DIExpression>(
+        BM->get<SPIRVExtInst>(Ops[DIExpressionIdx]));
 
   SPIRVWord Flags =
       getConstantValueOrLiteral(Ops, FlagsIdx, DebugInst->getExtSetKind());

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -577,7 +577,6 @@ enum {
   VariableIdx                = 7,
   FlagsIdx                   = 8,
   StaticMemberDeclarationIdx = 9,
-  DIExpressionIdx            = 10,
   MinOperandCount            = 9
 };
 }

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -577,6 +577,7 @@ enum {
   VariableIdx                = 7,
   FlagsIdx                   = 8,
   StaticMemberDeclarationIdx = 9,
+  DIExpressionIdx            = 10,
   MinOperandCount            = 9
 };
 }

--- a/test/DebugInfo/DebugInfo-GV-with-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-DIE.ll
@@ -1,0 +1,24 @@
+;; Ensure that DIExpressions are preserved in DIGlobalVariableExpressions
+;; This utilizes SPIRV DebugGlobalVariable's optional field DIExpression
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv -o %t.spv %t.bc
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; CHECK: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
+; CHECK: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true)
+
+!llvm.module.flags = !{!0, !1}
+!llvm.dbg.cu = !{!2}
+
+!0 = !{i32 7, !"Dwarf Version", i32 4}
+!1 = !{i32 2, !"Debug Info Version", i32 3}
+!2 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !3, producer: "clang", emissionKind: FullDebug, globals: !4)
+!3 = !DIFile(filename: "test.cpp", directory: "/path/to")
+!4 = !{!5}
+!5 = !DIGlobalVariableExpression(var: !6, expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
+!6 = distinct !DIGlobalVariable(name: "true", scope: !2, file: !3, line: 3777, type: !7, isLocal: true, isDefinition: true)
+!7 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !8)
+!8 = !DIBasicType(name: "bool", size: 8, encoding: DW_ATE_boolean)

--- a/test/DebugInfo/DebugInfo-GV-with-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-DIE.ll
@@ -1,5 +1,6 @@
 ;; Ensure that DIExpressions are preserved in DIGlobalVariableExpressions
-;; This utilizes SPIRV DebugGlobalVariable's optional field DIExpression
+;; This utilizes SPIRV DebugGlobalVariable's Variable field to hold the
+;; DIExpression.
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv -o %t.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200

--- a/test/DebugInfo/DebugInfo-GV-with-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-DIE.ll
@@ -3,10 +3,16 @@
 ;; DIExpression.
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -o %t.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
-; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
-; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
-; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llvm-spirv -o %t.100.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -o %t.100.rev.bc %t.100.spv
+; RUN: llvm-dis %t.100.rev.bc -o %t.100.rev.ll
+; RUN: FileCheck %s --input-file %t.100.rev.ll
+
+; RUN: llvm-spirv -o %t.200.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
+; RUN: llvm-spirv -r -o %t.200.rev.bc %t.200.spv
+; RUN: llvm-dis %t.200.rev.bc -o %t.200.rev.ll
+; RUN: FileCheck %s --input-file %t.200.rev.ll
 
 ; CHECK: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
 ; CHECK: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true)

--- a/test/DebugInfo/DebugInfo-GV-with-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-DIE.ll
@@ -4,15 +4,22 @@
 
 ; RUN: llvm-as %s -o %t.bc
 
+; RUN: llvm-spirv -o %t.100.spt %t.bc --spirv-debug-info-version=nonsemantic-shader-100 -spirv-text
+; RUN: FileCheck %s --input-file %t.100.spt --check-prefix CHECK-SPIRV
 ; RUN: llvm-spirv -o %t.100.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-100
 ; RUN: llvm-spirv -r -o %t.100.rev.bc %t.100.spv
 ; RUN: llvm-dis %t.100.rev.bc -o %t.100.rev.ll
 ; RUN: FileCheck %s --input-file %t.100.rev.ll --check-prefix CHECK-LLVM
 
+; RUN: llvm-spirv -o %t.200.spt %t.bc --spirv-debug-info-version=nonsemantic-shader-200 -spirv-text
+; RUN: FileCheck %s --input-file %t.200.spt --check-prefix CHECK-SPIRV
 ; RUN: llvm-spirv -o %t.200.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -o %t.200.rev.bc %t.200.spv
 ; RUN: llvm-dis %t.200.rev.bc -o %t.200.rev.ll
 ; RUN: FileCheck %s --input-file %t.200.rev.ll --check-prefix CHECK-LLVM
+
+; CHECK-SPIRV: [[EXPRESSION:[0-9]+]] [[#]] DebugExpression [[#]] [[#]]
+; CHECK-SPIRV: [[#]] [[#]] DebugGlobalVariable [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[EXPRESSION]] [[#]] {{$}}
 
 ; CHECK-LLVM: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
 ; CHECK-LLVM: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true)

--- a/test/DebugInfo/DebugInfo-GV-with-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-DIE.ll
@@ -2,7 +2,7 @@
 ;; This utilizes SPIRV DebugGlobalVariable's optional field DIExpression
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -o %t.spv %t.bc
+; RUN: llvm-spirv -o %t.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll

--- a/test/DebugInfo/DebugInfo-GV-with-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-DIE.ll
@@ -7,15 +7,15 @@
 ; RUN: llvm-spirv -o %t.100.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-100
 ; RUN: llvm-spirv -r -o %t.100.rev.bc %t.100.spv
 ; RUN: llvm-dis %t.100.rev.bc -o %t.100.rev.ll
-; RUN: FileCheck %s --input-file %t.100.rev.ll
+; RUN: FileCheck %s --input-file %t.100.rev.ll --check-prefix CHECK-LLVM
 
 ; RUN: llvm-spirv -o %t.200.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -o %t.200.rev.bc %t.200.spv
 ; RUN: llvm-dis %t.200.rev.bc -o %t.200.rev.ll
-; RUN: FileCheck %s --input-file %t.200.rev.ll
+; RUN: FileCheck %s --input-file %t.200.rev.ll --check-prefix CHECK-LLVM
 
-; CHECK: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
-; CHECK: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true)
+; CHECK-LLVM: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
+; CHECK-LLVM: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true)
 
 !llvm.module.flags = !{!0, !1}
 !llvm.dbg.cu = !{!2}

--- a/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
@@ -1,6 +1,7 @@
 ;; Ensure that DIExpressions are preserved in DIGlobalVariableExpressions
 ;; when a Static Member Declaration is also needed.
-;; This utilizes SPIRV DebugGlobalVariable's optional fields Static Member Declaration and DIExpression
+;; This utilizes SPIRV DebugGlobalVariable's Variable field to hold the
+;; DIExpression.
 
 ;; Declaration generated from:
 ;;

--- a/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
@@ -13,16 +13,23 @@
 
 ; RUN: llvm-as %s -o %t.bc
 
+; RUN: llvm-spirv -o %t.100.spt %t.bc --spirv-debug-info-version=nonsemantic-shader-100 -spirv-text
+; RUN: FileCheck %s --input-file %t.100.spt --check-prefix CHECK-SPIRV
 ; RUN: llvm-spirv -o %t.100.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-100
 ; RUN: llvm-spirv -r -o %t.100.rev.bc %t.100.spv
 ; RUN: llvm-dis %t.100.rev.bc -o %t.100.rev.ll
 ; RUN: FileCheck %s --input-file %t.100.rev.ll --check-prefix CHECK-LLVM
 
+; RUN: llvm-spirv -o %t.200.spt %t.bc --spirv-debug-info-version=nonsemantic-shader-200 -spirv-text
+; RUN: FileCheck %s --input-file %t.200.spt --check-prefix CHECK-SPIRV
 ; RUN: llvm-spirv -o %t.200.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -o %t.200.rev.bc %t.200.spv
 ; RUN: llvm-dis %t.200.rev.bc -o %t.200.rev.ll
 ; RUN: FileCheck %s --input-file %t.200.rev.ll --check-prefix CHECK-LLVM
 
+; CHECK-SPIRV-DAG: [[TYPE_MEMBER:[0-9]+]] [[#]] DebugTypeMember [[#]] [[#]] [[#]] [[#]]
+; CHECK-SPIRV-DAG: [[EXPRESSION:[0-9]+]] [[#]] DebugExpression [[#]] [[#]]
+; CHECK-SPIRV: [[#]] [[#]] DebugGlobalVariable [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[EXPRESSION]] [[#]] [[TYPE_MEMBER]] {{$}}
 
 ; CHECK-LLVM: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
 ; CHECK-LLVM: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true, declaration: ![[#DECLARATION:]])

--- a/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
@@ -11,7 +11,7 @@
 ;; int A::fully_specified;
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -o %t.spv %t.bc
+; RUN: llvm-spirv -o %t.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll

--- a/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
@@ -12,10 +12,17 @@
 ;; int A::fully_specified;
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -o %t.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
-; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
-; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
-; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llvm-spirv -o %t.100.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-100
+; RUN: llvm-spirv -r -o %t.100.rev.bc %t.100.spv
+; RUN: llvm-dis %t.100.rev.bc -o %t.100.rev.ll
+; RUN: FileCheck %s --input-file %t.100.rev.ll
+
+; RUN: llvm-spirv -o %t.200.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
+; RUN: llvm-spirv -r -o %t.200.rev.bc %t.200.spv
+; RUN: llvm-dis %t.200.rev.bc -o %t.200.rev.ll
+; RUN: FileCheck %s --input-file %t.200.rev.ll
+
 
 ; CHECK: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
 ; CHECK: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true, declaration: ![[#DECLARATION:]])

--- a/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
@@ -16,20 +16,20 @@
 ; RUN: llvm-spirv -o %t.100.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-100
 ; RUN: llvm-spirv -r -o %t.100.rev.bc %t.100.spv
 ; RUN: llvm-dis %t.100.rev.bc -o %t.100.rev.ll
-; RUN: FileCheck %s --input-file %t.100.rev.ll
+; RUN: FileCheck %s --input-file %t.100.rev.ll --check-prefix CHECK-LLVM
 
 ; RUN: llvm-spirv -o %t.200.spv %t.bc --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r -o %t.200.rev.bc %t.200.spv
 ; RUN: llvm-dis %t.200.rev.bc -o %t.200.rev.ll
-; RUN: FileCheck %s --input-file %t.200.rev.ll
+; RUN: FileCheck %s --input-file %t.200.rev.ll --check-prefix CHECK-LLVM
 
 
-; CHECK: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
-; CHECK: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true, declaration: ![[#DECLARATION:]])
-; CHECK: ![[#DECLARATION]] = !DIDerivedType(tag: DW_TAG_member, name: "fully_specified", scope: ![[#SCOPE:]], file: ![[#]], line: 2, baseType: ![[#BASETYPE:]], flags: DIFlagPublic | DIFlagStaticMember)
-; CHECK: ![[#SCOPE]] = {{.*}}!DICompositeType(tag: DW_TAG_structure_type, name: "A", file: ![[#]], line: 1, size: 8, flags: DIFlagTypePassByValue, elements: ![[#ELEMENTS:]], identifier: "_ZTS1A")
-; CHECK: ![[#ELEMENTS]] = !{![[#DECLARATION]]}
-; CHECK: ![[#BASETYPE]] = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+; CHECK-LLVM: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
+; CHECK-LLVM: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true, declaration: ![[#DECLARATION:]])
+; CHECK-LLVM: ![[#DECLARATION]] = !DIDerivedType(tag: DW_TAG_member, name: "fully_specified", scope: ![[#SCOPE:]], file: ![[#]], line: 2, baseType: ![[#BASETYPE:]], flags: DIFlagPublic | DIFlagStaticMember)
+; CHECK-LLVM: ![[#SCOPE]] = {{.*}}!DICompositeType(tag: DW_TAG_structure_type, name: "A", file: ![[#]], line: 1, size: 8, flags: DIFlagTypePassByValue, elements: ![[#ELEMENTS:]], identifier: "_ZTS1A")
+; CHECK-LLVM: ![[#ELEMENTS]] = !{![[#DECLARATION]]}
+; CHECK-LLVM: ![[#BASETYPE]] = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 
 !llvm.module.flags = !{!0, !1}
 !llvm.dbg.cu = !{!2}


### PR DESCRIPTION
Preserve DIExpression in DIGlobalVariableExpression.

Preserving DIExpressions is necessary because of this change in LLVM:

commit 638a8393615e911b729d5662096f60ef49f1c65e
Author: Michael Buch <michaelbuch12@gmail.com>
Date:   Mon Nov 13 06:04:27 2023 +0000

    Reland "[clang][DebugInfo] Emit global variable definitions for static data members with constant initializers" (#71780)