### PR TITLE
Remove internal values for SPV_INTEL_cache_controls

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2807,7 +2807,7 @@ static void transMetadataDecorations(Metadata *MD, SPIRVEntry *Target) {
       break;
     }
 
-    case spv::internal::DecorationCacheControlLoadINTEL: {
+    case DecorationCacheControlLoadINTEL: {
       ErrLog.checkError(
           NumOperands == 3, SPIRVEC_InvalidLlvmModule,
           "CacheControlLoadINTEL requires exactly 2 extra operands");
@@ -2824,11 +2824,10 @@ static void transMetadataDecorations(Metadata *MD, SPIRVEntry *Target) {
 
       Target->addDecorate(new SPIRVDecorateCacheControlLoadINTEL(
           Target, CacheLevel->getZExtValue(),
-          static_cast<internal::LoadCacheControlINTEL>(
-              CacheControl->getZExtValue())));
+          static_cast<LoadCacheControl>(CacheControl->getZExtValue())));
       break;
     }
-    case spv::internal::DecorationCacheControlStoreINTEL: {
+    case DecorationCacheControlStoreINTEL: {
       ErrLog.checkError(
           NumOperands == 3, SPIRVEC_InvalidLlvmModule,
           "CacheControlStoreINTEL requires exactly 2 extra operands");
@@ -2845,8 +2844,7 @@ static void transMetadataDecorations(Metadata *MD, SPIRVEntry *Target) {
 
       Target->addDecorate(new SPIRVDecorateCacheControlStoreINTEL(
           Target, CacheLevel->getZExtValue(),
-          static_cast<internal::StoreCacheControlINTEL>(
-              CacheControl->getZExtValue())));
+          static_cast<StoreCacheControl>(CacheControl->getZExtValue())));
       break;
     }
     default: {
@@ -3302,8 +3300,7 @@ AnnotationDecorations tryParseAnnotationString(SPIRVModule *BM,
           Decorates.LatencyControlVec.emplace_back(
               static_cast<Decoration>(DecorationKind), std::move(DecValues));
         } else if (AllowCacheControls &&
-                   DecorationKind ==
-                       internal::DecorationCacheControlLoadINTEL) {
+                   DecorationKind == DecorationCacheControlLoadINTEL) {
           Decorates.CacheControlVec.emplace_back(
               static_cast<Decoration>(DecorationKind), std::move(DecValues));
         } else if (DecorationKind == DecorationMemoryINTEL) {
@@ -3564,7 +3561,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
       }
       break;
     }
-    case spv::internal::DecorationCacheControlLoadINTEL: {
+    case DecorationCacheControlLoadINTEL: {
       if (M->isAllowedToUseExtension(ExtensionID::SPV_INTEL_cache_controls)) {
         M->getErrorLog().checkError(
             I.second.size() == 2, SPIRVEC_InvalidLlvmModule,
@@ -3574,8 +3571,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
         StringRef(I.second[0]).getAsInteger(10, CacheLevel);
         StringRef(I.second[1]).getAsInteger(10, CacheControl);
         E->addDecorate(new SPIRVDecorateCacheControlLoadINTEL(
-            E, CacheLevel,
-            static_cast<internal::LoadCacheControlINTEL>(CacheControl)));
+            E, CacheLevel, static_cast<LoadCacheControl>(CacheControl)));
       }
     }
 

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -214,8 +214,8 @@ public:
       return ExtensionID::SPV_INTEL_fpga_latency_control;
     case DecorationFPMaxErrorDecorationINTEL:
       return ExtensionID::SPV_INTEL_fp_max_error;
-    case internal::DecorationCacheControlLoadINTEL:
-    case internal::DecorationCacheControlStoreINTEL:
+    case DecorationCacheControlLoadINTEL:
+    case DecorationCacheControlStoreINTEL:
       return ExtensionID::SPV_INTEL_cache_controls;
     default:
       return {};
@@ -932,32 +932,31 @@ public:
 class SPIRVDecorateCacheControlLoadINTEL : public SPIRVDecorate {
 public:
   // Complete constructor for SPIRVDecorateCacheControlLoadINTEL
-  SPIRVDecorateCacheControlLoadINTEL(
-      SPIRVEntry *TheTarget, SPIRVWord CacheLevel,
-      spv::internal::LoadCacheControlINTEL CacheControl)
-      : SPIRVDecorate(spv::internal::DecorationCacheControlLoadINTEL, TheTarget,
-                      CacheLevel, static_cast<SPIRVWord>(CacheControl)){};
+  SPIRVDecorateCacheControlLoadINTEL(SPIRVEntry *TheTarget,
+                                     SPIRVWord CacheLevel,
+                                     LoadCacheControl CacheControl)
+      : SPIRVDecorate(DecorationCacheControlLoadINTEL, TheTarget, CacheLevel,
+                      static_cast<SPIRVWord>(CacheControl)) {}
 
-  SPIRVWord getCacheLevel() const { return Literals.at(0); };
-  spv::internal::LoadCacheControlINTEL getCacheControl() const {
-    return static_cast<spv::internal::LoadCacheControlINTEL>(Literals.at(1));
-  };
+  SPIRVWord getCacheLevel() const { return Literals.at(0); }
+  LoadCacheControl getCacheControl() const {
+    return static_cast<LoadCacheControl>(Literals.at(1));
+  }
 };
 
 class SPIRVDecorateCacheControlStoreINTEL : public SPIRVDecorate {
 public:
   // Complete constructor for SPIRVDecorateCacheControlStoreINTEL
-  SPIRVDecorateCacheControlStoreINTEL(
-      SPIRVEntry *TheTarget, SPIRVWord CacheLevel,
-      spv::internal::StoreCacheControlINTEL CacheControl)
-      : SPIRVDecorate(spv::internal::DecorationCacheControlStoreINTEL,
-                      TheTarget, CacheLevel,
-                      static_cast<SPIRVWord>(CacheControl)){};
+  SPIRVDecorateCacheControlStoreINTEL(SPIRVEntry *TheTarget,
+                                      SPIRVWord CacheLevel,
+                                      StoreCacheControl CacheControl)
+      : SPIRVDecorate(DecorationCacheControlStoreINTEL, TheTarget, CacheLevel,
+                      static_cast<SPIRVWord>(CacheControl)) {}
 
-  SPIRVWord getCacheLevel() const { return Literals.at(0); };
-  spv::internal::StoreCacheControlINTEL getCacheControl() const {
-    return static_cast<spv::internal::StoreCacheControlINTEL>(Literals.at(1));
-  };
+  SPIRVWord getCacheLevel() const { return Literals.at(0); }
+  StoreCacheControl getCacheControl() const {
+    return static_cast<StoreCacheControl>(Literals.at(1));
+  }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -492,10 +492,9 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
                {CapabilityGlobalVariableFPGADecorationsINTEL});
   ADD_VEC_INIT(internal::DecorationArgumentAttributeINTEL,
                {CapabilityFunctionPointersINTEL});
-  ADD_VEC_INIT(internal::DecorationCacheControlLoadINTEL,
-               {internal::CapabilityCacheControlsINTEL});
-  ADD_VEC_INIT(internal::DecorationCacheControlStoreINTEL,
-               {internal::CapabilityCacheControlsINTEL});
+  ADD_VEC_INIT(DecorationCacheControlLoadINTEL, {CapabilityCacheControlsINTEL});
+  ADD_VEC_INIT(DecorationCacheControlStoreINTEL,
+               {CapabilityCacheControlsINTEL});
   ADD_VEC_INIT(DecorationConduitKernelArgumentINTEL,
                {CapabilityFPGAArgumentInterfacesINTEL});
   ADD_VEC_INIT(DecorationRegisterMapKernelArgumentINTEL,

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -208,6 +208,9 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationInitModeINTEL, "InitModeINTEL");
   add(DecorationImplementInRegisterMapINTEL, "ImplementInRegisterMapINTEL");
 
+  add(DecorationCacheControlLoadINTEL, "CacheControlLoadINTEL");
+  add(DecorationCacheControlStoreINTEL, "CacheControlStoreINTEL");
+
   // From spirv_internal.hpp
   add(internal::DecorationCallableFunctionINTEL, "CallableFunctionINTEL");
   add(internal::DecorationRuntimeAlignedINTEL, "RuntimeAlignedINTEL");
@@ -215,8 +218,6 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(internal::DecorationInitModeINTEL, "InitModeINTEL");
   add(internal::DecorationImplementInCSRINTEL, "ImplementInCSRINTEL");
   add(internal::DecorationArgumentAttributeINTEL, "ArgumentAttributeINTEL");
-  add(internal::DecorationCacheControlLoadINTEL, "CacheControlLoadINTEL");
-  add(internal::DecorationCacheControlStoreINTEL, "CacheControlStoreINTEL");
 
   add(DecorationMax, "Max");
 }

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -93,8 +93,6 @@ enum InternalDecoration {
   IDecInitModeINTEL = 6148,
   IDecImplementInCSRINTEL = 6149,
   IDecArgumentAttributeINTEL = 6409,
-  IDecCacheControlLoadINTEL = 6442,
-  IDecCacheControlStoreINTEL = 6443
 };
 
 enum InternalCapability {
@@ -151,21 +149,6 @@ enum InternalJointMatrixCTI {
 enum InternalBuiltIn {
   IBuiltInSubDeviceIDINTEL = 6135,
   IBuiltInGlobalHWThreadIDINTEL = 6136,
-};
-
-enum class LoadCacheControlINTEL {
-  Uncached = 0,
-  Cached = 1,
-  Streaming = 2,
-  InvalidateAfterRead = 3,
-  ConstCached = 4
-};
-
-enum class StoreCacheControlINTEL {
-  Uncached = 0,
-  WriteThrough = 1,
-  WriteBack = 2,
-  Streaming = 3
 };
 
 #define _SPIRV_OP(x, y) constexpr x x##y = static_cast<x>(I##x##y);
@@ -276,10 +259,6 @@ constexpr Decoration DecorationImplementInCSRINTEL =
     static_cast<Decoration>(IDecImplementInCSRINTEL);
 constexpr Decoration DecorationArgumentAttributeINTEL =
     static_cast<Decoration>(IDecArgumentAttributeINTEL);
-constexpr Decoration DecorationCacheControlLoadINTEL =
-    static_cast<Decoration>(IDecCacheControlLoadINTEL);
-constexpr Decoration DecorationCacheControlStoreINTEL =
-    static_cast<Decoration>(IDecCacheControlStoreINTEL);
 
 constexpr Capability CapabilityFastCompositeINTEL =
     static_cast<Capability>(ICapFastCompositeINTEL);


### PR DESCRIPTION
The Headers for this extension were published so we should use them instead:
https://github.com/KhronosGroup/SPIRV-Headers/commit/a8af2ce341cfd73a44a37bf62642a2cdf45938df