### PR TITLE
switch task sequence enum to new available enum

### DIFF
--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -78,7 +78,7 @@ enum InternalOp {
   IOpCooperativeMatrixStoreCheckedINTEL = 6194,
   IOpCooperativeMatrixConstructCheckedINTEL = 6195,
   IOpJointMatrixWorkItemLengthINTEL = 6410,
-  IOpTypeTaskSequenceINTEL = 6411,
+  IOpTypeTaskSequenceINTEL = 6199,
   IOpComplexFMulINTEL = 6415,
   IOpComplexFDivINTEL = 6416,
   IOpRoundFToTF32INTEL = 6426,


### PR DESCRIPTION
Task Sequence Specification was created without explicitly reserving the 6411 token enum. During spec review, that number was reserved by CooperativeMatrixPrefetchINTEL, but Task Sequence was not updated to use a new enum at that point in time, resulting in development with the old enum. 6199 is the newly (confirmed) reserved token enum.