### PR TITLE
[SPV-IR -> SPIRV] Fix image builtin unsigned type not preserved

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -892,6 +892,13 @@ inline bool getParameterTypes(CallInst *CI, SmallVectorImpl<Type *> &ArgTys) {
   return getParameterTypes(CI->getCalledFunction(), ArgTys);
 }
 
+enum ParamSignedness { Signed = 0, Unsigned, Unknown };
+
+/// Extract signedness of return type and parameter types from a mangled
+/// function name.
+bool getRetParamSignedness(Function *F, ParamSignedness &RetSignedness,
+                           SmallVectorImpl<ParamSignedness> &ArgSignedness);
+
 /// Mangle a function from OpenCL extended instruction set in SPIR-V friendly IR
 /// manner
 std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -892,7 +892,7 @@ inline bool getParameterTypes(CallInst *CI, SmallVectorImpl<Type *> &ArgTys) {
   return getParameterTypes(CI->getCalledFunction(), ArgTys);
 }
 
-enum ParamSignedness { Signed = 0, Unsigned, Unknown };
+enum class ParamSignedness { Signed = 0, Unsigned, Unknown };
 
 /// Extract signedness of return type and parameter types from a mangled
 /// function name.

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -881,6 +881,46 @@ bool getParameterTypes(Function *F, SmallVectorImpl<Type *> &ArgTys,
   return DemangledSuccessfully;
 }
 
+bool getRetParamSignedness(Function *F, ParamSignedness &RetSignedness,
+                           SmallVectorImpl<ParamSignedness> &ArgSignedness) {
+  using namespace llvm::itanium_demangle;
+  StringRef Name = F->getName();
+  if (!Name.starts_with("_Z") || F->arg_empty())
+    return false;
+
+  ManglingParser<DefaultAllocator> Demangler(Name.begin(), Name.end());
+  // If it's not a function name encoding, bail out.
+  auto *RootNode = dyn_cast_or_null<FunctionEncoding>(Demangler.parse());
+  if (!RootNode)
+    return false;
+
+  auto GetSignedness = [](const itanium_demangle::Node *N) {
+    if (!N)
+      return ParamSignedness::Unknown;
+    if (const auto *Vec = dyn_cast<itanium_demangle::VectorType>(N))
+      N = Vec->getBaseType();
+    if (const auto *Name = dyn_cast<NameType>(N)) {
+      StringRef Arg(stringify(Name));
+      if (Arg.starts_with("unsigned"))
+        return ParamSignedness::Unsigned;
+      else if (Arg.equals("char") || Arg.equals("short") || Arg.equals("int") ||
+               Arg.equals("long"))
+        return ParamSignedness::Signed;
+    }
+    return ParamSignedness::Unknown;
+  };
+  RetSignedness = GetSignedness(RootNode->getReturnType());
+  ArgSignedness.resize(F->arg_size());
+  for (const auto &[I, ParamType] : llvm::enumerate(RootNode->getParams())) {
+    if (F->getArg(I)->getType()->isIntOrIntVectorTy())
+      ArgSignedness[I] = GetSignedness(ParamType);
+    else
+      ArgSignedness[I] = ParamSignedness::Unknown;
+  }
+
+  return true;
+}
+
 CallInst *mutateCallInst(
     Module *M, CallInst *CI,
     std::function<std::string(CallInst *, std::vector<Value *> &)> ArgMutate,

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -903,8 +903,8 @@ bool getRetParamSignedness(Function *F, ParamSignedness &RetSignedness,
       StringRef Arg(stringify(Name));
       if (Arg.starts_with("unsigned"))
         return ParamSignedness::Unsigned;
-      else if (Arg.equals("char") || Arg.equals("short") || Arg.equals("int") ||
-               Arg.equals("long"))
+      if (Arg.equals("char") || Arg.equals("short") || Arg.equals("int") ||
+          Arg.equals("long"))
         return ParamSignedness::Signed;
     }
     return ParamSignedness::Unknown;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -117,6 +117,45 @@ static SPIRVWord convertFloatToSPIRVWord(float F) {
   return FPMaxError.Spir;
 }
 
+/// Return one of the SPIR-V 1.4 SignExtend or ZeroExtend image operands
+/// for a function name, or 0 if the function does not return or
+/// write an integer type.
+int getImageSignZeroExt(Function *F) {
+  bool IsSigned = false;
+  bool IsUnsigned = false;
+
+  ParamSignedness RetSignedness;
+  SmallVector<ParamSignedness, 4> ArgSignedness;
+  if (!getRetParamSignedness(F, RetSignedness, ArgSignedness))
+    return 0;
+
+  StringRef Name = F->getName();
+  Name = Name.substr(Name.find(kSPIRVName::Prefix));
+  Name.consume_front(kSPIRVName::Prefix);
+  if (Name.consume_front("ImageRead") ||
+      Name.consume_front("ImageSampleExplicitLod")) {
+    if (RetSignedness == ParamSignedness::Signed)
+      IsSigned = true;
+    else if (RetSignedness == ParamSignedness::Unsigned)
+      IsUnsigned = true;
+    else if (F->getReturnType()->isIntOrIntVectorTy() &&
+             Name.consume_front("_R")) {
+      // Return type is mangled after _R, e.g. _Z23__spirv_ImageRead_Rint2li
+      IsSigned = isMangledTypeSigned(Name[0]);
+      IsUnsigned = Name.starts_with("u");
+    }
+  } else if (Name.starts_with("ImageWrite")) {
+    IsSigned = (ArgSignedness[2] == ParamSignedness::Signed);
+    IsUnsigned = (ArgSignedness[2] == ParamSignedness::Unsigned);
+  }
+
+  if (IsSigned)
+    return ImageOperandsMask::ImageOperandsSignExtendMask;
+  if (IsUnsigned)
+    return ImageOperandsMask::ImageOperandsZeroExtendMask;
+  return 0;
+}
+
 } // namespace
 
 namespace SPIRV {
@@ -5888,45 +5927,6 @@ Op LLVMToSPIRVBase::transBoolOpCode(SPIRVValue *Opn, Op OC) {
     return OC;
   IntBoolOpMap::find(OC, &OC);
   return OC;
-}
-
-/// Return one of the SPIR-V 1.4 SignExtend or ZeroExtend image operands
-/// for a function name, or 0 if the function does not return or
-/// write an integer type.
-static int getImageSignZeroExt(Function *F) {
-  bool IsSigned = false;
-  bool IsUnsigned = false;
-
-  ParamSignedness RetSignedness;
-  SmallVector<ParamSignedness, 4> ArgSignedness;
-  if (!getRetParamSignedness(F, RetSignedness, ArgSignedness))
-    return 0;
-
-  StringRef Name = F->getName();
-  Name = Name.substr(Name.find(kSPIRVName::Prefix));
-  Name.consume_front(kSPIRVName::Prefix);
-  if (Name.consume_front("ImageRead") ||
-      Name.consume_front("ImageSampleExplicitLod")) {
-    if (RetSignedness == ParamSignedness::Signed)
-      IsSigned = true;
-    else if (RetSignedness == ParamSignedness::Unsigned)
-      IsUnsigned = true;
-    else if (F->getReturnType()->isIntOrIntVectorTy() &&
-             Name.consume_front("_R")) {
-      // Return type is mangled after _R, e.g. _Z23__spirv_ImageRead_Rint2li
-      IsSigned = isMangledTypeSigned(Name[0]);
-      IsUnsigned = Name.starts_with("u");
-    }
-  } else if (Name.starts_with("ImageWrite")) {
-    IsSigned = (ArgSignedness[2] == ParamSignedness::Signed);
-    IsUnsigned = (ArgSignedness[2] == ParamSignedness::Unsigned);
-  }
-
-  if (IsSigned)
-    return ImageOperandsMask::ImageOperandsSignExtendMask;
-  if (IsUnsigned)
-    return ImageOperandsMask::ImageOperandsZeroExtendMask;
-  return 0;
 }
 
 SPIRVInstruction *

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5991,9 +5991,11 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
                            ? cast<ConstantInt>(Args[I])->getZExtValue()
                            : transValue(Args[I], BB)->getId());
     }
-    if (Args.size() <= getImageOperandsIndex(OC))
-      if (int SignZeroExt = getImageSignZeroExt(CI->getCalledFunction()))
-        SPArgs.push_back(SignZeroExt);
+    if (BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
+      if (Args.size() <= getImageOperandsIndex(OC))
+        if (int SignZeroExt = getImageSignZeroExt(CI->getCalledFunction()))
+          SPArgs.push_back(SignZeroExt);
+    }
     BM->addInstTemplate(SPI, SPArgs, BB, SPRetTy);
     return SPI;
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5982,8 +5982,7 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     std::vector<SPIRVWord> SPArgs;
     for (size_t I = 0, E = Args.size(); I != E; ++I) {
       if (Args[I]->getType()->isPointerTy()) {
-        Value *Pointee = Args[I]->stripPointerCasts();
-        (void)Pointee;
+        [[maybe_unused]] Value *Pointee = Args[I]->stripPointerCasts();
         assert((Pointee == Args[I] || !isa<Function>(Pointee)) &&
                "Illegal use of a function pointer type");
       }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5890,6 +5890,45 @@ Op LLVMToSPIRVBase::transBoolOpCode(SPIRVValue *Opn, Op OC) {
   return OC;
 }
 
+/// Return one of the SPIR-V 1.4 SignExtend or ZeroExtend image operands
+/// for a function name, or 0 if the function does not return or
+/// write an integer type.
+static int getImageSignZeroExt(Function *F) {
+  bool IsSigned = false;
+  bool IsUnsigned = false;
+
+  ParamSignedness RetSignedness;
+  SmallVector<ParamSignedness, 4> ArgSignedness;
+  if (!getRetParamSignedness(F, RetSignedness, ArgSignedness))
+    return 0;
+
+  StringRef Name = F->getName();
+  Name = Name.substr(Name.find(kSPIRVName::Prefix));
+  Name.consume_front(kSPIRVName::Prefix);
+  if (Name.consume_front("ImageRead") ||
+      Name.consume_front("ImageSampleExplicitLod")) {
+    if (RetSignedness == ParamSignedness::Signed)
+      IsSigned = true;
+    else if (RetSignedness == ParamSignedness::Unsigned)
+      IsUnsigned = true;
+    else if (F->getReturnType()->isIntOrIntVectorTy() &&
+             Name.consume_front("_R")) {
+      // Return type is mangled after _R, e.g. _Z23__spirv_ImageRead_Rint2li
+      IsSigned = isMangledTypeSigned(Name[0]);
+      IsUnsigned = Name.starts_with("u");
+    }
+  } else if (Name.starts_with("ImageWrite")) {
+    IsSigned = (ArgSignedness[2] == ParamSignedness::Signed);
+    IsUnsigned = (ArgSignedness[2] == ParamSignedness::Unsigned);
+  }
+
+  if (IsSigned)
+    return ImageOperandsMask::ImageOperandsSignExtendMask;
+  if (IsUnsigned)
+    return ImageOperandsMask::ImageOperandsZeroExtendMask;
+  return 0;
+}
+
 SPIRVInstruction *
 LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
                                                      SPIRVBasicBlock *BB) {
@@ -5931,6 +5970,32 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     return BM->addSampledImageInst(transType(SampledImgTy),
                                    transValue(Image, BB),
                                    transValue(Sampler, BB), BB);
+  }
+  case OpImageRead:
+  case OpImageSampleExplicitLod:
+  case OpImageWrite: {
+    // Image Op needs handling of SignExtend or ZeroExtend image operands.
+    auto Args = getArguments(CI);
+    SPIRVType *SPRetTy =
+        CI->getType()->isVoidTy() ? nullptr : transScavengedType(CI);
+    auto *SPI = SPIRVInstTemplateBase::create(OC);
+    std::vector<SPIRVWord> SPArgs;
+    for (size_t I = 0, E = Args.size(); I != E; ++I) {
+      if (Args[I]->getType()->isPointerTy()) {
+        Value *Pointee = Args[I]->stripPointerCasts();
+        (void)Pointee;
+        assert((Pointee == Args[I] || !isa<Function>(Pointee)) &&
+               "Illegal use of a function pointer type");
+      }
+      SPArgs.push_back(SPI->isOperandLiteral(I)
+                           ? cast<ConstantInt>(Args[I])->getZExtValue()
+                           : transValue(Args[I], BB)->getId());
+    }
+    if (Args.size() <= getImageOperandsIndex(OC))
+      if (int SignZeroExt = getImageSignZeroExt(CI->getCalledFunction()))
+        SPArgs.push_back(SignZeroExt);
+    BM->addInstTemplate(SPI, SPArgs, BB, SPRetTy);
+    return SPI;
   }
   case OpFixedSqrtINTEL:
   case OpFixedRecipINTEL:

--- a/test/transcoding/image_signedness_spv_ir.ll
+++ b/test/transcoding/image_signedness_spv_ir.ll
@@ -1,23 +1,34 @@
-; Test that signedness of calls to SPV-IR image builtin is preserved.
+; Test that signedness of calls to SPV-IR image builtin is preserved in SPIRV.
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
 target triple = "spir64-unknown-unknown"
 
+; CHECK-SPIRV: Constant {{[0-9]+}} [[CONSTANT_FLOAT_2:[0-9]+]] 1073741824
+
 define dso_local spir_kernel void @reads() {
-; CHECK-LABEL: spir_kernel void @reads(
-; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ImageRead_Ruint4PU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii
-; CHECK-SPV-IR: call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii
-; CHECK-SPV-IR: call spir_func i16 @_Z25__spirv_ImageRead_RushortPU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z25__spirv_ImageRead_Rfloat2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i
-; CHECK-SPV-IR: call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i
+; CHECK-SPIRV: ImageRead {{.*}} 4096
+; CHECK-SPIRV: ImageRead {{.*}} 4096
+; CHECK-SPIRV: ImageRead {{.*}} 8192
+; CHECK-SPIRV: ImageRead {{.*}} 4096
+; CHECK-SPIRV: ImageRead {{.*}} 8192
+; CHECK-SPIRV: ImageRead
+; CHECK-SPIRV: ImageRead
+
+; CHECK-SPV-IR-LABEL: spir_kernel void @reads(
+; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer, i32 4096)
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer, i32 4096)
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ImageRead_Ruint4PU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer, i32 8192)
+; CHECK-SPV-IR: call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
+; CHECK-SPV-IR: call spir_func i16 @_Z25__spirv_ImageRead_RushortPU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer, i32 8192)
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z25__spirv_ImageRead_Rfloat2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+; CHECK-SPV-IR: call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
 
   %1 = tail call spir_func i32 @_Z17__spirv_ImageReadIi14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer)
   %2 = tail call spir_func <2 x i32> @_Z17__spirv_ImageReadIDv2_i14ocl_image2d_roS0_ET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
@@ -38,14 +49,22 @@ declare dso_local spir_func <2 x float> @_Z17__spirv_ImageReadIDv2_f14ocl_image1
 declare dso_local spir_func half @_Z17__spirv_ImageReadIDF16_14ocl_image2d_roDv2_iET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
 
 define dso_local spir_kernel void @writes() {
-; CHECK-LABEL: spir_kernel void @writes(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iii(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iS2_i(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iDv4_ji(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1isi(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iti(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_f(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDh(
+; CHECK-SPIRV: ImageWrite {{.*}} 4096
+; CHECK-SPIRV: ImageWrite {{.*}} 4096
+; CHECK-SPIRV: ImageWrite {{.*}} 8192
+; CHECK-SPIRV: ImageWrite {{.*}} 4096
+; CHECK-SPIRV: ImageWrite {{.*}} 8192
+; CHECK-SPIRV: ImageWrite
+; CHECK-SPIRV: ImageWrite
+
+; CHECK-SPV-IR-LABEL: spir_kernel void @writes(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iii(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) undef, <4 x i32> zeroinitializer, i32 0, i32 4096)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iS2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, <2 x i32> zeroinitializer, i32 4096)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iDv4_ji(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) undef, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer, i32 8192)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1isi(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i16 0, i32 4096)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iti(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) undef, <4 x i32> zeroinitializer, i16 0, i32 8192)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_f(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x float> zeroinitializer)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDh(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, half 0xH0000)
 
   call spir_func void @_Z18__spirv_ImageWriteI14ocl_image3d_woDv4_iiEvT_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) undef, <4 x i32> zeroinitializer, i32 zeroinitializer)
   call spir_func void @_Z18__spirv_ImageWriteI14ocl_image2d_woDv2_iS1_EvT_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, <2 x i32> zeroinitializer)
@@ -66,43 +85,64 @@ declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image1d_woiDv2_fE
 declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image2d_woDv2_iDF16_EvT_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, half)
 
 define dso_local spir_kernel void @reads2() {
-; CHECK-LABE: spir_kernel void @reads2(
-; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
-; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
-; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
-; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
-; CHECK-SPV-IR: call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
-; CHECK-SPV-IR: call spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
-; CHECK-SPV-IR: call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(
-; CHECK-SPV-IR: call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(
+; CHECK-SPIRV: ImageRead {{.*}} 4096
+; CHECK-SPIRV: ImageRead {{.*}} 4097 [[CONSTANT_FLOAT_2]]
+; CHECK-SPIRV: ImageRead {{.*}} 4096
+; CHECK-SPIRV: ImageRead {{.*}} 4096
+; CHECK-SPIRV: ImageRead {{.*}} 8192
+; CHECK-SPIRV: ImageRead {{.*}} 8193 [[CONSTANT_FLOAT_2]]
+; CHECK-SPIRV: ImageRead {{.*}} 8192
+; CHECK-SPIRV: ImageRead {{.*}} 8192
+; CHECK-SPIRV: ImageRead {{.*}} 4096
+; CHECK-SPIRV: ImageRead {{.*}} 8192
+; CHECK-SPIRV: ImageRead {{.*}} 4096
+; CHECK-SPIRV: ImageRead {{.*}} 8192
+; CHECK-SPIRV: ImageRead
+; CHECK-SPIRV: ImageRead
+
+; CHECK-SPV-IR-LABEL: spir_kernel void @reads2(
+; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
+; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4097, float 2.000000e+00)
+; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer, i32 4096)
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
+; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 8192)
+; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 8193, float 2.000000e+00)
+; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer, i32 8192)
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 8192)
+; CHECK-SPV-IR: call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
+; CHECK-SPV-IR: call spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 8192)
+; CHECK-SPV-IR: call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 8192)
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+; CHECK-SPV-IR: call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 
   %1 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
-  %2 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
-  %3 = call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %2 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 1, float 2.000000e+00)
+  %3 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+  %4 = call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 
-  %4 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %5 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
-  %6 = call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %5 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %6 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 1, float 2.000000e+00)
+  %7 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+  %8 = call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 
-  %7 = call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %8 = call spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %9 = call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %10 = call spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %11 = call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %12 = call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %9 = call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %10 = call spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %11 = call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %12 = call spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %13 = call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %14 = call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 
   ret void
 }
 
 declare spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32, i32)
+declare spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32, i32, float)
 declare spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
 declare spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
 
 declare spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32, i32, float)
 declare spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
 declare spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
 
@@ -114,21 +154,37 @@ declare spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Imag
 declare spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
 
 define dso_local spir_kernel void @writes2() {
-; CHECK-LABE: spir_kernel void @writes2(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iii(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ii(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iji(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iji(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ji(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ici(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ihi(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1isi(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ti(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_f(
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDh(
+; CHECK-SPIRV: ImageWrite {{.*}} 4096
+; CHECK-SPIRV: ImageWrite {{.*}} 4097 [[CONSTANT_FLOAT_2]]
+; CHECK-SPIRV: ImageWrite {{.*}} 4096
+; CHECK-SPIRV: ImageWrite {{.*}} 4096
+; CHECK-SPIRV: ImageWrite {{.*}} 8192
+; CHECK-SPIRV: ImageWrite {{.*}} 8192
+; CHECK-SPIRV: ImageWrite {{.*}} 8192
+; CHECK-SPIRV: ImageWrite {{.*}} 4096
+; CHECK-SPIRV: ImageWrite {{.*}} 8192
+; CHECK-SPIRV: ImageWrite {{.*}} 4096
+; CHECK-SPIRV: ImageWrite {{.*}} 8192
+; CHECK-SPIRV: ImageWrite
+; CHECK-SPIRV: ImageWrite
+
+; CHECK-SPV-IR-LABEL: spir_kernel void @writes2(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 4096)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iiif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 4097, float 2.000000e+00)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, i32 0, i32 4096)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i32> zeroinitializer, i32 4096)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iji(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 8192)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iji(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, i32 0, i32 8192)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ji(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i32> zeroinitializer, i32 8192)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ici(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i8 0, i32 4096)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ihi(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i8 0, i32 8192)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1isi(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i16 0, i32 4096)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ti(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i16> zeroinitializer, i32 8192)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_f(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <4 x float> zeroinitializer)
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDh(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, half 0xH0000)
 
   call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 4096)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iiif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 1, float 2.000000e+00)
   call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, i32 0)
   call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i32> zeroinitializer)
 
@@ -147,6 +203,7 @@ define dso_local spir_kernel void @writes2() {
 }
 
 declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i32, i32)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iiif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i32, i32, float)
 declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, i32)
 declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, <2 x i32>)
 

--- a/test/transcoding/image_signedness_spv_ir.ll
+++ b/test/transcoding/image_signedness_spv_ir.ll
@@ -10,8 +10,6 @@
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
 target triple = "spir64-unknown-unknown"
 
-; CHECK-SPIRV: Constant {{[0-9]+}} [[CONSTANT_FLOAT_2:[0-9]+]] 1073741824
-
 define dso_local spir_kernel void @reads() {
 ; CHECK-SPIRV: ImageRead {{.*}} 4096
 ; CHECK-SPIRV: ImageRead {{.*}} 4096
@@ -20,6 +18,7 @@ define dso_local spir_kernel void @reads() {
 ; CHECK-SPIRV: ImageRead {{.*}} 8192
 ; CHECK-SPIRV: ImageRead
 ; CHECK-SPIRV: ImageRead
+; CHECK-SPIRV: ImageSampleExplicitLod {{.*}} 8194
 
 ; CHECK-SPV-IR-LABEL: spir_kernel void @reads(
 ; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer, i32 4096)
@@ -29,6 +28,7 @@ define dso_local spir_kernel void @reads() {
 ; CHECK-SPV-IR: call spir_func i16 @_Z25__spirv_ImageRead_RushortPU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer, i32 8192)
 ; CHECK-SPV-IR: call spir_func <2 x float> @_Z25__spirv_ImageRead_Rfloat2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 ; CHECK-SPV-IR: call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z37__spirv_ImageSampleExplicitLod_Ruint4PU3AS140__spirv_SampledImage__void_0_0_0_0_0_0_0fif(target("spirv.SampledImage", void, 0, 0, 0, 0, 0, 0, 0) undef, float 0.000000e+00, i32 8194, float 0.000000e+00)
 
   %1 = tail call spir_func i32 @_Z17__spirv_ImageReadIi14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer)
   %2 = tail call spir_func <2 x i32> @_Z17__spirv_ImageReadIDv2_i14ocl_image2d_roS0_ET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
@@ -37,6 +37,8 @@ define dso_local spir_kernel void @reads() {
   %5 = tail call spir_func zeroext i16 @_Z17__spirv_ImageReadIt14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer)
   %6 = tail call spir_func <2 x float> @_Z17__spirv_ImageReadIDv2_f14ocl_image1d_roiET_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
   %7 = tail call spir_func half @_Z17__spirv_ImageReadIDF16_14ocl_image2d_roDv2_iET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+
+  %8 = tail call spir_func <4 x i32> @_Z30__spirv_ImageSampleExplicitLodI32__spirv_SampledImage__image1d_roDv4_jfET0_T_T1_if(target("spirv.SampledImage", void, 0, 0, 0, 0, 0, 0, 0) undef, float 0.000000e+00, i32 2, float 0.000000e+00)
   ret void
 }
 
@@ -47,6 +49,7 @@ declare dso_local spir_func signext i16 @_Z17__spirv_ImageReadIs14ocl_image1d_ro
 declare dso_local spir_func zeroext i16 @_Z17__spirv_ImageReadIt14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0), <4 x i32>)
 declare dso_local spir_func <2 x float> @_Z17__spirv_ImageReadIDv2_f14ocl_image1d_roiET_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
 declare dso_local spir_func half @_Z17__spirv_ImageReadIDF16_14ocl_image2d_roDv2_iET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
+declare dso_local spir_func <4 x i32> @_Z30__spirv_ImageSampleExplicitLodI32__spirv_SampledImage__image1d_roDv4_jfET0_T_T1_if(target("spirv.SampledImage", void, 0, 0, 0, 0, 0, 0, 0), float noundef, i32 noundef, float noundef)
 
 define dso_local spir_kernel void @writes() {
 ; CHECK-SPIRV: ImageWrite {{.*}} 4096
@@ -86,11 +89,9 @@ declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image2d_woDv2_iDF
 
 define dso_local spir_kernel void @reads2() {
 ; CHECK-SPIRV: ImageRead {{.*}} 4096
-; CHECK-SPIRV: ImageRead {{.*}} 4097 [[CONSTANT_FLOAT_2]]
 ; CHECK-SPIRV: ImageRead {{.*}} 4096
 ; CHECK-SPIRV: ImageRead {{.*}} 4096
 ; CHECK-SPIRV: ImageRead {{.*}} 8192
-; CHECK-SPIRV: ImageRead {{.*}} 8193 [[CONSTANT_FLOAT_2]]
 ; CHECK-SPIRV: ImageRead {{.*}} 8192
 ; CHECK-SPIRV: ImageRead {{.*}} 8192
 ; CHECK-SPIRV: ImageRead {{.*}} 4096
@@ -102,11 +103,9 @@ define dso_local spir_kernel void @reads2() {
 
 ; CHECK-SPV-IR-LABEL: spir_kernel void @reads2(
 ; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
-; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4097, float 2.000000e+00)
 ; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer, i32 4096)
 ; CHECK-SPV-IR: call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
 ; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 8192)
-; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 8193, float 2.000000e+00)
 ; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer, i32 8192)
 ; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 8192)
 ; CHECK-SPV-IR: call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
@@ -117,32 +116,28 @@ define dso_local spir_kernel void @reads2() {
 ; CHECK-SPV-IR: call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 
   %1 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
-  %2 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 1, float 2.000000e+00)
-  %3 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
-  %4 = call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %2 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+  %3 = call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 
-  %5 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %6 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 1, float 2.000000e+00)
-  %7 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
-  %8 = call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %4 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %5 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+  %6 = call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 
-  %9 = call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %10 = call spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %11 = call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %12 = call spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %13 = call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
-  %14 = call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %7 = call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %8 = call spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %9 = call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %10 = call spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %11 = call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %12 = call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
 
   ret void
 }
 
 declare spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32, i32)
-declare spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32, i32, float)
 declare spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
 declare spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
 
 declare spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
-declare spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0iif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32, i32, float)
 declare spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
 declare spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
 
@@ -155,7 +150,6 @@ declare spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0
 
 define dso_local spir_kernel void @writes2() {
 ; CHECK-SPIRV: ImageWrite {{.*}} 4096
-; CHECK-SPIRV: ImageWrite {{.*}} 4097 [[CONSTANT_FLOAT_2]]
 ; CHECK-SPIRV: ImageWrite {{.*}} 4096
 ; CHECK-SPIRV: ImageWrite {{.*}} 4096
 ; CHECK-SPIRV: ImageWrite {{.*}} 8192
@@ -170,7 +164,6 @@ define dso_local spir_kernel void @writes2() {
 
 ; CHECK-SPV-IR-LABEL: spir_kernel void @writes2(
 ; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 4096)
-; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iiif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 4097, float 2.000000e+00)
 ; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, i32 0, i32 4096)
 ; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i32> zeroinitializer, i32 4096)
 ; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iji(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 8192)
@@ -184,7 +177,6 @@ define dso_local spir_kernel void @writes2() {
 ; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDh(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, half 0xH0000)
 
   call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 4096)
-  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iiif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 1, float 2.000000e+00)
   call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, i32 0)
   call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i32> zeroinitializer)
 
@@ -203,7 +195,6 @@ define dso_local spir_kernel void @writes2() {
 }
 
 declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i32, i32)
-declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iiif(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i32, i32, float)
 declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, i32)
 declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, <2 x i32>)
 

--- a/test/transcoding/image_signedness_spv_ir.ll
+++ b/test/transcoding/image_signedness_spv_ir.ll
@@ -1,0 +1,162 @@
+; Test that signedness of calls to SPV-IR image builtin is preserved.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define dso_local spir_kernel void @reads() {
+; CHECK-LABEL: spir_kernel void @reads(
+; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ImageRead_Ruint4PU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii
+; CHECK-SPV-IR: call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii
+; CHECK-SPV-IR: call spir_func i16 @_Z25__spirv_ImageRead_RushortPU3AS133__spirv_Image__void_2_0_0_0_0_0_0Dv4_ii
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z25__spirv_ImageRead_Rfloat2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i
+; CHECK-SPV-IR: call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i
+
+  %1 = tail call spir_func i32 @_Z17__spirv_ImageReadIi14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer)
+  %2 = tail call spir_func <2 x i32> @_Z17__spirv_ImageReadIDv2_i14ocl_image2d_roS0_ET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+  %3 = tail call spir_func <4 x i32> @_Z17__spirv_ImageReadIDv4_j14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer)
+  %4 = tail call spir_func signext i16 @_Z17__spirv_ImageReadIs14ocl_image1d_roiET_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %5 = tail call spir_func zeroext i16 @_Z17__spirv_ImageReadIt14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) undef, <4 x i32> zeroinitializer)
+  %6 = tail call spir_func <2 x float> @_Z17__spirv_ImageReadIDv2_f14ocl_image1d_roiET_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %7 = tail call spir_func half @_Z17__spirv_ImageReadIDF16_14ocl_image2d_roDv2_iET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+  ret void
+}
+
+declare dso_local spir_func i32 @_Z17__spirv_ImageReadIi14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0), <4 x i32>)
+declare dso_local spir_func <2 x i32> @_Z17__spirv_ImageReadIDv2_i14ocl_image2d_roS0_ET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
+declare dso_local spir_func <4 x i32> @_Z17__spirv_ImageReadIDv4_j14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0), <4 x i32>)
+declare dso_local spir_func signext i16 @_Z17__spirv_ImageReadIs14ocl_image1d_roiET_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare dso_local spir_func zeroext i16 @_Z17__spirv_ImageReadIt14ocl_image3d_roDv4_iET_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0), <4 x i32>)
+declare dso_local spir_func <2 x float> @_Z17__spirv_ImageReadIDv2_f14ocl_image1d_roiET_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare dso_local spir_func half @_Z17__spirv_ImageReadIDF16_14ocl_image2d_roDv2_iET_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
+
+define dso_local spir_kernel void @writes() {
+; CHECK-LABEL: spir_kernel void @writes(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iii(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iS2_i(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iDv4_ji(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1isi(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_2_0_0_0_0_0_1Dv4_iti(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_f(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iDh(
+
+  call spir_func void @_Z18__spirv_ImageWriteI14ocl_image3d_woDv4_iiEvT_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) undef, <4 x i32> zeroinitializer, i32 zeroinitializer)
+  call spir_func void @_Z18__spirv_ImageWriteI14ocl_image2d_woDv2_iS1_EvT_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, <2 x i32> zeroinitializer)
+  call spir_func void @_Z18__spirv_ImageWriteI14ocl_image3d_woDv4_iDv4_jEvT_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) undef, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer)
+  call spir_func void @_Z18__spirv_ImageWriteI14ocl_image1d_woisEvT_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i16 signext 0)
+  call spir_func void @_Z18__spirv_ImageWriteI14ocl_image3d_woDv4_itEvT_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) undef, <4 x i32> zeroinitializer, i16 zeroext 0)
+  call spir_func void @_Z18__spirv_ImageWriteI14ocl_image1d_woiDv2_fEvT_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x float> zeroinitializer)
+  call spir_func void @_Z18__spirv_ImageWriteI14ocl_image2d_woDv2_iDF16_EvT_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, half zeroinitializer)
+  ret void
+}
+
+declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image3d_woDv4_iiEvT_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1), <4 x i32>, i32)
+declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image2d_woDv2_iS1_EvT_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, <2 x i32>)
+declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image3d_woDv4_iDv4_jEvT_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1), <4 x i32>, <4 x i32>)
+declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image1d_woisEvT_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i16 signext)
+declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image3d_woDv4_itEvT_T0_T1_(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1), <4 x i32>, i16 zeroext)
+declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image1d_woiDv2_fEvT_T0_T1_(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, <2 x float>)
+declare dso_local spir_func void @_Z18__spirv_ImageWriteI14ocl_image2d_woDv2_iDF16_EvT_T0_T1_(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, half)
+
+define dso_local spir_kernel void @reads2() {
+; CHECK-LABE: spir_kernel void @reads2(
+; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
+; CHECK-SPV-IR: call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
+; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
+; CHECK-SPV-IR: call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_ii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
+; CHECK-SPV-IR: call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
+; CHECK-SPV-IR: call spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
+; CHECK-SPV-IR: call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(
+; CHECK-SPV-IR: call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(
+
+  %1 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0, i32 4096)
+  %2 = call spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+  %3 = call spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+
+  %4 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %5 = call spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) undef, <2 x i32> zeroinitializer)
+  %6 = call spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+
+  %7 = call spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %8 = call spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %9 = call spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %10 = call spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %11 = call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+  %12 = call spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) undef, i32 0)
+
+  ret void
+}
+
+declare spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0ii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32, i32)
+declare spir_func i32 @_Z22__spirv_ImageRead_RintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
+declare spir_func <2 x i32> @_Z23__spirv_ImageRead_Rint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+
+declare spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare spir_func i32 @_Z23__spirv_ImageRead_RuintPU3AS133__spirv_Image__void_1_0_0_0_0_0_0Dv2_i(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0), <2 x i32>)
+declare spir_func <2 x i32> @_Z24__spirv_ImageRead_Ruint2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+
+declare spir_func i8 @_Z23__spirv_ImageRead_RcharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare spir_func i8 @_Z24__spirv_ImageRead_RucharPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare spir_func i16 @_Z24__spirv_ImageRead_RshortPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare spir_func <2 x i16> @_Z26__spirv_ImageRead_Rushort2PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+declare spir_func half @_Z23__spirv_ImageRead_RhalfPU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0), i32)
+
+define dso_local spir_kernel void @writes2() {
+; CHECK-LABE: spir_kernel void @writes2(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iii(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ii(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iji(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_iji(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ji(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ici(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ihi(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1isi(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_ti(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_f(
+; CHECK-SPV-IR: call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDh(
+
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0, i32 4096)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, i32 0)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i32> zeroinitializer)
+
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ij(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i32 0)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_ij(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) undef, <2 x i32> zeroinitializer, i32 0)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_j(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i32> zeroinitializer)
+
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ic(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i8 0)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ih(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i8 0)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1is(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, i16 0)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_t(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <2 x i16> zeroinitializer)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_f(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, <4 x float> zeroinitializer)
+  call spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDh(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) undef, i32 0, half zeroinitializer)
+
+  ret void
+}
+
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iii(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i32, i32)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_ii(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, i32)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_i(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, <2 x i32>)
+
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ij(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i32)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_1_0_0_0_0_0_1Dv2_ij(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, i32)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_j(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, <2 x i32>)
+
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ic(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i8)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1ih(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i8)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1is(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, i16)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv2_t(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, <2 x i16>)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDv4_f(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, <4 x float>)
+declare spir_func void @_Z18__spirv_ImageWritePU3AS133__spirv_Image__void_0_0_0_0_0_0_1iDh(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1), i32, half)


### PR DESCRIPTION
This PR preserves unsigned return type of image read and unsigned texel
type of image write builtins as ZeroExtend image operand in SPIRV.