### PR TITLE
[DebugInfo] Guard Expression in DebugGlobalVariable with nonsemantic

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1186,7 +1186,7 @@ LLVMToSPIRVDbgTran::transDbgGlobalVariable(const DIGlobalVariable *GV) {
     Ops.push_back(transDbgEntry(StaticMember)->getId());
 
   // Check if Ops[VariableIdx] has no information
-  if (Ops[VariableIdx] == getDebugInfoNoneId()) {
+  if (isNonSemanticDebugInfo() && Ops[VariableIdx] == getDebugInfoNoneId()) {
     // Check if GV has an associated GVE with a non-empty DIExpression.
     // The non-empty DIExpression gives the initial value of the GV.
     for (const DIGlobalVariableExpression *GVE : DIF.global_variables()) {

--- a/test/DebugInfo/DebugInfo-GV-with-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-DIE.ll
@@ -1,4 +1,5 @@
 ;; Ensure that DIExpressions are preserved in DIGlobalVariableExpressions
+;; if nonsemantic debug info is enabled.
 ;; This utilizes SPIRV DebugGlobalVariable's Variable field to hold the
 ;; DIExpression.
 
@@ -23,6 +24,14 @@
 
 ; CHECK-LLVM: ![[#]] = !DIGlobalVariableExpression(var: ![[#GV:]], expr: !DIExpression(DW_OP_constu, 1, DW_OP_stack_value))
 ; CHECK-LLVM: ![[#GV]] = distinct !DIGlobalVariable(name: "true", scope: ![[#]], file: ![[#]], line: 3777, type: ![[#]], isLocal: true, isDefinition: true)
+
+;; Ensure SPIR-V DebugGlobalVariable's Variable field does not hold a DIExpression if nonsemantic debug info is not enabled
+
+; RUN: llvm-spirv -o %t.spt %t.bc -spirv-text
+; RUN: FileCheck %s --input-file %t.spt --check-prefix CHECK-NONE-SPIRV
+
+; CHECK-NONE-SPIRV: [[DEBUG_INFO_NONE:[0-9]+]] [[#]] DebugInfoNone
+; CHECK-NONE-SPIRV: [[#]] [[#]] DebugGlobalVariable [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[DEBUG_INFO_NONE]] [[#]] {{$}}
 
 !llvm.module.flags = !{!0, !1}
 !llvm.dbg.cu = !{!2}

--- a/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
+++ b/test/DebugInfo/DebugInfo-GV-with-SMD-and-DIE.ll
@@ -1,4 +1,5 @@
 ;; Ensure that DIExpressions are preserved in DIGlobalVariableExpressions
+;; if nonsemantic debug info is enabled
 ;; when a Static Member Declaration is also needed.
 ;; This utilizes SPIRV DebugGlobalVariable's Variable field to hold the
 ;; DIExpression.
@@ -37,6 +38,15 @@
 ; CHECK-LLVM: ![[#SCOPE]] = {{.*}}!DICompositeType(tag: DW_TAG_structure_type, name: "A", file: ![[#]], line: 1, size: 8, flags: DIFlagTypePassByValue, elements: ![[#ELEMENTS:]], identifier: "_ZTS1A")
 ; CHECK-LLVM: ![[#ELEMENTS]] = !{![[#DECLARATION]]}
 ; CHECK-LLVM: ![[#BASETYPE]] = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+
+;; Ensure SPIR-V DebugGlobalVariable's Variable field does not hold a DIExpression if nonsemantic debug info is not enabled
+
+; RUN: llvm-spirv -o %t.spt %t.bc -spirv-text
+; RUN: FileCheck %s --input-file %t.spt --check-prefix CHECK-NONE-SPIRV
+
+; CHECK-NONE-SPIRV-DAG: [[TYPE_MEMBER:[0-9]+]] [[#]] DebugTypeMember [[#]] [[#]] [[#]] [[#]]
+; CHECK-NONE-SPIRV-DAG: [[DEBUG_INFO_NONE:[0-9]+]] [[#]] DebugInfoNone
+; CHECK-NONE-SPIRV: [[#]] [[#]] DebugGlobalVariable [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[DEBUG_INFO_NONE]] [[#]] [[TYPE_MEMBER]] {{$}}
 
 !llvm.module.flags = !{!0, !1}
 !llvm.dbg.cu = !{!2}


### PR DESCRIPTION
Guard placing a DIExpression in SPIR-V's DebugGlobalVariable's Variable field with a nonsemantic check.