### PR TITLE
Workaround LLVM 15 bug with getting an element of a PointerUnion

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -426,7 +426,7 @@ SPIRVToLLVMDbgTran::transTypeArrayNonSemantic(const SPIRVExtInst *DebugInst) {
       auto *SR = transDebugInst<DISubrange>(BM->get<SPIRVExtInst>(Ops[I]));
       // LLVM 15 - exclusive workaround, get from a pointer union seem to be
       // bugged
-      if (SR->getCount().is<ConstantInt *>())
+      if (isa<ConstantInt *>(SR->getCount()))
         if (auto *Count = SR->getCount().get<ConstantInt *>())
           TotalCount *= Count->getSExtValue() > 0 ? Count->getSExtValue() : 0;
       Subscripts.push_back(SR);
@@ -452,7 +452,7 @@ SPIRVToLLVMDbgTran::transTypeArrayDynamic(const SPIRVExtInst *DebugInst) {
     auto *SR = transDebugInst<DISubrange>(BM->get<SPIRVExtInst>(Ops[I]));
     // LLVM 15 - exclusive workaround, get from a pointer union seem to be
     // bugged
-    if (SR->getCount().is<ConstantInt *>())
+    if (isa<ConstantInt *>(SR->getCount()))
       if (auto *Count = SR->getCount().get<ConstantInt *>())
         TotalCount *= Count->getSExtValue() > 0 ? Count->getSExtValue() : 0;
     Subscripts.push_back(SR);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -424,8 +424,11 @@ SPIRVToLLVMDbgTran::transTypeArrayNonSemantic(const SPIRVExtInst *DebugInst) {
   if (DebugInst->getExtOp() == SPIRVDebug::TypeArray) {
     for (size_t I = SubrangesIdx; I < Ops.size(); ++I) {
       auto *SR = transDebugInst<DISubrange>(BM->get<SPIRVExtInst>(Ops[I]));
-      if (auto *Count = SR->getCount().get<ConstantInt *>())
-        TotalCount *= Count->getSExtValue() > 0 ? Count->getSExtValue() : 0;
+      // LLVM 15 - exclusive workaround, get from a pointer union seem to be
+      // bugged
+      if (SR->getCount().is<ConstantInt *>())
+        if (auto *Count = SR->getCount().get<ConstantInt *>())
+          TotalCount *= Count->getSExtValue() > 0 ? Count->getSExtValue() : 0;
       Subscripts.push_back(SR);
     }
   }
@@ -447,8 +450,11 @@ SPIRVToLLVMDbgTran::transTypeArrayDynamic(const SPIRVExtInst *DebugInst) {
   SmallVector<llvm::Metadata *, 8> Subscripts;
   for (size_t I = SubrangesIdx; I < Ops.size(); ++I) {
     auto *SR = transDebugInst<DISubrange>(BM->get<SPIRVExtInst>(Ops[I]));
-    if (auto *Count = SR->getCount().get<ConstantInt *>())
-      TotalCount *= Count->getSExtValue() > 0 ? Count->getSExtValue() : 0;
+    // LLVM 15 - exclusive workaround, get from a pointer union seem to be
+    // bugged
+    if (SR->getCount().is<ConstantInt *>())
+      if (auto *Count = SR->getCount().get<ConstantInt *>())
+        TotalCount *= Count->getSExtValue() > 0 ? Count->getSExtValue() : 0;
     Subscripts.push_back(SR);
   }
   DINodeArray SubscriptArray =


### PR DESCRIPTION
It seems like casting from pointer union on LLVM 15 branch is bugged. Here we are crashing in transTypeArrayDynamic attempting to get a ConstantInt from debug subrange count of on line 450: if (auto *Count = SR->getCount().get<ConstantInt *>()). Count here is:
 (const llvm::PointerUnion<llvm::ConstantInt*, llvm::DIVariable*,
llvm::DIExpression*> * const)
so we should be able to cast it to ConstantInt, and it's happening successfully on main and llvm_release_140 branch (code, test and translation flow in this case is identical for all branches), and only on LLVM15 it results in a crash.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2444