### PR TITLE
[Backport to 16] Fix of ParentIdx mismatch for DebugTypeInheritance in SPIRV.debug.h (#2490)

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -154,7 +154,8 @@ private:
 
   DINode *transTypedef(const SPIRVExtInst *DebugInst);
 
-  DINode *transTypeInheritance(const SPIRVExtInst *DebugInst);
+  DINode *transTypeInheritance(const SPIRVExtInst *DebugInst,
+                               DIType *ChildClass);
 
   DINode *transImportedEntry(const SPIRVExtInst *DebugInst);
 

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -1,5 +1,6 @@
 #ifndef SPIRV_DEBUG_H
 #define SPIRV_DEBUG_H
+#include "SPIRVEnum.h"
 #include "SPIRVUtil.h"
 #include "spirv/unified1/spirv.hpp"
 #include "spirv_internal.hpp"
@@ -440,15 +441,27 @@ enum {
 }
 
 namespace TypeInheritance {
+namespace NonSemantic {
 enum {
-  ChildIdx     = 0,
-  ParentIdx    = 1,
-  OffsetIdx    = 2,
-  SizeIdx      = 3,
-  FlagsIdx     = 4,
-  OperandCount = 5
+  ParentIdx       = 0,
+  OffsetIdx       = 1,
+  SizeIdx         = 2,
+  FlagsIdx        = 3,
+  OperandCount    = 4
 };
 }
+
+namespace OpenCL {
+enum {
+  ChildIdx        = 0,
+  ParentIdx       = 1,
+  OffsetIdx       = 2,
+  SizeIdx         = 3,
+  FlagsIdx        = 4,
+  OperandCount    = 5
+};
+}
+} // namespace TypeInheritance
 
 namespace TypePtrToMember {
 enum {
@@ -846,7 +859,10 @@ inline bool hasDbgInstParentScopeIdx(const uint32_t Kind,
     ParentScopeIdx = TypeMember::ParentIdx;
     return true;
   case SPIRVDebug::TypeInheritance:
-    ParentScopeIdx = TypeInheritance::ParentIdx;
+    if (Kind == SPIRV::SPIRVEIS_OpenCL_DebugInfo_100)
+      ParentScopeIdx = TypeInheritance::OpenCL::ParentIdx;
+    else
+      ParentScopeIdx = TypeInheritance::NonSemantic::ParentIdx;
     return true;
   case SPIRVDebug::TypePtrToMember:
     ParentScopeIdx = TypePtrToMember::ParentIdx;


### PR DESCRIPTION
Fixed ParentIdx was mismatched for DebugTypeInheritance type in context of NonSemantic.Shader.DebugInfo.100. That lead to heap buffer overflow in SPIRVExtInst::getExtOp getter when instruction was incorrectly casted to SPIRVExtInst as parent of the culprit instruction in SPIRVToLLVMDbgTran::getDIBuilder. The mismatch happen because in previous used standard OpenCL.DebugInfo.100 DebugTypeInheritance had Child field as zero indexed argument. In newer standard that field is removed.