### PR TITLE
[Backport to 17] Fix globals' type deduction in TypeScavenger

### DIFF
--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -619,6 +619,12 @@ void SPIRVTypeScavenger::typeGlobalValue(GlobalValue &GV, Constant *Init) {
       auto It = DeducedTypes.find(C);
       if (It != DeducedTypes.end())
         return It->second;
+    } else if (auto *GEP = dyn_cast<GEPOperator>(C)) {
+      auto *ResultTy =
+          TypedPointerType::get(GEP->getResultElementType(),
+                                GEP->getType()->getPointerAddressSpace());
+      DeducedTypes[C] = ResultTy;
+      return ResultTy;
     }
 
     return getUnknownTyped(C->getType());

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1307,8 +1307,17 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
-  if (auto ConstUE = dyn_cast<ConstantExpr>(V)) {
-    auto Inst = ConstUE->getAsInstruction();
+  if (auto *ConstUE = dyn_cast<ConstantExpr>(V)) {
+    if (auto *GEP = dyn_cast<GEPOperator>(ConstUE)) {
+      std::vector<SPIRVValue *> Indices;
+      for (unsigned I = 0, E = GEP->getNumIndices(); I != E; ++I)
+        Indices.push_back(transValue(GEP->getOperand(I + 1), nullptr));
+      auto *TransPointerOperand = transValue(GEP->getPointerOperand(), nullptr);
+      SPIRVType *TranslatedTy = transScavengedType(GEP);
+      return BM->addPtrAccessChainInst(TranslatedTy, TransPointerOperand,
+                                       Indices, nullptr, GEP->isInBounds());
+    }
+    auto *Inst = ConstUE->getAsInstruction();
     SPIRVDBG(dbgs() << "ConstantExpr: " << *ConstUE << '\n';
              dbgs() << "Instruction: " << *Inst << '\n';)
     auto BI = transValue(Inst, nullptr, false);

--- a/test/layout.ll
+++ b/test/layout.ll
@@ -43,22 +43,27 @@
 ; CHECK-NOT: {{[0-9]*}} Variable
 ; CHECK-NOT: {{[0-9]*}} Function
 
-; CHECK: {{[0-9]*}} TypeInt [[TypeInt:[0-9]+]] 32
-; CHECK: {{[0-9]*}} TypeInt [[TypeI8:[0-9]+]] 8
-; CHECK: {{[0-9]*}} Constant [[TypeInt]] [[Two:[0-9]+]] 2
-; CHECK: {{[0-9]*}} TypePointer [[TPointer:[0-9]+]]
-; CHECK: {{[0-9]*}} TypePointer [[SConstOpType:[0-9]+]]
+; CHECK: {{[0-9]*}} TypeInt [[TypeInt32:[0-9]+]] 32
+; CHECK: {{[0-9]*}} TypeInt [[TypeInt8:[0-9]+]] 8
+; CHECK: {{[0-9]*}} Constant [[TypeInt32]] [[Int32Two:[0-9]+]] 2
+; CHECK: {{[0-9]*}} TypeArray [[TypeArrayInt32:[0-9]+]] [[TypeInt32]] [[Int32Two]]
+; CHECK: {{[0-9]*}} TypePointer [[TypePtr5ArrayInt32:[0-9]+]] 5 [[TypeArrayInt32]]
+; CHECK: {{[0-9]*}} TypePointer [[TypePtr5Int32:[0-9]+]] 5 [[TypeInt32]]
+; CHECK: {{[0-9]*}} TypePointer [[TypePtr5Ptr5Int32:[0-9]+]] 5 [[TypePtr5Int32]]
 ; CHECK: {{[0-9]*}} TypeFloat [[TypeFloat:[0-9]+]]
-; CHECK: {{[0-9]*}} TypeArray [[TypeArray:[0-9]+]] [[TypeFloat]] [[Two]]
-; CHECK: {{[0-9]*}} TypeVector [[TypeVectorInt3:[0-9]+]] [[TypeInt]] 3
-; CHECK: {{[0-9]*}} TypePointer [[TPointerI8:[0-9]+]] 8 [[TypeI8]]
-; CHECK: {{[0-9]*}} TypeStruct [[BID:[0-9]+]] {{[0-9]+}} [[TPointerI8]]
+; CHECK: {{[0-9]*}} TypeArray [[TypeArrayFloat:[0-9]+]] [[TypeFloat]] [[Int32Two]]
+; CHECK: {{[0-9]*}} TypePointer [[TypePtr8ArrayFloat:[0-9]+]] 0 [[TypeArrayFloat]]
+; CHECK: {{[0-9]*}} TypeVector [[TypeVectorInt32:[0-9]+]] [[TypeInt32]] 3
+; CHECK: {{[0-9]*}} TypePointer [[TypePtr8VectorInt32:[0-9]+]] 0 [[TypeVectorInt32]]
+; CHECK: {{[0-9]*}} TypePointer [[TypePtr0Int8:[0-9]+]] 8 [[TypeInt8]]
+; CHECK: {{[0-9]*}} TypeStruct [[BID:[0-9]+]] {{[0-9]+}} [[TypePtr0Int8]]
 ; CHECK: {{[0-9]*}} TypeStruct [[CID:[0-9]+]] {{[0-9]+}} [[BID]]
 ; CHECK: {{[0-9]*}} TypeStruct [[AID:[0-9]+]] {{[0-9]+}} [[CID]]
 ; CHECK: {{[0-9]*}} TypeVoid [[Void:[0-9]+]]
-; CHECK: {{[0-9]*}} TypeFunction [[TypeBar1:[0-9]+]] [[Void]] [[SConstOpType]]
-; CHECK: {{[0-9]*}} Variable [[TPointer]] [[Var:[0-9]+]]
-; CHECK: {{[0-9]*}} SpecConstantOp [[SConstOpType]] [[SConstOp:[0-9]+]] 70 [[Var]]
+; CHECK: {{[0-9]*}} TypePointer [[TypePtr5Int8:[0-9]+]] 5 [[TypeInt8]]
+; CHECK: {{[0-9]*}} TypeFunction [[TypeBar1:[0-9]+]] [[Void]] [[TypePtr5Int8]]
+; CHECK: {{[0-9]*}} Variable [[TypePtr5ArrayInt32]] [[Var:[0-9]+]]
+; CHECK: {{[0-9]*}} SpecConstantOp [[TypePtr5Int32]] [[SConstOp:[0-9]+]] 70 [[Var]]
 ; CHECK: {{[0-9]*}} Variable {{[0-9]+}} {{[0-9]+}} 5 [[SConstOp]]
 
 ; CHECK-NOT: {{[0-9]*}} Capability

--- a/test/type-scavenger/globals.ll
+++ b/test/type-scavenger/globals.ll
@@ -9,12 +9,18 @@ target triple = "spir-unknown-unknown"
 ; CHECK-DAG: TypeInt [[I8:[0-9]+]] 8 0
 ; CHECK-DAG: TypeInt [[I16:[0-9]+]] 16 0
 ; CHECK-DAG: TypeInt [[I32:[0-9]+]] 32 0
+; CHECK-DAG: TypeInt [[I64:[0-9]+]] 64 0
 ; CHECK-DAG: TypePointer [[I8PTR:[0-9]+]] 5 [[I8]]
 ; CHECK-DAG: TypePointer [[I16PTR:[0-9]+]] 5 [[I16]]
 ; CHECK-DAG: TypePointer [[I16PTRPTR:[0-9]+]] 5 [[I16PTR]]
 ; CHECK-DAG: TypePointer [[I32PTR:[0-9]+]] 5 [[I32]]
+; CHECK-DAG: TypePointer [[I32PTRPTR:[0-9]+]] 5 [[I32PTR]]
 ; CHECK-DAG: TypeArray [[I8PTRx2:[0-9]+]] [[I8PTR]]
 ; CHECK-DAG: TypePointer [[I8PTRx2PTR:[0-9]+]] 5 [[I8PTRx2]]
+; CHECK-DAG: TypeArray [[I32x4:[0-9]+]] [[I32]]
+; CHECK-DAG: TypeArray [[I32x3x4:[0-9]+]] [[I32x4]]
+; CHECK-DAG: TypeArray [[I32x2x3x4:[0-9]+]] [[I32x3x4]]
+; CHECK-DAG: TypePointer [[I32x2x3x4PTR:[0-9]+]] 5 [[I32x2x3x4]]
 ; CHECK: Variable [[I16PTR]] [[A:[0-9]+]] 5
 ; CHECK: Variable [[I32PTR]] [[B:[0-9]+]] 5
 ; CHECK: Variable [[I16PTRPTR]] [[C:[0-9]+]] 5 [[A]]
@@ -22,12 +28,18 @@ target triple = "spir-unknown-unknown"
 ; CHECK: SpecConstantOp [[I8PTR]] [[BI8:[0-9]+]] 124 [[B]]
 ; CHECK: ConstantComposite [[I8PTRx2]] [[DINIT:[0-9]+]] [[AI8]] [[BI8]]
 ; CHECK: Variable [[I8PTRx2PTR]] [[D:[0-9]+]] 5 [[DINIT]]
+; CHECK: ConstantComposite [[I32x2x3x4]] [[FINIT:[0-9]+]]
+; CHECK: Variable [[I32x2x3x4PTR]] [[F:[0-9]+]] 5 [[FINIT]]
+; CHECK: SpecConstantOp [[I32PTR]] [[GINIT:[0-9]+]] 70 [[F]]
+; CHECK: Variable [[I32PTRPTR]] [[G:[0-9]+]] 5 [[GINIT]]
 
 @a = addrspace(1) global i16 0
 @b = external addrspace(1) global i32
 @c = addrspace(1) global ptr addrspace(1) @a
 @d = addrspace(1) global [2 x ptr addrspace(1)] [ptr addrspace(1) @a, ptr addrspace(1) @b]
 ;@e = global [1 x ptr] [ptr @foo]
+@f = addrspace(1) global [2 x [3 x [4 x i32]]] [[3 x [4 x i32]] [[4 x i32] [i32 1, i32 2, i32 3, i32 4], [4 x i32] [i32 1, i32 2, i32 3, i32 4], [4 x i32] [i32 1, i32 2, i32 3, i32 4]], [3 x [4 x i32]] [[4 x i32] [i32 1, i32 2, i32 3, i32 4], [4 x i32] [i32 1, i32 2, i32 3, i32 4], [4 x i32] [i32 1, i32 2, i32 3, i32 4]]]
+@g = addrspace(1) global ptr addrspace(1) getelementptr inbounds ([2 x [3 x [4 x i32]]], ptr addrspace(1) @f, i64 0, i64 1, i64 2, i64 3)
 
 ; Function Attrs: nounwind
 define spir_kernel void @foo() {


### PR DESCRIPTION
If a global is initialized with a ConstantExpr returning a pointer (getelementptr), the right type has to be deduced instead of defaulting it to i8*.