### PR TITLE
[SPIR-V 1.5] Deprecate OpLessOrGreater in favor of OpFOrdNotEqual

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6097,6 +6097,11 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
   // Moreover, OpAtomicCompareExchangeWeak has been deprecated.
   if (OC == OpAtomicCompareExchangeWeak)
     OC = OpAtomicCompareExchange;
+
+  if (OC == OpLessOrGreater &&
+      BM->getSPIRVVersion() >= static_cast<SPIRVWord>(VersionNumber::SPIRV_1_5))
+    OC = OpFOrdNotEqual;
+
   if (isGroupOpCode(OC))
     BM->addCapability(CapabilityGroups);
   switch (static_cast<size_t>(OC)) {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6098,8 +6098,12 @@ LLVMToSPIRVBase::transBuiltinToInstWithoutDecoration(Op OC, CallInst *CI,
   if (OC == OpAtomicCompareExchangeWeak)
     OC = OpAtomicCompareExchange;
 
+  // We should do this replacement only for SPIR-V 1.5, as OpLessOrGreater is
+  // deprecated there. However we do such replacement for the usual pipeline
+  // (not via SPIR-V friendly calls) without minding the version, so we can do
+  // such thing here as well.
   if (OC == OpLessOrGreater &&
-      BM->getSPIRVVersion() >= static_cast<SPIRVWord>(VersionNumber::SPIRV_1_5))
+      BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_5))
     OC = OpFOrdNotEqual;
 
   if (isGroupOpCode(OC))

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -968,6 +968,11 @@ protected:
       ResTy = Type;
     }
     assert(isCmpOpCode(OpCode) && "Invalid op code for cmp inst");
+    auto *Module = this->getModule();
+    if (OpCode == OpLessOrGreater)
+      assert(Module->getSPIRVVersion() <=
+                 static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4) &&
+             "OpLessOrGreater is deprecated starting from SPIR-V 1.5");
     assert((ResTy->isTypeBool() || ResTy->isTypeInt()) &&
            "Invalid type for compare instruction");
     assert(Op1Ty == Op2Ty && "Inconsistent types");

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -968,9 +968,8 @@ protected:
       ResTy = Type;
     }
     assert(isCmpOpCode(OpCode) && "Invalid op code for cmp inst");
-    auto *Module = this->getModule();
     if (OpCode == OpLessOrGreater)
-      assert(Module->getSPIRVVersion() <=
+      assert(this->getModule()->getSPIRVVersion() <=
                  static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4) &&
              "OpLessOrGreater is deprecated starting from SPIR-V 1.5");
     assert((ResTy->isTypeBool() || ResTy->isTypeInt()) &&

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -968,10 +968,6 @@ protected:
       ResTy = Type;
     }
     assert(isCmpOpCode(OpCode) && "Invalid op code for cmp inst");
-    if (OpCode == OpLessOrGreater)
-      assert(this->getModule()->getSPIRVVersion() <=
-                 static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4) &&
-             "OpLessOrGreater is deprecated starting from SPIR-V 1.5");
     assert((ResTy->isTypeBool() || ResTy->isTypeInt()) &&
            "Invalid type for compare instruction");
     assert(Op1Ty == Op2Ty && "Inconsistent types");

--- a/test/transcoding/OpLessOrGreater.ll
+++ b/test/transcoding/OpLessOrGreater.ll
@@ -1,0 +1,45 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: spirv-val %t.spv
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; SPIR-V 1.5
+; CHECK-SPIRV: 66816
+
+; CHECK-SPIRV-NOT: LessOrGreater
+; CHECK-SPIRV: FOrdNotEqual
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_kernel void @test(float %a) local_unnamed_addr #0 {
+entry:
+; CHECK-LLVM: fcmp one float %a, %a
+  %call = tail call spir_func i1 @_Z21__spirv_LessOrGreater(float %a, float %a)
+  ret void
+}
+
+; This is needed to check that 1.5 is enabled
+define dso_local spir_kernel void @test2(i16 noundef signext %a, i32 noundef %id) local_unnamed_addr #0  {
+entry:
+  %call = tail call spir_func signext i16 @_Z31sub_group_non_uniform_broadcastsj(i16 noundef signext %a, i32 noundef %id)
+  ret void
+}
+
+declare spir_func noundef i1 @_Z21__spirv_LessOrGreater(float, float)
+declare spir_func signext i16 @_Z31sub_group_non_uniform_broadcastsj(i16 noundef signext, i32 noundef)
+
+attributes #0 = { convergent nounwind writeonly }
+
+!llvm.module.flags = !{!0}
+!opencl.ocl.version = !{!1}
+!opencl.spir.version = !{!1}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 2, i32 0}


### PR DESCRIPTION
This is a follow-up to 08884df