### PR TITLE
Regularize LLVM code to remove use of non standard integer types in fptoui and fptosi intrinsics

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -360,7 +360,7 @@ void SPIRVRegularizeLLVMBase::cleanupConversionToNonStdIntegers(Module *M) {
     auto IID = F->getIntrinsicID();
     if (IID != Intrinsic::fptosi_sat && IID != Intrinsic::fptoui_sat)
       continue;
-    for (auto I : F->users()) {
+    for (auto *I : F->users()) {
       if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(I)) {
         // TODO: Vector type not supported yet.
         if (isa<VectorType>(II->getType()))

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -357,6 +357,8 @@ void SPIRVRegularizeLLVMBase::cleanupConversionToNonStdIntegers(Module *M) {
   for (auto I = M->begin(), E = M->end(); I != E;) {
     Function *F = &(*I++);
     std::vector<Instruction *> ToErase;
+    // TODO: Improve parsing logic by identifying all fptoui.sat and fptosi.sat
+    // intrinsics and then iterating over their users.
     for (BasicBlock &BB : *F) {
       for (Instruction &I : BB) {
         if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(&I)) {
@@ -415,6 +417,7 @@ void SPIRVRegularizeLLVMBase::cleanupConversionToNonStdIntegers(Module *M) {
     }
     for (Instruction *V : ToErase) {
       assert(V->user_empty());
+      V->dropAllReferences();
       V->eraseFromParent();
     }
   }

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -345,8 +345,8 @@ void SPIRVRegularizeLLVMBase::cleanupConversionToNonStdIntegers(Module *M) {
                     IID, {Inst->getType(), II->getOperand(0)->getType()},
                     II->getOperand(0));
                 Inst->replaceAllUsesWith(NewII);
-                ToErase.push_back(&I);
                 ToErase.push_back(Inst);
+                ToErase.push_back(&I);
               }
             }
           }

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -435,7 +435,6 @@ void regularizeWithOverflowInstrinsics(StringRef MangledName, CallInst *Call,
   }
   ToErase.push_back(Call);
 }
-
 } // namespace
 
 /// Remove entities not representable by SPIR-V
@@ -444,6 +443,7 @@ bool SPIRVRegularizeLLVMBase::regularize() {
   addKernelEntryPoint(M);
   expandSYCLTypeUsing(M);
   cleanupConversionToNonStdIntegers(M);
+
   for (auto I = M->begin(), E = M->end(); I != E;) {
     Function *F = &(*I++);
     if (F->isDeclaration() && F->use_empty()) {

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -360,6 +360,9 @@ void SPIRVRegularizeLLVMBase::cleanupConversionToNonStdIntegers(Module *M) {
     for (BasicBlock &BB : *F) {
       for (Instruction &I : BB) {
         if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(&I)) {
+          // TODO: Vector type not supported yet.
+          if (isa<VectorType>(II->getType()))
+            continue;
           auto IID = II->getIntrinsicID();
           auto IntBitWidth = II->getType()->getScalarSizeInBits();
           if (IntBitWidth == 8 || IntBitWidth == 16 || IntBitWidth == 32 ||

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -96,6 +96,12 @@ public:
   void expandVEDWithSYCLTypeSRetArg(llvm::Function *F);
   void expandVIDWithSYCLTypeByValComp(llvm::Function *F);
 
+  // It is possible that incoming LLVM IR conversion instructions convert
+  // floating point to non-standard integer types. Such types are not supported
+  // in SPIR-V. This function cleans up such code and removes occurence of
+  // non-standard integer types.
+  void cleanupConversionToNonStdIntegers(llvm::Module *M);
+
   // According to the specification, the operands of a shift instruction must be
   // a scalar/vector of integer. When LLVM-IR contains a shift instruction with
   // i1 operands, they are treated as a bool. We need to extend them to i32 to

--- a/test/llvm-intrinsics/fp_to_arbitrary_size_int_intrinsic.ll
+++ b/test/llvm-intrinsics/fp_to_arbitrary_size_int_intrinsic.ll
@@ -1,8 +1,8 @@
 ;; Ensure @llvm.fptosi.sat.* and @llvm.fptoui.sat.* intrinsics are translated
 
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_arbitrary_precision_integers -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_arbitrary_precision_integers -o %t.spv
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM

--- a/test/llvm-intrinsics/fp_to_arbitrary_size_int_intrinsic.ll
+++ b/test/llvm-intrinsics/fp_to_arbitrary_size_int_intrinsic.ll
@@ -1,0 +1,93 @@
+;; Ensure @llvm.fptosi.sat.* and @llvm.fptoui.sat.* intrinsics are translated
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_arbitrary_precision_integers -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_arbitrary_precision_integers -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV: Capability Kernel
+; CHECK-SPIRV: Decorate [[SAT1:[0-9]+]] SaturatedConversion
+; CHECK-SPIRV: Decorate [[SAT2:[0-9]+]] SaturatedConversion
+; CHECK-SPIRV: Decorate [[SAT3:[0-9]+]] SaturatedConversion
+; CHECK-SPIRV: Decorate [[SAT4:[0-9]+]] SaturatedConversion
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; signed output
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; float input
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;; output i2
+; CHECK-SPIRV: ConvertFToS {{[0-9]+}} [[SAT1]]
+; CHECK-LLVM: define spir_kernel
+; CHECK-LLVM: convert_long_satf(float %input)
+define spir_kernel void @testfunction_float_to_signed_i2(float %input) {
+entry:
+   %0 = call i2 @llvm.fptosi.sat.i2.f32(float %input)
+   %1 = sext i2 %0 to i64
+   ret void
+}
+declare i2 @llvm.fptosi.sat.i2.f32(float)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; double input
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;; output i2
+; CHECK-SPIRV: ConvertFToS {{[0-9]+}} [[SAT2]]
+; CHECK-LLVM: define spir_kernel
+; CHECK-LLVM: convert_long_satd(double %input)
+define spir_kernel void @testfunction_double_to_signed_i2(double %input) {
+entry:
+   %0 = call i2 @llvm.fptosi.sat.i2.f64(double %input)
+   %1 = sext i2 %0 to i64
+   ret void
+}
+declare i2 @llvm.fptosi.sat.i2.f64(double)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; unsigned output
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; float input
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;; output i2
+; CHECK-SPIRV: ConvertFToU {{[0-9]+}} [[SAT3]]
+; CHECK-LLVM: define spir_kernel
+; CHECK-LLVM: convert_ulong_satf(float %input)
+define spir_kernel void @testfunction_float_to_unsigned_i2(float %input) {
+entry:
+   %0 = call i2 @llvm.fptoui.sat.i2.f32(float %input)
+   %1 = zext i2 %0 to i64
+   ret void
+}
+declare i2 @llvm.fptoui.sat.i2.f32(float)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; double input
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;;;;;;; output i2
+; CHECK-SPIRV: ConvertFToU {{[0-9]+}} [[SAT4]]
+; CHECK-LLVM: define spir_kernel
+; CHECK-LLVM: convert_ulong_satd(double %input)
+define spir_kernel void @testfunction_double_to_unsigned_i2(double %input) {
+entry:
+   %0 = call i2 @llvm.fptoui.sat.i2.f64(double %input)
+   %1 = zext i2 %0 to i64
+   ret void
+}
+declare i2 @llvm.fptoui.sat.i2.f64(double)

--- a/test/llvm-intrinsics/fp_to_arbitrary_size_int_intrinsic.ll
+++ b/test/llvm-intrinsics/fp_to_arbitrary_size_int_intrinsic.ll
@@ -39,19 +39,14 @@ entry:
 }
 declare i2 @llvm.fptosi.sat.i2.f32(float)
 
-; CHECK-SPIRV-DAG: Constant [[INT64TY]] [[I2UMAX:[0-9]+]] 3
-; CHECK-SPIRV-DAG: Constant [[INT64TY]] [[I2UMIN:[0-9]+]] 0 
+; CHECK-SPIRV-DAG: Constant [[INT64TY]] [[I2UMAX:[0-9]+]] 3 
 ; CHECK-SPIRV-DAG: ConvertFToU [[INT64TY]] [[SAT2]]
 ; CHECK-SPIRV-DAG: UGreaterThanEqual [[BOOLTY]] [[UGERES:[0-9]+]] [[SAT2]] [[I2UMAX]]
-; CHECK-SPIRV-DAG: ULessThanEqual [[BOOLTY]] [[ULERES:[0-9]+]] [[SAT2]] [[I2UMIN]]
 ; CHECK-SPIRV-DAG: Select [[INT64TY]] [[SELRES1U:[0-9]+]] [[UGERES]] [[I2UMAX]] [[SAT2]]
-; CHECK-SPIRV-DAG: Select [[INT64TY]] [[SELRES2U:[0-9]+]] [[ULERES]] [[I2UMIN]] [[SELRES1U]]
 ; CHECK-LLVM-DAG: define spir_kernel
 ; CHECK-LLVM-DAG: %[[R1:[0-9]+]] = {{.*}} i64 {{.*}}convert_ulong_satf(float %input)
 ; CHECK-LLVM-DAG: %[[R2:[0-9]+]] = icmp uge i64 %[[R1]], 3
-; CHECK-LLVM-DAG: %[[R3:[0-9]+]] = icmp ule i64 %[[R1]], 0
-; CHECK-LLVM-DAG: %[[R4:[0-9]+]] = select i1 %[[R2]], i64 3, i64 %[[R1]]
-; CHECK-LLVM-DAG: %[[R5:[0-9]+]] = select i1 %[[R3]], i64 0, i64 %[[R4]]
+; CHECK-LLVM-DAG: %[[R3:[0-9]+]] = select i1 %[[R2]], i64 3, i64 %[[R1]]
 
 define spir_kernel void @testfunction_float_to_unsigned_i2(float %input) {
 entry:


### PR DESCRIPTION
It is possible that incoming LLVM IR conversion instructions convert floating point to non-standard integer types. 
For e.g. %0 = call i2 @llvm.fptosi.sat.i2.f32(float %input)
Such types are not supported in SPIR-V. This PR cleans up such code and removes occurrence of non-standard integer types.

Thanks