### PR TITLE
Fix TaskSequenceCreateINTEL instruction verification

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -3938,7 +3938,7 @@ protected:
             ->getZExtIntValue();
     SPVErrLog.checkError(
         GetCapacity >= 0, SPIRVEC_InvalidInstruction,
-        InstName + "\nGetCapacity must be unsigned 32 bit integer.\n");
+        InstName + "\nGetCapacity must be an unsigned 32-bit integer.\n");
 
     const int AsyncCapacity =
         static_cast<SPIRVConstant *>(
@@ -3946,7 +3946,7 @@ protected:
             ->getZExtIntValue();
     SPVErrLog.checkError(
         AsyncCapacity >= 0, SPIRVEC_InvalidInstruction,
-        InstName + "\nAsyncCapacity must be unsigned 32 bit integer.\n");
+        InstName + "\nAsyncCapacity must be an unsigned 32-bit integer.\n");
   }
 };
 

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -3932,20 +3932,20 @@ protected:
         ClusterMode >= -1 && ClusterMode <= 1, SPIRVEC_InvalidInstruction,
         InstName + "\nClusterMode valid values are -1, 0, 1.\n");
 
-    const uint32_t GetCapacity =
+    const int GetCapacity =
         static_cast<SPIRVConstant *>(
             const_cast<SPIRVTaskSequenceCreateINTELInst *>(this)->getOperand(3))
             ->getZExtIntValue();
     SPVErrLog.checkError(
-        GetCapacity, SPIRVEC_InvalidInstruction,
+        GetCapacity >= 0, SPIRVEC_InvalidInstruction,
         InstName + "\nGetCapacity must be unsigned 32 bit integer.\n");
 
-    const uint32_t AsyncCapacity =
+    const int AsyncCapacity =
         static_cast<SPIRVConstant *>(
             const_cast<SPIRVTaskSequenceCreateINTELInst *>(this)->getOperand(4))
             ->getZExtIntValue();
     SPVErrLog.checkError(
-        AsyncCapacity, SPIRVEC_InvalidInstruction,
+        AsyncCapacity >= 0, SPIRVEC_InvalidInstruction,
         InstName + "\nAsyncCapacity must be unsigned 32 bit integer.\n");
   }
 };

--- a/test/extensions/INTEL/SPV_INTEL_task_sequence/negative/invalid_async_capacity.ll
+++ b/test/extensions/INTEL/SPV_INTEL_task_sequence/negative/invalid_async_capacity.ll
@@ -4,7 +4,7 @@
 
 ; CHECK-ERROR: InvalidInstruction: Can't translate llvm instruction:
 ; CHECK-ERROR-NEXT: TaskSequenceCreateINTEL
-; CHECK-ERROR-NEXT: AsyncCapacity must be unsigned 32 bit integer
+; CHECK-ERROR-NEXT: AsyncCapacity must be an unsigned 32-bit integer
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"

--- a/test/extensions/INTEL/SPV_INTEL_task_sequence/negative/invalid_async_capacity.ll
+++ b/test/extensions/INTEL/SPV_INTEL_task_sequence/negative/invalid_async_capacity.ll
@@ -1,0 +1,59 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_task_sequence 2>&1 \
+; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
+
+; CHECK-ERROR: InvalidInstruction: Can't translate llvm instruction:
+; CHECK-ERROR-NEXT: TaskSequenceCreateINTEL
+; CHECK-ERROR-NEXT: AsyncCapacity must be unsigned 32 bit integer
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+%"class.task_sequence" = type { target("spirv.TaskSequenceINTEL") }
+
+$_ZTS8MyKernel = comdat any
+
+; Function Attrs: convergent mustprogress norecurse nounwind
+define weak_odr dso_local spir_kernel void @_ZTS8MyKernel(ptr addrspace(1) noundef align 4 %_arg_in, ptr addrspace(1) noundef align 4 %_arg_res) local_unnamed_addr #0 comdat !srcloc !5 !kernel_arg_buffer_location !6 !sycl_fixed_targets !7 !sycl_kernel_omit_args !8 !stall_enable !9 {
+entry:
+  %myMultTask.i = alloca %"class.task_sequence", align 8
+  store i32 0, ptr %myMultTask.i, align 8
+  %call.i1 = call spir_func noundef target("spirv.TaskSequenceINTEL") @_Z31__spirv_TaskSequenceCreateINTEL(ptr noundef nonnull @_Z4multii, i32 noundef 10, i32 noundef -1, i32 noundef 17, i32 noundef zeroext -1) #3
+  %id.i = getelementptr inbounds %"class.task_sequence", ptr %myMultTask.i, i64 0, i32 0
+  store target("spirv.TaskSequenceINTEL") %call.i1, ptr %id.i, align 8
+  ret void
+}
+
+; Function Attrs: mustprogress norecurse nounwind
+define linkonce_odr dso_local spir_func noundef i32 @_Z4multii(i32 noundef %a, i32 noundef %b) #1 !srcloc !10 {
+entry:
+  %mul = mul nsw i32 %a, %b
+  ret i32 %mul
+}
+
+; Function Attrs: convergent nounwind
+declare dso_local spir_func noundef target("spirv.TaskSequenceINTEL") @_Z31__spirv_TaskSequenceCreateINTEL(ptr noundef, i32 noundef, i32 noundef, i32 noundef, i32 noundef zeroext) local_unnamed_addr #2
+
+attributes #0 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-fpga-cluster"="1" "sycl-module-id"="test.cpp" "sycl-optlevel"="2" "sycl-single-task" "uniform-work-group-size"="true" }
+attributes #1 = { mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-optlevel"="2" }
+attributes #2 = { convergent nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #3 = { convergent nounwind }
+
+!opencl.spir.version = !{!0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0}
+!spirv.Source = !{!1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1}
+!llvm.ident = !{!2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2}
+!llvm.module.flags = !{!3, !4}
+!sycl.specialization-constants = !{}
+!sycl.specialization-constants-default-values = !{}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 4, i32 100000}
+!2 = !{!"clang version 18.0.0git (https://github.com/bowenxue-intel/llvm.git bb1121cb47589e94ab65b81971a298b9d2c21ff6)"}
+!3 = !{i32 1, !"wchar_size", i32 4}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{i32 5445863}
+!6 = !{i32 -1, i32 -1}
+!7 = !{}
+!8 = !{i1 false, i1 false}
+!9 = !{i1 true}
+!10 = !{i32 5445350}

--- a/test/extensions/INTEL/SPV_INTEL_task_sequence/negative/invalid_get_capacity.ll
+++ b/test/extensions/INTEL/SPV_INTEL_task_sequence/negative/invalid_get_capacity.ll
@@ -1,0 +1,59 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_task_sequence 2>&1 \
+; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
+
+; CHECK-ERROR: InvalidInstruction: Can't translate llvm instruction:
+; CHECK-ERROR-NEXT: TaskSequenceCreateINTEL
+; CHECK-ERROR-NEXT: GetCapacity must be unsigned 32 bit integer.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+%"class.task_sequence" = type { target("spirv.TaskSequenceINTEL") }
+
+$_ZTS8MyKernel = comdat any
+
+; Function Attrs: convergent mustprogress norecurse nounwind
+define weak_odr dso_local spir_kernel void @_ZTS8MyKernel(ptr addrspace(1) noundef align 4 %_arg_in, ptr addrspace(1) noundef align 4 %_arg_res) local_unnamed_addr #0 comdat !srcloc !5 !kernel_arg_buffer_location !6 !sycl_fixed_targets !7 !sycl_kernel_omit_args !8 !stall_enable !9 {
+entry:
+  %myMultTask.i = alloca %"class.task_sequence", align 8
+  store i32 0, ptr %myMultTask.i, align 8
+  %call.i1 = call spir_func noundef target("spirv.TaskSequenceINTEL") @_Z31__spirv_TaskSequenceCreateINTEL(ptr noundef nonnull @_Z4multii, i32 noundef 10, i32 noundef -1, i32 noundef -1, i16 noundef zeroext 1) #3
+  %id.i = getelementptr inbounds %"class.task_sequence", ptr %myMultTask.i, i64 0, i32 0
+  store target("spirv.TaskSequenceINTEL") %call.i1, ptr %id.i, align 8
+  ret void
+}
+
+; Function Attrs: mustprogress norecurse nounwind
+define linkonce_odr dso_local spir_func noundef i32 @_Z4multii(i32 noundef %a, i32 noundef %b) #1 !srcloc !10 {
+entry:
+  %mul = mul nsw i32 %a, %b
+  ret i32 %mul
+}
+
+; Function Attrs: convergent nounwind
+declare dso_local spir_func noundef target("spirv.TaskSequenceINTEL") @_Z31__spirv_TaskSequenceCreateINTEL(ptr noundef, i32 noundef, i32 noundef, i32 noundef, i16 noundef zeroext) local_unnamed_addr #2
+
+attributes #0 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-fpga-cluster"="1" "sycl-module-id"="test.cpp" "sycl-optlevel"="2" "sycl-single-task" "uniform-work-group-size"="true" }
+attributes #1 = { mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-optlevel"="2" }
+attributes #2 = { convergent nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #3 = { convergent nounwind }
+
+!opencl.spir.version = !{!0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0, !0}
+!spirv.Source = !{!1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1, !1}
+!llvm.ident = !{!2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2, !2}
+!llvm.module.flags = !{!3, !4}
+!sycl.specialization-constants = !{}
+!sycl.specialization-constants-default-values = !{}
+
+!0 = !{i32 1, i32 2}
+!1 = !{i32 4, i32 100000}
+!2 = !{!"clang version 18.0.0git (https://github.com/bowenxue-intel/llvm.git bb1121cb47589e94ab65b81971a298b9d2c21ff6)"}
+!3 = !{i32 1, !"wchar_size", i32 4}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{i32 5445863}
+!6 = !{i32 -1, i32 -1}
+!7 = !{}
+!8 = !{i1 false, i1 false}
+!9 = !{i1 true}
+!10 = !{i32 5445350}

--- a/test/extensions/INTEL/SPV_INTEL_task_sequence/task_sequence.ll
+++ b/test/extensions/INTEL/SPV_INTEL_task_sequence/task_sequence.ll
@@ -50,7 +50,7 @@
 ; CHECK-SPIRV: TypePointer [[#PtrTS:]] 7 [[#TypeTS]]
 
 ; <id> Result Type <id> Result <id> Function Literal Pipelined Literal UseStallEnableClusters Literal GetCapacity Literal AsyncCapacity
-; CHECK-SPIRV: TaskSequenceCreateINTEL [[#TypeTS]] [[#CreateRes:]] [[#FuncId:]] 10 4294967295 17 1
+; CHECK-SPIRV: TaskSequenceCreateINTEL [[#TypeTS]] [[#CreateRes:]] [[#FuncId:]] 10 4294967295 17 0
 ; CHECK-SPIRV: InBoundsPtrAccessChain [[#PtrTS]] [[#GEP:]]
 ; CHECK-SPIRV: Store [[#GEP]] [[#CreateRes]]
 
@@ -80,9 +80,9 @@ define weak_odr dso_local spir_kernel void @_ZTS8MyKernel(ptr addrspace(1) nound
 entry:
   %myMultTask.i = alloca %"class.sycl::_V1::ext::intel::experimental::task_sequence.3", align 8
   store i32 0, ptr %myMultTask.i, align 8, !tbaa !10
-; CHECK-LLVM: %[[TSCreate:[a-z0-9.]+]] = call spir_func target("spirv.TaskSequenceINTEL") @_Z66__spirv_TaskSequenceCreateINTEL_RPU3AS125__spirv_TaskSequenceINTELPiiiii(ptr @_Z4multii, i32 10, i32 -1, i32 17, i32 1)
+; CHECK-LLVM: %[[TSCreate:[a-z0-9.]+]] = call spir_func target("spirv.TaskSequenceINTEL") @_Z66__spirv_TaskSequenceCreateINTEL_RPU3AS125__spirv_TaskSequenceINTELPiiiii(ptr @_Z4multii, i32 10, i32 -1, i32 17, i32 0)
 ; CHECK-LLVM: store target("spirv.TaskSequenceINTEL") %[[TSCreate]], ptr %id.i
-  %call.i1 = call spir_func noundef target("spirv.TaskSequenceINTEL") @_Z31__spirv_TaskSequenceCreateINTELIN4sycl3_V13ext5intel12experimental13task_sequenceIL_Z4multiiENS2_6oneapi12experimental10propertiesISt5tupleIJNS7_14property_valueINS4_13pipelined_keyEJSt17integral_constantIiLin1EEEEENSA_INS4_16fpga_cluster_keyEJSC_INS4_25fpga_cluster_options_enumELSG_1EEEEENSA_INS4_12balanced_keyEJEEENSA_INS4_23invocation_capacity_keyEJSC_IjLj10EEEEENSA_INS4_21response_capacity_keyEJSC_IjLj17EEEEEEEEEEEiJiiEEmPT_PFT0_DpT1_Ejjit(ptr noundef nonnull @_Z4multii, i32 noundef 10, i32 noundef -1, i32 noundef 17, i16 noundef zeroext 1) #3
+  %call.i1 = call spir_func noundef target("spirv.TaskSequenceINTEL") @_Z31__spirv_TaskSequenceCreateINTELIN4sycl3_V13ext5intel12experimental13task_sequenceIL_Z4multiiENS2_6oneapi12experimental10propertiesISt5tupleIJNS7_14property_valueINS4_13pipelined_keyEJSt17integral_constantIiLin1EEEEENSA_INS4_16fpga_cluster_keyEJSC_INS4_25fpga_cluster_options_enumELSG_1EEEEENSA_INS4_12balanced_keyEJEEENSA_INS4_23invocation_capacity_keyEJSC_IjLj10EEEEENSA_INS4_21response_capacity_keyEJSC_IjLj17EEEEEEEEEEEiJiiEEmPT_PFT0_DpT1_Ejjit(ptr noundef nonnull @_Z4multii, i32 noundef 10, i32 noundef -1, i32 noundef 17, i16 noundef zeroext 0) #3
   %id.i = getelementptr inbounds %"class.sycl::_V1::ext::intel::experimental::task_sequence.3", ptr %myMultTask.i, i64 0, i32 0
   store target("spirv.TaskSequenceINTEL") %call.i1, ptr %id.i, align 8, !tbaa !16
   br label %for.cond.i

--- a/test/extensions/INTEL/SPV_INTEL_task_sequence/task_sequence.ll
+++ b/test/extensions/INTEL/SPV_INTEL_task_sequence/task_sequence.ll
@@ -50,7 +50,7 @@
 ; CHECK-SPIRV: TypePointer [[#PtrTS:]] 7 [[#TypeTS]]
 
 ; <id> Result Type <id> Result <id> Function Literal Pipelined Literal UseStallEnableClusters Literal GetCapacity Literal AsyncCapacity
-; CHECK-SPIRV: TaskSequenceCreateINTEL [[#TypeTS]] [[#CreateRes:]] [[#FuncId:]] 10 4294967295 17 0
+; CHECK-SPIRV: TaskSequenceCreateINTEL [[#TypeTS]] [[#CreateRes:]] [[#FuncId:]] 10 4294967295 17 1
 ; CHECK-SPIRV: InBoundsPtrAccessChain [[#PtrTS]] [[#GEP:]]
 ; CHECK-SPIRV: Store [[#GEP]] [[#CreateRes]]
 
@@ -80,9 +80,9 @@ define weak_odr dso_local spir_kernel void @_ZTS8MyKernel(ptr addrspace(1) nound
 entry:
   %myMultTask.i = alloca %"class.sycl::_V1::ext::intel::experimental::task_sequence.3", align 8
   store i32 0, ptr %myMultTask.i, align 8, !tbaa !10
-; CHECK-LLVM: %[[TSCreate:[a-z0-9.]+]] = call spir_func target("spirv.TaskSequenceINTEL") @_Z66__spirv_TaskSequenceCreateINTEL_RPU3AS125__spirv_TaskSequenceINTELPiiiii(ptr @_Z4multii, i32 10, i32 -1, i32 17, i32 0)
+; CHECK-LLVM: %[[TSCreate:[a-z0-9.]+]] = call spir_func target("spirv.TaskSequenceINTEL") @_Z66__spirv_TaskSequenceCreateINTEL_RPU3AS125__spirv_TaskSequenceINTELPiiiii(ptr @_Z4multii, i32 10, i32 -1, i32 17, i32 1)
 ; CHECK-LLVM: store target("spirv.TaskSequenceINTEL") %[[TSCreate]], ptr %id.i
-  %call.i1 = call spir_func noundef target("spirv.TaskSequenceINTEL") @_Z31__spirv_TaskSequenceCreateINTELIN4sycl3_V13ext5intel12experimental13task_sequenceIL_Z4multiiENS2_6oneapi12experimental10propertiesISt5tupleIJNS7_14property_valueINS4_13pipelined_keyEJSt17integral_constantIiLin1EEEEENSA_INS4_16fpga_cluster_keyEJSC_INS4_25fpga_cluster_options_enumELSG_1EEEEENSA_INS4_12balanced_keyEJEEENSA_INS4_23invocation_capacity_keyEJSC_IjLj10EEEEENSA_INS4_21response_capacity_keyEJSC_IjLj17EEEEEEEEEEEiJiiEEmPT_PFT0_DpT1_Ejjit(ptr noundef nonnull @_Z4multii, i32 noundef 10, i32 noundef -1, i32 noundef 17, i16 noundef zeroext 0) #3
+  %call.i1 = call spir_func noundef target("spirv.TaskSequenceINTEL") @_Z31__spirv_TaskSequenceCreateINTELIN4sycl3_V13ext5intel12experimental13task_sequenceIL_Z4multiiENS2_6oneapi12experimental10propertiesISt5tupleIJNS7_14property_valueINS4_13pipelined_keyEJSt17integral_constantIiLin1EEEEENSA_INS4_16fpga_cluster_keyEJSC_INS4_25fpga_cluster_options_enumELSG_1EEEEENSA_INS4_12balanced_keyEJEEENSA_INS4_23invocation_capacity_keyEJSC_IjLj10EEEEENSA_INS4_21response_capacity_keyEJSC_IjLj17EEEEEEEEEEEiJiiEEmPT_PFT0_DpT1_Ejjit(ptr noundef nonnull @_Z4multii, i32 noundef 10, i32 noundef -1, i32 noundef 17, i16 noundef zeroext 1) #3
   %id.i = getelementptr inbounds %"class.sycl::_V1::ext::intel::experimental::task_sequence.3", ptr %myMultTask.i, i64 0, i32 0
   store target("spirv.TaskSequenceINTEL") %call.i1, ptr %id.i, align 8, !tbaa !16
   br label %for.cond.i


### PR DESCRIPTION
This patch fixes verification of Get/Async Capacity literals making translator accept zero values which are valid by spec.