### PR TITLE
[Backport to 18] Include `LLVMSPIRVLib.h` in `SPIRVError.cpp` (#2377)

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVError.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVError.cpp
@@ -36,6 +36,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "LLVMSPIRVLib.h"
+
 #include "SPIRVError.h"
 #include <string>
 


### PR DESCRIPTION
The prototype for `getErrorMessage()` is declared in `LLVMSPIRVLib.h`, but `SPIRVError.cpp` defining that function did not include `LLVMSPIRVLib.h`.  This can be problematic for builds that use `-fvisibility=hidden`.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2376

(cherry picked from commit 81f78d24db3662220d3c293f3ba0514fad3e0c94)