### PR TITLE
Include `LLVMSPIRVLib.h` in `SPIRVError.cpp`

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVError.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVError.cpp
@@ -36,6 +36,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "LLVMSPIRVLib.h"
+
 #include "SPIRVError.h"
 #include <string>
 


### PR DESCRIPTION
The prototype for `getErrorMessage()` is declared in `LLVMSPIRVLib.h`, but `SPIRVError.cpp` defining that function did not include `LLVMSPIRVLib.h`.  This can be problematic for builds that use `-fvisibility=hidden`.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2376