### PR TITLE
Handle OpVectorShuffle with differing vector sizes

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -60,6 +60,7 @@ using namespace llvm;
 
 namespace llvm {
 class IntrinsicInst;
+class IRBuilderBase;
 }
 
 namespace SPIRV {
@@ -551,6 +552,10 @@ void saveLLVMModule(Module *M, const std::string &OutputFile);
 std::string mapLLVMTypeToOCLType(const Type *Ty, bool Signed,
                                  Type *PointerElementType = nullptr);
 SPIRVDecorate *mapPostfixToDecorate(StringRef Postfix, SPIRVEntry *Target);
+
+/// Return vector V extended with poison elements to match the number of
+/// components of NewType.
+Value *extendVector(Value *V, FixedVectorType *NewType, IRBuilderBase &Builder);
 
 /// Add decorations to a SPIR-V entry.
 /// \param Decs Each string is a postfix without _ at the beginning.

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2225,15 +2225,11 @@ public:
 protected:
   void validate() const override {
     SPIRVInstruction::validate();
-    SPIRVId Vector1 = Ops[0];
-    SPIRVId Vector2 = Ops[1];
+    [[maybe_unused]] SPIRVId Vector1 = Ops[0];
     assert(OpCode == OpVectorShuffle);
     assert(Type->isTypeVector());
     assert(Type->getVectorComponentType() ==
            getValueType(Vector1)->getVectorComponentType());
-    if (getValue(Vector1)->isForward() || getValue(Vector2)->isForward())
-      return;
-    assert(getValueType(Vector1) == getValueType(Vector2));
     assert(Ops.size() - 2 == Type->getVectorComponentCount());
   }
 };

--- a/test/OpVectorShuffle.spvasm
+++ b/test/OpVectorShuffle.spvasm
@@ -25,7 +25,7 @@
                ; vec1 smaller than vec2
         %vs2 = OpVectorShuffle %uintv4 %pv2 %pv3 0 1 3 4
 ; CHECK: %[[VS2EXT:[0-9a-z]+]] = shufflevector <2 x i32> %0, <2 x i32> poison, <3 x i32> <i32 0, i32 1, i32 poison>
-; CHECK: shufflevector <3 x i32> %[[VS2EXT]], <3 x i32> %[[#]], <4 x i32> <i32 0, i32 1, i32 3, i32 4>
+; CHECK: shufflevector <3 x i32> %[[VS2EXT]], <3 x i32> %[[#]], <4 x i32> <i32 0, i32 1, i32 4, i32 5>
 
                ; vec1 larger than vec2
         %vs3 = OpVectorShuffle %uintv4 %pv3 %pv2 0 1 3 4

--- a/test/OpVectorShuffle.spvasm
+++ b/test/OpVectorShuffle.spvasm
@@ -1,0 +1,36 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %1 "testVecShuffle"
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+     %uintv2 = OpTypeVector %uint 2
+     %uintv3 = OpTypeVector %uint 3
+     %uintv4 = OpTypeVector %uint 4
+       %func = OpTypeFunction %void %uintv2 %uintv3
+
+          %1 = OpFunction %void None %func
+        %pv2 = OpFunctionParameter %uintv2
+        %pv3 = OpFunctionParameter %uintv3
+      %entry = OpLabel
+
+               ; Same vector lengths
+        %vs1 = OpVectorShuffle %uintv4 %pv3 %pv3 0 1 3 5
+; CHECK: shufflevector <3 x i32> %[[#]], <3 x i32> %[[#]], <4 x i32> <i32 0, i32 1, i32 3, i32 5>
+
+               ; vec1 smaller than vec2
+        %vs2 = OpVectorShuffle %uintv4 %pv2 %pv3 0 1 3 4
+; CHECK: %[[VS2EXT:[0-9a-z]+]] = shufflevector <2 x i32> %0, <2 x i32> poison, <3 x i32> <i32 0, i32 1, i32 poison>
+; CHECK: shufflevector <3 x i32> %[[VS2EXT]], <3 x i32> %[[#]], <4 x i32> <i32 0, i32 1, i32 3, i32 4>
+
+               ; vec1 larger than vec2
+        %vs3 = OpVectorShuffle %uintv4 %pv3 %pv2 0 1 3 4
+; CHECK: %[[VS3EXT:[0-9a-z]+]] = shufflevector <2 x i32> %0, <2 x i32> poison, <3 x i32> <i32 0, i32 1, i32 poison>
+; CHECK: shufflevector <3 x i32> %[[#]], <3 x i32> %[[VS3EXT]], <4 x i32> <i32 0, i32 1, i32 3, i32 4>
+
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
The SPIR-V to LLVM conversion would bail out when encountering an `OpVectorShuffle` whose vector operands differ in size.  SPIR-V allows differing vector sizes, but LLVM's `shufflevector` does not.

Remove the assert and insert an additional `shufflevector` to align the vector operands when needed.