### PR TITLE
Fix mangling issue

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -174,7 +174,7 @@ bool OCLToSPIRVBase::runOCLToSPIRV(Module &Module) {
       std::get<0>(Src) != spv::SourceLanguageOpenCL_CPP &&
       std::get<0>(Src) != spv::SourceLanguageCPP_for_OpenCL)
     return false;
-
+  SrcLang = std::get<0>(Src);
   CLVer = std::get<1>(Src);
 
   LLVM_DEBUG(dbgs() << "Enter OCLToSPIRV:\n");
@@ -203,7 +203,9 @@ void OCLToSPIRVBase::visitCallInst(CallInst &CI) {
 
   auto MangledName = F->getName();
   StringRef DemangledName;
-  if (!oclIsBuiltin(MangledName, DemangledName))
+
+  if (!oclIsBuiltin(MangledName, DemangledName,
+                    SrcLang != spv::SourceLanguageOpenCL_C))
     return;
 
   LLVM_DEBUG(dbgs() << "DemangledName: " << DemangledName << '\n');

--- a/lib/SPIRV/OCLToSPIRV.h
+++ b/lib/SPIRV/OCLToSPIRV.h
@@ -54,8 +54,8 @@ class OCLTypeToSPIRVBase;
 class OCLToSPIRVBase : public InstVisitor<OCLToSPIRVBase>, BuiltinCallHelper {
 public:
   OCLToSPIRVBase()
-      : BuiltinCallHelper(ManglingRules::SPIRV), Ctx(nullptr), CLVer(0),
-        OCLTypeToSPIRVPtr(nullptr) {}
+      : BuiltinCallHelper(ManglingRules::SPIRV), Ctx(nullptr), SrcLang(0),
+        CLVer(0), OCLTypeToSPIRVPtr(nullptr) {}
   virtual ~OCLToSPIRVBase() {}
   bool runOCLToSPIRV(Module &M);
 
@@ -267,6 +267,7 @@ public:
 
 private:
   LLVMContext *Ctx;
+  unsigned SrcLang;
   unsigned CLVer; /// OpenCL version as major*10+minor
   std::set<Instruction *> ValuesToDelete;
   OCLTypeToSPIRVBase *OCLTypeToSPIRVPtr;

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -77,7 +77,8 @@ OCLTypeToSPIRVBase &OCLTypeToSPIRVPass::run(llvm::Module &M,
 }
 
 OCLTypeToSPIRVBase::OCLTypeToSPIRVBase()
-    : BuiltinCallHelper(ManglingRules::None), M(nullptr), Ctx(nullptr) {}
+    : BuiltinCallHelper(ManglingRules::None), M(nullptr), Ctx(nullptr),
+      SrcLang(0) {}
 
 bool OCLTypeToSPIRVBase::runOCLTypeToSPIRV(Module &Module) {
   LLVM_DEBUG(dbgs() << "Enter OCLTypeToSPIRV:\n");
@@ -95,7 +96,7 @@ bool OCLTypeToSPIRVBase::runOCLTypeToSPIRV(Module &Module) {
       std::get<0>(Src) != spv::SourceLanguageOpenCL_CPP &&
       std::get<0>(Src) != spv::SourceLanguageCPP_for_OpenCL)
     return false;
-
+  SrcLang = std::get<0>(Src);
   for (auto &F : Module.functions())
     adaptArgumentsByMetadata(&F);
 

--- a/lib/SPIRV/OCLTypeToSPIRV.h
+++ b/lib/SPIRV/OCLTypeToSPIRV.h
@@ -67,6 +67,7 @@ public:
 private:
   llvm::Module *M;
   llvm::LLVMContext *Ctx;
+  unsigned SrcLang;
   // Map of argument/Function -> adapted type (probably TypedPointerType)
   std::unordered_map<llvm::Value *, llvm::Type *> AdaptedTy;
   std::set<llvm::Function *> WorkSet; // Functions to be adapted


### PR DESCRIPTION
In 80dfd864ae556369747074bbde8fc1d4c48547be, we turned on OCLToSPIRV and OCLTypeToSPIRV passes for OpenCL C++ and C++ for OpenCL source languages. In these passes, there are places where some names are mangled/unmangled. Existing code always passed IsCpp=false. With addition of C++ sources, we now need to store the Source language info and use it to figure out IsCpp.

Thanks