### PR TITLE
Use triple subarch to emit exact SPIR-V version

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6398,6 +6398,7 @@ bool runSpirvWriterPasses(Module *M, std::ostream *OS, std::string &ErrMsg,
                                       SPIRVEC_TripleMaxVersionIncompatible))
       return false;
     BM->setMinSPIRVVersion(ModuleVer);
+    BM->setMaxSPIRVVersion(ModuleVer);
   }
 
   ModulePassManager PassMgr;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -79,6 +79,7 @@ public:
 
   SPIRVModuleImpl(const SPIRV::TranslatorOpts &Opts) : SPIRVModuleImpl() {
     TranslationOpts = Opts;
+    MaxVersion = Opts.getMaxVersion();
   }
 
   ~SPIRVModuleImpl() override;
@@ -2156,7 +2157,7 @@ std::istream &operator>>(std::istream &I, SPIRVModule &M) {
   if (!M.getErrorLog().checkError(
           SPIRVVersionIsAllowed, SPIRVEC_InvalidModule,
           "incorrect SPIR-V version number " + to_string(MI.SPIRVVersion) +
-              " - it conflicts with --spirv-max-version which is set to " +
+              " - it conflicts with maximum allowed version which is set to " +
               to_string(M.getMaximumAllowedSPIRVVersion()))) {
     M.setInvalid();
     return I;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -183,6 +183,12 @@ public:
     setSPIRVVersion(std::max(static_cast<SPIRVWord>(Ver), getSPIRVVersion()));
   }
 
+  void setMaxSPIRVVersion(VersionNumber Ver) {
+    assert(static_cast<SPIRVWord>(Ver) >= getSPIRVVersion() &&
+           "Maximum version can't be lower than minimum version!");
+    MaxVersion = std::min(Ver, MaxVersion);
+  }
+
   // Object creation functions
   template <class T> T *add(T *Entry) {
     addEntry(Entry);
@@ -487,16 +493,16 @@ public:
 
   virtual bool
   isAllowedToUseVersion(SPIRV::VersionNumber RequestedVersion) const final {
-    return TranslationOpts.isAllowedToUseVersion(RequestedVersion);
+    return RequestedVersion <= MaxVersion;
   }
 
   virtual bool isAllowedToUseVersion(SPIRVWord RequestedVersion) const final {
-    return TranslationOpts.isAllowedToUseVersion(
+    return isAllowedToUseVersion(
         static_cast<SPIRV::VersionNumber>(RequestedVersion));
   }
 
   virtual SPIRV::VersionNumber getMaximumAllowedSPIRVVersion() const final {
-    return TranslationOpts.getMaxVersion();
+    return MaxVersion;
   }
 
   virtual bool
@@ -575,6 +581,7 @@ protected:
   bool ValidateCapability;
   bool AutoAddExtensions = true;
   SPIRV::TranslatorOpts TranslationOpts;
+  VersionNumber MaxVersion = VersionNumber::MaximumVersion;
 
 private:
   bool IsValid;

--- a/test/spirv-triple-with-version.ll
+++ b/test/spirv-triple-with-version.ll
@@ -11,9 +11,20 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64v1.2-unknown-unknown"
 
+; Check that the emitted SPIR-V version is not higher than the
+; requested due to a feature available in higher versions.
+define spir_func i32 @square(i32 %a) local_unnamed_addr #0 {
+entry:
+  %mul = mul nuw nsw i32 %a, %a ; Optional integer wrap decorations require v1.4.
+  ret i32 %mul
+}
+
+attributes #0 = { norecurse nounwind readnone}
+
 ; This is a module with a SPIR-V subarch.  Ensure that the SPIR-V version specified as the subarch is taken into account by llvm-spirv.
 
 ; CHECK-INVALID: TripleMaxVersionIncompatible: Triple version and maximum version are incompatible.
 
 ; 66048 = 0x10200, i.e. version 1.2
 ; CHECK12: 119734787 66048
+

--- a/test/spirv-version-controls.spt
+++ b/test/spirv-version-controls.spt
@@ -32,4 +32,4 @@
 ; RUN: llvm-spirv -r %t.spv --spirv-max-version=1.1 -o %t
 ; RUN: not llvm-spirv -r %t.spv --spirv-max-version=1.0 -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
-; CHECK-ERROR: Invalid SPIR-V module: incorrect SPIR-V version number 1.1 (65792) - it conflicts with --spirv-max-version which is set to 1.0 (65536)
+; CHECK-ERROR: Invalid SPIR-V module: incorrect SPIR-V version number 1.1 (65792) - it conflicts with maximum allowed version which is set to 1.0 (65536)


### PR DESCRIPTION
Use target triple's subarch component, if present, for setting exact SPIR-V version for the SPIR-V emission.

Resolves #1509.