### PR TITLE
[NFC] Remove extra semicolon

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -701,7 +701,7 @@ inline void SPIRVMap<NamedMaximumNumberOfRegisters, std::string>::init() {
   add(NamedMaximumNumberOfRegistersAutoINTEL, "AutoINTEL");
 }
 SPIRV_DEF_NAMEMAP(NamedMaximumNumberOfRegisters,
-                  SPIRVNamedMaximumNumberOfRegistersNameMap);
+                  SPIRVNamedMaximumNumberOfRegistersNameMap)
 
 } /* namespace SPIRV */
 


### PR DESCRIPTION
Fix the following compiler warning:

    .../SPIRVNameMapEnum.h:704:61: warning: extra ';' [-Wpedantic]