### PR TITLE
Fix handling of OpenCL convert_ builtins

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -751,9 +751,9 @@ void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
     TargetTyName = TargetTyName.substr(0, FirstUnderscoreLoc);
 
   // Validate target type name
-  std::regex e("([a-z]+)([0-9]*)$");
+  std::regex Expr("([a-z]+)([0-9]*)$");
   std::smatch DestTyMatch;
-  if (!std::regex_match(TargetTyName, DestTyMatch, e))
+  if (!std::regex_match(TargetTyName, DestTyMatch, Expr))
     return;
 
   // The first sub_match is the whole string; the next

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -765,7 +765,7 @@ void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
       "float",  "double", "half", "char", "uchar", "short",
       "ushort", "int",    "uint", "long", "ulong"};
 
-  if (auto It = ValidTypes.find(DestTy); It == ValidTypes.end())
+  if (ValidTypes.find(DestTy) == ValidTypes.end())
     return;
 
   // check that it's allowed vector size

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -761,18 +761,11 @@ void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
   std::string DestTy = DestTyMatch[1].str();
 
   // check it's valid type name
-  SmallVector<StringRef, 11> ValidTypes = {"float", "double", "half",   "char",
-                                           "uchar", "short",  "ushort", "int",
-                                           "uint",  "long",   "ulong"};
-  bool IsValidType = false;
-  for (auto I : ValidTypes) {
-    auto Found = DestTy.find(I);
-    if (Found != std::string::npos) {
-      IsValidType = true;
-      break;
-    }
-  }
-  if (!IsValidType)
+  static std::unordered_set<std::string> ValidTypes = {
+      "float",  "double", "half", "char", "uchar", "short",
+      "ushort", "int",    "uint", "long", "ulong"};
+
+  if (auto It = ValidTypes.find(DestTy); It == ValidTypes.end())
     return;
 
   // check that it's allowed vector size

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -52,6 +52,7 @@
 #include "llvm/Support/Debug.h"
 
 #include <algorithm>
+#include <regex>
 #include <set>
 
 using namespace llvm;
@@ -724,6 +725,13 @@ void OCLToSPIRVBase::visitCallBarrier(CallInst *CI) {
 
 void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
                                       StringRef DemangledName) {
+  // OpenCL Explicit Conversions (6.4.3) formed as below for scalars:
+  // destType convert_destType<_sat><_roundingMode>(sourceType)
+  // and for vector type:
+  // destTypeN convert_destTypeN<_sat><_roundingMode>(sourceTypeN)
+  // If the demangled name is not matching the suggested pattern and does not
+  // meet allowed destination type restrictions - this is not an OpenCL builtin,
+  // return from the function and translate such CallInst as a function call.
   if (eraseUselessConvert(CI, MangledName, DemangledName))
     return;
   Op OC = OpNop;
@@ -734,16 +742,63 @@ void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
   if (auto *VecTy = dyn_cast<VectorType>(SrcTy))
     SrcTy = VecTy->getElementType();
   auto IsTargetInt = isa<IntegerType>(TargetTy);
+  auto TargetSigned = DemangledName[8] != 'u';
 
   std::string TargetTyName(
       DemangledName.substr(strlen(kOCLBuiltinName::ConvertPrefix)));
   auto FirstUnderscoreLoc = TargetTyName.find('_');
   if (FirstUnderscoreLoc != std::string::npos)
     TargetTyName = TargetTyName.substr(0, FirstUnderscoreLoc);
+
+  // Validate target type name
+  std::regex e("([a-z]+)([0-9]*)$");
+  std::smatch DestTyMatch;
+  if (!std::regex_match(TargetTyName, DestTyMatch, e))
+    return;
+
+  // The first sub_match is the whole string; the next
+  // sub_match is the first parenthesized expression.
+  std::string DestTy = DestTyMatch[1].str();
+
+  // check it's valid type name
+  SmallVector<StringRef, 11> ValidTypes = {"float", "double", "half",   "char",
+                                           "uchar", "short",  "ushort", "int",
+                                           "uint",  "long",   "ulong"};
+  bool IsValidType = false;
+  for (auto I : ValidTypes) {
+    auto Found = DestTy.find(I);
+    if (Found != std::string::npos) {
+      IsValidType = true;
+      break;
+    }
+  }
+  if (!IsValidType)
+    return;
+
+  // check that it's allowed vector size
+  std::string VecSize = DestTyMatch[2].str();
+  if (!VecSize.empty()) {
+    int Size = stoi(VecSize);
+    switch (Size) {
+    case 2:
+    case 3:
+    case 4:
+    case 8:
+    case 16:
+      break;
+    default:
+      return;
+    }
+  }
+  DemangledName = DemangledName.drop_front(
+      strlen(kOCLBuiltinName::ConvertPrefix) + TargetTyName.size());
   TargetTyName = std::string("_R") + TargetTyName;
 
+  if (!DemangledName.empty() && !DemangledName.starts_with("_sat") &&
+      !DemangledName.starts_with("_rt"))
+    return;
+
   std::string Sat = DemangledName.find("_sat") != StringRef::npos ? "_sat" : "";
-  auto TargetSigned = DemangledName[8] != 'u';
   if (isa<IntegerType>(SrcTy)) {
     bool Signed = isLastFuncParamSigned(MangledName);
     if (IsTargetInt) {

--- a/test/transcoding/OpenCL/convert_functions.ll
+++ b/test/transcoding/OpenCL/convert_functions.ll
@@ -1,0 +1,55 @@
+; This test checks that functions with `convert_` prefix are translated as
+; OpenCL builtins only in case they match the specification. Otherwise, we
+; expect such functions to be translated to SPIR-V FunctionCall.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -r -o - | llvm-dis -o %t.rev.ll
+; RUN: FileCheck < %t.rev.ll %s -check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: Name [[#Func:]] "_Z18convert_float_func"
+; CHECK-SPIRV: TypeVoid [[#VoidTy:]]
+; CHECK-SPIRV: TypeFloat [[#FloatTy:]] 32
+
+; CHECK-SPIRV: Function [[#VoidTy]] [[#Func]]
+; CHECK-SPIRV: ConvertSToF [[#FloatTy]] [[#ConvertId:]] [[#]]
+; CHECK-SPIRV: FunctionCall [[#VoidTy]] [[#]] [[#Func]] [[#ConvertId]]
+; CHECK-SPIRV-NOT: FConvert
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir"
+
+; Function Attrs: convergent noinline norecurse nounwind optnone
+define dso_local spir_func void @_Z18convert_float_func(float noundef %x) #0 {
+entry:
+  %x.addr = alloca float, align 4
+  store float %x, ptr %x.addr, align 4
+  ret void
+}
+
+; Function Attrs: convergent noinline norecurse nounwind optnone
+define dso_local spir_func void @convert_int_bf16(i32 noundef %x) #0 {
+entry:
+  %x.addr = alloca i32, align 4
+  store i32 %x, ptr %x.addr, align 4
+  %0 = load i32, ptr %x.addr, align 4
+; CHECK-LLVM: %[[Call:[a-z]+]] = sitofp i32 %[[#]] to float
+  %call = call spir_func float @_Z13convert_floati(i32 noundef %0) #1
+; CHECK-LLVM: call spir_func void @_Z18convert_float_func(float %[[Call]])
+  call spir_func void @_Z18convert_float_func(float noundef %call) #0
+  ret void
+}
+
+; Function Attrs: convergent nounwind willreturn memory(none)
+declare spir_func float @_Z13convert_floati(i32 noundef) #1
+
+attributes #0 = { convergent nounwind }
+attributes #1 = { convergent nounwind willreturn memory(none) }
+
+!opencl.ocl.version = !{!0}
+!opencl.spir.version = !{!0}
+
+!0 = !{i32 3, i32 0}


### PR DESCRIPTION
This change fixes cases when the input function name does not match OpenCL spec but starts with `convert_` prefix, e.g. `convert_float_42`.