### PR TITLE
Use VersionNumber instead of SPIRVWord

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -86,9 +86,9 @@ inline constexpr std::string_view formatVersionNumber(uint32_t Version) {
   return "unknown";
 }
 
-inline bool isSPIRVVersionKnown(uint32_t Ver) {
-  return Ver >= static_cast<uint32_t>(VersionNumber::MinimumVersion) &&
-         Ver <= static_cast<uint32_t>(VersionNumber::MaximumVersion);
+inline bool isSPIRVVersionKnown(VersionNumber Ver) {
+  return Ver >= VersionNumber::MinimumVersion &&
+         Ver <= VersionNumber::MaximumVersion;
 }
 
 enum class ExtensionID : uint32_t {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4923,7 +4923,7 @@ std::optional<SPIRVModuleReport> getSpirvReport(std::istream &IS,
     return {};
   }
   D >> Word;
-  if (!isSPIRVVersionKnown(Word)) {
+  if (!isSPIRVVersionKnown(static_cast<VersionNumber>(Word))) {
     ErrCode = SPIRVEC_InvalidVersionNumber;
     return {};
   }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -157,7 +157,7 @@ public:
   virtual bool isEntryPoint(SPIRVExecutionModelKind, SPIRVId) const = 0;
   virtual unsigned short getGeneratorId() const = 0;
   virtual unsigned short getGeneratorVer() const = 0;
-  virtual SPIRVWord getSPIRVVersion() const = 0;
+  virtual VersionNumber getSPIRVVersion() const = 0;
   virtual const std::vector<SPIRVExtInst *> &getDebugInstVec() const = 0;
   virtual const std::vector<SPIRVExtInst *> &getAuxDataInstVec() const = 0;
 
@@ -177,15 +177,15 @@ public:
   virtual void setGeneratorId(unsigned short) = 0;
   virtual void setGeneratorVer(unsigned short) = 0;
   virtual void resolveUnknownStructFields() = 0;
-  virtual void setSPIRVVersion(SPIRVWord) = 0;
+  virtual void setSPIRVVersion(VersionNumber) = 0;
   virtual void insertEntryNoId(SPIRVEntry *Entry) = 0;
 
   void setMinSPIRVVersion(VersionNumber Ver) {
-    setSPIRVVersion(std::max(static_cast<SPIRVWord>(Ver), getSPIRVVersion()));
+    setSPIRVVersion(std::max(Ver, getSPIRVVersion()));
   }
 
   void setMaxSPIRVVersion(VersionNumber Ver) {
-    assert(static_cast<SPIRVWord>(Ver) >= getSPIRVVersion() &&
+    assert(Ver >= getSPIRVVersion() &&
            "Maximum version can't be lower than minimum version!");
     MaxVersion = std::min(Ver, MaxVersion);
   }


### PR DESCRIPTION
~~This reduces the number of required type casts.~~
This unifies all the version methods used in translator.