### PR TITLE
Fix reverse translation of non-constant values of OpCompositeConstruct pt.2

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2243,8 +2243,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
       auto *VT = cast<FixedVectorType>(transType(CC->getType()));
       Value *NewVec = ConstantVector::getSplat(
-          VT->getElementCount(),
-          PoisonValue::get(VT->getElementType()));
+          VT->getElementCount(), PoisonValue::get(VT->getElementType()));
 
       for (size_t I = 0; I < Constituents.size(); I++) {
         NewVec = InsertElementInst::Create(NewVec, Constituents[I],

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2237,11 +2237,39 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     }
 
     switch (static_cast<size_t>(BV->getType()->getOpCode())) {
-    case OpTypeVector:
-      return mapValue(BV, ConstantVector::get(CV));
+    case OpTypeVector: {
+      if (!HasRtValues)
+        return mapValue(BV, ConstantVector::get(CV));
+
+      auto *VT = cast<FixedVectorType>(transType(CC->getType()));
+      Value *NewVec = ConstantVector::getSplat(
+          VT->getElementCount(),
+          PoisonValue::get(VT->getElementType()));
+
+      for (size_t I = 0; I < Constituents.size(); I++) {
+        NewVec = InsertElementInst::Create(NewVec, Constituents[I],
+                                           getInt32(M, I), "", BB);
+      }
+      return mapValue(BV, NewVec);
+    }
     case OpTypeArray: {
       auto *AT = cast<ArrayType>(transType(CC->getType()));
-      return mapValue(BV, ConstantArray::get(AT, CV));
+      if (!HasRtValues)
+        return mapValue(BV, ConstantArray::get(AT, CV));
+
+      AllocaInst *Alloca = new AllocaInst(AT, SPIRAS_Private, "", BB);
+
+      // get pointer to the element of the array
+      // store the result of argument
+      for (size_t I = 0; I < Constituents.size(); I++) {
+        auto *GEP = GetElementPtrInst::Create(
+            Constituents[I]->getType(), Alloca, {getInt32(M, I)}, "gep", BB);
+        GEP->setIsInBounds(true);
+        new StoreInst(Constituents[I], GEP, false, BB);
+      }
+
+      auto *Load = new LoadInst(AT, Alloca, "load", false, BB);
+      return mapValue(BV, Load);
     }
     case OpTypeStruct: {
       auto *ST = cast<StructType>(transType(CC->getType()));

--- a/test/composite_construct_array_non_constant.spvasm
+++ b/test/composite_construct_array_non_constant.spvasm
@@ -1,0 +1,53 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s
+
+; CHECK: define spir_func [4 x i8] @non_constant_array_elements(i8 %[[#ARG0:]], i8 %[[#ARG1:]])
+; CHECK: %[[#ArrayPtr:]] = alloca [4 x i8]
+; CHECK: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 0
+; CHECK: store i8 %[[#ARG1]], ptr %[[GEP]]
+; CHECK: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 1
+; CHECK: store i8 %[[#ARG0]], ptr %[[GEP1]]
+; CHECK: %[[GEP2:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 2
+; CHECK: store i8 0, ptr %[[GEP2]]
+; CHECK: %[[GEP3:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 3
+; CHECK: store i8 10, ptr %[[GEP3]]
+
+; CHECK: %[[LoadArr:[0-9a-z.]+]] = load [4 x i8], ptr %[[#ArrayPtr]]
+; CHECK: ret [4 x i8] %[[LoadArr]]
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 23
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Int8
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource Unknown 0
+               OpName %_arr_uchar_uint_4 "arrtype"
+               OpName %non_constant_array_elements "non_constant_array_elements"
+               OpDecorate %non_constant_array_elements LinkageAttributes "non_constant_array_elements" Export
+      %uchar = OpTypeInt 8 0
+       %uint = OpTypeInt 32 0
+   %uchar_10 = OpConstant %uchar 10
+    %uchar_0 = OpConstant %uchar 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+    %_arr_uchar_uint_4 = OpTypeArray %uchar %uint_4
+          %5 = OpTypeFunction %_arr_uchar_uint_4 %uchar %uchar
+%_ptr_Function_uint = OpTypePointer Function %uint
+%non_constant_array_elements = OpFunction %_arr_uchar_uint_4 None %5
+        %484 = OpFunctionParameter %uchar
+        %485 = OpFunctionParameter %uchar
+          %7 = OpLabel
+         %14 = OpCompositeConstruct %_arr_uchar_uint_4 %485 %484 %uchar_0 %uchar_10
+               OpReturnValue %14
+               OpFunctionEnd

--- a/test/composite_construct_struct_non_constant.spt
+++ b/test/composite_construct_struct_non_constant.spt
@@ -2,16 +2,16 @@
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis %t.bc
-; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
+; RUN: FileCheck < %t.ll %s
 
-; CHECK-LLVM: %[[StructTy:[0-9a-z.]+]] = type { float, i32 }
-; CHECK-LLVM: %[[#StructPtr:]] = alloca %[[StructTy]]
-; CHECK-LLVM: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds float, ptr %[[#StructPtr]], i32 0
-; CHECK-LLVM: store float %[[#]], ptr %[[GEP]]
-; CHECK-LLVM: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i32, ptr %[[#StructPtr]], i32 1
-; CHECK-LLVM: store i32 %[[#]], ptr %[[GEP1]]
-; CHECK-LLVM: %[[LoadStr:[0-9a-z.]+]] = load %[[StructTy]], ptr %[[#StructPtr]]
-; CHECK-LLVM: ret %[[StructTy]] %[[LoadStr]]
+; CHECK: %[[StructTy:[0-9a-z.]+]] = type { float, i32 }
+; CHECK: %[[#StructPtr:]] = alloca %[[StructTy]]
+; CHECK: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds float, ptr %[[#StructPtr]], i32 0
+; CHECK: store float %[[#]], ptr %[[GEP]]
+; CHECK: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i32, ptr %[[#StructPtr]], i32 1
+; CHECK: store i32 %[[#]], ptr %[[GEP1]]
+; CHECK: %[[LoadStr:[0-9a-z.]+]] = load %[[StructTy]], ptr %[[#StructPtr]]
+; CHECK: ret %[[StructTy]] %[[LoadStr]]
 
 119734787 65536 393230 23 0 
 2 Capability Addresses 

--- a/test/composite_construct_vector_non_constant.spvasm
+++ b/test/composite_construct_vector_non_constant.spvasm
@@ -1,0 +1,40 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s
+
+; CHECK: define spir_func <3 x i32> @non_constant_vector_elements(i32 %[[#ARG0:]], i32 %[[#ARG1:]])
+; CHECK: %[[#VEC0:]] = insertelement <3 x i32> poison, i32 %[[#ARG1]], i32 0
+; CHECK: %[[#VEC1:]] = insertelement <3 x i32> %[[#VEC0]], i32 %[[#ARG0]], i32 1
+; CHECK: %[[#VEC2:]] = insertelement <3 x i32> %[[#VEC1]], i32 1, i32 2
+; CHECK: ret <3 x i32> %[[#VEC2]]
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 23
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource Unknown 0
+               OpName %vectype "vectype"
+               OpName %non_constant_vector_elements "non_constant_vector_elements"
+               OpDecorate %non_constant_vector_elements LinkageAttributes "non_constant_vector_elements" Export
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+    %vectype = OpTypeVector %uint 3
+          %5 = OpTypeFunction %vectype %uint %uint
+%_ptr_Function_uint = OpTypePointer Function %uint
+%non_constant_vector_elements = OpFunction %vectype None %5
+        %484 = OpFunctionParameter %uint
+        %485 = OpFunctionParameter %uint
+          %7 = OpLabel
+         %14 = OpCompositeConstruct %vectype %485 %484 %uint_1
+               OpReturnValue %14
+               OpFunctionEnd


### PR DESCRIPTION
This patch introduces a way to use runtime values for array and vector types. It continues #2256