### PR TITLE
[NFCI] Prepare for non-instrinsic debug info

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5525,6 +5525,7 @@ void LLVMToSPIRVBase::transFunction(Function *I) {
   // is used to ensure blocks are written in the right order.
   const DominatorTree DT(*I);
   for (BasicBlock &FI : stablePreDominatorTraversal(*I, DT)) {
+    FI.convertFromNewDbgValues();
     transValue(&FI, nullptr);
   }
   for (auto &FI : *I) {

--- a/test/DebugInfo/DebugDeclareUnused.cl
+++ b/test/DebugInfo/DebugDeclareUnused.cl
@@ -5,6 +5,10 @@
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
+// RUN: %clang_cc1 %s -triple spir -disable-llvm-passes -debug-info-kind=standalone -emit-llvm-bc -o - | llvm-spirv -spirv-mem2reg -o %t.spv
+// RUN: llvm-spirv --experimental-debuginfo-iterators=1 %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv -r --experimental-debuginfo-iterators=1 %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
 
 void foo() {
   int a;

--- a/test/DebugInfo/DebugInfoLLVMArg.ll
+++ b/test/DebugInfo/DebugInfoLLVMArg.ll
@@ -15,6 +15,20 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-200
 
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions --experimental-debuginfo-iterators=1
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt --experimental-debuginfo-iterators=1
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV-OCL
+; RUN: llvm-spirv -r --experimental-debuginfo-iterators=1 %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-OCL
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200 --experimental-debuginfo-iterators=1
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt --experimental-debuginfo-iterators=1
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV-200
+; RUN: llvm-spirv -r --experimental-debuginfo-iterators=1 %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-200
+
 ; CHECK-SPIRV-200-DAG: TypeInt [[#INT32:]] 32 0
 ; CHECK-SPIRV-200-DAG: Constant [[#INT32:]] [[#CONST1:]] 1 {{$}}
 ; CHECK-SPIRV-200-DAG: Constant [[#INT32]] [[#CONST0:]] 0

--- a/test/DebugInfo/DebugInfoTypeInheritance.ll
+++ b/test/DebugInfo/DebugInfoTypeInheritance.ll
@@ -13,6 +13,21 @@
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
 
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt --experimental-debuginfo-iterators=1
+; RUN: FileCheck %s --input-file %t.spt --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-OCL
+; RUN: llvm-spirv %t.bc -o %t.spv --experimental-debuginfo-iterators=1
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --experimental-debuginfo-iterators=1
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-100 -o %t.spt --experimental-debuginfo-iterators=1
+; RUN: FileCheck %s --input-file %t.spt --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-NONSEM
+; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-100 -o %t.spv --experimental-debuginfo-iterators=1
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc --experimental-debuginfo-iterators=1
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
 ; CHECK-SPIRV: String [[#Str_C:]] "C"
 ; CHECK-SPIRV: String [[#Str_B:]] "B"
 ; CHECK-SPIRV: String [[#Str_A:]] "A"

--- a/test/DebugInfo/DebugInfoWithUnknownIntrinsics.ll
+++ b/test/DebugInfo/DebugInfoWithUnknownIntrinsics.ll
@@ -4,6 +4,12 @@
 ; RUN: llvm-dis %t.bc -o %t.ll
 ; RUN: FileCheck %s --input-file %t.ll  -check-prefix=LLVM
 
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+all --spirv-allow-unknown-intrinsics --experimental-debuginfo-iterators=1
+; RUN: llvm-spirv -r %t.spv -o %t.bc --experimental-debuginfo-iterators=1
+; RUN: llvm-dis %t.bc -o %t.ll
+; RUN: FileCheck %s --input-file %t.ll  -check-prefix=LLVM
+
 ; ModuleID = 'test.bc'
 source_filename = "test.cl"
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"

--- a/test/DebugInfo/expr-opcode.ll
+++ b/test/DebugInfo/expr-opcode.ll
@@ -13,6 +13,21 @@
 ; RUN: llc -mtriple=%triple -dwarf-version=5 -filetype=obj -O0 < %t.rev.ll
 ; RUN: llc -mtriple=%triple -dwarf-version=4 -filetype=obj -O0 < %t.rev.ll
 
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-allow-extra-diexpressions --experimental-debuginfo-iterators=1
+; RUN: llvm-spirv -r --experimental-debuginfo-iterators=1 %t.spv -o - | llvm-dis -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llc -mtriple=%triple -dwarf-version=5 -filetype=obj -O0 < %t.rev.ll
+; RUN: llc -mtriple=%triple -dwarf-version=4 -filetype=obj -O0 < %t.rev.ll
+
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200 --experimental-debuginfo-iterators=1
+; RUN: llvm-spirv -r --experimental-debuginfo-iterators=1 %t.spv -o - | llvm-dis -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llc -mtriple=%triple -dwarf-version=5 -filetype=obj -O0 < %t.rev.ll
+; RUN: llc -mtriple=%triple -dwarf-version=4 -filetype=obj -O0 < %t.rev.ll
+
 ; CHECK: DW_OP_constu, 42
 ; CHECK: DW_OP_plus_uconst, 42
 ; CHECK: DW_OP_plus


### PR DESCRIPTION
For now just convert BB with convertFromNewDbgValues, will figure out something smarter a bit later.

I've updated several tests with dbg.declare intrinsic adding --experimental-debuginfo-iterators=1 to check if it works.

Resolved https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2357 for now