### PR TITLE
[Backport to 14] Fix reverse translation of non-constant values of OpCompositeConstruct

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2151,12 +2151,39 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     }
 
     switch (static_cast<size_t>(BV->getType()->getOpCode())) {
-    case OpTypeVector:
-      return mapValue(BV, ConstantVector::get(CV));
-    case OpTypeArray:
-      return mapValue(
-          BV, ConstantArray::get(dyn_cast<ArrayType>(transType(CC->getType())),
-                                 CV));
+    case OpTypeVector: {
+      if (!HasRtValues)
+        return mapValue(BV, ConstantVector::get(CV));
+
+      auto *VT = cast<FixedVectorType>(transType(CC->getType()));
+      Value *NewVec = ConstantVector::getSplat(
+          VT->getElementCount(), PoisonValue::get(VT->getElementType()));
+
+      for (size_t I = 0; I < Constituents.size(); I++) {
+        NewVec = InsertElementInst::Create(NewVec, Constituents[I],
+                                           getInt32(M, I), "", BB);
+      }
+      return mapValue(BV, NewVec);
+    }
+    case OpTypeArray: {
+      auto *AT = cast<ArrayType>(transType(CC->getType()));
+      if (!HasRtValues)
+        return mapValue(BV, ConstantArray::get(AT, CV));
+
+      AllocaInst *Alloca = new AllocaInst(AT, SPIRAS_Private, "", BB);
+
+      // get pointer to the element of the array
+      // store the result of argument
+      for (size_t I = 0; I < Constituents.size(); I++) {
+        auto *GEP = GetElementPtrInst::Create(
+            Constituents[I]->getType(), Alloca, {getInt32(M, I)}, "gep", BB);
+        GEP->setIsInBounds(true);
+        new StoreInst(Constituents[I], GEP, false, BB);
+      }
+
+      auto *Load = new LoadInst(AT, Alloca, "load", false, BB);
+      return mapValue(BV, Load);
+    }
     case OpTypeStruct: {
       auto *ST = cast<StructType>(transType(CC->getType()));
       if (!HasRtValues)

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2142,9 +2142,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto CC = static_cast<SPIRVCompositeConstruct *>(BV);
     auto Constituents = transValue(CC->getOperands(), F, BB);
     std::vector<Constant *> CV;
+    bool HasRtValues = false;
     for (const auto &I : Constituents) {
-      CV.push_back(dyn_cast<Constant>(I));
+      auto *C = dyn_cast<Constant>(I);
+      CV.push_back(C);
+      if (!HasRtValues && C == nullptr)
+        HasRtValues = true;
     }
+
     switch (static_cast<size_t>(BV->getType()->getOpCode())) {
     case OpTypeVector:
       return mapValue(BV, ConstantVector::get(CV));
@@ -2152,10 +2157,25 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       return mapValue(
           BV, ConstantArray::get(dyn_cast<ArrayType>(transType(CC->getType())),
                                  CV));
-    case OpTypeStruct:
-      return mapValue(BV,
-                      ConstantStruct::get(
-                          dyn_cast<StructType>(transType(CC->getType())), CV));
+    case OpTypeStruct: {
+      auto *ST = cast<StructType>(transType(CC->getType()));
+      if (!HasRtValues)
+        return mapValue(BV, ConstantStruct::get(ST, CV));
+
+      AllocaInst *Alloca = new AllocaInst(ST, SPIRAS_Private, "", BB);
+
+      // get pointer to the element of structure
+      // store the result of argument
+      for (size_t I = 0; I < Constituents.size(); I++) {
+        auto *GEP = GetElementPtrInst::Create(
+            Constituents[I]->getType(), Alloca, {getInt32(M, I)}, "gep", BB);
+        GEP->setIsInBounds(true);
+        new StoreInst(Constituents[I], GEP, false, BB);
+      }
+
+      auto *Load = new LoadInst(ST, Alloca, "load", false, BB);
+      return mapValue(BV, Load);
+    }
     case internal::OpTypeJointMatrixINTEL:
     case OpTypeCooperativeMatrixKHR:
       return mapValue(BV, transSPIRVBuiltinFromInst(CC, BB));

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2176,7 +2176,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       // store the result of argument
       for (size_t I = 0; I < Constituents.size(); I++) {
         auto *GEP = GetElementPtrInst::Create(
-            Constituents[I]->getType(), Alloca, {getInt32(M, I)}, "gep", BB);
+            AT, Alloca, {getInt32(M, 0), getInt32(M, I)}, "gep", BB);
         GEP->setIsInBounds(true);
         new StoreInst(Constituents[I], GEP, false, BB);
       }
@@ -2195,7 +2195,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       // store the result of argument
       for (size_t I = 0; I < Constituents.size(); I++) {
         auto *GEP = GetElementPtrInst::Create(
-            Constituents[I]->getType(), Alloca, {getInt32(M, I)}, "gep", BB);
+            ST, Alloca, {getInt32(M, 0), getInt32(M, I)}, "gep", BB);
         GEP->setIsInBounds(true);
         new StoreInst(Constituents[I], GEP, false, BB);
       }

--- a/test/composite_construct_array_non_constant.spvasm
+++ b/test/composite_construct_array_non_constant.spvasm
@@ -1,0 +1,53 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s
+
+; CHECK: define spir_func [4 x i8] @non_constant_array_elements(i8 %[[#ARG0:]], i8 %[[#ARG1:]])
+; CHECK: %[[#ArrayPtr:]] = alloca [4 x i8]
+; CHECK: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 0
+; CHECK: store i8 %[[#ARG1]], ptr %[[GEP]]
+; CHECK: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 1
+; CHECK: store i8 %[[#ARG0]], ptr %[[GEP1]]
+; CHECK: %[[GEP2:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 2
+; CHECK: store i8 0, ptr %[[GEP2]]
+; CHECK: %[[GEP3:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 3
+; CHECK: store i8 10, ptr %[[GEP3]]
+
+; CHECK: %[[LoadArr:[0-9a-z.]+]] = load [4 x i8], ptr %[[#ArrayPtr]]
+; CHECK: ret [4 x i8] %[[LoadArr]]
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 23
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Int8
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource Unknown 0
+               OpName %_arr_uchar_uint_4 "arrtype"
+               OpName %non_constant_array_elements "non_constant_array_elements"
+               OpDecorate %non_constant_array_elements LinkageAttributes "non_constant_array_elements" Export
+      %uchar = OpTypeInt 8 0
+       %uint = OpTypeInt 32 0
+   %uchar_10 = OpConstant %uchar 10
+    %uchar_0 = OpConstant %uchar 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+    %_arr_uchar_uint_4 = OpTypeArray %uchar %uint_4
+          %5 = OpTypeFunction %_arr_uchar_uint_4 %uchar %uchar
+%_ptr_Function_uint = OpTypePointer Function %uint
+%non_constant_array_elements = OpFunction %_arr_uchar_uint_4 None %5
+        %484 = OpFunctionParameter %uchar
+        %485 = OpFunctionParameter %uchar
+          %7 = OpLabel
+         %14 = OpCompositeConstruct %_arr_uchar_uint_4 %485 %484 %uchar_0 %uchar_10
+               OpReturnValue %14
+               OpFunctionEnd

--- a/test/composite_construct_array_non_constant.spvasm
+++ b/test/composite_construct_array_non_constant.spvasm
@@ -7,16 +7,16 @@
 
 ; CHECK: define spir_func [4 x i8] @non_constant_array_elements(i8 %[[#ARG0:]], i8 %[[#ARG1:]])
 ; CHECK: %[[#ArrayPtr:]] = alloca [4 x i8]
-; CHECK: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 0
-; CHECK: store i8 %[[#ARG1]], ptr %[[GEP]]
-; CHECK: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 1
-; CHECK: store i8 %[[#ARG0]], ptr %[[GEP1]]
-; CHECK: %[[GEP2:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 2
-; CHECK: store i8 0, ptr %[[GEP2]]
-; CHECK: %[[GEP3:[0-9a-z.]+]] = getelementptr inbounds i8, ptr %[[#ArrayPtr]], i32 3
-; CHECK: store i8 10, ptr %[[GEP3]]
+; CHECK: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds [4 x i8], [4 x i8]* %[[#ArrayPtr]], i32 0, i32 0
+; CHECK: store i8 %[[#ARG1]], i8* %[[GEP]]
+; CHECK: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds [4 x i8], [4 x i8]* %[[#ArrayPtr]], i32 0, i32 1
+; CHECK: store i8 %[[#ARG0]], i8* %[[GEP1]]
+; CHECK: %[[GEP2:[0-9a-z.]+]] = getelementptr inbounds [4 x i8], [4 x i8]* %[[#ArrayPtr]], i32 0, i32 2
+; CHECK: store i8 0, i8* %[[GEP2]]
+; CHECK: %[[GEP3:[0-9a-z.]+]] = getelementptr inbounds [4 x i8], [4 x i8]* %[[#ArrayPtr]], i32 0, i32 3
+; CHECK: store i8 10, i8* %[[GEP3]]
 
-; CHECK: %[[LoadArr:[0-9a-z.]+]] = load [4 x i8], ptr %[[#ArrayPtr]]
+; CHECK: %[[LoadArr:[0-9a-z.]+]] = load [4 x i8], [4 x i8]* %[[#ArrayPtr]]
 ; CHECK: ret [4 x i8] %[[LoadArr]]
 
 ; SPIR-V

--- a/test/composite_construct_struct_non_constant.spt
+++ b/test/composite_construct_struct_non_constant.spt
@@ -6,11 +6,11 @@
 
 ; CHECK: %[[StructTy:[0-9a-z.]+]] = type { float, i32 }
 ; CHECK: %[[#StructPtr:]] = alloca %[[StructTy]]
-; CHECK: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds float, ptr %[[#StructPtr]], i32 0
-; CHECK: store float %[[#]], ptr %[[GEP]]
-; CHECK: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i32, ptr %[[#StructPtr]], i32 1
-; CHECK: store i32 %[[#]], ptr %[[GEP1]]
-; CHECK: %[[LoadStr:[0-9a-z.]+]] = load %[[StructTy]], ptr %[[#StructPtr]]
+; CHECK: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds %[[StructTy]], %[[StructTy]]* %[[#StructPtr]], i32 0, i32 0
+; CHECK: store float %[[#]], float* %[[GEP]]
+; CHECK: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds %[[StructTy]], %[[StructTy]]* %[[#StructPtr]], i32 0, i32 1
+; CHECK: store i32 %[[#]], i32* %[[GEP1]]
+; CHECK: %[[LoadStr:[0-9a-z.]+]] = load %[[StructTy]], %[[StructTy]]* %[[#StructPtr]]
 ; CHECK: ret %[[StructTy]] %[[LoadStr]]
 
 119734787 65536 393230 23 0

--- a/test/composite_construct_struct_non_constant.spt
+++ b/test/composite_construct_struct_non_constant.spt
@@ -2,16 +2,16 @@
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc
 ; RUN: llvm-dis %t.bc
-; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
+; RUN: FileCheck < %t.ll %s
 
-; CHECK-LLVM: %[[StructTy:[0-9a-z.]+]] = type { float, i32 }
-; CHECK-LLVM: %[[#StructPtr:]] = alloca %[[StructTy]]
-; CHECK-LLVM: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds float, ptr %[[#StructPtr]], i32 0
-; CHECK-LLVM: store float %[[#]], ptr %[[GEP]]
-; CHECK-LLVM: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i32, ptr %[[#StructPtr]], i32 1
-; CHECK-LLVM: store i32 %[[#]], ptr %[[GEP1]]
-; CHECK-LLVM: %[[LoadStr:[0-9a-z.]+]] = load %[[StructTy]], ptr %[[#StructPtr]]
-; CHECK-LLVM: ret %[[StructTy]] %[[LoadStr]]
+; CHECK: %[[StructTy:[0-9a-z.]+]] = type { float, i32 }
+; CHECK: %[[#StructPtr:]] = alloca %[[StructTy]]
+; CHECK: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds float, ptr %[[#StructPtr]], i32 0
+; CHECK: store float %[[#]], ptr %[[GEP]]
+; CHECK: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i32, ptr %[[#StructPtr]], i32 1
+; CHECK: store i32 %[[#]], ptr %[[GEP1]]
+; CHECK: %[[LoadStr:[0-9a-z.]+]] = load %[[StructTy]], ptr %[[#StructPtr]]
+; CHECK: ret %[[StructTy]] %[[LoadStr]]
 
 119734787 65536 393230 23 0
 2 Capability Addresses

--- a/test/composite_construct_struct_non_constant.spt
+++ b/test/composite_construct_struct_non_constant.spt
@@ -1,0 +1,48 @@
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis %t.bc
+; RUN: FileCheck < %t.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: %[[StructTy:[0-9a-z.]+]] = type { float, i32 }
+; CHECK-LLVM: %[[#StructPtr:]] = alloca %[[StructTy]]
+; CHECK-LLVM: %[[GEP:[0-9a-z.]+]] = getelementptr inbounds float, ptr %[[#StructPtr]], i32 0
+; CHECK-LLVM: store float %[[#]], ptr %[[GEP]]
+; CHECK-LLVM: %[[GEP1:[0-9a-z.]+]] = getelementptr inbounds i32, ptr %[[#StructPtr]], i32 1
+; CHECK-LLVM: store i32 %[[#]], ptr %[[GEP1]]
+; CHECK-LLVM: %[[LoadStr:[0-9a-z.]+]] = load %[[StructTy]], ptr %[[#StructPtr]]
+; CHECK-LLVM: ret %[[StructTy]] %[[LoadStr]]
+
+119734787 65536 393230 23 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 2 2
+3 Source 0 0
+5 Name 2 "structtype"
+9 Name 6 "non_constant_struct_fields"
+11 Decorate 6 LinkageAttributes "non_constant_struct_fields" Export
+4 Decorate 9 Alignment 4
+4 Decorate 11 Alignment 4
+4 TypeInt 4 32 0
+4 Constant 4 17 0
+4 Constant 4 20 1
+3 TypeFloat 3 32
+4 TypeStruct 2 3 4
+
+3 TypeFunction 5 2
+4 TypePointer 8 7 4
+4 TypePointer 10 7 3
+
+5 Function 2 6 0 5
+
+2 Label 7
+4 Variable 8 9 7
+4 Variable 10 11 7
+4 Load 4 12 9
+4 Load 3 13 11
+5 CompositeConstruct 2 14 13 12
+2 ReturnValue 14
+
+1 FunctionEnd

--- a/test/composite_construct_vector_non_constant.spvasm
+++ b/test/composite_construct_vector_non_constant.spvasm
@@ -1,0 +1,40 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s
+
+; CHECK: define spir_func <3 x i32> @non_constant_vector_elements(i32 %[[#ARG0:]], i32 %[[#ARG1:]])
+; CHECK: %[[#VEC0:]] = insertelement <3 x i32> poison, i32 %[[#ARG1]], i32 0
+; CHECK: %[[#VEC1:]] = insertelement <3 x i32> %[[#VEC0]], i32 %[[#ARG0]], i32 1
+; CHECK: %[[#VEC2:]] = insertelement <3 x i32> %[[#VEC1]], i32 1, i32 2
+; CHECK: ret <3 x i32> %[[#VEC2]]
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 23
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource Unknown 0
+               OpName %vectype "vectype"
+               OpName %non_constant_vector_elements "non_constant_vector_elements"
+               OpDecorate %non_constant_vector_elements LinkageAttributes "non_constant_vector_elements" Export
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+    %vectype = OpTypeVector %uint 3
+          %5 = OpTypeFunction %vectype %uint %uint
+%_ptr_Function_uint = OpTypePointer Function %uint
+%non_constant_vector_elements = OpFunction %vectype None %5
+        %484 = OpFunctionParameter %uint
+        %485 = OpFunctionParameter %uint
+          %7 = OpLabel
+         %14 = OpCompositeConstruct %vectype %485 %484 %uint_1
+               OpReturnValue %14
+               OpFunctionEnd


### PR DESCRIPTION
This patch introduces a way to use runtime values for structure fields, array and vector types.

Original changes: a6f017a and 4db768c