### PR TITLE
[Backport to 12] Update LongConstantCompositeINTEL to LongCompositesINTEL capability after Headers change

### DIFF
--- a/include/LLVMSPIRVExtensions.inc
+++ b/include/LLVMSPIRVExtensions.inc
@@ -34,7 +34,9 @@ EXT(SPV_INTEL_variable_length_array)
 EXT(SPV_INTEL_fp_fast_math_mode)
 EXT(SPV_INTEL_fpga_cluster_attributes)
 EXT(SPV_INTEL_loop_fuse)
-EXT(SPV_INTEL_long_constant_composite)
+EXT(SPV_INTEL_long_composites)
+EXT(SPV_INTEL_long_constant_composite) // TODO: rename to
+                                       // SPV_INTEL_long_composites later
 EXT(SPV_INTEL_optnone)
 EXT(SPV_INTEL_memory_access_aliasing)
 EXT(SPV_INTEL_split_barrier)

--- a/test/long-constant-array.ll
+++ b/test/long-constant-array.ll
@@ -9,7 +9,7 @@
 ; TODO: run validator once it supports the extension
 ; RUNx: spirv-val %t.spv
 
-; CHECK-SPIRV: Capability LongConstantCompositeINTEL 
+; CHECK-SPIRV: Capability LongConstantCompositeINTEL
 ; CHECK-SPIRV: Extension "SPV_INTEL_long_constant_composite"
 ; CHECK-SPIRV: TypeInt [[TInt:[0-9]+]] 8
 ; CHECK-SPIRV: Constant {{[0-9]+}} [[ArrSize:[0-9]+]] 78000

--- a/test/long-type-struct.ll
+++ b/test/long-type-struct.ll
@@ -10,7 +10,7 @@
 
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
-; CHECK-SPIRV: Capability LongConstantCompositeINTEL 
+; CHECK-SPIRV: Capability LongConstantCompositeINTEL
 ; CHECK-SPIRV: Extension "SPV_INTEL_long_constant_composite"
 ; CHECK-SPIRV: TypeForwardPointer [[TFwdPtr:[0-9]+]]
 ; CHECK-SPIRV: TypeInt [[TInt:[0-9]+]]


### PR DESCRIPTION
The original change:
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/0166a0fb86dc6c0e8903436bbc3a89bc3273ebc0

* replace internal SPV_INTEL_long_composites ext with the published SPV_INTEL_long_composites
* don't rename extension for now