### PR TITLE
Insert `OpVariable` instructions after `OpPhi`

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVBasicBlock.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVBasicBlock.cpp
@@ -91,7 +91,10 @@ SPIRVInstruction *SPIRVBasicBlock::getVariableInsertionPoint() const {
   auto IP =
       std::find_if(InstVec.begin(), InstVec.end(), [](SPIRVInstruction *Inst) {
         return !(isa<OpVariable>(Inst) || isa<OpLine>(Inst) ||
-                 isa<OpNoLine>(Inst));
+                 isa<OpNoLine>(Inst) ||
+                 // Note: OpVariable and OpPhi instructions do not belong to the
+                 // same block in a valid SPIR-V module.
+                 isa<OpPhi>(Inst));
       });
   if (IP == InstVec.end())
     return nullptr;


### PR DESCRIPTION
Although `OpPhi` and `OpVariable` instructions should not be in the same SPIR-V block in a valid module, take into account this case when inserting new `OpVariable` operations.

No test added, as no valid SPIR-V module can lead to this scenario.