### PR TITLE
Fix of ParentIdx mismatch for DebugTypeInheritance in SPIRV.debug.h

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1216,9 +1216,9 @@ DINode *SPIRVToLLVMDbgTran::transTypedef(const SPIRVExtInst *DebugInst) {
 DINode *SPIRVToLLVMDbgTran::transTypeInheritance(const SPIRVExtInst *DebugInst,
                                                  DIType *ChildClass) {
   using namespace SPIRVDebug::Operand::TypeInheritance;
-  // The value is used when assertions are enabled 
-  [[maybe_unused]] unsigned MinOperandCount;  
-  unsigned  ParentIdx, OffsetIdx, FlagsIdx;
+  // The value is used when assertions are enabled
+  [[maybe_unused]] unsigned MinOperandCount;
+  unsigned ParentIdx, OffsetIdx, FlagsIdx;
   if (isNonSemanticDebugInfo(DebugInst->getExtSetKind())) {
     if (!ChildClass) {
       // Will be translated later when processing TypeMember's parent

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1216,7 +1216,9 @@ DINode *SPIRVToLLVMDbgTran::transTypedef(const SPIRVExtInst *DebugInst) {
 DINode *SPIRVToLLVMDbgTran::transTypeInheritance(const SPIRVExtInst *DebugInst,
                                                  DIType *ChildClass) {
   using namespace SPIRVDebug::Operand::TypeInheritance;
-  unsigned MinOperandCount, ParentIdx, OffsetIdx, FlagsIdx;
+  // The value is used when assertions are enabled 
+  [[maybe_unused]] unsigned MinOperandCount;  
+  unsigned  ParentIdx, OffsetIdx, FlagsIdx;
   if (isNonSemanticDebugInfo(DebugInst->getExtSetKind())) {
     if (!ChildClass) {
       // Will be translated later when processing TypeMember's parent

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1217,25 +1217,25 @@ DINode *SPIRVToLLVMDbgTran::transTypeInheritance(const SPIRVExtInst *DebugInst,
                                                  DIType *ChildClass) {
   using namespace SPIRVDebug::Operand::TypeInheritance;
   // The value is used when assertions are enabled
-  [[maybe_unused]] unsigned MinOperandCount;
+  [[maybe_unused]] unsigned OperandCount;
   unsigned ParentIdx, OffsetIdx, FlagsIdx;
   if (isNonSemanticDebugInfo(DebugInst->getExtSetKind())) {
     if (!ChildClass) {
       // Will be translated later when processing TypeMember's parent
       return nullptr;
     }
-    MinOperandCount = NonSemantic::MinOperandCount;
+    OperandCount = NonSemantic::OperandCount;
     ParentIdx = NonSemantic::ParentIdx;
     OffsetIdx = NonSemantic::OffsetIdx;
     FlagsIdx = NonSemantic::FlagsIdx;
   } else {
-    MinOperandCount = OpenCL::MinOperandCount;
+    OperandCount = NonSemantic::OperandCount;
     ParentIdx = OpenCL::ParentIdx;
     OffsetIdx = OpenCL::OffsetIdx;
     FlagsIdx = OpenCL::FlagsIdx;
   }
   const SPIRVWordVec &Ops = DebugInst->getArguments();
-  assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
+  assert(Ops.size() >= OperandCount && "Invalid number of operands");
   DIType *Parent =
       transDebugInst<DIType>(BM->get<SPIRVExtInst>(Ops[ParentIdx]));
   DINode::DIFlags Flags = DINode::FlagZero;

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -509,7 +509,6 @@ enum {
   OffsetIdx       = 1,
   SizeIdx         = 2,
   FlagsIdx        = 3,
-  MinOperandCount = 3,
   OperandCount    = 4
 };
 }
@@ -521,7 +520,6 @@ enum {
   OffsetIdx       = 2,
   SizeIdx         = 3,
   FlagsIdx        = 4,
-  MinOperandCount = 4,
   OperandCount    = 5
 };
 }

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -991,7 +991,10 @@ inline bool hasDbgInstParentScopeIdx(
     ParentScopeIdx = TypeMember::OpenCL::ParentIdx;
     return true;
   case SPIRVDebug::TypeInheritance:
-    ParentScopeIdx = TypeInheritance::ParentIdx;
+    if (ExtKind == SPIRV::SPIRVEIS_OpenCL_DebugInfo_100)
+      ParentScopeIdx = TypeInheritance::ParentIdx;
+    else
+      ParentScopeIdx = TypeInheritance::ChildIdx;
     return true;
   case SPIRVDebug::TypePtrToMember:
     ParentScopeIdx = TypePtrToMember::ParentIdx;

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -503,17 +503,29 @@ enum {
 } // namespace TypeMember
 
 namespace TypeInheritance {
+namespace NonSemantic {
+enum {
+  ParentIdx       = 0,
+  OffsetIdx       = 1,
+  SizeIdx         = 2,
+  FlagsIdx        = 3,
+  MinOperandCount = 3,
+  OperandCount    = 4
+};
+}
+
+namespace OpenCL {
 enum {
   ChildIdx        = 0,
   ParentIdx       = 1,
   OffsetIdx       = 2,
   SizeIdx         = 3,
   FlagsIdx        = 4,
-  // NonSemantic
   MinOperandCount = 4,
   OperandCount    = 5
 };
 }
+} // namespace TypeInheritance
 
 namespace TypePtrToMember {
 enum {
@@ -992,9 +1004,9 @@ inline bool hasDbgInstParentScopeIdx(
     return true;
   case SPIRVDebug::TypeInheritance:
     if (ExtKind == SPIRV::SPIRVEIS_OpenCL_DebugInfo_100)
-      ParentScopeIdx = TypeInheritance::ParentIdx;
+      ParentScopeIdx = TypeInheritance::OpenCL::ParentIdx;
     else
-      ParentScopeIdx = TypeInheritance::ChildIdx;
+      ParentScopeIdx = TypeInheritance::NonSemantic::ParentIdx;
     return true;
   case SPIRVDebug::TypePtrToMember:
     ParentScopeIdx = TypePtrToMember::ParentIdx;


### PR DESCRIPTION
Fixed ParentIdx was mismatched for DebugTypeInheritance type in context of NonSemantic.Shader.DebugInfo.100. That lead to heap buffer overflow in SPIRVExtInst::getExtOp getter when instruction was incorrectly casted
to SPIRVExtInst as parent of the culprit instruction in SPIRVToLLVMDbgTran::getDIBuilder. The missmatch happen because in previous used standard OpenCL.DebugInfo.100 DebugTypeInheritance had Child field as zero indexed argument. In newer standard that field is removed.