### PR TITLE
[NFC] Revert change to Fortran array test

### DIFF
--- a/test/DebugInfo/NonSemantic/Shader200/FortranArray.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranArray.ll
@@ -7,11 +7,11 @@
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: [[#CompUnit:]] [[#]] DebugCompilationUnit
-; CHECK-SPIRV-DAG: [[#EntryFunc:]] [[#]] DebugFunction [[#]]
 ; CHECK-SPIRV-DAG: [[#None:]] [[#]] DebugInfoNone
-; CHECK-SPIRV: [[#BaseTy:]] [[#]] DebugTypeBasic
-; CHECK-SPIRV: [[#Subrange:]] [[#]] DebugTypeSubrange
-; CHECK-SPIRV: DebugTypeArrayDynamic [[#BaseTy]] [[#]] [[#]] [[#None]] [[#None]] [[#Subrange]]
+; CHECK-SPIRV-DAG: [[#BaseTy:]] [[#]] DebugTypeBasic
+; CHECK-SPIRV-DAG: [[#Subrange:]] [[#]] DebugTypeSubrange
+; CHECK-SPIRV-DAG: DebugTypeArrayDynamic [[#BaseTy]] [[#]] [[#]] [[#None]] [[#None]] [[#Subrange]]
+; CHECK-SPIRV-DAG: [[#EntryFunc:]] [[#]] DebugFunction [[#]]
 ; CHECK-SPIRV: DebugEntryPoint [[#EntryFunc]] [[#CompUnit]] [[#]] [[#]] {{$}}
 
 ; CHECK-LLVM: !DICompileUnit(language: DW_LANG_Fortran95

--- a/test/DebugInfo/NonSemantic/Shader200/FortranArray.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranArray.ll
@@ -7,11 +7,11 @@
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: [[#CompUnit:]] [[#]] DebugCompilationUnit
+; CHECK-SPIRV-DAG: [[#EntryFunc:]] [[#]] DebugFunction [[#]]
 ; CHECK-SPIRV-DAG: [[#None:]] [[#]] DebugInfoNone
 ; CHECK-SPIRV: [[#BaseTy:]] [[#]] DebugTypeBasic
 ; CHECK-SPIRV: [[#Subrange:]] [[#]] DebugTypeSubrange
 ; CHECK-SPIRV: DebugTypeArrayDynamic [[#BaseTy]] [[#]] [[#]] [[#None]] [[#None]] [[#Subrange]]
-; CHECK-SPIRV-DAG: [[#EntryFunc:]] [[#]] DebugFunction [[#]]
 ; CHECK-SPIRV: DebugEntryPoint [[#EntryFunc]] [[#CompUnit]] [[#]] [[#]] {{$}}
 
 ; CHECK-LLVM: !DICompileUnit(language: DW_LANG_Fortran95


### PR DESCRIPTION
Revert change to Fortran array test.  Previous change was in:

> Author: Viktoria Maximova <viktoria.maksimova@intel.com>
> Date:   Tue Jan 16 17:16:33 2024 +0100
> 
>     Fix DebugInfo/NonSemantic/Shader200/FortranArray.ll (#2303)
> 
>     The change is needed after llvm/llvm-project@fc6faa11
> 

The LLVM change that motivated the change to FortranArray.ll has been reverted:

> Author: Davide Italiano <davidino@fb.com>
> Date:   Tue Jan 16 16:56:24 2024 -0800
> 
>     Revert "[CloneFunction][DebugInfo] Avoid cloning DILocalVariables of inlined functions (#75385)"
> 
>     This reverts commit fc6faa1113e9069f41b5500db051210af0eea843.