### PR TITLE
CounterBuffer decoration is supported from 1.4 without extension

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -100,6 +100,7 @@ public:
     case DecorationMaxByteOffset:
       return VersionNumber::SPIRV_1_1;
     case DecorationUserSemantic:
+    case DecorationCounterBuffer:
       return VersionNumber::SPIRV_1_4;
 
     default:


### PR DESCRIPTION
Do nothing for now, as it's not used in translator.

Addresses p.6 of #2460