### PR TITLE
Never emit CapabilityShader for bitreverse

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3837,8 +3837,12 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     return nullptr;
   }
   case Intrinsic::bitreverse: {
-    if (!BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_bit_instructions)) {
-      BM->addCapability(CapabilityShader);
+    if (!BM->getErrorLog().checkError(
+            BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_bit_instructions),
+            SPIRVEC_InvalidFunctionCall, II,
+            "Translation of llvm.bitreverse intrinsic requires "
+            "SPV_KHR_bit_instructions extension.")) {
+      return nullptr;
     }
     SPIRVType *Ty = transType(II->getType());
     SPIRVValue *Op = transValue(II->getArgOperand(0), BB);

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -3007,10 +3007,7 @@ _SPIRV_OP(SUDotAccSatKHR, true, 6, true, 3)
 class SPIRVBitOp : public SPIRVInstTemplateBase {
 public:
   SPIRVCapVec getRequiredCapability() const override {
-    if (Module->isAllowedToUseExtension(ExtensionID::SPV_KHR_bit_instructions))
-      return getVec(CapabilityBitInstructions);
-
-    return getVec(CapabilityShader);
+    return getVec(CapabilityBitInstructions);
   }
 
   std::optional<ExtensionID> getRequiredExtension() const override {

--- a/test/extensions/KHR/SPV_KHR_bit_instructions/capabilities.ll
+++ b/test/extensions/KHR/SPV_KHR_bit_instructions/capabilities.ll
@@ -1,19 +1,17 @@
 ; RUN: llvm-as %s -o %t.bc
 
-; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=-SPV_KHR_bit_instructions -o %t.txt
-; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-COMMON,CHECK-WITHOUT-EXT
+; RUN: not llvm-spirv %t.bc -spirv-text --spirv-ext=-SPV_KHR_bit_instructions -o - 2>&1 | FileCheck %s --check-prefixes=CHECK-WITHOUT-EXT
 
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_KHR_bit_instructions -o %t.txt
-; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-COMMON,CHECK-WITH-EXT
+; RUN: FileCheck < %t.txt %s --check-prefixes=CHECK-WITH-EXT
 
-; CHECK-WITHOUT-EXT: Capability Shader
+; CHECK-WITHOUT-EXT: Unexpected llvm intrinsic:
+; CHECK-WITHOUT-EXT: Translation of llvm.bitreverse intrinsic requires SPV_KHR_bit_instructions extension.
 
-; CHECK-WITH-EXT-NOT: Capability Shader
 ; CHECK-WITH-EXT: Capability BitInstructions
-; CHECK-WITH-EXT-NOT: Capability Shader
 ; CHECK-WITH-EXT: Extension "SPV_KHR_bit_instructions"
 
-; CHECK-COMMON: 4 BitReverse
+; CHECK-WITH-EXT: 4 BitReverse
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"

--- a/test/transcoding/OpBitReverse_i32.ll
+++ b/test/transcoding/OpBitReverse_i32.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_bit_instructions -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_bit_instructions %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/transcoding/OpBitReverse_v2i16.ll
+++ b/test/transcoding/OpBitReverse_v2i16.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_bit_instructions -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_bit_instructions %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 


### PR DESCRIPTION
This translator currently only supports the OpenCL/compute "flavour" of SPIR-V, but for the `llvm.bitreverse` intrinsic it could produce SPIR-V modules declaring the `Shader` Capability.

When translating `llvm.bitreverse` without having the `SPV_KHR_bit_instructions` extension enabled, avoid producing SPIR-V modules declaring the `Shader` Capability and report an error instead.