### PR TITLE
map to unordered_map for SPIRVIdToEntryMap type

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -484,7 +484,7 @@ private:
   SPIRVAddressingModelKind AddrModel;
   SPIRVMemoryModelKind MemoryModel;
 
-  typedef std::map<SPIRVId, SPIRVEntry *> SPIRVIdToEntryMap;
+  typedef std::unordered_map<SPIRVId, SPIRVEntry *> SPIRVIdToEntryMap;
   typedef std::set<SPIRVEntry *> SPIRVEntrySet;
   typedef std::set<SPIRVId> SPIRVIdSet;
   typedef std::vector<SPIRVId> SPIRVIdVec;


### PR DESCRIPTION
In cpp std::map type is a red-black tree implementation. It's search time is O(log N) and 
pointers are scattered through memory. 
In comparison unordered_map is a hash table which doesn't have the same iteration guarantees 
as red-black tree but it's search time is O(1) plus the constants like calculating hash function and 
load from the table.
The SPIRVModuleImpl::SPIRVIdToEntryMap is used in SPIRVModuleImpl::getEntry function which is widely used
as a key component of the parser.
It's a small fix but yields around 30% speedup for translation SPIR-V to IR.