### PR TITLE
[NFC] Use unordered_map for better performance

### DIFF
--- a/lib/SPIRV/Mangler/Mangler.cpp
+++ b/lib/SPIRV/Mangler/Mangler.cpp
@@ -66,7 +66,7 @@ public:
           ThistypeStr << NType;
       }
 #endif
-      std::map<std::string, unsigned>::iterator I =
+      std::unordered_map<std::string, unsigned>::iterator I =
           Substitutions.find(ThistypeStr.str());
       if (I == Substitutions.end())
         return false;
@@ -195,7 +195,7 @@ private:
   // Holds the mangled string representing the prototype of the function.
   std::stringstream &Stream;
   unsigned SeqId;
-  std::map<std::string, unsigned> Substitutions;
+  std::unordered_map<std::string, unsigned> Substitutions;
 };
 
 //

--- a/lib/SPIRV/Mangler/Mangler.cpp
+++ b/lib/SPIRV/Mangler/Mangler.cpp
@@ -15,7 +15,7 @@
 #include "NameMangleAPI.h"
 #include "ParameterType.h"
 #include <algorithm>
-#include <map>
+#include <unordered_map>
 #include <sstream>
 #include <string>
 

--- a/lib/SPIRV/Mangler/Mangler.cpp
+++ b/lib/SPIRV/Mangler/Mangler.cpp
@@ -15,9 +15,9 @@
 #include "NameMangleAPI.h"
 #include "ParameterType.h"
 #include <algorithm>
-#include <unordered_map>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 
 // According to IA64 name mangling spec,
 // builtin vector types should not be substituted

--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -68,7 +68,7 @@ private:
   llvm::Module *M;
   llvm::LLVMContext *Ctx;
   // Map of argument/Function -> adapted type (probably TypedPointerType)
-  std::map<llvm::Value *, llvm::Type *> AdaptedTy;
+  std::unordered_map<llvm::Value *, llvm::Type *> AdaptedTy;
   std::set<llvm::Function *> WorkSet; // Functions to be adapted
 
   void adaptFunctionArguments(llvm::Function *F);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -748,7 +748,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
   }
   if (LC & LoopControlDependencyArrayINTELMask) {
     // Collect pointer variable <-> safelen information
-    std::map<Value *, unsigned> PointerSflnMap;
+    std::unordered_map<Value *, unsigned> PointerSflnMap;
     unsigned NumOperandPairs = LoopControlParameters[NumParam];
     unsigned OperandsEndIndex = NumParam + NumOperandPairs * 2;
     assert(OperandsEndIndex <= LoopControlParameters.size() &&
@@ -763,7 +763,7 @@ void SPIRVToLLVM::setLLVMLoopMetadata(const LoopInstType *LM,
 
     // A single run over the loop to retrieve all GetElementPtr instructions
     // that access relevant array variables
-    std::map<Value *, std::vector<GetElementPtrInst *>> ArrayGEPMap;
+    std::unordered_map<Value *, std::vector<GetElementPtrInst *>> ArrayGEPMap;
     for (const auto &BB : LoopObj->blocks()) {
       for (Instruction &I : *BB) {
         auto *GEP = dyn_cast<GetElementPtrInst>(&I);

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -151,7 +151,8 @@ public:
   // A SPIRV value may be translated to a load instruction of a placeholder
   // global variable. This map records load instruction of these placeholders
   // which are supposed to be replaced by the real values later.
-  typedef std::unordered_map<SPIRVValue *, LoadInst *> SPIRVToLLVMPlaceholderMap;
+  typedef std::unordered_map<SPIRVValue *, LoadInst *>
+      SPIRVToLLVMPlaceholderMap;
 
   typedef std::unordered_map<const BasicBlock *, const SPIRVValue *>
       SPIRVToLLVMLoopMetadataMap;

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -151,9 +151,9 @@ public:
   // A SPIRV value may be translated to a load instruction of a placeholder
   // global variable. This map records load instruction of these placeholders
   // which are supposed to be replaced by the real values later.
-  typedef std::map<SPIRVValue *, LoadInst *> SPIRVToLLVMPlaceholderMap;
+  typedef std::unordered_map<SPIRVValue *, LoadInst *> SPIRVToLLVMPlaceholderMap;
 
-  typedef std::map<const BasicBlock *, const SPIRVValue *>
+  typedef std::unordered_map<const BasicBlock *, const SPIRVValue *>
       SPIRVToLLVMLoopMetadataMap;
 
   // Store all the allocations to Struct Types that are further

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5341,7 +5341,7 @@ LLVMToSPIRVBase::collectEntryPointInterfaces(SPIRVFunction *SF, Function *F) {
 }
 
 void LLVMToSPIRVBase::mutateFuncArgType(
-    const std::map<unsigned, Type *> &ChangedType, Function *F) {
+    const std::unordered_map<unsigned, Type *> &ChangedType, Function *F) {
   for (auto &I : ChangedType) {
     for (auto UI = F->user_begin(), UE = F->user_end(); UI != UE; ++UI) {
       auto *Call = dyn_cast<CallInst>(*UI);
@@ -5576,7 +5576,7 @@ bool LLVMToSPIRVBase::translate() {
 
   for (auto &F : *M) {
     auto *FT = F.getFunctionType();
-    std::map<unsigned, Type *> ChangedType;
+    std::unordered_map<unsigned, Type *> ChangedType;
     oclGetMutatedArgumentTypesByBuiltin(FT, ChangedType, &F);
     mutateFuncArgType(ChangedType, &F);
   }
@@ -5616,7 +5616,7 @@ llvm::IntegerType *LLVMToSPIRVBase::getSizetType(unsigned AS) {
 }
 
 void LLVMToSPIRVBase::oclGetMutatedArgumentTypesByBuiltin(
-    llvm::FunctionType *FT, std::map<unsigned, Type *> &ChangedType,
+    llvm::FunctionType *FT, std::unordered_map<unsigned, Type *> &ChangedType,
     Function *F) {
   StringRef Demangled;
   if (!oclIsBuiltin(F->getName(), Demangled))

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -227,10 +227,9 @@ private:
   bool oclGetExtInstIndex(const std::string &MangledName,
                           const std::string &DemangledName,
                           SPIRVWord *EntryPoint);
-  void
-  oclGetMutatedArgumentTypesByBuiltin(llvm::FunctionType *FT,
-                                      std::unordered_map<unsigned, Type *> &ChangedType,
-                                      Function *F);
+  void oclGetMutatedArgumentTypesByBuiltin(
+      llvm::FunctionType *FT, std::unordered_map<unsigned, Type *> &ChangedType,
+      Function *F);
   bool isBuiltinTransToInst(Function *F);
   bool isBuiltinTransToExtInst(Function *F,
                                SPIRVExtInstSetKind *BuiltinSet = nullptr,
@@ -244,8 +243,9 @@ private:
   SPIRVValue *transBuiltinToConstant(StringRef DemangledName, CallInst *CI);
   SPIRVInstruction *transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
                                                         SPIRVBasicBlock *BB);
-  void mutateFuncArgType(const std::unordered_map<unsigned, Type *> &ChangedType,
-                         Function *F);
+  void
+  mutateFuncArgType(const std::unordered_map<unsigned, Type *> &ChangedType,
+                    Function *F);
 
   SPIRVValue *transSpcvCast(CallInst *CI, SPIRVBasicBlock *BB);
   SPIRVValue *oclTransSpvcCastSampler(CallInst *CI, SPIRVBasicBlock *BB);

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -229,7 +229,7 @@ private:
                           SPIRVWord *EntryPoint);
   void
   oclGetMutatedArgumentTypesByBuiltin(llvm::FunctionType *FT,
-                                      std::map<unsigned, Type *> &ChangedType,
+                                      std::unordered_map<unsigned, Type *> &ChangedType,
                                       Function *F);
   bool isBuiltinTransToInst(Function *F);
   bool isBuiltinTransToExtInst(Function *F,
@@ -244,7 +244,7 @@ private:
   SPIRVValue *transBuiltinToConstant(StringRef DemangledName, CallInst *CI);
   SPIRVInstruction *transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
                                                         SPIRVBasicBlock *BB);
-  void mutateFuncArgType(const std::map<unsigned, Type *> &ChangedType,
+  void mutateFuncArgType(const std::unordered_map<unsigned, Type *> &ChangedType,
                          Function *F);
 
   SPIRVValue *transSpcvCast(CallInst *CI, SPIRVBasicBlock *BB);

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -760,7 +760,7 @@ namespace Operation {
 enum {
   OpCodeIdx = 0
 };
-static std::map<ExpressionOpCode, unsigned> OpCountMap {
+static std::unordered_map<ExpressionOpCode, unsigned> OpCountMap {
   { Deref,              1 },
   { Plus,               1 },
   { Minus,              1 },

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -80,7 +80,7 @@ SPIRVEntry *SPIRVEntry::create(Op OpCode) {
 #undef _SPIRV_OP
   };
 
-  typedef std::map<Op, SPIRVFactoryTy> OpToFactoryMapTy;
+  typedef std::unordered_map<Op, SPIRVFactoryTy> OpToFactoryMapTy;
   static const OpToFactoryMapTy OpToFactoryMap(std::begin(Table),
                                                std::end(Table));
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -500,12 +500,12 @@ private:
   typedef std::vector<SPIRVAsmTargetINTEL *> SPIRVAsmTargetVector;
   typedef std::vector<SPIRVAsmINTEL *> SPIRVAsmVector;
   typedef std::vector<SPIRVEntryPoint *> SPIRVEntryPointVec;
-  typedef std::map<SPIRVId, SPIRVExtInstSetKind> SPIRVIdToInstructionSetMap;
-  std::map<SPIRVExtInstSetKind, SPIRVId> ExtInstSetIds;
-  typedef std::map<SPIRVId, SPIRVExtInstSetKind> SPIRVIdToBuiltinSetMap;
-  typedef std::map<SPIRVExecutionModelKind, SPIRVIdSet> SPIRVExecModelIdSetMap;
+  typedef std::unordered_map<SPIRVId, SPIRVExtInstSetKind> SPIRVIdToInstructionSetMap;
+  std::unordered_map<SPIRVExtInstSetKind, SPIRVId> ExtInstSetIds;
+  typedef std::unordered_map<SPIRVId, SPIRVExtInstSetKind> SPIRVIdToBuiltinSetMap;
+  typedef std::unordered_map<SPIRVExecutionModelKind, SPIRVIdSet> SPIRVExecModelIdSetMap;
   typedef std::unordered_map<std::string, SPIRVString *> SPIRVStringMap;
-  typedef std::map<SPIRVTypeStruct *, std::vector<std::pair<unsigned, SPIRVId>>>
+  typedef std::unordered_map<SPIRVTypeStruct *, std::vector<std::pair<unsigned, SPIRVId>>>
       SPIRVUnknownStructFieldMap;
   typedef std::vector<SPIRVEntry *> SPIRVAliasInstMDVec;
   typedef std::unordered_map<llvm::MDNode *, SPIRVEntry *> SPIRVAliasInstMDMap;
@@ -539,7 +539,7 @@ private:
   SPIRVTypeVoid *VoidTy;
   SmallDenseMap<unsigned, SPIRVTypeInt *, 4> IntTypeMap;
   SmallDenseMap<unsigned, SPIRVTypeFloat *, 4> FloatTypeMap;
-  std::map<unsigned, SPIRVConstant *> LiteralMap;
+  std::unordered_map<unsigned, SPIRVConstant *> LiteralMap;
   std::vector<SPIRVExtInst *> DebugInstVec;
   std::vector<SPIRVExtInst *> AuxDataInstVec;
   std::vector<SPIRVModuleProcessed *> ModuleProcessedVec;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -500,12 +500,16 @@ private:
   typedef std::vector<SPIRVAsmTargetINTEL *> SPIRVAsmTargetVector;
   typedef std::vector<SPIRVAsmINTEL *> SPIRVAsmVector;
   typedef std::vector<SPIRVEntryPoint *> SPIRVEntryPointVec;
-  typedef std::unordered_map<SPIRVId, SPIRVExtInstSetKind> SPIRVIdToInstructionSetMap;
+  typedef std::unordered_map<SPIRVId, SPIRVExtInstSetKind>
+      SPIRVIdToInstructionSetMap;
   std::unordered_map<SPIRVExtInstSetKind, SPIRVId> ExtInstSetIds;
-  typedef std::unordered_map<SPIRVId, SPIRVExtInstSetKind> SPIRVIdToBuiltinSetMap;
-  typedef std::unordered_map<SPIRVExecutionModelKind, SPIRVIdSet> SPIRVExecModelIdSetMap;
+  typedef std::unordered_map<SPIRVId, SPIRVExtInstSetKind>
+      SPIRVIdToBuiltinSetMap;
+  typedef std::unordered_map<SPIRVExecutionModelKind, SPIRVIdSet>
+      SPIRVExecModelIdSetMap;
   typedef std::unordered_map<std::string, SPIRVString *> SPIRVStringMap;
-  typedef std::unordered_map<SPIRVTypeStruct *, std::vector<std::pair<unsigned, SPIRVId>>>
+  typedef std::unordered_map<SPIRVTypeStruct *,
+                             std::vector<std::pair<unsigned, SPIRVId>>>
       SPIRVUnknownStructFieldMap;
   typedef std::vector<SPIRVEntry *> SPIRVAliasInstMDVec;
   typedef std::unordered_map<llvm::MDNode *, SPIRVEntry *> SPIRVAliasInstMDMap;


### PR DESCRIPTION
Use unordered_map instead of map for better performance.