### PR TITLE
Start moving away from insert-before Instruction pointers

### DIFF
--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -68,7 +68,8 @@ void SPIRVLowerBoolBase::visitTruncInst(TruncInst &I) {
   if (isBoolType(I.getType())) {
     auto *Op = I.getOperand(0);
     auto *And = BinaryOperator::CreateAnd(
-        Op, getScalarOrVectorConstantInt(Op->getType(), 1, false), "", &I);
+        Op, getScalarOrVectorConstantInt(Op->getType(), 1, false), "",
+        I.getIterator());
     And->setDebugLoc(I.getDebugLoc());
     auto *Zero = getScalarOrVectorConstantInt(Op->getType(), 0, false);
     auto *Cmp = new ICmpInst(&I, CmpInst::ICMP_NE, And, Zero);
@@ -85,7 +86,7 @@ void SPIRVLowerBoolBase::handleExtInstructions(Instruction &I) {
     auto *One = getScalarOrVectorConstantInt(
         Ty, (Opcode == Instruction::SExt) ? ~0 : 1, false);
     assert(Zero && One && "Couldn't create constant int");
-    auto *Sel = SelectInst::Create(Op, One, Zero, "", &I);
+    auto *Sel = SelectInst::Create(Op, One, Zero, "", I.getIterator());
     replace(&I, Sel);
   }
 }
@@ -100,7 +101,7 @@ void SPIRVLowerBoolBase::handleCastInstructions(Instruction &I) {
     auto *Zero = getScalarOrVectorConstantInt(Ty, 0, false);
     auto *One = getScalarOrVectorConstantInt(Ty, 1, false);
     assert(Zero && One && "Couldn't create constant int");
-    auto *Sel = SelectInst::Create(Op, One, Zero, "", &I);
+    auto *Sel = SelectInst::Create(Op, One, Zero, "", I.getIterator());
     Sel->setDebugLoc(I.getDebugLoc());
     I.setOperand(0, Sel);
   }

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1196,10 +1196,12 @@ SPIRVToLLVM::expandOCLBuiltinWithScalarArg(CallInst *CI,
       else {
         NewVec = ConstantVector::getSplat(
             VecElemCount, Constant::getNullValue(Arg->getType()));
-        NewVec = InsertElementInst::Create(NewVec, Arg, getInt32(M, 0), "", CI);
+        NewVec = InsertElementInst::Create(NewVec, Arg, getInt32(M, 0), "",
+                                           CI->getIterator());
         NewVec = new ShuffleVectorInst(
             NewVec, NewVec,
-            ConstantVector::getSplat(VecElemCount, getInt32(M, 0)), "", CI);
+            ConstantVector::getSplat(VecElemCount, getInt32(M, 0)), "",
+            CI->getIterator());
       }
       NewVec->takeName(Arg);
       return NewVec;

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -276,9 +276,9 @@ void SPIRVToOCLBase::visitCallSPIRVImageQuerySize(CallInst *CI) {
     // The width of integer type returning by OpImageQuerySize[Lod] may
     // differ from i32
     if (CI->getType()->getScalarType() != Int32Ty) {
-      GetImageSize = CastInst::CreateIntegerCast(GetImageSize,
-                                                 CI->getType()->getScalarType(),
-                                                 false, CI->getName(), CI);
+      GetImageSize = CastInst::CreateIntegerCast(
+          GetImageSize, CI->getType()->getScalarType(), false, CI->getName(),
+          CI->getIterator());
     }
   } else {
     assert((ImgDim == 2 || ImgDim == 3) && "invalid image type");
@@ -298,7 +298,7 @@ void SPIRVToOCLBase::visitCallSPIRVImageQuerySize(CallInst *CI) {
           FixedVectorType::get(
               CI->getType()->getScalarType(),
               cast<FixedVectorType>(GetImageSize->getType())->getNumElements()),
-          false, CI->getName(), CI);
+          false, CI->getName(), CI->getIterator());
     }
   }
 
@@ -313,7 +313,7 @@ void SPIRVToOCLBase::visitCallSPIRVImageQuerySize(CallInst *CI) {
              "OpImageQuerySize[Lod] must return <2 x iN> vector type");
       GetImageSize = InsertElementInst::Create(
           UndefValue::get(VecTy), GetImageSize, ConstantInt::get(Int32Ty, 0),
-          CI->getName(), CI);
+          CI->getName(), CI->getIterator());
     } else {
       // get_image_dim and OpImageQuerySize returns different vector
       // types for arrayed and 3d images.
@@ -324,7 +324,7 @@ void SPIRVToOCLBase::visitCallSPIRVImageQuerySize(CallInst *CI) {
 
       GetImageSize = new ShuffleVectorInst(
           GetImageSize, UndefValue::get(GetImageSize->getType()), Mask,
-          CI->getName(), CI);
+          CI->getName(), CI->getIterator());
     }
   }
 
@@ -341,12 +341,13 @@ void SPIRVToOCLBase::visitCallSPIRVImageQuerySize(CallInst *CI) {
     // differ from size_t which is returned by get_image_array_size
     if (GetImageArraySize->getType() != VecTy->getElementType()) {
       GetImageArraySize = CastInst::CreateIntegerCast(
-          GetImageArraySize, VecTy->getElementType(), false, CI->getName(), CI);
+          GetImageArraySize, VecTy->getElementType(), false, CI->getName(),
+          CI->getIterator());
     }
     GetImageSize = InsertElementInst::Create(
         GetImageSize, GetImageArraySize,
         ConstantInt::get(Int32Ty, VecTy->getNumElements() - 1), CI->getName(),
-        CI);
+        CI->getIterator());
   }
 
   assert(GetImageSize && "must not be null");

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -263,7 +263,7 @@ void SPIRVToOCL20Base::visitCallSPIRVEnqueueKernel(CallInst *CI, Op OC) {
   auto Mutator = mutateCallInst(CI, FName.str());
   Mutator.mapArg(6, [=](IRBuilder<> &Builder, Value *Invoke) {
     Value *Replace = CastInst::CreatePointerBitCastOrAddrSpaceCast(
-        Invoke, Builder.getPtrTy(SPIRAS_Generic), "", CI);
+        Invoke, Builder.getPtrTy(SPIRAS_Generic), "", CI->getIterator());
     return std::make_pair(
         Replace, TypedPointerType::get(Builder.getInt8Ty(), SPIRAS_Generic));
   });

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2164,13 +2164,13 @@ bool lowerBuiltinCallsToVariables(Module *M) {
       auto *CI = dyn_cast<CallInst>(U);
       assert(CI && "invalid instruction");
       const DebugLoc &DLoc = CI->getDebugLoc();
-      Instruction *NewValue = new LoadInst(GVType, BV, "", CI);
+      Instruction *NewValue = new LoadInst(GVType, BV, "", CI->getIterator());
       if (DLoc)
         NewValue->setDebugLoc(DLoc);
       LLVM_DEBUG(dbgs() << "Transform: " << *CI << " => " << *NewValue << '\n');
       if (IsVec) {
-        NewValue =
-            ExtractElementInst::Create(NewValue, CI->getArgOperand(0), "", CI);
+        NewValue = ExtractElementInst::Create(NewValue, CI->getArgOperand(0),
+                                              "", CI->getIterator());
         if (DLoc)
           NewValue->setDebugLoc(DLoc);
         LLVM_DEBUG(dbgs() << *NewValue << '\n');
@@ -2268,11 +2268,12 @@ bool postProcessBuiltinWithArrayArguments(Function *F,
           if (!T->isArrayTy())
             continue;
           auto *Alloca = new AllocaInst(T, 0, "", &(*FBegin));
-          new StoreInst(I, Alloca, false, CI);
+          new StoreInst(I, Alloca, false, CI->getIterator());
           auto *Zero =
               ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));
           Value *Index[] = {Zero, Zero};
-          I = GetElementPtrInst::CreateInBounds(T, Alloca, Index, "", CI);
+          I = GetElementPtrInst::CreateInBounds(T, Alloca, Index, "",
+                                                CI->getIterator());
         }
         return Name.str();
       },

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5437,7 +5437,7 @@ void LLVMToSPIRVBase::mutateFuncArgType(
       auto CastF = M->getOrInsertFunction(SPCV_CAST, I.second, OrigTy);
       std::vector<Value *> Args;
       Args.push_back(Arg);
-      auto *Cast = CallInst::Create(CastF, Args, "", Call);
+      auto *Cast = CallInst::Create(CastF, Args, "", Call->getIterator());
       Call->replaceUsesOfWith(Arg, Cast);
       SPIRVDBG(dbgs() << "[mutate arg type] -> " << *Cast << '\n');
     }


### PR DESCRIPTION
In preparation for LLVM's [deprecation](https://discourse.llvm.org/t/psa-instruction-constructors-changing-to-iterator-only-insertion/77845) of Instruction constructors and Create methods that accept `Instruction` pointers, upgrade call sites to pass an iterator instead of an `Instruction` pointer.

This patch only upgrades constructor and `Create` calls that were trivial to upgrade with no impact on the test suite.  Some calls remain to be upgraded as future work.