### PR TITLE
Add SPIR-V 1.5 enum value

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -54,6 +54,7 @@ class IntrinsicInst;
 
 namespace SPIRV {
 
+/// SPIR-V versions known to translator.
 enum class VersionNumber : uint32_t {
   // See section 2.3 of SPIR-V spec: Physical Layout of a SPIR_V Module and
   // Instruction
@@ -62,10 +63,9 @@ enum class VersionNumber : uint32_t {
   SPIRV_1_2 = 0x00010200,
   SPIRV_1_3 = 0x00010300,
   SPIRV_1_4 = 0x00010400,
-  // TODO: populate this enum with the latest versions (up to 1.5) once
-  // translator get support of corresponding features
+  SPIRV_1_5 = 0x00010500,
   MinimumVersion = SPIRV_1_0,
-  MaximumVersion = SPIRV_1_4
+  MaximumVersion = SPIRV_1_5
 };
 
 inline constexpr std::string_view formatVersionNumber(uint32_t Version) {
@@ -80,6 +80,8 @@ inline constexpr std::string_view formatVersionNumber(uint32_t Version) {
     return "1.3";
   case static_cast<uint32_t>(VersionNumber::SPIRV_1_4):
     return "1.4";
+  case static_cast<uint32_t>(VersionNumber::SPIRV_1_5):
+    return "1.5";
   }
   return "unknown";
 }

--- a/test/negative/spirv-version-controls-1.spt
+++ b/test/negative/spirv-version-controls-1.spt
@@ -1,4 +1,4 @@
-119734787 66816 393230 12 0
+119734787 67072 393230 12 0
 2 Capability Addresses
 2 Capability Kernel
 5 ExtInstImport 1 "OpenCL.std"
@@ -29,5 +29,4 @@
 
 ; RUN: not llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
-; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (66816)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.4 (66560)
-
+; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (67072)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.5 (66816)

--- a/test/negative/spirv-version-controls-2.spt
+++ b/test/negative/spirv-version-controls-2.spt
@@ -29,6 +29,4 @@
 
 ; RUN: not llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
-; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (1024)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.4 (66560)
-
-
+; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (1024)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.5 (66816)

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -111,7 +111,9 @@ static cl::opt<VersionNumber> MaxSPIRVVersion(
                clEnumValN(VersionNumber::SPIRV_1_1, "1.1", "SPIR-V 1.1"),
                clEnumValN(VersionNumber::SPIRV_1_2, "1.2", "SPIR-V 1.2"),
                clEnumValN(VersionNumber::SPIRV_1_3, "1.3", "SPIR-V 1.3"),
-               clEnumValN(VersionNumber::SPIRV_1_4, "1.4", "SPIR-V 1.4")),
+               clEnumValN(VersionNumber::SPIRV_1_4, "1.4", "SPIR-V 1.4"),
+               clEnumValN(VersionNumber::SPIRV_1_5, "1.5",
+                          "SPIR-V 1.5 (experimental)")),
     cl::init(VersionNumber::MaximumVersion));
 
 static cl::list<std::string>


### PR DESCRIPTION
Recognize SPIR-V 1.5 modules and allow specifying the `--spirv-max-version=1.5` option.

This does not implement any SPIR-V 1.5 functionality yet, so mark 1.5 as "experimental".