### PR TITLE
Map LinkOnceODR to weak_odr instead of linkonce_odr

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4850,7 +4850,7 @@ SPIRVToLLVM::transLinkageType(const SPIRVValue *V) {
     }
     return GlobalValue::ExternalLinkage;
   case LinkageTypeLinkOnceODR:
-    return GlobalValue::LinkOnceODRLinkage;
+    return GlobalValue::WeakODRLinkage;
   default:
     llvm_unreachable("Invalid linkage type");
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6570,7 +6570,7 @@ LLVMToSPIRVBase::transLinkageType(const GlobalValue *GV) {
     return SPIRVLinkageTypeKind::LinkageTypeImport;
   if (GV->hasInternalLinkage() || GV->hasPrivateLinkage())
     return spv::internal::LinkageTypeInternal;
-  if (GV->hasLinkOnceODRLinkage())
+  if (GV->hasLinkOnceODRLinkage() || GV->hasWeakODRLinkage())
     if (BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_linkonce_odr))
       return SPIRVLinkageTypeKind::LinkageTypeLinkOnceODR;
   return SPIRVLinkageTypeKind::LinkageTypeExport;

--- a/test/extensions/KHR/SPV_KHR_linkonce_odr/LinkOnceODR.ll
+++ b/test/extensions/KHR/SPV_KHR_linkonce_odr/LinkOnceODR.ll
@@ -12,16 +12,18 @@
 ; CHECK-SPIRV: Extension "SPV_KHR_linkonce_odr"
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} LinkageAttributes "GV" LinkOnceODR 
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} LinkageAttributes "square" LinkOnceODR 
+; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} LinkageAttributes "add1" LinkOnceODR
 
 ; CHECK-SPIRV-NOEXT-NOT: Extension "SPV_KHR_linkonce_odr"
 ; CHECK-SPIRV-NOEXT-NOT: Decorate {{[0-9]+}} LinkageAttributes "GV" LinkOnceODR 
 ; CHECK-SPIRV-NOEXT-NOT: Decorate {{[0-9]+}} LinkageAttributes "square" LinkOnceODR 
+; CHECK-SPIRV-NOEXT-NOT: Decorate {{[0-9]+}} LinkageAttributes "add1" LinkOnceODR
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"
 
-; CHECK-LLVM: @GV = linkonce_odr addrspace(1) global [3 x i32] zeroinitializer, align 4
-@GV = linkonce_odr addrspace(1) global [3 x i32] zeroinitializer, align 4
+; CHECK-LLVM: @GV = weak_odr addrspace(1) global [3 x i32] zeroinitializer, align 4
+@GV = weak_odr addrspace(1) global [3 x i32] zeroinitializer, align 4
 
 define spir_kernel void @k() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
 entry:
@@ -29,8 +31,8 @@ entry:
   ret void
 }
 
-; CHECK-LLVM: define linkonce_odr spir_func i32 @square(i32 %in)
-define linkonce_odr dso_local spir_func i32 @square(i32 %in) {
+; CHECK-LLVM: define weak_odr spir_func i32 @square(i32 %in)
+define weak_odr dso_local spir_func i32 @square(i32 %in) {
 entry:
   %in.addr = alloca i32, align 4
   store i32 %in, ptr %in.addr, align 4
@@ -38,6 +40,14 @@ entry:
   %1 = load i32, ptr %in.addr, align 4
   %mul = mul nsw i32 %0, %1
   ret i32 %mul
+}
+
+; Verify that linkonce_odr is mapped to LinkOnceODR too.
+; CHECK-LLVM: define weak_odr spir_func i32 @add1(i32 %in)
+define linkonce_odr dso_local spir_func i32 @add1(i32 %in) {
+entry:
+  %add = add nsw i32 %in, 1
+  ret i32 %add
 }
 
 !llvm.module.flags = !{!1}


### PR DESCRIPTION
The translator currently maps SPIR-V's `LinkOnceODR` to llvm's `linkonce_odr`, but that allows llvm to discard unreferenced globals, causing linking failures when linking `linkonce_odr` symbols from multiple modules. llvm's `weak_odr` has the same merging semantics as llvm's `linkonce_odr`, except that unreferenced globals may not be discarded.

SPIR-V's `LinkOnceODR` is "Same as the `Export` linkage type but a function or global variable with this linkage type will be merged with other functions or global variables of the same name when linkage occurs".  Unreferenced globals with `Export` linkage (that gets mapped to `common` or `external` llvm linkage) are not discarded, so `weak_odr` seems to be a better fit for `LinkOnceODR`.

When producing SPIR-V, map both `linkonce_odr` and `weak_odr` to `LinkOnceODR` for backwards compatibility, and add an llvm function with the previous `linkonce_odr` linkage to the test.