### PR TITLE
Drop redundant -S in clang invocation of mem2reg test

### DIFF
--- a/test/mem2reg.cl
+++ b/test/mem2reg.cl
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -O0 -S -triple spir-unknown-unknown -cl-std=CL2.0 -x cl -disable-O0-optnone %s -emit-llvm-bc -o %t.bc
+// RUN: %clang_cc1 -O0 -triple spir-unknown-unknown -cl-std=CL2.0 -x cl -disable-O0-optnone %s -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv -s %t.bc
 // RUN: llvm-dis < %t.bc | FileCheck %s --check-prefixes=CHECK-WO
 // RUN: llvm-spirv -s -spirv-mem2reg %t.bc -o %t.opt.bc


### PR DESCRIPTION
Update a test after llvm-project commit e74a7a9fd79a ("cc1: Report an error for multiple actions unless separated by -main-file-name (#91140)", 2024-05-07).