### PR TITLE
Make storage class of builtins to be Input

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1553,8 +1553,11 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     // Force SPIRV BuiltIn variable's name to be __spirv_BuiltInXXXX.
     // No matter what BV's linkage name is.
     SPIRVBuiltinVariableKind BVKind;
-    if (BVar->isBuiltin(&BVKind))
+    if (BVar->isBuiltin(&BVKind)) {
       BV->setName(prefixSPIRVName(SPIRVBuiltInNameMap::map(BVKind)));
+      // BuiltinVars are globals that reside in addrspace(1).
+      AddrSpace = SPIRSPIRVAddrSpaceMap::rmap(StorageClassCrossWorkgroup);
+    }
     auto *LVar = new GlobalVariable(*M, Ty, IsConst, LinkageTy,
                                     /*Initializer=*/nullptr, BV->getName(), 0,
                                     GlobalVariable::NotThreadLocal, AddrSpace);

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -82,16 +82,18 @@ public:
   // instead.
   enum class FuncTransMode { Decl, Pointer };
 
-  SPIRVType *transType(Type *T);
-  SPIRVType *transPointerType(Type *PointeeTy, unsigned AddrSpace);
-  SPIRVType *transPointerType(SPIRVType *PointeeTy, unsigned AddrSpace);
+  SPIRVType *transType(Type *T, bool IsBuiltin = false);
+  SPIRVType *transPointerType(Type *PointeeTy, unsigned AddrSpace,
+                              bool IsBuiltin = false);
+  SPIRVType *transPointerType(SPIRVType *PointeeTy, unsigned AddrSpace,
+                              bool IsBuiltin = false);
   SPIRVType *transSPIRVOpaqueType(StringRef STName, unsigned AddrSpace);
   SPIRVType *
   transSPIRVJointMatrixINTELType(SmallVector<std::string, 8> Postfixes);
   /// Use the type scavenger to get the correct type for V. This is equivalent
   /// to transType(V->getType()) if V is not a pointer type; otherwise, it tries
   /// to pick an appropriate pointee type for V.
-  SPIRVType *transScavengedType(Value *V);
+  SPIRVType *transScavengedType(Value *V, bool IsBuiltin = false);
 
   SPIRVValue *getTranslatedValue(const Value *) const;
 

--- a/test/builtin-functions.ll
+++ b/test/builtin-functions.ll
@@ -16,7 +16,7 @@
 ; CHECK-FUNCTION-FORMAT-REV: declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32)
 ; CHECK-FUNCTION-FORMAT-OCL-REV: declare spir_func i64 @_Z12get_group_idj(i32)
 
-; CHECK-GLOBAL-FORMAT-REV: @__spirv_BuiltInWorkgroupId = external addrspace(7) constant <3 x i64>
+; CHECK-GLOBAL-FORMAT-REV: @__spirv_BuiltInWorkgroupId = external addrspace(1) constant <3 x i64>
 
 ; ModuleID = 'test.bc'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/test/builtin-storage-class.ll
+++ b/test/builtin-storage-class.ll
@@ -1,0 +1,22 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck --check-prefix=CHECK-SPIRV %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+; CHECK-SPIRV: Name [[BuiltinId:[0-9]+]] "__spirv_BuiltInWorkgroupId"
+; CHECK-SPIRV-DAG: Decorate [[BuiltinId]] BuiltIn
+; CHECK-SPIRV-DAG: TypePointer [[PointerTypeId:[0-9]+]] 1
+; CHECK-SPIRV-DAG: Variable [[PointerTypeId]] [[BuiltinId]] 1
+
+; ModuleID = 'test.bc'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@__spirv_BuiltInWorkgroupId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+; Function Attrs: convergent norecurse nounwind
+define weak_odr dso_local spir_kernel void @foo() {
+entry:
+  %0 = load i64, ptr addrspace(1) @__spirv_BuiltInWorkgroupId, align 32
+ ret void
+}


### PR DESCRIPTION
In case of builtin variables and their users, the storage class function should be StorageClassInput, irrespective of the incoming addrspace.
Ref: https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Env.html
Sec 2.9. Built-in variables.

This fixes https://github.com/intel/llvm/issues/6703

Thanks
Sincerely