### PR TITLE
Add IAddCarry and ISubBorrow builtins

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2480,20 +2480,12 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return mapValue(BV,
                     transRelational(static_cast<SPIRVInstruction *>(BV), BB));
   case OpIAddCarry: {
-    IRBuilder Builder(BB);
     auto *BC = static_cast<SPIRVBinary *>(BV);
-    return mapValue(BV, Builder.CreateBinaryIntrinsic(
-                            Intrinsic::uadd_with_overflow,
-                            transValue(BC->getOperand(0), F, BB),
-                            transValue(BC->getOperand(1), F, BB)));
+    return mapValue(BV, transBuiltinFromInst("__spirv_IAddCarry", BC, BB));    
   }
   case OpISubBorrow: {
-    IRBuilder Builder(BB);
     auto *BC = static_cast<SPIRVBinary *>(BV);
-    return mapValue(BV, Builder.CreateBinaryIntrinsic(
-                            Intrinsic::usub_with_overflow,
-                            transValue(BC->getOperand(0), F, BB),
-                            transValue(BC->getOperand(1), F, BB)));
+    return mapValue(BV, transBuiltinFromInst("__spirv_ISubBorrow", BC, BB));    
   }
   case OpGetKernelWorkGroupSize:
   case OpGetKernelPreferredWorkGroupSizeMultiple:

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2481,11 +2481,11 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
                     transRelational(static_cast<SPIRVInstruction *>(BV), BB));
   case OpIAddCarry: {
     auto *BC = static_cast<SPIRVBinary *>(BV);
-    return mapValue(BV, transBuiltinFromInst("__spirv_IAddCarry", BC, BB));    
+    return mapValue(BV, transBuiltinFromInst("__spirv_IAddCarry", BC, BB));
   }
   case OpISubBorrow: {
     auto *BC = static_cast<SPIRVBinary *>(BV);
-    return mapValue(BV, transBuiltinFromInst("__spirv_ISubBorrow", BC, BB));    
+    return mapValue(BV, transBuiltinFromInst("__spirv_ISubBorrow", BC, BB));
   }
   case OpGetKernelWorkGroupSize:
   case OpGetKernelPreferredWorkGroupSizeMultiple:

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2190,7 +2190,6 @@ bool postProcessBuiltinReturningStruct(Function *F) {
       }
       SmallVector<Type *> ArgTys;
       getFunctionTypeParameterTypes(F->getFunctionType(), ArgTys);
-      
       ArgTys.insert(ArgTys.begin(), A->getType());
       auto *NewF =
           getOrCreateFunction(M, Type::getVoidTy(*Context), ArgTys, Name);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -65,7 +65,6 @@
 #include "SPIRVUtil.h"
 #include "SPIRVValue.h"
 #include "VectorComputeUtil.h"
-#include "spirv/unified1/spirv.hpp"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSwitch.h"

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6388,16 +6388,16 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
     Function *F = CI->getCalledFunction();
     StructType *St = cast<StructType>(F->getParamStructRetType(0));
     SPIRVValue *V = BM->addBinaryInst(OpIAddCarry, transType(St),
-                      transValue(CI->getArgOperand(1), BB),
-                      transValue(CI->getArgOperand(2), BB), BB);
+                                      transValue(CI->getArgOperand(1), BB),
+                                      transValue(CI->getArgOperand(2), BB), BB);
     return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), V, {}, BB);
   }
   case OpISubBorrow: {
     Function *F = CI->getCalledFunction();
     StructType *St = cast<StructType>(F->getParamStructRetType(0));
     SPIRVValue *V = BM->addBinaryInst(OpISubBorrow, transType(St),
-                             transValue(CI->getArgOperand(1), BB),
-                             transValue(CI->getArgOperand(2), BB), BB);
+                                      transValue(CI->getArgOperand(1), BB),
+                                      transValue(CI->getArgOperand(2), BB), BB);
     return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), V, {}, BB);
   }
   case OpGroupNonUniformShuffleDown: {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -65,6 +65,7 @@
 #include "SPIRVUtil.h"
 #include "SPIRVValue.h"
 #include "VectorComputeUtil.h"
+#include "spirv/unified1/spirv.hpp"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -6382,6 +6383,20 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
         transValue(CI->getArgOperand(0), BB)->getId()};
     return BM->addCompositeConstructInst(transType(CI->getType()), Operands,
                                          BB);
+  }
+  case OpIAddCarry: {
+    Function *F = CI->getCalledFunction();
+    StructType *St = cast<StructType>(F->getParamStructRetType(0));
+    return BM->addBinaryInst(OpIAddCarry, transType(St),
+                             transValue(CI->getArgOperand(1), BB),
+                             transValue(CI->getArgOperand(2), BB), BB);
+  }
+  case OpISubBorrow: {
+    Function *F = CI->getCalledFunction();
+    StructType *St = cast<StructType>(F->getParamStructRetType(0));
+    return BM->addBinaryInst(OpISubBorrow, transType(St),
+                             transValue(CI->getArgOperand(1), BB),
+                             transValue(CI->getArgOperand(2), BB), BB);
   }
   case OpGroupNonUniformShuffleDown: {
     Function *F = CI->getCalledFunction();

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6387,16 +6387,18 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
   case OpIAddCarry: {
     Function *F = CI->getCalledFunction();
     StructType *St = cast<StructType>(F->getParamStructRetType(0));
-    return BM->addBinaryInst(OpIAddCarry, transType(St),
-                             transValue(CI->getArgOperand(1), BB),
-                             transValue(CI->getArgOperand(2), BB), BB);
+    SPIRVValue *V = BM->addBinaryInst(OpIAddCarry, transType(St),
+                      transValue(CI->getArgOperand(1), BB),
+                      transValue(CI->getArgOperand(2), BB), BB);
+    return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), V, {}, BB);
   }
   case OpISubBorrow: {
     Function *F = CI->getCalledFunction();
     StructType *St = cast<StructType>(F->getParamStructRetType(0));
-    return BM->addBinaryInst(OpISubBorrow, transType(St),
+    SPIRVValue *V = BM->addBinaryInst(OpISubBorrow, transType(St),
                              transValue(CI->getArgOperand(1), BB),
                              transValue(CI->getArgOperand(2), BB), BB);
+    return BM->addStoreInst(transValue(CI->getArgOperand(0), BB), V, {}, BB);
   }
   case OpGroupNonUniformShuffleDown: {
     Function *F = CI->getCalledFunction();

--- a/test/iaddcarry_builtin.ll
+++ b/test/iaddcarry_builtin.ll
@@ -7,121 +7,127 @@
 
 target triple = "spir64-unknown-unknown"
 
+%i8struct = type {i8, i8}
+%i16struct = type {i16, i16}
+%i32struct = type {i32, i32}
+%i64struct = type {i64, i64}
+%vecstruct = type {<4 x i32>, <4 x i32>}
+
 ; CHECK-SPIRV:                    [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
 ; CHECK-SPIRV:                   [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
 ; CHECK-SPIRV:                     [[uint:%[a-z0-9_]+]] = OpTypeInt 32
 ; CHECK-SPIRV:                    [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
 ; CHECK-SPIRV:                     [[void:%[a-z0-9_]+]] = OpTypeVoid
-; CHECK-SPIRV:                [[_struct_9:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
-; CHECK-SPIRV:  [[_ptr_Function__struct_9:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_9]]
-; CHECK-SPIRV:               [[_struct_19:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
-; CHECK-SPIRV: [[_ptr_Function__struct_19:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_19]]
-; CHECK-SPIRV:               [[_struct_29:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
-; CHECK-SPIRV: [[_ptr_Function__struct_29:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_29]]
-; CHECK-SPIRV:               [[_struct_39:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
-; CHECK-SPIRV: [[_ptr_Function__struct_39:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_39]]
+; CHECK-SPIRV:                 [[i8struct:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
+; CHECK-SPIRV:   [[_ptr_Function_i8struct:%[a-z0-9_]+]] = OpTypePointer Function [[i8struct]]
+; CHECK-SPIRV:                [[i16struct:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
+; CHECK-SPIRV:  [[_ptr_Function_i16struct:%[a-z0-9_]+]] = OpTypePointer Function [[i16struct]]
+; CHECK-SPIRV:                [[i32struct:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV:  [[_ptr_Function_i32struct:%[a-z0-9_]+]] = OpTypePointer Function [[i32struct]]
+; CHECK-SPIRV:                [[i64struct:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK-SPIRV:  [[_ptr_Function_i64struct:%[a-z0-9_]+]] = OpTypePointer Function [[i64struct]]
 ; CHECK-SPIRV:                   [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
-; CHECK-SPIRV:               [[_struct_49:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
-; CHECK-SPIRV: [[_ptr_Function__struct_49:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_49]]
+; CHECK-SPIRV:                [[vecstruct:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV:  [[_ptr_Function_vecstruct:%[a-z0-9_]+]] = OpTypePointer Function [[vecstruct]]
 
-; CHECK-LLVM-DAG: [[structtype:%[a-z0-9_.]+]] = type { i8, i8 }
-; CHECK-LLVM-DAG: [[structtype_0:%[a-z0-9_.]+]] = type { i16, i16 }
-; CHECK-LLVM-DAG: [[structtype_1:%[a-z0-9_.]+]] = type { i32, i32 }
-; CHECK-LLVM-DAG: [[structtype_2:%[a-z0-9_.]+]] = type { i64, i64 }
-; CHECK-LLVM-DAG: [[structtype_3:%[a-z0-9_.]+]] = type { <4 x i32>, <4 x i32> }
+; CHECK-LLVM-DAG: [[i8struct:%[a-z0-9_.]+]] = type { i8, i8 }
+; CHECK-LLVM-DAG: [[i16struct:%[a-z0-9_.]+]] = type { i16, i16 }
+; CHECK-LLVM-DAG: [[i32struct:%[a-z0-9_.]+]] = type { i32, i32 }
+; CHECK-LLVM-DAG: [[i64struct:%[a-z0-9_.]+]] = type { i64, i64 }
+; CHECK-LLVM-DAG: [[vecstruct:%[a-z0-9_.]+]] = type { <4 x i32>, <4 x i32> }
 
 define spir_func void @test_builtin_iaddcarrycc(i8 %a, i8 %b) {
   entry:
-  %0 = alloca {i8, i8}
-  call void @_Z17__spirv_IAddCarrycc(ptr sret ({i8, i8}) %0, i8 %a, i8 %b)
+  %0 = alloca %i8struct
+  call void @_Z17__spirv_IAddCarrycc(ptr sret (%i8struct) %0, i8 %a, i8 %b)
   ret void
 }
 ; CHECK-SPIRV:           [[a:%[a-z0-9_]+]] = OpFunctionParameter [[uchar]]
 ; CHECK-SPIRV:           [[b:%[a-z0-9_]+]] = OpFunctionParameter [[uchar]]
 ; CHECK-SPIRV:       [[entry:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_11:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_9]] Function
-; CHECK-SPIRV:      [[var_12:%[a-z0-9_]+]] = OpIAddCarry [[_struct_9]] [[a]] [[b]]
+; CHECK-SPIRV:      [[var_11:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_i8struct]] Function
+; CHECK-SPIRV:      [[var_12:%[a-z0-9_]+]] = OpIAddCarry [[i8struct]] [[a]] [[b]]
 ; CHECK-SPIRV:                               OpStore [[var_11]] [[var_12]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarrycc(ptr sret([[structtype]]) %0, i8 %a, i8 %b)
+; CHECK-LLVM:   %0 = alloca [[i8struct]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarrycc(ptr sret([[i8struct]]) %0, i8 %a, i8 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryss(i16 %a, i16 %b) {
   entry:
-  %0 = alloca {i16, i16}
-  call void @_Z17__spirv_IAddCarryss(ptr sret ({i16, i16}) %0, i16 %a, i16 %b)
+  %0 = alloca %i16struct
+  call void @_Z17__spirv_IAddCarryss(ptr sret (%i16struct) %0, i16 %a, i16 %b)
   ret void
 }
 ; CHECK-SPIRV:         [[a_0:%[a-z0-9_]+]] = OpFunctionParameter [[ushort]]
 ; CHECK-SPIRV:         [[b_0:%[a-z0-9_]+]] = OpFunctionParameter [[ushort]]
 ; CHECK-SPIRV:     [[entry_0:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_21:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_19]] Function
-; CHECK-SPIRV:      [[var_22:%[a-z0-9_]+]] = OpIAddCarry [[_struct_19]] [[a_0]] [[b_0]]
+; CHECK-SPIRV:      [[var_21:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_i16struct]] Function
+; CHECK-SPIRV:      [[var_22:%[a-z0-9_]+]] = OpIAddCarry [[i16struct]] [[a_0]] [[b_0]]
 ; CHECK-SPIRV:                               OpStore [[var_21]] [[var_22]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype_0]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryss(ptr sret([[structtype_0]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   %0 = alloca [[i16struct]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryss(ptr sret([[i16struct]]) %0, i16 %a, i16 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryii(i32 %a, i32 %b) {
   entry:
-  %0 = alloca {i32, i32}
-  call void @_Z17__spirv_IAddCarryii(ptr sret ({i32, i32}) %0, i32 %a, i32 %b)
+  %0 = alloca %i32struct
+  call void @_Z17__spirv_IAddCarryii(ptr sret (%i32struct) %0, i32 %a, i32 %b)
   ret void
 }
 ; CHECK-SPIRV:         [[a_1:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
 ; CHECK-SPIRV:         [[b_1:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
 ; CHECK-SPIRV:     [[entry_1:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_31:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_29]] Function
-; CHECK-SPIRV:      [[var_32:%[a-z0-9_]+]] = OpIAddCarry [[_struct_29]] [[a_1]] [[b_1]]
+; CHECK-SPIRV:      [[var_31:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_i32struct]] Function
+; CHECK-SPIRV:      [[var_32:%[a-z0-9_]+]] = OpIAddCarry [[i32struct]] [[a_1]] [[b_1]]
 ; CHECK-SPIRV:                               OpStore [[var_31]] [[var_32]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype_1]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryii(ptr sret([[structtype_1]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   %0 = alloca [[i32struct]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryii(ptr sret([[i32struct]]) %0, i32 %a, i32 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryll(i64 %a, i64 %b) {
   entry:
-  %0 = alloca {i64, i64}
-  call void @_Z17__spirv_IAddCarryll(ptr sret ({i64, i64}) %0, i64 %a, i64 %b)
+  %0 = alloca %i64struct
+  call void @_Z17__spirv_IAddCarryll(ptr sret (%i64struct) %0, i64 %a, i64 %b)
   ret void
 }
 ; CHECK-SPIRV:         [[a_2:%[a-z0-9_]+]] = OpFunctionParameter [[ulong]]
 ; CHECK-SPIRV:         [[b_2:%[a-z0-9_]+]] = OpFunctionParameter [[ulong]]
 ; CHECK-SPIRV:     [[entry_2:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_41:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_39]] Function
-; CHECK-SPIRV:      [[var_42:%[a-z0-9_]+]] = OpIAddCarry [[_struct_39]] [[a_2]] [[b_2]]
+; CHECK-SPIRV:      [[var_41:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_i64struct]] Function
+; CHECK-SPIRV:      [[var_42:%[a-z0-9_]+]] = OpIAddCarry [[i64struct]] [[a_2]] [[b_2]]
 ; CHECK-SPIRV:                               OpStore [[var_41]] [[var_42]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype_2]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryll(ptr sret([[structtype_2]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   %0 = alloca [[i64struct]]
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryll(ptr sret([[i64struct]]) %0, i64 %a, i64 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
   entry:
-  %0 = alloca {<4 x i32>, <4 x i32>}
-  call void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}) %0, <4 x i32> %a, <4 x i32> %b)
+  %0 = alloca %vecstruct
+  call void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret (%vecstruct) %0, <4 x i32> %a, <4 x i32> %b)
   ret void
 }
 ; CHECK-SPIRV:         [[a_3:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
 ; CHECK-SPIRV:         [[b_3:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
 ; CHECK-SPIRV:     [[entry_3:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_51:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_49]] Function
-; CHECK-SPIRV:      [[var_52:%[a-z0-9_]+]] = OpIAddCarry [[_struct_49]] [[a_3]] [[b_3]]
+; CHECK-SPIRV:      [[var_51:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_vecstruct]] Function
+; CHECK-SPIRV:      [[var_52:%[a-z0-9_]+]] = OpIAddCarry [[vecstruct]] [[a_3]] [[b_3]]
 ; CHECK-SPIRV:                               OpStore [[var_51]] [[var_52]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype_3]], align 16
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret([[structtype_3]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %0 = alloca [[vecstruct]]
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
 ; CHECK-LLVM:   ret void
-declare void @_Z17__spirv_IAddCarrycc(ptr sret({i8, i8}), i8, i8)
-declare void @_Z17__spirv_IAddCarryss(ptr sret({i16, i16}), i16, i16)
-declare void @_Z17__spirv_IAddCarryii(ptr sret({i32, i32}), i32, i32)
-declare void @_Z17__spirv_IAddCarryll(ptr sret({i64, i64}), i64, i64)
-declare void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}), <4 x i32>, <4 x i32>)
+declare void @_Z17__spirv_IAddCarrycc(ptr sret(%i8struct), i8, i8)
+declare void @_Z17__spirv_IAddCarryss(ptr sret(%i16struct), i16, i16)
+declare void @_Z17__spirv_IAddCarryii(ptr sret(%i32struct), i32, i32)
+declare void @_Z17__spirv_IAddCarryll(ptr sret(%i64struct), i64, i64)
+declare void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret (%vecstruct), <4 x i32>, <4 x i32>)

--- a/test/iaddcarry_builtin.ll
+++ b/test/iaddcarry_builtin.ll
@@ -3,7 +3,7 @@
 ; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-; llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s
 
 target triple = "spir64-unknown-unknown"
 
@@ -24,6 +24,12 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV:               [[_struct_49:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
 ; CHECK-SPIRV: [[_ptr_Function__struct_49:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_49]]
 
+; CHECK-LLVM-DAG: [[structtype:%[a-z0-9_.]+]] = type { i8, i8 }
+; CHECK-LLVM-DAG: [[structtype_0:%[a-z0-9_.]+]] = type { i16, i16 }
+; CHECK-LLVM-DAG: [[structtype_1:%[a-z0-9_.]+]] = type { i32, i32 }
+; CHECK-LLVM-DAG: [[structtype_2:%[a-z0-9_.]+]] = type { i64, i64 }
+; CHECK-LLVM-DAG: [[structtype_3:%[a-z0-9_.]+]] = type { <4 x i32>, <4 x i32> }
+
 define spir_func void @test_builtin_iaddcarrycc(i8 %a, i8 %b) {
   entry:
   %0 = alloca {i8, i8}
@@ -35,9 +41,13 @@ define spir_func void @test_builtin_iaddcarrycc(i8 %a, i8 %b) {
 ; CHECK-SPIRV:       [[entry:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_11:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_9]] Function
 ; CHECK-SPIRV:      [[var_12:%[a-z0-9_]+]] = OpIAddCarry [[_struct_9]] [[a]] [[b]]
+; CHECK-SPIRV:                               OpStore [[var_11]] [[var_12]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarrycc(ptr sret([[structtype]]) %0, i8 %a, i8 %b)
+; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryss(i16 %a, i16 %b) {
   entry:
   %0 = alloca {i16, i16}
@@ -49,9 +59,13 @@ define spir_func void @test_builtin_iaddcarryss(i16 %a, i16 %b) {
 ; CHECK-SPIRV:     [[entry_0:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_21:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_19]] Function
 ; CHECK-SPIRV:      [[var_22:%[a-z0-9_]+]] = OpIAddCarry [[_struct_19]] [[a_0]] [[b_0]]
+; CHECK-SPIRV:                               OpStore [[var_21]] [[var_22]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype_0]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryss(ptr sret([[structtype_0]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryii(i32 %a, i32 %b) {
   entry:
   %0 = alloca {i32, i32}
@@ -63,9 +77,13 @@ define spir_func void @test_builtin_iaddcarryii(i32 %a, i32 %b) {
 ; CHECK-SPIRV:     [[entry_1:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_31:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_29]] Function
 ; CHECK-SPIRV:      [[var_32:%[a-z0-9_]+]] = OpIAddCarry [[_struct_29]] [[a_1]] [[b_1]]
+; CHECK-SPIRV:                               OpStore [[var_31]] [[var_32]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype_1]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryii(ptr sret([[structtype_1]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryll(i64 %a, i64 %b) {
   entry:
   %0 = alloca {i64, i64}
@@ -77,9 +95,13 @@ define spir_func void @test_builtin_iaddcarryll(i64 %a, i64 %b) {
 ; CHECK-SPIRV:     [[entry_2:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_41:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_39]] Function
 ; CHECK-SPIRV:      [[var_42:%[a-z0-9_]+]] = OpIAddCarry [[_struct_39]] [[a_2]] [[b_2]]
+; CHECK-SPIRV:                               OpStore [[var_41]] [[var_42]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype_2]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryll(ptr sret([[structtype_2]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
   entry:
   %0 = alloca {<4 x i32>, <4 x i32>}
@@ -91,12 +113,15 @@ define spir_func void @test_builtin_iaddcarryDv4_xS_(<4 x i32> %a, <4 x i32> %b)
 ; CHECK-SPIRV:     [[entry_3:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_51:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_49]] Function
 ; CHECK-SPIRV:      [[var_52:%[a-z0-9_]+]] = OpIAddCarry [[_struct_49]] [[a_3]] [[b_3]]
+; CHECK-SPIRV:                               OpStore [[var_51]] [[var_52]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype_3]], align 16
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret([[structtype_3]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   ret void
 declare void @_Z17__spirv_IAddCarrycc(ptr sret({i8, i8}), i8, i8)
 declare void @_Z17__spirv_IAddCarryss(ptr sret({i16, i16}), i16, i16)
 declare void @_Z17__spirv_IAddCarryii(ptr sret({i32, i32}), i32, i32)
 declare void @_Z17__spirv_IAddCarryll(ptr sret({i64, i64}), i64, i64)
 declare void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}), <4 x i32>, <4 x i32>)
-

--- a/test/iaddcarry_builtin.ll
+++ b/test/iaddcarry_builtin.ll
@@ -1,0 +1,102 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV:                    [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
+; CHECK-SPIRV:                   [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
+; CHECK-SPIRV:                     [[uint:%[a-z0-9_]+]] = OpTypeInt 32
+; CHECK-SPIRV:                    [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
+; CHECK-SPIRV:                     [[void:%[a-z0-9_]+]] = OpTypeVoid
+; CHECK-SPIRV:                [[_struct_9:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
+; CHECK-SPIRV:  [[_ptr_Function__struct_9:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_9]]
+; CHECK-SPIRV:               [[_struct_19:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
+; CHECK-SPIRV: [[_ptr_Function__struct_19:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_19]]
+; CHECK-SPIRV:               [[_struct_29:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV: [[_ptr_Function__struct_29:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_29]]
+; CHECK-SPIRV:               [[_struct_39:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK-SPIRV: [[_ptr_Function__struct_39:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_39]]
+; CHECK-SPIRV:                   [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV:               [[_struct_49:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV: [[_ptr_Function__struct_49:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_49]]
+
+define spir_func void @test_builtin_iaddcarrycc(i8 %a, i8 %b) {
+  entry:
+  %0 = alloca {i8, i8}
+  call void @_Z17__spirv_IAddCarrycc(ptr sret ({i8, i8}) %0, i8 %a, i8 %b)
+  ret void
+}
+; CHECK-SPIRV:           [[a:%[a-z0-9_]+]] = OpFunctionParameter [[uchar]]
+; CHECK-SPIRV:           [[b:%[a-z0-9_]+]] = OpFunctionParameter [[uchar]]
+; CHECK-SPIRV:       [[entry:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_11:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_9]] Function
+; CHECK-SPIRV:      [[var_12:%[a-z0-9_]+]] = OpIAddCarry [[_struct_9]] [[a]] [[b]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+define spir_func void @test_builtin_iaddcarryss(i16 %a, i16 %b) {
+  entry:
+  %0 = alloca {i16, i16}
+  call void @_Z17__spirv_IAddCarryss(ptr sret ({i16, i16}) %0, i16 %a, i16 %b)
+  ret void
+}
+; CHECK-SPIRV:         [[a_0:%[a-z0-9_]+]] = OpFunctionParameter [[ushort]]
+; CHECK-SPIRV:         [[b_0:%[a-z0-9_]+]] = OpFunctionParameter [[ushort]]
+; CHECK-SPIRV:     [[entry_0:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_21:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_19]] Function
+; CHECK-SPIRV:      [[var_22:%[a-z0-9_]+]] = OpIAddCarry [[_struct_19]] [[a_0]] [[b_0]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+define spir_func void @test_builtin_iaddcarryii(i32 %a, i32 %b) {
+  entry:
+  %0 = alloca {i32, i32}
+  call void @_Z17__spirv_IAddCarryii(ptr sret ({i32, i32}) %0, i32 %a, i32 %b)
+  ret void
+}
+; CHECK-SPIRV:         [[a_1:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:         [[b_1:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:     [[entry_1:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_31:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_29]] Function
+; CHECK-SPIRV:      [[var_32:%[a-z0-9_]+]] = OpIAddCarry [[_struct_29]] [[a_1]] [[b_1]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+define spir_func void @test_builtin_iaddcarryll(i64 %a, i64 %b) {
+  entry:
+  %0 = alloca {i64, i64}
+  call void @_Z17__spirv_IAddCarryll(ptr sret ({i64, i64}) %0, i64 %a, i64 %b)
+  ret void
+}
+; CHECK-SPIRV:         [[a_2:%[a-z0-9_]+]] = OpFunctionParameter [[ulong]]
+; CHECK-SPIRV:         [[b_2:%[a-z0-9_]+]] = OpFunctionParameter [[ulong]]
+; CHECK-SPIRV:     [[entry_2:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_41:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_39]] Function
+; CHECK-SPIRV:      [[var_42:%[a-z0-9_]+]] = OpIAddCarry [[_struct_39]] [[a_2]] [[b_2]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+define spir_func void @test_builtin_iaddcarryDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
+  entry:
+  %0 = alloca {<4 x i32>, <4 x i32>}
+  call void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}) %0, <4 x i32> %a, <4 x i32> %b)
+  ret void
+}
+; CHECK-SPIRV:         [[a_3:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:         [[b_3:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:     [[entry_3:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_51:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_49]] Function
+; CHECK-SPIRV:      [[var_52:%[a-z0-9_]+]] = OpIAddCarry [[_struct_49]] [[a_3]] [[b_3]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+declare void @_Z17__spirv_IAddCarrycc(ptr sret({i8, i8}), i8, i8)
+declare void @_Z17__spirv_IAddCarryss(ptr sret({i16, i16}), i16, i16)
+declare void @_Z17__spirv_IAddCarryii(ptr sret({i32, i32}), i32, i32)
+declare void @_Z17__spirv_IAddCarryll(ptr sret({i64, i64}), i64, i64)
+declare void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}), <4 x i32>, <4 x i32>)
+

--- a/test/iaddcarry_builtin.ll
+++ b/test/iaddcarry_builtin.ll
@@ -1,3 +1,4 @@
+; REQUIRES: spirv-dis
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
@@ -13,28 +14,32 @@ target triple = "spir64-unknown-unknown"
 %i64struct = type {i64, i64}
 %vecstruct = type {<4 x i32>, <4 x i32>}
 
-; CHECK-SPIRV:                    [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
-; CHECK-SPIRV:                   [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
-; CHECK-SPIRV:                     [[uint:%[a-z0-9_]+]] = OpTypeInt 32
-; CHECK-SPIRV:                    [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
-; CHECK-SPIRV:                     [[void:%[a-z0-9_]+]] = OpTypeVoid
-; CHECK-SPIRV:                 [[i8struct:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
-; CHECK-SPIRV:   [[_ptr_Function_i8struct:%[a-z0-9_]+]] = OpTypePointer Function [[i8struct]]
-; CHECK-SPIRV:                [[i16struct:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
-; CHECK-SPIRV:  [[_ptr_Function_i16struct:%[a-z0-9_]+]] = OpTypePointer Function [[i16struct]]
-; CHECK-SPIRV:                [[i32struct:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
-; CHECK-SPIRV:  [[_ptr_Function_i32struct:%[a-z0-9_]+]] = OpTypePointer Function [[i32struct]]
-; CHECK-SPIRV:                [[i64struct:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
-; CHECK-SPIRV:  [[_ptr_Function_i64struct:%[a-z0-9_]+]] = OpTypePointer Function [[i64struct]]
-; CHECK-SPIRV:                   [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
-; CHECK-SPIRV:                [[vecstruct:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
-; CHECK-SPIRV:  [[_ptr_Function_vecstruct:%[a-z0-9_]+]] = OpTypePointer Function [[vecstruct]]
+; CHECK-SPIRV-DAG:                     [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
+; CHECK-SPIRV-DAG:                    [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
+; CHECK-SPIRV-DAG:                      [[uint:%[a-z0-9_]+]] = OpTypeInt 32
+; CHECK-SPIRV-DAG:                     [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
+; CHECK-SPIRV-DAG:                      [[void:%[a-z0-9_]+]] = OpTypeVoid
+; CHECK-SPIRV-DAG:                  [[i8struct:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
+; CHECK-SPIRV-DAG:    [[_ptr_Function_i8struct:%[a-z0-9_]+]] = OpTypePointer Function [[i8struct]]
+; CHECK-SPIRV-DAG:                 [[i16struct:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
+; CHECK-SPIRV-DAG:   [[_ptr_Function_i16struct:%[a-z0-9_]+]] = OpTypePointer Function [[i16struct]]
+; CHECK-SPIRV-DAG:                 [[i32struct:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV-DAG:   [[_ptr_Function_i32struct:%[a-z0-9_]+]] = OpTypePointer Function [[i32struct]]
+; CHECK-SPIRV-DAG:                 [[i64struct:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK-SPIRV-DAG:   [[_ptr_Function_i64struct:%[a-z0-9_]+]] = OpTypePointer Function [[i64struct]]
+; CHECK-SPIRV-DAG:                    [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV-DAG:                 [[vecstruct:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV-DAG:   [[_ptr_Function_vecstruct:%[a-z0-9_]+]] = OpTypePointer Function [[vecstruct]]
+; CHECK-SPIRV-DAG:               [[struct_anon:%[a-z0-9_.]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV-DAG: [[_ptr_Function_struct_anon:%[a-z0-9_]+]] = OpTypePointer Function [[struct_anon]]
+; CHECK-SPIRV-DAG:  [[_ptr_Generic_struct_anon:%[a-z0-9_]+]] = OpTypePointer Generic [[struct_anon]]
 
 ; CHECK-LLVM-DAG: [[i8struct:%[a-z0-9_.]+]] = type { i8, i8 }
 ; CHECK-LLVM-DAG: [[i16struct:%[a-z0-9_.]+]] = type { i16, i16 }
 ; CHECK-LLVM-DAG: [[i32struct:%[a-z0-9_.]+]] = type { i32, i32 }
 ; CHECK-LLVM-DAG: [[i64struct:%[a-z0-9_.]+]] = type { i64, i64 }
 ; CHECK-LLVM-DAG: [[vecstruct:%[a-z0-9_.]+]] = type { <4 x i32>, <4 x i32> }
+; CHECK-LLVM-DAG: [[struct_anon:%[a-z0-9_.]+]] = type { i32, i32 }
 
 define spir_func void @test_builtin_iaddcarrycc(i8 %a, i8 %b) {
   entry:
@@ -126,6 +131,30 @@ define spir_func void @test_builtin_iaddcarryDv4_xS_(<4 x i32> %a, <4 x i32> %b)
 ; CHECK-LLVM:   %0 = alloca [[vecstruct]]
 ; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
 ; CHECK-LLVM:   ret void
+
+%struct.anon = type { i32, i32 }
+
+define spir_func void @test_builtin_iaddcarry_anon(i32 %a, i32 %b) {
+  entry:
+  %0 = alloca %struct.anon
+  %1 = addrspacecast ptr %0 to ptr addrspace(4)
+  call spir_func void @_Z17__spirv_IAddCarryIiiE4anonIT_T0_ES1_S2_(ptr addrspace(4) sret(%struct.anon) align 4 %1, i32 %a, i32 %b)
+  ret void
+}
+; CHECK-SPIRV:        [[a_4:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:        [[b_4:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:    [[entry_4:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:     [[var_59:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_struct_anon]] Function
+; CHECK-SPIRV:     [[var_61:%[a-z0-9_]+]] = OpPtrCastToGeneric [[_ptr_Generic_struct_anon]] [[var_59]]
+; CHECK-SPIRV:     [[var_62:%[a-z0-9_]+]] = OpIAddCarry [[struct_anon]] [[a_4]] [[b_4]]
+; CHECK-SPIRV:                              OpStore [[var_61]] [[var_62]]
+
+; CHECK-LLVM:  %0 = alloca [[struct_anon]], align 8
+; CHECK-LLVM:  %1 = addrspacecast ptr %0 to ptr addrspace(4)
+; CHECK-LLVM:  call spir_func void @_Z17__spirv_IAddCarryii.1(ptr addrspace(4) sret([[struct_anon]]) %1, i32 %a, i32 %b)
+; CHECK-LLVM:  ret void
+
+declare void @_Z17__spirv_IAddCarryIiiE4anonIT_T0_ES1_S2_(ptr addrspace(4) sret(%struct.anon) align 4, i32, i32)
 declare void @_Z17__spirv_IAddCarrycc(ptr sret(%i8struct), i8, i8)
 declare void @_Z17__spirv_IAddCarryss(ptr sret(%i16struct), i16, i16)
 declare void @_Z17__spirv_IAddCarryii(ptr sret(%i32struct), i32, i32)

--- a/test/isubborrow_builtin.ll
+++ b/test/isubborrow_builtin.ll
@@ -1,0 +1,102 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV:                    [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
+; CHECK-SPIRV:                   [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
+; CHECK-SPIRV:                     [[uint:%[a-z0-9_]+]] = OpTypeInt 32
+; CHECK-SPIRV:                    [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
+; CHECK-SPIRV:                     [[void:%[a-z0-9_]+]] = OpTypeVoid
+; CHECK-SPIRV:                [[_struct_9:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
+; CHECK-SPIRV:  [[_ptr_Function__struct_9:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_9]]
+; CHECK-SPIRV:               [[_struct_19:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
+; CHECK-SPIRV: [[_ptr_Function__struct_19:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_19]]
+; CHECK-SPIRV:               [[_struct_29:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV: [[_ptr_Function__struct_29:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_29]]
+; CHECK-SPIRV:               [[_struct_39:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK-SPIRV: [[_ptr_Function__struct_39:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_39]]
+; CHECK-SPIRV:                   [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV:               [[_struct_49:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV: [[_ptr_Function__struct_49:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_49]]
+
+define spir_func void @test_builtin_isubborrowcc(i8 %a, i8 %b) {
+  entry:
+  %0 = alloca {i8, i8}
+  call void @_Z18__spirv_ISubBorrowcc(ptr sret ({i8, i8}) %0, i8 %a, i8 %b)
+  ret void
+}
+; CHECK-SPIRV:           [[a:%[a-z0-9_]+]] = OpFunctionParameter [[uchar]]
+; CHECK-SPIRV:           [[b:%[a-z0-9_]+]] = OpFunctionParameter [[uchar]]
+; CHECK-SPIRV:       [[entry:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_11:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_9]] Function
+; CHECK-SPIRV:      [[var_12:%[a-z0-9_]+]] = OpISubBorrow [[_struct_9]] [[a]] [[b]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+define spir_func void @test_builtin_isubborrowss(i16 %a, i16 %b) {
+  entry:
+  %0 = alloca {i16, i16}
+  call void @_Z18__spirv_ISubBorrowss(ptr sret ({i16, i16}) %0, i16 %a, i16 %b)
+  ret void
+}
+; CHECK-SPIRV:         [[a_0:%[a-z0-9_]+]] = OpFunctionParameter [[ushort]]
+; CHECK-SPIRV:         [[b_0:%[a-z0-9_]+]] = OpFunctionParameter [[ushort]]
+; CHECK-SPIRV:     [[entry_0:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_21:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_19]] Function
+; CHECK-SPIRV:      [[var_22:%[a-z0-9_]+]] = OpISubBorrow [[_struct_19]] [[a_0]] [[b_0]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+define spir_func void @test_builtin_isubborrowii(i32 %a, i32 %b) {
+  entry:
+  %0 = alloca {i32, i32}
+  call void @_Z18__spirv_ISubBorrowii(ptr sret ({i32, i32}) %0, i32 %a, i32 %b)
+  ret void
+}
+; CHECK-SPIRV:         [[a_1:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:         [[b_1:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:     [[entry_1:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_31:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_29]] Function
+; CHECK-SPIRV:      [[var_32:%[a-z0-9_]+]] = OpISubBorrow [[_struct_29]] [[a_1]] [[b_1]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+define spir_func void @test_builtin_isubborrowll(i64 %a, i64 %b) {
+  entry:
+  %0 = alloca {i64, i64}
+  call void @_Z18__spirv_ISubBorrowll(ptr sret ({i64, i64}) %0, i64 %a, i64 %b)
+  ret void
+}
+; CHECK-SPIRV:         [[a_2:%[a-z0-9_]+]] = OpFunctionParameter [[ulong]]
+; CHECK-SPIRV:         [[b_2:%[a-z0-9_]+]] = OpFunctionParameter [[ulong]]
+; CHECK-SPIRV:     [[entry_2:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_41:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_39]] Function
+; CHECK-SPIRV:      [[var_42:%[a-z0-9_]+]] = OpISubBorrow [[_struct_39]] [[a_2]] [[b_2]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+define spir_func void @test_builtin_isubborrowDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
+  entry:
+  %0 = alloca {<4 x i32>, <4 x i32>}
+  call void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}) %0, <4 x i32> %a, <4 x i32> %b)
+  ret void
+}
+; CHECK-SPIRV:         [[a_3:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:         [[b_3:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:     [[entry_3:%[a-z0-9_]+]] = OpLabel
+; CHECK-SPIRV:      [[var_51:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_49]] Function
+; CHECK-SPIRV:      [[var_52:%[a-z0-9_]+]] = OpISubBorrow [[_struct_49]] [[a_3]] [[b_3]]
+; CHECK-SPIRV:                               OpReturn
+; CHECK-SPIRV:                               OpFunctionEnd
+
+declare void @_Z18__spirv_ISubBorrowcc(ptr sret({i8, i8}), i8, i8)
+declare void @_Z18__spirv_ISubBorrowss(ptr sret({i16, i16}), i16, i16)
+declare void @_Z18__spirv_ISubBorrowii(ptr sret({i32, i32}), i32, i32)
+declare void @_Z18__spirv_ISubBorrowll(ptr sret({i64, i64}), i64, i64)
+declare void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}), <4 x i32>, <4 x i32>)
+

--- a/test/isubborrow_builtin.ll
+++ b/test/isubborrow_builtin.ll
@@ -3,26 +3,32 @@
 ; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-; llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s
 
 target triple = "spir64-unknown-unknown"
 
-; CHECK-SPIRV:                    [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
-; CHECK-SPIRV:                   [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
-; CHECK-SPIRV:                     [[uint:%[a-z0-9_]+]] = OpTypeInt 32
-; CHECK-SPIRV:                    [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
-; CHECK-SPIRV:                     [[void:%[a-z0-9_]+]] = OpTypeVoid
-; CHECK-SPIRV:                [[_struct_9:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
-; CHECK-SPIRV:  [[_ptr_Function__struct_9:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_9]]
-; CHECK-SPIRV:               [[_struct_19:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
-; CHECK-SPIRV: [[_ptr_Function__struct_19:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_19]]
-; CHECK-SPIRV:               [[_struct_29:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
-; CHECK-SPIRV: [[_ptr_Function__struct_29:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_29]]
-; CHECK-SPIRV:               [[_struct_39:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
-; CHECK-SPIRV: [[_ptr_Function__struct_39:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_39]]
-; CHECK-SPIRV:                   [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
-; CHECK-SPIRV:               [[_struct_49:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
-; CHECK-SPIRV: [[_ptr_Function__struct_49:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_49]]
+; CHECK-SPIRV-DAG:                    [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
+; CHECK-SPIRV-DAG:                   [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
+; CHECK-SPIRV-DAG:                     [[uint:%[a-z0-9_]+]] = OpTypeInt 32
+; CHECK-SPIRV-DAG:                    [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
+; CHECK-SPIRV-DAG:                     [[void:%[a-z0-9_]+]] = OpTypeVoid
+; CHECK-SPIRV-DAG:                [[_struct_9:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
+; CHECK-SPIRV-DAG:  [[_ptr_Function__struct_9:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_9]]
+; CHECK-SPIRV-DAG:               [[_struct_19:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_19:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_19]]
+; CHECK-SPIRV-DAG:               [[_struct_29:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_29:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_29]]
+; CHECK-SPIRV-DAG:               [[_struct_39:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_39:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_39]]
+; CHECK-SPIRV-DAG:                   [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV-DAG:               [[_struct_49:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_49:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_49]]
+
+; CHECK-LLVM-DAG: [[structtype:%[a-z0-9_.]+]] = type { i8, i8 }
+; CHECK-LLVM-DAG: [[structtype_0:%[a-z0-9_.]+]] = type { i16, i16 }
+; CHECK-LLVM-DAG: [[structtype_1:%[a-z0-9_.]+]] = type { i32, i32 }
+; CHECK-LLVM-DAG: [[structtype_2:%[a-z0-9_.]+]] = type { i64, i64 }
+; CHECK-LLVM-DAG: [[structtype_3:%[a-z0-9_.]+]] = type { <4 x i32>, <4 x i32> }
 
 define spir_func void @test_builtin_isubborrowcc(i8 %a, i8 %b) {
   entry:
@@ -35,8 +41,13 @@ define spir_func void @test_builtin_isubborrowcc(i8 %a, i8 %b) {
 ; CHECK-SPIRV:       [[entry:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_11:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_9]] Function
 ; CHECK-SPIRV:      [[var_12:%[a-z0-9_]+]] = OpISubBorrow [[_struct_9]] [[a]] [[b]]
+; CHECK-SPIRV:                               OpStore [[var_11]] [[var_12]]
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
+
+; CHECK-LLVM:   %0 = alloca [[structtype]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowcc(ptr sret([[structtype]]) %0, i8 %a, i8 %b)
+; CHECK-LLVM:   ret void
 
 define spir_func void @test_builtin_isubborrowss(i16 %a, i16 %b) {
   entry:
@@ -49,9 +60,13 @@ define spir_func void @test_builtin_isubborrowss(i16 %a, i16 %b) {
 ; CHECK-SPIRV:     [[entry_0:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_21:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_19]] Function
 ; CHECK-SPIRV:      [[var_22:%[a-z0-9_]+]] = OpISubBorrow [[_struct_19]] [[a_0]] [[b_0]]
+; CHECK-SPIRV:                               OpStore [[var_21]] [[var_22]]
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype_0]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowss(ptr sret([[structtype_0]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowii(i32 %a, i32 %b) {
   entry:
   %0 = alloca {i32, i32}
@@ -63,9 +78,13 @@ define spir_func void @test_builtin_isubborrowii(i32 %a, i32 %b) {
 ; CHECK-SPIRV:     [[entry_1:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_31:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_29]] Function
 ; CHECK-SPIRV:      [[var_32:%[a-z0-9_]+]] = OpISubBorrow [[_struct_29]] [[a_1]] [[b_1]]
+; CHECK-SPIRV:                               OpStore [[var_31]] [[var_32]]
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype_1]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowii(ptr sret([[structtype_1]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowll(i64 %a, i64 %b) {
   entry:
   %0 = alloca {i64, i64}
@@ -77,9 +96,13 @@ define spir_func void @test_builtin_isubborrowll(i64 %a, i64 %b) {
 ; CHECK-SPIRV:     [[entry_2:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_41:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_39]] Function
 ; CHECK-SPIRV:      [[var_42:%[a-z0-9_]+]] = OpISubBorrow [[_struct_39]] [[a_2]] [[b_2]]
+; CHECK-SPIRV:                               OpStore [[var_41]] [[var_42]]
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype_2]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowll(ptr sret([[structtype_2]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
   entry:
   %0 = alloca {<4 x i32>, <4 x i32>}
@@ -91,9 +114,13 @@ define spir_func void @test_builtin_isubborrowDv4_xS_(<4 x i32> %a, <4 x i32> %b
 ; CHECK-SPIRV:     [[entry_3:%[a-z0-9_]+]] = OpLabel
 ; CHECK-SPIRV:      [[var_51:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_49]] Function
 ; CHECK-SPIRV:      [[var_52:%[a-z0-9_]+]] = OpISubBorrow [[_struct_49]] [[a_3]] [[b_3]]
+; CHECK-SPIRV:                               OpStore [[var_51]] [[var_52]]
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
+; CHECK-LLVM:   %0 = alloca [[structtype_3]], align 16
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret([[structtype_3]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   ret void
 declare void @_Z18__spirv_ISubBorrowcc(ptr sret({i8, i8}), i8, i8)
 declare void @_Z18__spirv_ISubBorrowss(ptr sret({i16, i16}), i16, i16)
 declare void @_Z18__spirv_ISubBorrowii(ptr sret({i32, i32}), i32, i32)

--- a/test/isubborrow_builtin.ll
+++ b/test/isubborrow_builtin.ll
@@ -7,123 +7,127 @@
 
 target triple = "spir64-unknown-unknown"
 
-; CHECK-SPIRV-DAG:                    [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
-; CHECK-SPIRV-DAG:                   [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
-; CHECK-SPIRV-DAG:                     [[uint:%[a-z0-9_]+]] = OpTypeInt 32
-; CHECK-SPIRV-DAG:                    [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
-; CHECK-SPIRV-DAG:                     [[void:%[a-z0-9_]+]] = OpTypeVoid
-; CHECK-SPIRV-DAG:                [[_struct_9:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
-; CHECK-SPIRV-DAG:  [[_ptr_Function__struct_9:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_9]]
-; CHECK-SPIRV-DAG:               [[_struct_19:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
-; CHECK-SPIRV-DAG: [[_ptr_Function__struct_19:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_19]]
-; CHECK-SPIRV-DAG:               [[_struct_29:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
-; CHECK-SPIRV-DAG: [[_ptr_Function__struct_29:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_29]]
-; CHECK-SPIRV-DAG:               [[_struct_39:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
-; CHECK-SPIRV-DAG: [[_ptr_Function__struct_39:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_39]]
-; CHECK-SPIRV-DAG:                   [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
-; CHECK-SPIRV-DAG:               [[_struct_49:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
-; CHECK-SPIRV-DAG: [[_ptr_Function__struct_49:%[a-z0-9_]+]] = OpTypePointer Function [[_struct_49]]
+%i8struct = type {i8, i8}
+%i16struct = type {i16, i16}
+%i32struct = type {i32, i32}
+%i64struct = type {i64, i64}
+%vecstruct = type {<4 x i32>, <4 x i32>}
 
-; CHECK-LLVM-DAG: [[structtype:%[a-z0-9_.]+]] = type { i8, i8 }
-; CHECK-LLVM-DAG: [[structtype_0:%[a-z0-9_.]+]] = type { i16, i16 }
-; CHECK-LLVM-DAG: [[structtype_1:%[a-z0-9_.]+]] = type { i32, i32 }
-; CHECK-LLVM-DAG: [[structtype_2:%[a-z0-9_.]+]] = type { i64, i64 }
-; CHECK-LLVM-DAG: [[structtype_3:%[a-z0-9_.]+]] = type { <4 x i32>, <4 x i32> }
+; CHECK-SPIRV:                    [[uchar:%[a-z0-9_]+]] = OpTypeInt 8
+; CHECK-SPIRV:                   [[ushort:%[a-z0-9_]+]] = OpTypeInt 16
+; CHECK-SPIRV:                     [[uint:%[a-z0-9_]+]] = OpTypeInt 32
+; CHECK-SPIRV:                    [[ulong:%[a-z0-9_]+]] = OpTypeInt 64
+; CHECK-SPIRV:                     [[void:%[a-z0-9_]+]] = OpTypeVoid
+; CHECK-SPIRV:                 [[i8struct:%[a-z0-9_]+]] = OpTypeStruct [[uchar]] [[uchar]]
+; CHECK-SPIRV:   [[_ptr_Function_i8struct:%[a-z0-9_]+]] = OpTypePointer Function [[i8struct]]
+; CHECK-SPIRV:                [[i16struct:%[a-z0-9_]+]] = OpTypeStruct [[ushort]] [[ushort]]
+; CHECK-SPIRV:  [[_ptr_Function_i16struct:%[a-z0-9_]+]] = OpTypePointer Function [[i16struct]]
+; CHECK-SPIRV:                [[i32struct:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV:  [[_ptr_Function_i32struct:%[a-z0-9_]+]] = OpTypePointer Function [[i32struct]]
+; CHECK-SPIRV:                [[i64struct:%[a-z0-9_]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK-SPIRV:  [[_ptr_Function_i64struct:%[a-z0-9_]+]] = OpTypePointer Function [[i64struct]]
+; CHECK-SPIRV:                   [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV:                [[vecstruct:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV:  [[_ptr_Function_vecstruct:%[a-z0-9_]+]] = OpTypePointer Function [[vecstruct]]
+
+; CHECK-LLVM-DAG: [[i8struct:%[a-z0-9_.]+]] = type { i8, i8 }
+; CHECK-LLVM-DAG: [[i16struct:%[a-z0-9_.]+]] = type { i16, i16 }
+; CHECK-LLVM-DAG: [[i32struct:%[a-z0-9_.]+]] = type { i32, i32 }
+; CHECK-LLVM-DAG: [[i64struct:%[a-z0-9_.]+]] = type { i64, i64 }
+; CHECK-LLVM-DAG: [[vecstruct:%[a-z0-9_.]+]] = type { <4 x i32>, <4 x i32> }
 
 define spir_func void @test_builtin_isubborrowcc(i8 %a, i8 %b) {
   entry:
-  %0 = alloca {i8, i8}
-  call void @_Z18__spirv_ISubBorrowcc(ptr sret ({i8, i8}) %0, i8 %a, i8 %b)
+  %0 = alloca %i8struct
+  call void @_Z18__spirv_ISubBorrowcc(ptr sret (%i8struct) %0, i8 %a, i8 %b)
   ret void
 }
 ; CHECK-SPIRV:           [[a:%[a-z0-9_]+]] = OpFunctionParameter [[uchar]]
 ; CHECK-SPIRV:           [[b:%[a-z0-9_]+]] = OpFunctionParameter [[uchar]]
 ; CHECK-SPIRV:       [[entry:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_11:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_9]] Function
-; CHECK-SPIRV:      [[var_12:%[a-z0-9_]+]] = OpISubBorrow [[_struct_9]] [[a]] [[b]]
-; CHECK-SPIRV:                               OpStore [[var_11]] [[var_12]]
+; CHECK-SPIRV:      [[var_11:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_i8struct]] Function
+; CHECK-SPIRV:      [[var_12:%[a-z0-9_]+]] = OpISubBorrow [[i8struct]] [[a]] [[b]]
+; CHECK-SPIRV:                               OpStore [[var_11]] [[var_12]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowcc(ptr sret([[structtype]]) %0, i8 %a, i8 %b)
+; CHECK-LLVM:   %0 = alloca [[i8struct]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowcc(ptr sret([[i8struct]]) %0, i8 %a, i8 %b)
 ; CHECK-LLVM:   ret void
-
 define spir_func void @test_builtin_isubborrowss(i16 %a, i16 %b) {
   entry:
-  %0 = alloca {i16, i16}
-  call void @_Z18__spirv_ISubBorrowss(ptr sret ({i16, i16}) %0, i16 %a, i16 %b)
+  %0 = alloca %i16struct
+  call void @_Z18__spirv_ISubBorrowss(ptr sret (%i16struct) %0, i16 %a, i16 %b)
   ret void
 }
 ; CHECK-SPIRV:         [[a_0:%[a-z0-9_]+]] = OpFunctionParameter [[ushort]]
 ; CHECK-SPIRV:         [[b_0:%[a-z0-9_]+]] = OpFunctionParameter [[ushort]]
 ; CHECK-SPIRV:     [[entry_0:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_21:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_19]] Function
-; CHECK-SPIRV:      [[var_22:%[a-z0-9_]+]] = OpISubBorrow [[_struct_19]] [[a_0]] [[b_0]]
-; CHECK-SPIRV:                               OpStore [[var_21]] [[var_22]]
+; CHECK-SPIRV:      [[var_21:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_i16struct]] Function
+; CHECK-SPIRV:      [[var_22:%[a-z0-9_]+]] = OpISubBorrow [[i16struct]] [[a_0]] [[b_0]]
+; CHECK-SPIRV:                               OpStore [[var_21]] [[var_22]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype_0]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowss(ptr sret([[structtype_0]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   %0 = alloca [[i16struct]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowss(ptr sret([[i16struct]]) %0, i16 %a, i16 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowii(i32 %a, i32 %b) {
   entry:
-  %0 = alloca {i32, i32}
-  call void @_Z18__spirv_ISubBorrowii(ptr sret ({i32, i32}) %0, i32 %a, i32 %b)
+  %0 = alloca %i32struct
+  call void @_Z18__spirv_ISubBorrowii(ptr sret (%i32struct) %0, i32 %a, i32 %b)
   ret void
 }
 ; CHECK-SPIRV:         [[a_1:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
 ; CHECK-SPIRV:         [[b_1:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
 ; CHECK-SPIRV:     [[entry_1:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_31:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_29]] Function
-; CHECK-SPIRV:      [[var_32:%[a-z0-9_]+]] = OpISubBorrow [[_struct_29]] [[a_1]] [[b_1]]
-; CHECK-SPIRV:                               OpStore [[var_31]] [[var_32]]
+; CHECK-SPIRV:      [[var_31:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_i32struct]] Function
+; CHECK-SPIRV:      [[var_32:%[a-z0-9_]+]] = OpISubBorrow [[i32struct]] [[a_1]] [[b_1]]
+; CHECK-SPIRV:                               OpStore [[var_31]] [[var_32]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype_1]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowii(ptr sret([[structtype_1]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   %0 = alloca [[i32struct]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowii(ptr sret([[i32struct]]) %0, i32 %a, i32 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowll(i64 %a, i64 %b) {
   entry:
-  %0 = alloca {i64, i64}
-  call void @_Z18__spirv_ISubBorrowll(ptr sret ({i64, i64}) %0, i64 %a, i64 %b)
+  %0 = alloca %i64struct
+  call void @_Z18__spirv_ISubBorrowll(ptr sret (%i64struct) %0, i64 %a, i64 %b)
   ret void
 }
 ; CHECK-SPIRV:         [[a_2:%[a-z0-9_]+]] = OpFunctionParameter [[ulong]]
 ; CHECK-SPIRV:         [[b_2:%[a-z0-9_]+]] = OpFunctionParameter [[ulong]]
 ; CHECK-SPIRV:     [[entry_2:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_41:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_39]] Function
-; CHECK-SPIRV:      [[var_42:%[a-z0-9_]+]] = OpISubBorrow [[_struct_39]] [[a_2]] [[b_2]]
-; CHECK-SPIRV:                               OpStore [[var_41]] [[var_42]]
+; CHECK-SPIRV:      [[var_41:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_i64struct]] Function
+; CHECK-SPIRV:      [[var_42:%[a-z0-9_]+]] = OpISubBorrow [[i64struct]] [[a_2]] [[b_2]]
+; CHECK-SPIRV:                               OpStore [[var_41]] [[var_42]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype_2]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowll(ptr sret([[structtype_2]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   %0 = alloca [[i64struct]]
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowll(ptr sret([[i64struct]]) %0, i64 %a, i64 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
   entry:
-  %0 = alloca {<4 x i32>, <4 x i32>}
-  call void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}) %0, <4 x i32> %a, <4 x i32> %b)
+  %0 = alloca %vecstruct
+  call void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret (%vecstruct) %0, <4 x i32> %a, <4 x i32> %b)
   ret void
 }
 ; CHECK-SPIRV:         [[a_3:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
 ; CHECK-SPIRV:         [[b_3:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
 ; CHECK-SPIRV:     [[entry_3:%[a-z0-9_]+]] = OpLabel
-; CHECK-SPIRV:      [[var_51:%[a-z0-9_]+]] = OpVariable [[_ptr_Function__struct_49]] Function
-; CHECK-SPIRV:      [[var_52:%[a-z0-9_]+]] = OpISubBorrow [[_struct_49]] [[a_3]] [[b_3]]
-; CHECK-SPIRV:                               OpStore [[var_51]] [[var_52]]
+; CHECK-SPIRV:      [[var_51:%[a-z0-9_]+]] = OpVariable [[_ptr_Function_vecstruct]] Function
+; CHECK-SPIRV:      [[var_52:%[a-z0-9_]+]] = OpISubBorrow [[vecstruct]] [[a_3]] [[b_3]]
+; CHECK-SPIRV:                               OpStore [[var_51]] [[var_52]] 
 ; CHECK-SPIRV:                               OpReturn
 ; CHECK-SPIRV:                               OpFunctionEnd
 
-; CHECK-LLVM:   %0 = alloca [[structtype_3]], align 16
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret([[structtype_3]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %0 = alloca [[vecstruct]]
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
 ; CHECK-LLVM:   ret void
-declare void @_Z18__spirv_ISubBorrowcc(ptr sret({i8, i8}), i8, i8)
-declare void @_Z18__spirv_ISubBorrowss(ptr sret({i16, i16}), i16, i16)
-declare void @_Z18__spirv_ISubBorrowii(ptr sret({i32, i32}), i32, i32)
-declare void @_Z18__spirv_ISubBorrowll(ptr sret({i64, i64}), i64, i64)
-declare void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret ({<4 x i32>, <4 x i32>}), <4 x i32>, <4 x i32>)
-
+declare void @_Z18__spirv_ISubBorrowcc(ptr sret(%i8struct), i8, i8)
+declare void @_Z18__spirv_ISubBorrowss(ptr sret(%i16struct), i16, i16)
+declare void @_Z18__spirv_ISubBorrowii(ptr sret(%i32struct), i32, i32)
+declare void @_Z18__spirv_ISubBorrowll(ptr sret(%i64struct), i64, i64)
+declare void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret (%vecstruct), <4 x i32>, <4 x i32>)

--- a/test/llvm-intrinsics/uadd.with.overflow.ll
+++ b/test/llvm-intrinsics/uadd.with.overflow.ll
@@ -45,9 +45,7 @@ entry:
  ret void
 }
 
-
 declare {i16, i1} @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
 declare {i32, i1} @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
 declare {i64, i1} @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
 declare {<4 x i32>, <4 x i1>} @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
-declare void @__spirv_IAddCarryii(ptr sret({i32, i32}), i32, i32)

--- a/test/llvm-intrinsics/uadd.with.overflow.ll
+++ b/test/llvm-intrinsics/uadd.with.overflow.ll
@@ -3,8 +3,6 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; Current implementation doesn't comply with specification and should be fixed in future.
 ; TODO: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-; RUN: llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s
 
 target triple = "spir64-unknown-unknown"
 
@@ -22,10 +20,6 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV: IAddCarry [[#S1TYPE]]
 ; CHECK-SPIRV: IAddCarry [[#S2TYPE]]
 ; CHECK-SPIRV: IAddCarry [[#S3TYPE]]
-; CHECK-LLVM: call { i16, i1 } @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
-; CHECK-LLVM: call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
-; CHECK-LLVM: call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
-; CHECK-LLVM: call { <4 x i32>, <4 x i1> } @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
 
 define spir_func void @test_uadd_with_overflow_i16(i16 %a, i16 %b) {
 entry:
@@ -51,7 +45,9 @@ entry:
  ret void
 }
 
+
 declare {i16, i1} @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
 declare {i32, i1} @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
 declare {i64, i1} @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
 declare {<4 x i32>, <4 x i1>} @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+declare void @__spirv_IAddCarryii(ptr sret({i32, i32}), i32, i32)

--- a/test/llvm-intrinsics/usub.with.overflow.ll
+++ b/test/llvm-intrinsics/usub.with.overflow.ll
@@ -3,11 +3,8 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; Current implementation doesn't comply with specification and should be fixed in future.
 ; TODO: spirv-val %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-; RUN: llvm-dis %t.rev.bc -o - | FileCheck --check-prefix CHECK-LLVM %s
 
 target triple = "spir64-unknown-unknown"
-
 
 ; CHECK-SPIRV: TypeInt [[#I16TYPE:]] 16
 ; CHECK-SPIRV: TypeInt [[#I32TYPE:]] 32
@@ -23,10 +20,6 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV: ISubBorrow [[#S1TYPE]]
 ; CHECK-SPIRV: ISubBorrow [[#S2TYPE]]
 ; CHECK-SPIRV: ISubBorrow [[#S3TYPE]]
-; CHECK-LLVM: call { i16, i1 } @llvm.usub.with.overflow.i16(i16 %a, i16 %b)
-; CHECK-LLVM: call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
-; CHECK-LLVM: call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
-; CHECK-LLVM: call { <4 x i32>, <4 x i1> } @llvm.usub.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
 
 define spir_func void @test_usub_with_overflow_i16(i16 %a, i16 %b) {
 entry:

--- a/test/transcoding/BuildNDRange.ll
+++ b/test/transcoding/BuildNDRange.ll
@@ -18,8 +18,8 @@
 ; CHECK-SPIRV-DAG: Constant {{[0-9]+}} [[LWS]] 456
 ; CHECK-SPIRV-DAG: Constant {{[0-9]+}} [[GWO]] 0
 
-; CHECK-LLVM: call spir_func void @_Z10ndrange_1Djjj(ptr sret(%struct.ndrange_t) %ndrange, i32 0, i32 123, i32 456)
-; CHECK-LLVM-SPV: call spir_func void @_Z23__spirv_BuildNDRange_1Diii(ptr sret(%struct.ndrange_t) %ndrange, i32 123, i32 456, i32 0)
+; CHECK-LLVM: call spir_func void @_Z10ndrange_1Djjj(ptr sret(%struct.ndrange_t) %1, i32 0, i32 123, i32 456)
+; CHECK-LLVM-SPV: call spir_func void @_Z23__spirv_BuildNDRange_1Diii(ptr sret(%struct.ndrange_t) %1, i32 123, i32 456, i32 0)
 
 ; ModuleID = 'BuildNDRange.bc'
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/transcoding/BuildNDRange.ll
+++ b/test/transcoding/BuildNDRange.ll
@@ -18,8 +18,8 @@
 ; CHECK-SPIRV-DAG: Constant {{[0-9]+}} [[LWS]] 456
 ; CHECK-SPIRV-DAG: Constant {{[0-9]+}} [[GWO]] 0
 
-; CHECK-LLVM: call spir_func void @_Z10ndrange_1Djjj(ptr sret(%struct.ndrange_t) %1, i32 0, i32 123, i32 456)
-; CHECK-LLVM-SPV: call spir_func void @_Z23__spirv_BuildNDRange_1Diii(ptr sret(%struct.ndrange_t) %1, i32 123, i32 456, i32 0)
+; CHECK-LLVM: call spir_func void @_Z10ndrange_1Djjj(ptr sret(%struct.ndrange_t) %ndrange, i32 0, i32 123, i32 456)
+; CHECK-LLVM-SPV: call spir_func void @_Z23__spirv_BuildNDRange_1Diii(ptr sret(%struct.ndrange_t) %ndrange, i32 123, i32 456, i32 0)
 
 ; ModuleID = 'BuildNDRange.bc'
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
The fix adds support for IR builtin calls
__spirv_IAddCarry and __spirv_ISubBorrow.
It's also first part of fix which removes noncompliance of uadd/sub_with_overflow intrinsics.
SPIRVUtil changes are needed to support situations where builtin don't have corresponding store instruction.