### PR TITLE
[NFC] Move enableAllExtensions out of header

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -162,11 +162,7 @@ public:
     GenKernelArgNameMD = ArgNameMD;
   }
 
-  void enableAllExtensions() {
-#define EXT(X) ExtStatusMap[ExtensionID::X] = true;
-#include "LLVMSPIRVExtensions.inc"
-#undef EXT
-  }
+  void enableAllExtensions();
 
   void enableGenArgNameMD() { GenKernelArgNameMD = true; }
 

--- a/lib/SPIRV/LLVMSPIRVOpts.cpp
+++ b/lib/SPIRV/LLVMSPIRVOpts.cpp
@@ -47,6 +47,12 @@
 using namespace llvm;
 using namespace SPIRV;
 
+void TranslatorOpts::enableAllExtensions() {
+#define EXT(X) ExtStatusMap[ExtensionID::X] = true;
+#include "LLVMSPIRVExtensions.inc"
+#undef EXT
+}
+
 bool TranslatorOpts::isUnknownIntrinsicAllowed(IntrinsicInst *II) const
     noexcept {
   if (!SPIRVAllowUnknownIntrinsics.has_value())


### PR DESCRIPTION
The list of extensions has grown considerably, which makes this member function definition fairly large.  Move it out of the header.