### PR TITLE
[NFC] Return a VersionNumber from getRequiredSPIRVVersion

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -89,21 +89,21 @@ public:
     }
   }
 
-  SPIRVWord getRequiredSPIRVVersion() const override {
+  VersionNumber getRequiredSPIRVVersion() const override {
     switch (Dec) {
     case DecorationSpecId:
       if (getModule()->hasCapability(CapabilityKernel))
-        return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_1);
+        return VersionNumber::SPIRV_1_1;
       else
-        return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_0);
+        return VersionNumber::SPIRV_1_0;
 
     case DecorationMaxByteOffset:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_1);
+      return VersionNumber::SPIRV_1_1;
     case DecorationUserSemantic:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4);
+      return VersionNumber::SPIRV_1_4;
 
     default:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_0);
+      return VersionNumber::SPIRV_1_0;
     }
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -592,8 +592,7 @@ void SPIRVEntry::updateModuleVersion() const {
   if (!Module)
     return;
 
-  Module->setMinSPIRVVersion(
-      static_cast<VersionNumber>(getRequiredSPIRVVersion()));
+  Module->setMinSPIRVVersion(getRequiredSPIRVVersion());
 }
 
 spv_ostream &operator<<(spv_ostream &O, const SPIRVEntry &E) {

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -76,7 +76,7 @@ class SPIRVExtInst;
   void decode(std::istream &I) override;
 
 #define _REQ_SPIRV_VER(Version)                                                \
-  SPIRVWord getRequiredSPIRVVersion() const override { return Version; }
+  VersionNumber getRequiredSPIRVVersion() const override { return Version; }
 
 // Add implementation of encode/decode functions to a class.
 // Used out side of class definition.
@@ -417,8 +417,8 @@ public:
   void validateBuiltin(SPIRVWord, SPIRVWord) const;
 
   // By default assume SPIRV 1.0 as required version
-  virtual SPIRVWord getRequiredSPIRVVersion() const {
-    return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_0);
+  virtual VersionNumber getRequiredSPIRVVersion() const {
+    return VersionNumber::SPIRV_1_0;
   }
 
   virtual std::vector<SPIRVEntry *> getNonLiteralOperands() const {
@@ -683,16 +683,16 @@ public:
     return getCapability(ExecMode);
   }
 
-  SPIRVWord getRequiredSPIRVVersion() const override {
+  VersionNumber getRequiredSPIRVVersion() const override {
     switch (ExecMode) {
     case ExecutionModeFinalizer:
     case ExecutionModeInitializer:
     case ExecutionModeSubgroupSize:
     case ExecutionModeSubgroupsPerWorkgroup:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_1);
+      return VersionNumber::SPIRV_1_1;
 
     default:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_0);
+      return VersionNumber::SPIRV_1_0;
     }
   }
 
@@ -730,8 +730,8 @@ public:
   }
   // Incomplete constructor
   SPIRVExecutionModeId() : SPIRVExecutionMode() {}
-  SPIRVWord getRequiredSPIRVVersion() const override {
-    return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_2);
+  VersionNumber getRequiredSPIRVVersion() const override {
+    return VersionNumber::SPIRV_1_2;
   }
 };
 
@@ -870,7 +870,7 @@ public:
   SPIRVCapability() : Kind(CapabilityMatrix) {}
   _SPIRV_DCL_ENCDEC
 
-  SPIRVWord getRequiredSPIRVVersion() const override {
+  VersionNumber getRequiredSPIRVVersion() const override {
     switch (Kind) {
     case CapabilityGroupNonUniform:
     case CapabilityGroupNonUniformVote:
@@ -879,15 +879,15 @@ public:
     case CapabilityGroupNonUniformShuffle:
     case CapabilityGroupNonUniformShuffleRelative:
     case CapabilityGroupNonUniformClustered:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_3);
+      return VersionNumber::SPIRV_1_3;
 
     case CapabilityNamedBarrier:
     case CapabilitySubgroupDispatch:
     case CapabilityPipeStorage:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_1);
+      return VersionNumber::SPIRV_1_1;
 
     default:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_0);
+      return VersionNumber::SPIRV_1_0;
     }
   }
 
@@ -1022,8 +1022,8 @@ public:
   SPIRVModuleProcessed() { updateModuleVersion(); }
   _SPIRV_DCL_ENCDEC
   void validate() const override;
-  SPIRVWord getRequiredSPIRVVersion() const override {
-    return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_1);
+  VersionNumber getRequiredSPIRVVersion() const override {
+    return VersionNumber::SPIRV_1_1;
   }
 
   std::string getProcessStr();

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2512,20 +2512,20 @@ public:
     return getVec(CapabilityGroupNonUniformBallot);
   }
 
-  SPIRVWord getRequiredSPIRVVersion() const override {
+  VersionNumber getRequiredSPIRVVersion() const override {
     switch (OpCode) {
     case OpGroupNonUniformBroadcast: {
       assert(Ops.size() == 3 && "Expecting (Execution, Value, Id) operands");
       if (!isConstantOpCode(getOperand(2)->getOpCode())) {
         // Before version 1.5, Id must come from a constant instruction.
-        return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_5);
+        return VersionNumber::SPIRV_1_5;
       }
       break;
     }
     default:
       break;
     }
-    return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_3);
+    return VersionNumber::SPIRV_1_3;
   }
 };
 


### PR DESCRIPTION
This eliminates the need for casts, making the various overrides easier to read.