### PR TITLE
[Backport to 17][DebugInfo] Fix SPIR-V consumption of DebugInfoNone f…

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -352,7 +352,7 @@ SPIRVToLLVMDbgTran::transTypeArrayOpenCL(const SPIRVExtInst *DebugInst) {
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
   DIType *BaseTy =
-      transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+      transNonNullDebugType(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
   size_t TotalCount = 1;
   SmallVector<llvm::Metadata *, 8> Subscripts;
   // Ops looks like: { BaseType, count1|upperBound1, count2|upperBound2, ...,
@@ -412,7 +412,7 @@ SPIRVToLLVMDbgTran::transTypeArrayNonSemantic(const SPIRVExtInst *DebugInst) {
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
   DIType *BaseTy =
-      transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+      transNonNullDebugType(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
   size_t TotalCount = 1;
   SmallVector<llvm::Metadata *, 8> Subscripts;
   if (DebugInst->getExtOp() == SPIRVDebug::TypeArray) {
@@ -436,7 +436,7 @@ SPIRVToLLVMDbgTran::transTypeArrayDynamic(const SPIRVExtInst *DebugInst) {
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
   DIType *BaseTy =
-      transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+      transNonNullDebugType(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
   size_t TotalCount = 1;
   SmallVector<llvm::Metadata *, 8> Subscripts;
   for (size_t I = SubrangesIdx; I < Ops.size(); ++I) {
@@ -479,7 +479,7 @@ SPIRVToLLVMDbgTran::transTypeVector(const SPIRVExtInst *DebugInst) {
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
   DIType *BaseTy =
-      transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
+      transNonNullDebugType(BM->get<SPIRVExtInst>(Ops[BaseTypeIdx]));
   SPIRVWord Count = getConstantValueOrLiteral(Ops, ComponentCountIdx,
                                               DebugInst->getExtSetKind());
   // FIXME: The current design of SPIR-V Debug Info doesn't provide a field
@@ -686,8 +686,7 @@ SPIRVToLLVMDbgTran::transTypeMemberOpenCL(const SPIRVExtInst *DebugInst) {
       getConstantValueOrLiteral(Ops, LineIdx, DebugInst->getExtSetKind());
   StringRef Name = getString(Ops[NameIdx]);
   DIScope *Scope = getScope(BM->getEntry(Ops[ParentIdx]));
-  DIType *BaseType =
-      transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DIType *BaseType = transNonNullDebugType(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
   uint64_t OffsetInBits =
       BM->get<SPIRVConstant>(Ops[OffsetIdx])->getZExtIntValue();
   SPIRVWord SPIRVFlags =
@@ -733,8 +732,7 @@ SPIRVToLLVMDbgTran::transTypeMemberNonSemantic(const SPIRVExtInst *DebugInst,
   SPIRVWord LineNo =
       getConstantValueOrLiteral(Ops, LineIdx, DebugInst->getExtSetKind());
   StringRef Name = getString(Ops[NameIdx]);
-  DIType *BaseType =
-      transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DIType *BaseType = transNonNullDebugType(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
   uint64_t OffsetInBits =
       BM->get<SPIRVConstant>(Ops[OffsetIdx])->getZExtIntValue();
   SPIRVWord SPIRVFlags =
@@ -841,9 +839,9 @@ SPIRVToLLVMDbgTran::transTypePtrToMember(const SPIRVExtInst *DebugInst) {
   const SPIRVWordVec &Ops = DebugInst->getArguments();
   assert(Ops.size() >= OperandCount && "Invalid number of operands");
   SPIRVExtInst *Member = BM->get<SPIRVExtInst>(Ops[MemberTypeIdx]);
-  DIType *PointeeTy = transDebugInst<DIType>(Member);
+  DIType *PointeeTy = transNonNullDebugType(Member);
   SPIRVExtInst *ContainingTy = BM->get<SPIRVExtInst>(Ops[ParentIdx]);
-  DIType *BaseTy = transDebugInst<DIType>(ContainingTy);
+  DIType *BaseTy = transNonNullDebugType(ContainingTy);
   return getDIBuilder(DebugInst).createMemberPointerType(PointeeTy, BaseTy, 0);
 }
 
@@ -1104,7 +1102,7 @@ MDNode *SPIRVToLLVMDbgTran::transGlobalVariable(const SPIRVExtInst *DebugInst) {
   assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
 
   StringRef Name = getString(Ops[NameIdx]);
-  DIType *Ty = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DIType *Ty = transNonNullDebugType(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
   DIFile *File = getFile(Ops[SourceIdx]);
   SPIRVWord LineNo =
       getConstantValueOrLiteral(Ops, LineIdx, DebugInst->getExtSetKind());
@@ -1170,7 +1168,7 @@ DINode *SPIRVToLLVMDbgTran::transLocalVariable(const SPIRVExtInst *DebugInst) {
   DIFile *File = getFile(Ops[SourceIdx]);
   SPIRVWord LineNo =
       getConstantValueOrLiteral(Ops, LineIdx, DebugInst->getExtSetKind());
-  DIType *Ty = transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DIType *Ty = transNonNullDebugType(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
   DINode::DIFlags Flags = DINode::FlagZero;
   SPIRVWord SPIRVFlags =
       getConstantValueOrLiteral(Ops, FlagsIdx, DebugInst->getExtSetKind());
@@ -1398,6 +1396,13 @@ MDNode *SPIRVToLLVMDbgTran::transExpression(const SPIRVExtInst *DebugInst) {
   }
   ArrayRef<uint64_t> Addr(Ops.data(), Ops.size());
   return getDIBuilder(DebugInst).createExpression(Addr);
+}
+
+DIType *
+SPIRVToLLVMDbgTran::transNonNullDebugType(const SPIRVExtInst *DebugInst) {
+  if (DebugInst->getExtOp() != SPIRVDebug::DebugInfoNone)
+    return transDebugInst<DIType>(DebugInst);
+  return getDIBuilder(DebugInst).createUnspecifiedType("SPIRV unknown type");
 }
 
 MDNode *SPIRVToLLVMDbgTran::transDebugInstImpl(const SPIRVExtInst *DebugInst) {

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -83,6 +83,7 @@ public:
     DebugInstCache[DebugInst] = Res;
     return static_cast<T *>(Res);
   }
+
   Instruction *transDebugIntrinsic(const SPIRVExtInst *DebugInst,
                                    BasicBlock *BB);
   void finalize();
@@ -98,6 +99,8 @@ private:
   unsigned getLineNo(const SPIRVEntry *E);
 
   MDNode *transDebugInstImpl(const SPIRVExtInst *DebugInst);
+
+  DIType *transNonNullDebugType(const SPIRVExtInst *DebugInst);
 
   llvm::DebugLoc transDebugLocation(const SPIRVExtInst *DebugInst);
 

--- a/test/DebugInfo/DebugInfoGlobalVariableNone.spvasm
+++ b/test/DebugInfo/DebugInfoGlobalVariableNone.spvasm
@@ -1,0 +1,54 @@
+; Tests translation of GlobalVariable with DebugInfoNone type
+
+; REQUIRES: spirv-as
+
+; RUN: spirv-as %s --target-env spv1.1 -o %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; CHECK-LLVM: distinct !DIGlobalVariable(name: "i", linkageName: "_ZL1i", scope: ![[#]], file: ![[#]], line: 1, type: ![[#Type:]], isLocal: true, isDefinition: true)
+; CHECK-LLVM: ![[#Type]] = !DIBasicType(tag: DW_TAG_unspecified_type, name: "SPIRV unknown type")
+
+; SPIR-V
+; Version: 1.1
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 24
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+          %1 = OpExtInstImport "OpenCL.std"
+          %2 = OpExtInstImport "OpenCL.DebugInfo.100"
+               OpMemoryModel Physical64 OpenCL
+          %8 = OpString "/tmp/global.cpp"
+         %13 = OpString "int"
+         %17 = OpString "main"
+         %18 = OpString ""
+         %21 = OpString "i"
+         %22 = OpString "_ZL1i"
+               OpSource Unknown 0
+               OpName %main "main"
+               OpName %entry "entry"
+               OpModuleProcessed "Debuginfoproducer:clangversion3.4"
+               OpDecorate %main LinkageAttributes "main" Export
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+    %uint_32 = OpConstant %uint 32
+          %4 = OpTypeFunction %uint
+       %void = OpTypeVoid
+         %10 = OpExtInst %void %2 DebugInfoNone
+         %11 = OpExtInst %void %2 DebugSource %8
+         %12 = OpExtInst %void %2 DebugCompilationUnit 65536 3 %11 CPP_for_OpenCL
+         %15 = OpExtInst %void %2 DebugTypeBasic %13 %uint_32 Signed
+         %16 = OpExtInst %void %2 DebugTypeFunction None %15
+         %19 = OpExtInst %void %2 DebugInfoNone
+         %20 = OpExtInst %void %2 DebugFunction %17 %16 %11 2 0 %12 %18 FlagIsDefinition|FlagPrototyped|FlagIsOptimized 2 %main %19
+         %23 = OpExtInst %void %2 DebugGlobalVariable %21 %10 %11 1 0 %12 %22 %19 FlagIsLocal|FlagIsDefinition
+       %main = OpFunction %uint None %4
+      %entry = OpLabel
+         %24 = OpExtInst %void %2 DebugScope %20
+               OpLine %8 4 0
+               OpReturnValue %uint_0
+               OpFunctionEnd
+

--- a/test/DebugInfo/DebugInfoTypeInheritance.spvasm
+++ b/test/DebugInfo/DebugInfoTypeInheritance.spvasm
@@ -1,0 +1,90 @@
+; Tests translation of DebugTypeInheritance and DebugLocalVariable with
+; DebugInfoNone type
+
+; REQUIRES: spirv-as
+
+; RUN: spirv-as %s --target-env spv1.1 -o %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; CHECK-LLVM: DILocalVariable(name: "c", scope: !9, file: !3, line: 7, type: ![[#Type:]])
+; CHECK-LLVM: ![[#Type]] = !DIBasicType(tag: DW_TAG_unspecified_type, name: "SPIRV unknown type")
+; CHECK-LLVM-NOT: DW_TAG_inheritance
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 62
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Int8
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "OpenCL.std"
+          %2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Physical64 OpenCL
+         %15 = OpString "/app/example.cpp"
+         %17 = OpString "0"
+         %20 = OpString ""
+         %26 = OpString "int"
+         %31 = OpString "_ZTS1C"
+         %32 = OpString "C"
+         %35 = OpString "_ZTS1B"
+         %36 = OpString "B"
+         %38 = OpString "_ZTS1A"
+         %39 = OpString "A"
+         %48 = OpString "foo"
+         %49 = OpString "_Z3foov"
+         %53 = OpString "c"
+               OpSource Unknown 0
+               OpName %_Z3foov "_Z3foov"
+               OpName %class_C "class.C"
+               OpDecorate %_Z3foov LinkageAttributes "_Z3foov" Export
+               OpDecorate %10 Alignment 1
+       %uint = OpTypeInt 32 0
+      %uchar = OpTypeInt 8 0
+     %uint_0 = OpConstant %uint 0
+     %uint_1 = OpConstant %uint 1
+ %uint_65536 = OpConstant %uint 65536
+     %uint_4 = OpConstant %uint 4
+     %uint_6 = OpConstant %uint 6
+    %uint_32 = OpConstant %uint 32
+     %uint_8 = OpConstant %uint 8
+ %uint_32768 = OpConstant %uint 32768
+     %uint_3 = OpConstant %uint 3
+     %uint_2 = OpConstant %uint 2
+   %uint_136 = OpConstant %uint 136
+     %uint_7 = OpConstant %uint 7
+    %uint_11 = OpConstant %uint 11
+    %uint_12 = OpConstant %uint 12
+          %4 = OpTypeFunction %uint
+    %class_C = OpTypeStruct %uchar
+%_ptr_Function_class_C = OpTypePointer Function %class_C
+       %void = OpTypeVoid
+         %12 = OpExtInst %void %2 DebugInfoNone
+         %16 = OpExtInst %void %2 DebugSource %15
+         %19 = OpExtInst %void %2 DebugBuildIdentifier %17 %uint_1
+         %21 = OpExtInst %void %2 DebugStoragePath %20
+         %25 = OpExtInst %void %2 DebugCompilationUnit %uint_65536 %uint_4 %16 %uint_6
+         %28 = OpExtInst %void %2 DebugTypeBasic %26 %uint_32 %uint_4 %12
+         %29 = OpExtInst %void %2 DebugTypeFunction %uint_0 %28
+         %37 = OpExtInst %void %2 DebugTypeComposite %39 %uint_0 %16 %uint_1 %uint_0 %25 %38 %uint_8 %uint_32768
+         %43 = OpExtInst %void %2 DebugTypeInheritance %37 %uint_0 %uint_0 %uint_3
+         %34 = OpExtInst %void %2 DebugTypeComposite %36 %uint_0 %16 %uint_2 %uint_0 %25 %35 %uint_8 %uint_32768 %43
+         %46 = OpExtInst %void %2 DebugTypeInheritance %34 %uint_0 %uint_0 %uint_3
+         %30 = OpExtInst %void %2 DebugTypeComposite %32 %uint_0 %16 %uint_3 %uint_0 %25 %31 %uint_8 %uint_32768 %46
+         %51 = OpExtInst %void %2 DebugFunction %48 %29 %16 %uint_4 %uint_0 %25 %49 %uint_136 %uint_4 %12
+         %55 = OpExtInst %void %2 DebugLocalVariable %53 %12 %16 %uint_7 %uint_0 %51 %uint_0
+         %56 = OpExtInst %void %2 DebugExpression
+    %_Z3foov = OpFunction %uint DontInline %4
+          %6 = OpLabel
+         %52 = OpExtInst %void %2 DebugFunctionDefinition %51 %_Z3foov
+         %10 = OpVariable %_ptr_Function_class_C Function
+         %57 = OpExtInst %void %2 DebugScope %51
+         %60 = OpExtInst %void %2 DebugLine %15 %uint_7 %uint_7 %uint_11 %uint_12
+         %13 = OpExtInst %void %2 DebugDeclare %55 %10 %56
+         %61 = OpExtInst %void %2 DebugLine %15 %uint_8 %uint_8 %uint_3 %uint_4
+               OpReturnValue %uint_0
+               OpFunctionEnd

--- a/test/DebugInfo/DebugInfoTypePtrToMember.spvasm
+++ b/test/DebugInfo/DebugInfoTypePtrToMember.spvasm
@@ -1,0 +1,60 @@
+; Tests translation of DebugTypePtrToMember DebugInfoNone type
+
+; REQUIRES: spirv-as
+
+; RUN: spirv-as %s --target-env spv1.1 -o %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; CHECK-LLVM: !DIDerivedType(tag: DW_TAG_ptr_to_member_type, baseType: ![[#Type:]]
+; CHECK-LLVM: ![[#Type]] = !DIBasicType(tag: DW_TAG_unspecified_type, name: "SPIRV unknown type")
+
+; SPIR-V
+; Version: 1.0
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 35
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Int64
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "OpenCL.std"
+          %2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+               OpMemoryModel Physical64 OpenCL
+          %7 = OpString "./foo.cpp"
+         %10 = OpString "0"
+         %14 = OpString ""
+         %20 = OpString "int"
+         %26 = OpString "_ZTS3Foo"
+         %27 = OpString "Foo"
+         %32 = OpString "x"
+               OpSource Unknown 0
+               OpName %x "x"
+               OpDecorate %x LinkageAttributes "x" Export
+               OpDecorate %x Alignment 8
+      %ulong = OpTypeInt 64 0
+       %uint = OpTypeInt 32 0
+%ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
+     %uint_1 = OpConstant %uint 1
+ %uint_65536 = OpConstant %uint 65536
+     %uint_2 = OpConstant %uint 2
+     %uint_6 = OpConstant %uint 6
+    %uint_32 = OpConstant %uint 32
+     %uint_4 = OpConstant %uint 4
+     %uint_0 = OpConstant %uint 0
+    %uint_16 = OpConstant %uint 16
+     %uint_8 = OpConstant %uint 8
+%_ptr_CrossWorkgroup_ulong = OpTypePointer CrossWorkgroup %ulong
+       %void = OpTypeVoid
+          %x = OpVariable %_ptr_CrossWorkgroup_ulong CrossWorkgroup %ulong_18446744073709551615
+          %9 = OpExtInst %void %2 DebugSource %7
+         %13 = OpExtInst %void %2 DebugBuildIdentifier %10 %uint_1
+         %15 = OpExtInst %void %2 DebugStoragePath %14
+         %19 = OpExtInst %void %2 DebugCompilationUnit %uint_65536 %uint_2 %9 %uint_6
+         %23 = OpExtInst %void %2 DebugInfoNone
+         %24 = OpExtInst %void %2 DebugTypeBasic %20 %uint_32 %uint_4 %23
+         %25 = OpExtInst %void %2 DebugTypeComposite %27 %uint_1 %9 %uint_1 %uint_0 %19 %26 %uint_0 %uint_16
+         %31 = OpExtInst %void %2 DebugTypePtrToMember %23 %25
+         %34 = OpExtInst %void %2 DebugGlobalVariable %32 %31 %9 %uint_4 %uint_0 %19 %14 %x %uint_8

--- a/test/DebugInfo/DebugInfoTypeVector.spvasm
+++ b/test/DebugInfo/DebugInfoTypeVector.spvasm
@@ -70,7 +70,7 @@
          %29 = OpExtInst %void %2 DebugSource %27 %28
          %30 = OpExtInst %void %2 DebugCompilationUnit 65536 5 %29 OpenCL_C
          %34 = OpExtInst %void %2 DebugTypeBasic %32 %uint_16 Signed
-         %35 = OpExtInst %void %2 DebugTypeVector %34 4
+         %35 = OpExtInst %void %2 DebugTypeVector %15 4
          %38 = OpExtInst %void %2 DebugSource %36 %37
          %39 = OpExtInst %void %2 DebugTypedef %31 %35 %38 0 0 %30
          %40 = OpExtInst %void %2 DebugTypePointer %39 CrossWorkgroup None

--- a/test/DebugInfo/DebugInfoTypeVector.spvasm
+++ b/test/DebugInfo/DebugInfoTypeVector.spvasm
@@ -1,0 +1,111 @@
+; Tests translation of DebugTypeVector DebugInfoNone type
+
+; REQUIRES: spirv-as
+
+; RUN: spirv-as %s --target-env spv1.1 -o %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; CHECK-LLVM: !DICompositeType(tag: DW_TAG_array_type, baseType: ![[#Type:]], flags: DIFlagVector
+; CHECK-LLVM: ![[#Type]] = !DIBasicType(tag: DW_TAG_unspecified_type, name: "SPIRV unknown type")
+
+; SPIR-V
+; Version: 1.1
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 61
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpCapability Int16
+          %1 = OpExtInstImport "OpenCL.std"
+          %2 = OpExtInstImport "OpenCL.DebugInfo.100"
+               OpMemoryModel Physical32 OpenCL
+               OpEntryPoint Kernel %23 "do_add_sub" %__spirv_BuiltInGlobalInvocationId
+         %27 = OpString "/app/<stdin>"
+         %28 = OpString "//__CSK_MD5:df3c6ff4eef4b9de43419af39216b003"
+         %31 = OpString "short4"
+         %32 = OpString "short"
+         %36 = OpString "/opt/compiler-explorer/clang-assertions-trunk-20240209/lib/clang/19/include/opencl-c-base.h"
+         %37 = OpString "//__CSK_MD5:0cbe46031b64656ef87e922672ce4bdc"
+         %42 = OpString "size_t"
+         %43 = OpString "unsigned int"
+         %47 = OpString "do_add_sub"
+         %48 = OpString "/app/example.cl"
+         %50 = OpString ""
+         %52 = OpString "add_out"
+         %54 = OpString "g"
+               OpSource OpenCL_C 102000
+               OpName %__spirv_BuiltInGlobalInvocationId "__spirv_BuiltInGlobalInvocationId"
+               OpName %do_add_sub "do_add_sub"
+               OpName %add_out "add_out"
+               OpName %entry "entry"
+               OpName %call "call"
+               OpName %arrayidx "arrayidx"
+               OpName %add_out_0 "add_out"
+               OpModuleProcessed "Debug info producer: clang version 19.0.0git (https://github.com/llvm/llvm-project.git 2572f45c7d6c081ba9b4fa344e928182f8df7773)"
+               OpDecorate %__spirv_BuiltInGlobalInvocationId LinkageAttributes "__spirv_BuiltInGlobalInvocationId" Import
+               OpDecorate %__spirv_BuiltInGlobalInvocationId Constant
+               OpDecorate %__spirv_BuiltInGlobalInvocationId BuiltIn GlobalInvocationId
+               OpDecorate %do_add_sub LinkageAttributes "do_add_sub" Export
+               OpDecorate %add_out FuncParamAttr NoCapture
+               OpDecorate %add_out Alignment 8
+               OpDecorate %add_out_0 FuncParamAttr NoCapture
+               OpDecorate %add_out_0 Alignment 8
+       %uint = OpTypeInt 32 0
+     %ushort = OpTypeInt 16 0
+   %ushort_2 = OpConstant %ushort 2
+    %uint_16 = OpConstant %uint 16
+    %uint_32 = OpConstant %uint 32
+     %v3uint = OpTypeVector %uint 3
+%_ptr_Input_v3uint = OpTypePointer Input %v3uint
+       %void = OpTypeVoid
+   %v4ushort = OpTypeVector %ushort 4
+%_ptr_CrossWorkgroup_v4ushort = OpTypePointer CrossWorkgroup %v4ushort
+         %11 = OpTypeFunction %void %_ptr_CrossWorkgroup_v4ushort
+%__spirv_BuiltInGlobalInvocationId = OpVariable %_ptr_Input_v3uint Input
+         %22 = OpConstantComposite %v4ushort %ushort_2 %ushort_2 %ushort_2 %ushort_2
+         %15 = OpExtInst %void %2 DebugInfoNone
+         %29 = OpExtInst %void %2 DebugSource %27 %28
+         %30 = OpExtInst %void %2 DebugCompilationUnit 65536 5 %29 OpenCL_C
+         %34 = OpExtInst %void %2 DebugTypeBasic %32 %uint_16 Signed
+         %35 = OpExtInst %void %2 DebugTypeVector %34 4
+         %38 = OpExtInst %void %2 DebugSource %36 %37
+         %39 = OpExtInst %void %2 DebugTypedef %31 %35 %38 0 0 %30
+         %40 = OpExtInst %void %2 DebugTypePointer %39 CrossWorkgroup None
+         %41 = OpExtInst %void %2 DebugTypeFunction None %15 %40
+         %45 = OpExtInst %void %2 DebugTypeBasic %43 %uint_32 Unsigned
+         %46 = OpExtInst %void %2 DebugTypedef %42 %45 %38 0 0 %30
+         %49 = OpExtInst %void %2 DebugSource %48 %28
+         %51 = OpExtInst %void %2 DebugFunction %47 %41 %49 1 0 %30 %50 FlagIsDefinition|FlagPrototyped|FlagIsOptimized 2 %do_add_sub %15
+         %53 = OpExtInst %void %2 DebugLocalVariable %52 %40 %49 1 0 %51 None 1
+         %55 = OpExtInst %void %2 DebugLocalVariable %54 %46 %49 3 0 %51 None
+         %56 = OpExtInst %void %2 DebugOperation Constu 0
+         %57 = OpExtInst %void %2 DebugOperation Swap
+         %58 = OpExtInst %void %2 DebugOperation Xderef
+         %59 = OpExtInst %void %2 DebugExpression %56 %57 %58
+ %do_add_sub = OpFunction %void None %11
+    %add_out = OpFunctionParameter %_ptr_CrossWorkgroup_v4ushort
+      %entry = OpLabel
+         %60 = OpExtInst %void %2 DebugScope %51
+               OpLine %48 0 0
+         %16 = OpExtInst %void %2 DebugValue %53 %add_out %59
+               OpLine %48 3 16
+         %17 = OpLoad %v3uint %__spirv_BuiltInGlobalInvocationId Aligned 16
+       %call = OpCompositeExtract %uint %17 0
+               OpLine %48 0 0
+         %19 = OpExtInst %void %2 DebugValue %55 %call %59
+               OpLine %48 4 5
+   %arrayidx = OpInBoundsPtrAccessChain %_ptr_CrossWorkgroup_v4ushort %add_out %call
+               OpLine %48 4 16
+               OpStore %arrayidx %22 Aligned 8
+               OpLine %48 5 1
+               OpReturn
+               OpFunctionEnd
+         %23 = OpFunction %void None %11
+  %add_out_0 = OpFunctionParameter %_ptr_CrossWorkgroup_v4ushort
+         %25 = OpLabel
+         %26 = OpFunctionCall %void %do_add_sub %add_out_0
+               OpReturn
+               OpFunctionEnd

--- a/test/DebugInfo/DebugTypeMember.spvasm
+++ b/test/DebugInfo/DebugTypeMember.spvasm
@@ -1,0 +1,62 @@
+; Tests translation of DebugTypeMember with DebugInfoNone type
+
+; REQUIRES: spirv-as
+
+; RUN: spirv-as %s --target-env spv1.1 -o %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
+
+; CHECK-LLVM: ![[#Type:]] = !DIBasicType(tag: DW_TAG_unspecified_type, name: "SPIRV unknown type")
+; CHECK-LLVM: !DIDerivedType(tag: DW_TAG_member, name: "anon_static_decl_var", scope: ![[#]], file: ![[#]], line: 5, baseType: ![[#Type]], flags: DIFlagPublic | DIFlagStaticMember, extraData: i32 351)
+
+; SPIR-V
+; Version: 1.1
+; Generator: Khronos LLVM/SPIR-V Translator; 14
+; Bound: 36
+; Schema: 0
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+          %1 = OpExtInstImport "OpenCL.std"
+          %2 = OpExtInstImport "OpenCL.DebugInfo.100"
+               OpMemoryModel Physical64 OpenCL
+          %8 = OpString "/testdir/test.cpp"
+         %12 = OpString "int"
+         %18 = OpString "anon_static_decl_struct"
+         %19 = OpString ""
+         %23 = OpString "anon_static_decl_var"
+         %28 = OpString "ref"
+         %29 = OpString "_Z3refv"
+               OpSource Unknown 0
+               OpName %_Z3refv "_Z3refv"
+               OpName %entry "entry"
+               OpModuleProcessed "Debug info producer: clang based Intel(R) oneAPI DPC++/C++ Compiler 2024.1.0 (2024.x.0.YYYYMMDD)"
+               OpDecorate %_Z3refv LinkageAttributes "_Z3refv" Export
+       %uint = OpTypeInt 32 0
+   %uint_351 = OpConstant %uint 351
+    %uint_32 = OpConstant %uint 32
+     %uint_8 = OpConstant %uint 8
+     %uint_0 = OpConstant %uint 0
+          %4 = OpTypeFunction %uint
+       %void = OpTypeVoid
+         %10 = OpExtInst %void %2 DebugSource %8
+         %11 = OpExtInst %void %2 DebugCompilationUnit 65536 4 %10 CPP_for_OpenCL
+         %14 = OpExtInst %void %2 DebugTypeBasic %12 %uint_32 Signed
+         %17 = OpExtInst %void %2 DebugInfoNone
+         %20 = OpExtInst %void %2 DebugSource %19
+         %21 = OpExtInst %void %2 DebugLexicalBlock %20 0 0 %11 %19
+         %25 = OpExtInst %void %2 DebugTypeMember %23 %17 %10 5 0 %16 %uint_0 %uint_0 FlagIsProtected|FlagIsPrivate|FlagStaticMember %uint_351
+         %16 = OpExtInst %void %2 DebugTypeComposite %18 Structure %10 4 0 %21 %17 %uint_8 FlagTypePassByValue %25
+         %27 = OpExtInst %void %2 DebugTypeFunction None %14
+         %30 = OpExtInst %void %2 DebugFunction %28 %27 %10 11 0 %11 %29 FlagIsDefinition|FlagPrototyped 11 %_Z3refv %17
+         %31 = OpExtInst %void %2 DebugOperation Constu 351
+         %32 = OpExtInst %void %2 DebugOperation StackValue
+         %33 = OpExtInst %void %2 DebugExpression %31 %32
+         %34 = OpExtInst %void %2 DebugGlobalVariable %23 %17 %10 5 0 %11 %19 %33 FlagIsLocal|FlagIsDefinition %25
+    %_Z3refv = OpFunction %uint None %4
+      %entry = OpLabel
+         %35 = OpExtInst %void %2 DebugScope %30
+               OpLine %8 12 3
+               OpReturnValue %uint_351
+               OpFunctionEnd

--- a/test/DebugInfo/NonSemantic/Shader200/FortranArrayNoType.spt
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranArrayNoType.spt
@@ -1,0 +1,75 @@
+; Tests translation of DebugTypeArrayDynamic with DebugInfoNone type
+
+; RUN: llvm-spirv -to-binary %s -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: ![[#]] = !DICompositeType(tag: DW_TAG_array_type, baseType: ![[#Type:]]
+; CHECK-LLVM: ![[#Type]] = !DIBasicType(tag: DW_TAG_unspecified_type, name: "SPIRV unknown type")
+
+119734787 65536 393230 49 0 
+2 Capability Addresses 
+2 Capability Linkage 
+2 Capability Kernel 
+8 Extension "SPV_KHR_non_semantic_info" 
+5 ExtInstImport 1 "OpenCL.std" 
+11 ExtInstImport 2 "NonSemantic.Shader.DebugInfo.200" 
+3 MemoryModel 2 2 
+11 String 7 "/test/declare_target_subroutine.F90" 
+3 String 9 "0" 
+3 String 13 "" 
+9 String 22 "declare_target_subroutine" 
+4 String 23 "MAIN__" 
+3 String 27 "a" 
+5 String 28 "INTEGER*4" 
+6 String 42 "iso_fortran_env" 
+3 Source 0 0 
+4 Name 5 "MAIN__" 
+
+6 Decorate 5 LinkageAttributes "MAIN__" Export 
+4 TypeInt 10 32 0 
+4 Constant 10 11 1 
+4 Constant 10 15 65536 
+4 Constant 10 16 4 
+4 Constant 10 17 206 
+4 Constant 10 20 0 
+4 Constant 10 24 23 
+4 Constant 10 25 8 
+4 Constant 10 29 32 
+4 Constant 10 31 149 
+4 Constant 10 40 28 
+4 Constant 10 45 24 
+2 TypeVoid 3 
+3 TypeFunction 4 3 
+
+
+6 ExtInst 3 8 2 DebugSource 7 
+7 ExtInst 3 12 2 DebugBuildIdentifier 9 11 
+6 ExtInst 3 14 2 DebugStoragePath 13 
+10 ExtInst 3 18 2 DebugCompilationUnit 15 16 8 17 13 
+5 ExtInst 3 19 2 DebugInfoNone 
+7 ExtInst 3 21 2 DebugTypeFunction 20 19 
+15 ExtInst 3 26 2 DebugFunction 22 21 8 24 20 18 23 25 24 19
+5 ExtInst 3 30 2 DebugInfoNone 
+6 ExtInst 3 32 2 DebugOperation 31 
+6 ExtInst 3 33 2 DebugExpression 32 
+6 ExtInst 3 34 2 DebugOperation 31 
+6 ExtInst 3 35 2 DebugExpression 34 
+6 ExtInst 3 36 2 DebugOperation 31 
+6 ExtInst 3 37 2 DebugExpression 36 
+9 ExtInst 3 38 2 DebugTypeSubrange 37 37 19 37 
+11 ExtInst 3 39 2 DebugTypeArrayDynamic 30 33 35 19 19 38 
+12 ExtInst 3 41 2 DebugLocalVariable 27 39 8 40 20 26 20 
+6 ExtInst 3 43 2 DebugSource 13 
+13 ExtInst 3 44 2 DebugModule 42 43 20 26 13 13 13 11 
+12 ExtInst 3 46 2 DebugImportedEntity 13 20 8 44 45 20 26 
+9 ExtInst 3 47 2 DebugEntryPoint 26 18 13 13 
+
+5 Function 3 5 0 4 
+
+2 Label 6 
+7 ExtInst 3 48 2 DebugFunctionDefinition 26 5 
+1 Return 
+
+1 FunctionEnd 
+


### PR DESCRIPTION
…or debug types (#2341)

OpenCL and NonSemantic DebugInfo specifications are flexible in terms of allowing any debug information be replaced with DebugInfoNone, so various of SPIR-V producers follow that and generate it for base types of several debug instructions, leaving SPIR-V consumers to handle this. By default the translator replaces missing debug info with tag: null, which is in most cases correct. Yet, there are situations, where it's not allowed by both LLVM and DWARF, for example for DW_TAG_array_type DWARF spec sets, that DW_AT_type attribute is mandatory. For such cases new transNonNullDebugType wrapper function was added to the translator, generating "DIBasicType(tag: DW_TAG_unspecified_type, name: "SPIRV unknown type")" where DebugInfoNone was used as the type. This function doesn't replace all calls to transDebugInst<DIType> as there are cases, where we can generate null type, for example DWARF doesn't require it for DW_TAG_typedef, hence I'm not changing translation flow in this case. Additionally to this, while DWARF requires type attribute for DW_TAG_pointer_type, LLVM does not, hence I'm not changing translation flow in this case as well.