### PR TITLE
Rewrite OpenCL explicit conversion builtins handling

### DIFF
--- a/test/transcoding/OpenCL/convert_functions.ll
+++ b/test/transcoding/OpenCL/convert_functions.ll
@@ -11,13 +11,18 @@
 ; RUN: FileCheck < %t.rev.ll %s -check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: Name [[#Func:]] "_Z18convert_float_func"
+; CHECK-SPIRV: Name [[#Func1:]] "_Z20convert_uint_satfunc"
+; CHECK-SPIRV: Name [[#Func2:]] "_Z21convert_float_rtzfunc"
 ; CHECK-SPIRV: TypeVoid [[#VoidTy:]]
 ; CHECK-SPIRV: TypeFloat [[#FloatTy:]] 32
 
 ; CHECK-SPIRV: Function [[#VoidTy]] [[#Func]]
 ; CHECK-SPIRV: ConvertSToF [[#FloatTy]] [[#ConvertId:]] [[#]]
 ; CHECK-SPIRV: FunctionCall [[#VoidTy]] [[#]] [[#Func]] [[#ConvertId]]
+; CHECK-SPIRV: FunctionCall [[#VoidTy]] [[#]] [[#Func1]] [[#]]
+; CHECK-SPIRV: FunctionCall [[#VoidTy]] [[#]] [[#Func2]] [[#ConvertId]]
 ; CHECK-SPIRV-NOT: FConvert
+; CHECK-SPIRV-NOT: ConvertUToF
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir"
@@ -30,6 +35,16 @@ entry:
   ret void
 }
 
+define dso_local spir_func void @_Z20convert_uint_satfunc(i32 noundef %x) #0 {
+entry:
+  ret void
+}
+
+define dso_local spir_func void @_Z21convert_float_rtzfunc(float noundef %x) #0 {
+entry:
+  ret void
+}
+
 ; Function Attrs: convergent noinline norecurse nounwind optnone
 define dso_local spir_func void @convert_int_bf16(i32 noundef %x) #0 {
 entry:
@@ -37,9 +52,13 @@ entry:
   store i32 %x, ptr %x.addr, align 4
   %0 = load i32, ptr %x.addr, align 4
 ; CHECK-LLVM: %[[Call:[a-z]+]] = sitofp i32 %[[#]] to float
-  %call = call spir_func float @_Z13convert_floati(i32 noundef %0) #1
 ; CHECK-LLVM: call spir_func void @_Z18convert_float_func(float %[[Call]])
+; CHECK-LLVM: call spir_func void @_Z20convert_uint_satfunc(i32 %[[#]])
+; CHECK-LLVM: call spir_func void @_Z21convert_float_rtzfunc(float %[[Call]])
+  %call = call spir_func float @_Z13convert_floati(i32 noundef %0) #1
   call spir_func void @_Z18convert_float_func(float noundef %call) #0
+  call spir_func void @_Z20convert_uint_satfunc(i32 noundef %0) #0
+  call spir_func void @_Z21convert_float_rtzfunc(float noundef %call) #0
   ret void
 }
 

--- a/test/transcoding/OpenCL/convert_functions.ll
+++ b/test/transcoding/OpenCL/convert_functions.ll
@@ -13,8 +13,8 @@
 ; CHECK-SPIRV: Name [[#Func:]] "_Z18convert_float_func"
 ; CHECK-SPIRV: Name [[#Func1:]] "_Z20convert_uint_satfunc"
 ; CHECK-SPIRV: Name [[#Func2:]] "_Z21convert_float_rtzfunc"
-; CHECK-SPIRV: TypeVoid [[#VoidTy:]]
-; CHECK-SPIRV: TypeFloat [[#FloatTy:]] 32
+; CHECK-SPIRV-DAG: TypeVoid [[#VoidTy:]]
+; CHECK-SPIRV-DAG: TypeFloat [[#FloatTy:]] 32
 
 ; CHECK-SPIRV: Function [[#VoidTy]] [[#Func]]
 ; CHECK-SPIRV: ConvertSToF [[#FloatTy]] [[#ConvertId:]] [[#]]


### PR DESCRIPTION
Check that builtin is valid mostly by matching the regular expression - remove unneeded checks.
This is a follow-up to #2443