### PR TITLE
Skip adding decorations for OpForward

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1454,7 +1454,12 @@ SPIRVValue *LLVMToSPIRVBase::transValue(Value *V, SPIRVBasicBlock *BB,
          "Invalid SPIRV BB");
 
   auto *BV = transValueWithoutDecoration(V, BB, CreateForward, FuncTrans);
-  if (!BV || !transDecoration(V, BV))
+  if (!BV)
+    return nullptr;
+  // Only translate decorations for non-forward instructions.  Forward
+  // instructions will have their decorations translated when the actual
+  // instruction is seen and rewritten to a real SPIR-V instruction.
+  if (!BV->isForward() && !transDecoration(V, BV))
     return nullptr;
   StringRef Name = V->getName();
   if (!Name.empty()) // Don't erase the name, which BM might already have


### PR DESCRIPTION
When a temporary `OpForward` instruction is needed during translation to SPIR-V, do not add the decorations yet, as that would result in duplicate decorations when the actual instruction is visited and the `OpForward` is replaced by a real SPIR-V instruction.

The SPIR-V Validator has recently started checking for duplicate decorations; this fixes some but not all issues arising from the new checks.

Contributes to https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2509 .