### PR TITLE
Disable new debug record format

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -5064,6 +5064,10 @@ llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM,
                          const SPIRV::TranslatorOpts &Opts,
                          std::string &ErrMsg) {
   std::unique_ptr<Module> M(new Module("", C));
+  // TODO: Migrate to the new debug record format.  Until then, keep using the
+  // old format.
+  M->setNewDbgInfoFormatFlag(false);
+
   SPIRVToLLVM BTL(M.get(), &BM);
 
   if (!BTL.translate()) {


### PR DESCRIPTION
After LLVM commit 91446e2aa687 ("Repply#2 "[RemoveDIs] Load into new debug info format by default in LLVM (#89799)"", 2024-05-03), we need to disable the new debug record format explicitly until we have migrated to the new format.