### PR TITLE
add API to query error message by an error code

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -135,6 +135,10 @@ struct SPIRVModuleTextReport {
 /// \returns String with the human-readable report.
 SPIRVModuleTextReport formatSpirvReport(const SPIRVModuleReport &Report);
 
+/// \brief Returns the message associated with the error code.
+/// \returns empty string if no known error code is found.
+std::string getErrorMessage(int ErrCode);
+
 } // End namespace SPIRV
 
 namespace llvm {

--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -38,6 +38,7 @@ set(SRC_LIST
   libSPIRV/SPIRVStream.cpp
   libSPIRV/SPIRVType.cpp
   libSPIRV/SPIRVValue.cpp
+  libSPIRV/SPIRVError.cpp
 )
 add_llvm_library(LLVMSPIRVLib
   ${SRC_LIST}

--- a/lib/SPIRV/libSPIRV/SPIRVError.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVError.cpp
@@ -1,4 +1,4 @@
-//===- SPIRVError.cpp - SPIR-V error code and checking ------------*- C++ -*-===//
+//===- SPIRVError.cpp - SPIR-V error code and checking ----------*- C++ -*-===//
 //
 //                     The LLVM/SPIRV Translator
 //

--- a/lib/SPIRV/libSPIRV/SPIRVError.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVError.cpp
@@ -1,0 +1,56 @@
+//===- SPIRVError.cpp - SPIR-V error code and checking ------------*- C++ -*-===//
+//
+//                     The LLVM/SPIRV Translator
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// Copyright (c) 2014 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal with the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimers.
+// Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimers in the documentation
+// and/or other materials provided with the distribution.
+// Neither the names of Advanced Micro Devices, Inc., nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// Software without specific prior written permission.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
+// THE SOFTWARE.
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements SPIRV error code and checking utility.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SPIRVError.h"
+#include <string>
+
+namespace SPIRV {
+
+// Return the message associated with the error code. If error code is invalid,
+// return the message associated with InternalMaxErrorCode.
+std::string getErrorMessage(int ErrCode) {
+  std::string ErrorMessage;
+  bool Found =
+      (ErrCode >= SPIRVEC_Success && ErrCode < SPIRVEC_InternalMaxErrorCode)
+          ? SPIRVErrorMap::find(static_cast<SPIRVErrorCode>(ErrCode),
+                                &ErrorMessage)
+          : false;
+  return Found ? ErrorMessage : std::string("Unknown error code");
+}
+
+} // namespace SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVError.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVError.cpp
@@ -5,7 +5,7 @@
 // This file is distributed under the University of Illinois Open Source
 // License. See LICENSE.TXT for details.
 //
-// Copyright (c) 2024 Intel Corporation. All rights reserved.
+// Copyright (c) 2024 The Khronos Group Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,7 +19,7 @@
 // Redistributions in binary form must reproduce the above copyright notice,
 // this list of conditions and the following disclaimers in the documentation
 // and/or other materials provided with the distribution.
-// Neither the names of Intel Corporation, nor the names of its
+// Neither the names of The Khronos Group, nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // Software without specific prior written permission.
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/lib/SPIRV/libSPIRV/SPIRVError.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVError.cpp
@@ -1,11 +1,11 @@
 //===- SPIRVError.cpp - SPIR-V error code and checking ----------*- C++ -*-===//
 //
-//                     The LLVM/SPIRV Translator
+//                     The LLVM/SPIR-V Translator
 //
 // This file is distributed under the University of Illinois Open Source
 // License. See LICENSE.TXT for details.
 //
-// Copyright (c) 2014 Advanced Micro Devices, Inc. All rights reserved.
+// Copyright (c) 2024 Intel Corporation. All rights reserved.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),
@@ -19,7 +19,7 @@
 // Redistributions in binary form must reproduce the above copyright notice,
 // this list of conditions and the following disclaimers in the documentation
 // and/or other materials provided with the distribution.
-// Neither the names of Advanced Micro Devices, Inc., nor the names of its
+// Neither the names of Intel Corporation, nor the names of its
 // contributors may be used to endorse or promote products derived from this
 // Software without specific prior written permission.
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/lib/SPIRV/libSPIRV/SPIRVError.h
+++ b/lib/SPIRV/libSPIRV/SPIRVError.h
@@ -174,18 +174,6 @@ inline bool SPIRVErrorLog::checkError(bool Cond, SPIRVErrorCode ErrCode,
   return Cond;
 }
 
-// Return the message associated with the error code or empty string if the
-// error code is invalid
-inline std::string getErrorMessage(int ErrCode) {
-  std::string ErrorMessage;
-  // It's ok if the error code is not present in the map, so we don't need to
-  // check a value returned by the find() call. ErrorMessage just keeps its
-  // value if the error code is not found.
-  if (ErrCode >= SPIRVEC_Success && ErrCode < SPIRVEC_InternalMaxErrorCode)
-    SPIRVErrorMap::find(static_cast<SPIRVErrorCode>(ErrCode), &ErrorMessage);
-  return ErrorMessage;
-}
-
 } // namespace SPIRV
 
 #endif // SPIRV_LIBSPIRV_SPIRVERROR_H

--- a/lib/SPIRV/libSPIRV/SPIRVError.h
+++ b/lib/SPIRV/libSPIRV/SPIRVError.h
@@ -174,6 +174,18 @@ inline bool SPIRVErrorLog::checkError(bool Cond, SPIRVErrorCode ErrCode,
   return Cond;
 }
 
+// Return the message associated with the error code or empty string if the
+// error code is invalid
+inline std::string getErrorMessage(int ErrCode) {
+  std::string ErrorMessage;
+  // It's ok if the error code is not present in the map, so we don't need to
+  // check a value returned by the find() call. ErrorMessage just keeps its
+  // value if the error code is not found.
+  if (ErrCode >= SPIRVEC_Success && ErrCode < SPIRVEC_InternalMaxErrorCode)
+    SPIRVErrorMap::find(static_cast<SPIRVErrorCode>(ErrCode), &ErrorMessage);
+  return ErrorMessage;
+}
+
 } // namespace SPIRV
 
 #endif // SPIRV_LIBSPIRV_SPIRVERROR_H

--- a/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVErrorEnum.h
@@ -1,5 +1,5 @@
 /* The error code name should be meaningful since it is part of error message */
-_SPIRV_OP(Success, "")
+_SPIRV_OP(Success, "Success")
 _SPIRV_OP(InvalidTargetTriple,
           "Expects spir-unknown-unknown or spir64-unknown-unknown.")
 _SPIRV_OP(InvalidSubArch, "Expecting v1.0-v1.4.")
@@ -28,3 +28,6 @@ _SPIRV_OP(InvalidVersionNumber,
           "Invalid Version Number.")
 _SPIRV_OP(UnspecifiedMemoryModel, "Unspecified Memory Model.")
 _SPIRV_OP(RepeatedMemoryModel, "Expects a single OpMemoryModel instruction.")
+
+/* This is the last error code to have a maximum valid value to compare to */
+_SPIRV_OP(InternalMaxErrorCode, "Unknown error code")

--- a/test/negative/spirv_report_bad_input.spt
+++ b/test/negative/spirv_report_bad_input.spt
@@ -3,7 +3,7 @@
 ; RUN: echo "0" > %t_corrupted.spv && cat %t.spv >> %t_corrupted.spv
 ; RUN: not llvm-spirv --spirv-print-report %t_corrupted.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
-; CHECK-ERROR: Invalid SPIR-V binary
+; CHECK-ERROR: Invalid SPIR-V binary: "InvalidMagicNumber: Invalid Magic Number."
 
 119734787 65536 393230 10 0
 2 Capability Addresses

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -837,7 +837,7 @@ int main(int Ac, char **Av) {
     std::optional<SPIRV::SPIRVModuleReport> BinReport =
         SPIRV::getSpirvReport(IFS, ErrCode);
     if (!BinReport) {
-      std::cerr << "Invalid SPIR-V binary, error code is " << ErrCode << "\n";
+      std::cerr << "Invalid SPIR-V binary: \"" << SPIRV::getErrorMessage(ErrCode) << "\"\n";
       return -1;
     }
 


### PR DESCRIPTION
The goal of the PR is to add API to SPIR-V LLVM Translator to query error message by an error code as discussed in https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2298

A need and possible application is a way to generate human-readable error info by error codes returned by other SPIRV Translator API calls, including getSpirvReport().