### PR TITLE
Disable automatic debug format conversion for 1 test

### DIFF
--- a/test/debug-label-skip.ll
+++ b/test/debug-label-skip.ll
@@ -1,4 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as --preserve-input-debuginfo-format %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 
 source_filename = "debug-label-bitcode.c"


### PR DESCRIPTION
Update a test after llvm-project commit llvm/llvm-project@379628d446e5 ("[RemoveDIs] Add flag to preserve the debug info format of input IR (#87379)", 2024-04-05).