### PR TITLE
Add --spirv-ext-inst option

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -248,7 +248,7 @@ private:
   // SPIR-V to LLVM translation options
   bool GenKernelArgNameMD = false;
   std::unordered_map<uint32_t, uint64_t> ExternalSpecialization;
-  // External instructions to use when translating from LLVM IR to SPIR-V
+  // Extended instruction set to use when translating from LLVM IR to SPIR-V
   ExtInst ExtInstValue = ExtInst::None;
   // Representation of built-ins, which should be used while translating from
   // SPIR-V to back to LLVM IR

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -99,6 +99,8 @@ enum class ExtensionID : uint32_t {
   Last,
 };
 
+enum class ExtInst : uint32_t { None, OpenCL };
+
 enum class BIsRepresentation : uint32_t { OpenCL12, OpenCL20, SPIRVFriendlyIR };
 
 enum class FPContractMode : uint32_t { On, Off, Fast };
@@ -180,6 +182,16 @@ public:
     return true;
   }
 
+  void setExtInst(ExtInst Value) {
+    // --spirv-ext-inst supersedes --spirv-replace-fmuladd-with-ocl-mad
+    ReplaceLLVMFmulAddWithOpenCLMad = false;    
+    ExtInstValue = Value;
+  }
+
+  ExtInst getExtInst() const {
+    return ExtInstValue;
+  }
+  
   void setDesiredBIsRepresentation(BIsRepresentation Value) {
     DesiredRepresentationOfBIs = Value;
   }
@@ -238,6 +250,8 @@ private:
   // SPIR-V to LLVM translation options
   bool GenKernelArgNameMD = false;
   std::unordered_map<uint32_t, uint64_t> ExternalSpecialization;
+  // External instructions to use when translating from LLVM IR to SPIR-V
+  ExtInst ExtInstValue = ExtInst::None;
   // Representation of built-ins, which should be used while translating from
   // SPIR-V to back to LLVM IR
   BIsRepresentation DesiredRepresentationOfBIs = BIsRepresentation::OpenCL12;

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -184,14 +184,12 @@ public:
 
   void setExtInst(ExtInst Value) {
     // --spirv-ext-inst supersedes --spirv-replace-fmuladd-with-ocl-mad
-    ReplaceLLVMFmulAddWithOpenCLMad = false;    
+    ReplaceLLVMFmulAddWithOpenCLMad = false;
     ExtInstValue = Value;
   }
 
-  ExtInst getExtInst() const {
-    return ExtInstValue;
-  }
-  
+  ExtInst getExtInst() const { return ExtInstValue; }
+
   void setDesiredBIsRepresentation(BIsRepresentation Value) {
     DesiredRepresentationOfBIs = Value;
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4207,7 +4207,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     // instruction set, as it has the same semantic for FULL_PROFILE OpenCL
     // devices (implementation-defined for EMBEDDED_PROFILE).
     if (BM->shouldReplaceLLVMFmulAddWithOpenCLMad() ||
-        BM->getExtInst()==SPIRV::ExtInst::OpenCL) {
+        BM->getExtInst() == SPIRV::ExtInst::OpenCL) {
       std::vector<SPIRVValue *> Ops{transValue(II->getArgOperand(0), BB),
                                     transValue(II->getArgOperand(1), BB),
                                     transValue(II->getArgOperand(2), BB)};

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4206,7 +4206,8 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     // If allowed, let's replace llvm.fmuladd.* with mad from OpenCL extended
     // instruction set, as it has the same semantic for FULL_PROFILE OpenCL
     // devices (implementation-defined for EMBEDDED_PROFILE).
-    if (BM->shouldReplaceLLVMFmulAddWithOpenCLMad()) {
+    if (BM->shouldReplaceLLVMFmulAddWithOpenCLMad() ||
+        BM->getExtInst()==SPIRV::ExtInst::OpenCL) {
       std::vector<SPIRVValue *> Ops{transValue(II->getArgOperand(0), BB),
                                     transValue(II->getArgOperand(1), BB),
                                     transValue(II->getArgOperand(2), BB)};

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -570,6 +570,10 @@ public:
     return SPIRVEIS_Debug;
   }
 
+  ExtInst getExtInst() const {
+    return TranslationOpts.getExtInst();
+  }
+  
   BIsRepresentation getDesiredBIsRepresentation() const {
     return TranslationOpts.getDesiredBIsRepresentation();
   }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -570,10 +570,8 @@ public:
     return SPIRVEIS_Debug;
   }
 
-  ExtInst getExtInst() const {
-    return TranslationOpts.getExtInst();
-  }
-  
+  ExtInst getExtInst() const { return TranslationOpts.getExtInst(); }
+
   BIsRepresentation getDesiredBIsRepresentation() const {
     return TranslationOpts.getDesiredBIsRepresentation();
   }

--- a/test/llvm-intrinsics/fmuladd.ll
+++ b/test/llvm-intrinsics/fmuladd.ll
@@ -1,12 +1,22 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t-default.spv
-; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=true -o %t-replace.spv
-; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=false -o %t-break.spv
+; RUN: llvm-spirv %t-default.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,REPLACE
+
+; preferred option for controlling fmuladd generation
+; RUN: llvm-spirv %t.bc --spirv-ext-inst=OpenCL.std -o %t-replace.spv
+; RUN: llvm-spirv %t.bc --spirv-ext-inst=none -o %t-break.spv
 ; RUN: spirv-val %t-replace.spv
 ; RUN: spirv-val %t-break.spv
-; RUN: llvm-spirv %t-default.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,REPLACE
 ; RUN: llvm-spirv %t-replace.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,REPLACE
 ; RUN: llvm-spirv %t-break.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,BREAK
+
+; legacy option for controlling fmuladd generation
+; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=true -o %t-replace.legacy.spv
+; RUN: llvm-spirv %t.bc --spirv-replace-fmuladd-with-ocl-mad=false -o %t-break.legacy.spv
+; RUN: spirv-val %t-replace.legacy.spv
+; RUN: spirv-val %t-break.legacy.spv
+; RUN: llvm-spirv %t-replace.legacy.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,REPLACE
+; RUN: llvm-spirv %t-break.legacy.spv -to-text -o - | FileCheck %s --check-prefixes=COMMON,BREAK
 
 ; COMMON-NOT: llvm.fmuladd
 

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -135,14 +135,15 @@ static cl::opt<bool> SPIRVGenKernelArgNameMD(
     cl::desc("Enable generating OpenCL kernel argument name "
              "metadata"));
 
-static cl::opt<SPIRV::ExtInst> ExtInst(
-    "spirv-ext-inst",
-    cl::desc("Specify external instructions to use when "
-             "translating from LLVM IR to SPIR-V"),
-    cl::values(
-        clEnumValN(SPIRV::ExtInst::None, "none", "No external instructions"),
-        clEnumValN(SPIRV::ExtInst::OpenCL, "OpenCL.std", "OpenCL instructions")),
-    cl::init(SPIRV::ExtInst::None));
+static cl::opt<SPIRV::ExtInst>
+    ExtInst("spirv-ext-inst",
+            cl::desc("Specify external instructions to use when "
+                     "translating from LLVM IR to SPIR-V"),
+            cl::values(clEnumValN(SPIRV::ExtInst::None, "none",
+                                  "No external instructions"),
+                       clEnumValN(SPIRV::ExtInst::OpenCL, "OpenCL.std",
+                                  "OpenCL instructions")),
+            cl::init(SPIRV::ExtInst::None));
 
 static cl::opt<SPIRV::BIsRepresentation> BIsRepresentation(
     "spirv-target-env",
@@ -723,8 +724,10 @@ int main(int Ac, char **Av) {
       std::cout << "Error: --spirv-ext-inst cannot be used more than once\n";
       return -1;
     } else if (SPIRVReplaceLLVMFmulAddWithOpenCLMad.getNumOccurrences()) {
-      std::cout << "Error: --spirv-ext-inst and --spirv-replace-fmuladd-with-ocl-mad cannot be used together\n";
-      return -1;      
+      std::cout
+          << "Error: --spirv-ext-inst and --spirv-replace-fmuladd-with-ocl-mad "
+             "cannot be used together\n";
+      return -1;
     } else if (IsReverse) {
       errs() << "Note: --spirv-ext-inst option ignored as it only "
                 "affects translation from LLVM IR to SPIR-V";

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -135,16 +135,16 @@ static cl::opt<bool> SPIRVGenKernelArgNameMD(
     cl::desc("Enable generating OpenCL kernel argument name "
              "metadata"));
 
-static cl::opt<SPIRV::ExtInst>
-    ExtInst("spirv-ext-inst",
-            cl::desc("Specify the external instruction set to use when "
-                     "translating from a LLVM intrinsic function to SPIR-V.  "
-                     "Otherwise the LLVM intrinsic function will be emulated."),
-            cl::values(clEnumValN(SPIRV::ExtInst::None, "none",
-                                  "No external instructions"),
-                       clEnumValN(SPIRV::ExtInst::OpenCL, "OpenCL.std",
-                                  "OpenCL instructions")),
-            cl::init(SPIRV::ExtInst::None));
+static cl::opt<SPIRV::ExtInst> ExtInst(
+    "spirv-ext-inst",
+    cl::desc("Specify the extended instruction set to use when "
+             "translating from a LLVM intrinsic function to SPIR-V.  "
+             "If none, some LLVM intrinsic functions will be emulated."),
+    cl::values(clEnumValN(SPIRV::ExtInst::None, "none",
+                          "No extended instructions"),
+               clEnumValN(SPIRV::ExtInst::OpenCL, "OpenCL.std",
+                          "OpenCL.std extended instruction set")),
+    cl::init(SPIRV::ExtInst::None));
 
 static cl::opt<SPIRV::BIsRepresentation> BIsRepresentation(
     "spirv-target-env",
@@ -264,7 +264,7 @@ static cl::opt<SPIRV::DebugInfoEIS> DebugEIS(
 static cl::opt<bool> SPIRVReplaceLLVMFmulAddWithOpenCLMad(
     "spirv-replace-fmuladd-with-ocl-mad",
     cl::desc("Allow replacement of llvm.fmuladd.* intrinsic with OpenCL mad "
-             "instruction from OpenCL extended instruction set"),
+             "instruction from OpenCL extended instruction set (deprecated)"),
     cl::init(true));
 
 static cl::opt<SPIRV::BuiltinFormat> SPIRVBuiltinFormat(
@@ -722,12 +722,13 @@ int main(int Ac, char **Av) {
 
   if (ExtInst.getNumOccurrences() != 0) {
     if (ExtInst.getNumOccurrences() > 1) {
-      std::cout << "Error: --spirv-ext-inst cannot be used more than once\n";
+      errs() << "Error: --spirv-ext-inst cannot be used more than once\n";
       return -1;
     } else if (SPIRVReplaceLLVMFmulAddWithOpenCLMad.getNumOccurrences()) {
-      std::cout
+      errs()
           << "Error: --spirv-ext-inst and --spirv-replace-fmuladd-with-ocl-mad "
-             "cannot be used together\n";
+             "cannot be used together.  --spirv-replace-fmuladd-with-ocl-mad "
+             "is deprecated and --spirv-ext-inst is preferred.\n";
       return -1;
     } else if (IsReverse) {
       errs() << "Note: --spirv-ext-inst option ignored as it only "

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -137,8 +137,9 @@ static cl::opt<bool> SPIRVGenKernelArgNameMD(
 
 static cl::opt<SPIRV::ExtInst>
     ExtInst("spirv-ext-inst",
-            cl::desc("Specify external instructions to use when "
-                     "translating from LLVM IR to SPIR-V"),
+            cl::desc("Specify the external instruction set to use when "
+                     "translating from a LLVM intrinsic function to SPIR-V.  "
+                     "Otherwise the LLVM intrinsic function will be emulated."),
             cl::values(clEnumValN(SPIRV::ExtInst::None, "none",
                                   "No external instructions"),
                        clEnumValN(SPIRV::ExtInst::OpenCL, "OpenCL.std",

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -135,6 +135,15 @@ static cl::opt<bool> SPIRVGenKernelArgNameMD(
     cl::desc("Enable generating OpenCL kernel argument name "
              "metadata"));
 
+static cl::opt<SPIRV::ExtInst> ExtInst(
+    "spirv-ext-inst",
+    cl::desc("Specify external instructions to use when "
+             "translating from LLVM IR to SPIR-V"),
+    cl::values(
+        clEnumValN(SPIRV::ExtInst::None, "none", "No external instructions"),
+        clEnumValN(SPIRV::ExtInst::OpenCL, "OpenCL.std", "OpenCL instructions")),
+    cl::init(SPIRV::ExtInst::None));
+
 static cl::opt<SPIRV::BIsRepresentation> BIsRepresentation(
     "spirv-target-env",
     cl::desc("Specify a representation of different SPIR-V Instructions which "
@@ -708,6 +717,21 @@ int main(int Ac, char **Av) {
     return Ret;
 
   SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, ExtensionsStatus);
+
+  if (ExtInst.getNumOccurrences() != 0) {
+    if (ExtInst.getNumOccurrences() > 1) {
+      std::cout << "Error: --spirv-ext-inst cannot be used more than once\n";
+      return -1;
+    } else if (SPIRVReplaceLLVMFmulAddWithOpenCLMad.getNumOccurrences()) {
+      std::cout << "Error: --spirv-ext-inst and --spirv-replace-fmuladd-with-ocl-mad cannot be used together\n";
+      return -1;      
+    } else if (IsReverse) {
+      errs() << "Note: --spirv-ext-inst option ignored as it only "
+                "affects translation from LLVM IR to SPIR-V";
+    }
+    Opts.setExtInst(ExtInst);
+  }
+
   if (BIsRepresentation.getNumOccurrences() != 0) {
     if (!IsReverse) {
       errs() << "Note: --spirv-target-env option ignored as it only "


### PR DESCRIPTION
Add option --spirv-ext-inst=[none|OpenCL.std] to control what external instructions can be used when translating form LLVM IR to SPIR-V.