### PR TITLE
Fix GV initialized with undef translation

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -446,7 +446,7 @@ public:
       : SPIRVInstruction(TheInitializer ? 5 : 4, OpVariable, TheType, TheId,
                          TheBB, TheM),
         StorageClass(TheStorageClass) {
-    if (TheInitializer)
+    if (TheInitializer && !TheInitializer->isUndef())
       Initializer.push_back(TheInitializer->getId());
     Name = TheName;
     validate();

--- a/test/transcoding/undef-gv.ll
+++ b/test/transcoding/undef-gv.ll
@@ -1,0 +1,34 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: Decorate [[#Var:]] LinkageAttributes "v" Export
+; CHECK-SPIRV: Variable [[#]] [[#Var]] [[#]] {{$}}
+; CHECK-SPIRV-NOT: OpUndef
+
+; CHECK-LLVM: @v = common addrspace(1) global i32 0, align 4
+
+; ModuleID = 'after.bc'
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir64-unknown-unknown"
+
+@v = addrspace(1) global i32 undef, align 4
+
+!spirv.MemoryModel = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!spirv.Source = !{!1}
+!opencl.spir.version = !{!2}
+!opencl.ocl.version = !{!2}
+!opencl.used.extensions = !{!3}
+!opencl.used.optional.core.features = !{!3}
+!spirv.Generator = !{!4}
+
+!0 = !{i32 2, i32 2}
+!1 = !{i32 3, i32 200000}
+!2 = !{i32 2, i32 0}
+!3 = !{}
+!4 = !{i16 6, i16 14}


### PR DESCRIPTION
Previously the translator would create OpVariable with init field pointing to OpUndef. That is not conformant with the specification, so when LLVM GV is initialized with undef - we should skip initializer in SPIR-V.

Later in the reader it's likely to become zeroinitialized, but it depends on the linkage and storage class. Checking correctness of this logic goes outside of this patch.

Fixes part of https://github.com/intel/llvm/issues/9961