### PR TITLE
Introduce SPIR-V 1.6 version

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -64,8 +64,9 @@ enum class VersionNumber : uint32_t {
   SPIRV_1_3 = 0x00010300,
   SPIRV_1_4 = 0x00010400,
   SPIRV_1_5 = 0x00010500,
+  SPIRV_1_6 = 0x00010600,
   MinimumVersion = SPIRV_1_0,
-  MaximumVersion = SPIRV_1_5
+  MaximumVersion = SPIRV_1_6
 };
 
 inline constexpr std::string_view formatVersionNumber(uint32_t Version) {
@@ -82,6 +83,8 @@ inline constexpr std::string_view formatVersionNumber(uint32_t Version) {
     return "1.4";
   case static_cast<uint32_t>(VersionNumber::SPIRV_1_5):
     return "1.5";
+  case static_cast<uint32_t>(VersionNumber::SPIRV_1_6):
+    return "1.6";
   }
   return "unknown";
 }

--- a/test/negative/spirv-version-controls-1.spt
+++ b/test/negative/spirv-version-controls-1.spt
@@ -1,4 +1,4 @@
-119734787 67072 393230 12 0
+119734787 67328 393230 12 0
 2 Capability Addresses
 2 Capability Kernel
 5 ExtInstImport 1 "OpenCL.std"
@@ -29,4 +29,4 @@
 
 ; RUN: not llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
-; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (67072)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.5 (66816)
+; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (67328)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.6 (67072)

--- a/test/negative/spirv-version-controls-2.spt
+++ b/test/negative/spirv-version-controls-2.spt
@@ -29,4 +29,4 @@
 
 ; RUN: not llvm-spirv %s -to-binary -o - 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
-; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (1024)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.5 (66816)
+; CHECK-ERROR: Invalid SPIR-V module: unsupported SPIR-V version number 'unknown (1024)'. Range of supported/known SPIR-V versions is 1.0 (65536) - 1.6 (67072)

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -112,7 +112,9 @@ static cl::opt<VersionNumber> MaxSPIRVVersion(
                clEnumValN(VersionNumber::SPIRV_1_2, "1.2", "SPIR-V 1.2"),
                clEnumValN(VersionNumber::SPIRV_1_3, "1.3", "SPIR-V 1.3"),
                clEnumValN(VersionNumber::SPIRV_1_4, "1.4", "SPIR-V 1.4"),
-               clEnumValN(VersionNumber::SPIRV_1_5, "1.5", "SPIR-V 1.5")),
+               clEnumValN(VersionNumber::SPIRV_1_5, "1.5", "SPIR-V 1.5"),
+               clEnumValN(VersionNumber::SPIRV_1_6, "1.6",
+                          "SPIR-V 1.6 (experimental)")),
     cl::init(VersionNumber::MaximumVersion));
 
 static cl::list<std::string>


### PR DESCRIPTION
Recognize SPIR-V 1.6 modules and allow specifying the `--spirv-max-version=1.6` option.

This does not implement any SPIR-V 1.6 functionality yet, so mark it as "experimental".