### PR TITLE
Move away from some more insert-before constructors; NFC

### DIFF
--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -72,7 +72,7 @@ void SPIRVLowerBoolBase::visitTruncInst(TruncInst &I) {
         I.getIterator());
     And->setDebugLoc(I.getDebugLoc());
     auto *Zero = getScalarOrVectorConstantInt(Op->getType(), 0, false);
-    auto *Cmp = new ICmpInst(&I, CmpInst::ICMP_NE, And, Zero);
+    auto *Cmp = new ICmpInst(I.getIterator(), CmpInst::ICMP_NE, And, Zero);
     replace(&I, Cmp);
   }
 }

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -207,7 +207,7 @@ void SPIRVToOCL20Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
   // instructions returns this new/original value as a resulting value.
   AllocaInst *PExpected = new AllocaInst(
       MemTy, 0, "expected",
-      &*CI->getParent()->getParent()->getEntryBlock().getFirstInsertionPt());
+      CI->getParent()->getParent()->getEntryBlock().getFirstInsertionPt());
   PExpected->setAlignment(Align(MemTy->getScalarSizeInBits() / 8));
 
   // Tail call implies that the callee doesn't access alloca from the caller.

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2272,7 +2272,7 @@ bool postProcessBuiltinWithArrayArguments(Function *F,
           auto *T = I->getType();
           if (!T->isArrayTy())
             continue;
-          auto *Alloca = new AllocaInst(T, 0, "", &(*FBegin));
+          auto *Alloca = new AllocaInst(T, 0, "", FBegin);
           new StoreInst(I, Alloca, false, CI->getIterator());
           auto *Zero =
               ConstantInt::getNullValue(Type::getInt32Ty(T->getContext()));


### PR DESCRIPTION
In preparation for LLVM's [deprecation](https://discourse.llvm.org/t/psa-instruction-constructors-changing-to-iterator-only-insertion/77845) of `Instruction` constructors and `Create` methods that accept `Instruction` pointers, upgrade call sites to pass an iterator instead of an `Instruction` pointer.

This is a continuation of #2498, updating some cases that are different from the bulk changes done earlier.