### PR TITLE
cmake: Add spirv-dis lit feature

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,11 @@ if(SPIRV_TOOLS_FOUND AND NOT SPIRV-Tools-tools_FOUND)
     set(SPIRV_TOOLS_SPIRV_AS_FOUND True)
   endif()
 
+  find_program(SPIRV_TOOLS_SPIRV_DIS NAMES spirv-dis PATHS ${SPIRV_TOOLS_PREFIX}/bin)
+  if(SPIRV_TOOLS_SPIRV_DIS)
+    set(SPIRV_TOOLS_SPIRV_DIS_FOUND True)
+  endif()
+
   find_program(SPIRV_TOOLS_SPIRV_LINK NAMES spirv-link PATHS ${SPIRV_TOOLS_PREFIX}/bin)
   if(SPIRV_TOOLS_SPIRV_LINK)
     set(SPIRV_TOOLS_SPIRV_LINK_FOUND True)
@@ -31,6 +36,10 @@ elseif(SPIRV-Tools-tools_FOUND)
 
   if(TARGET spirv-as)
     set(SPIRV_TOOLS_SPIRV_AS_FOUND True)
+  endif()
+
+  if(TARGET spirv-dis)
+    set(SPIRV_TOOLS_SPIRV_DIS_FOUND True)
   endif()
 
   if(TARGET spirv-link)
@@ -56,6 +65,11 @@ endif()
 if(NOT SPIRV_TOOLS_SPIRV_AS_FOUND)
   message(WARNING "spirv-as not found! SPIR-V assembly tests will not be run.")
   set(SPIRV_TOOLS_SPIRV_AS_FOUND False)
+endif()
+
+if(NOT SPIRV_TOOLS_SPIRV_DIS_FOUND)
+  message(WARNING "spirv-as not found! SPIR-V disassembly tests will not be run.")
+  set(SPIRV_TOOLS_SPIRV_DIS_FOUND False)
 endif()
 
 if(NOT SPIRV_TOOLS_SPIRV_LINK_FOUND)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -65,6 +65,11 @@ if config.spirv_tools_have_spirv_as:
     config.available_features.add('spirv-as')
     using_spirv_tools = True
 
+if config.spirv_tools_have_spirv_dis:
+    llvm_config.add_tool_substitutions(['spirv-dis'], [config.spirv_tools_bin_dir])
+    config.available_features.add('spirv-dis')
+    using_spirv_tools = True
+
 if config.spirv_tools_have_spirv_link:
     llvm_config.add_tool_substitutions(['spirv-link'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-link')

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -20,6 +20,7 @@ config.python_executable = "@PYTHON_EXECUTABLE@"
 config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
 config.spirv_tools_found = "@SPIRV_TOOLS_FOUND@"
 config.spirv_tools_have_spirv_as = @SPIRV_TOOLS_SPIRV_AS_FOUND@
+config.spirv_tools_have_spirv_dis = @SPIRV_TOOLS_SPIRV_DIS_FOUND@
 config.spirv_tools_have_spirv_link = @SPIRV_TOOLS_SPIRV_LINK_FOUND@
 config.spirv_tools_have_spirv_val = @SPIRV_TOOLS_SPIRV_VAL_FOUND@
 config.spirv_tools_bin_dir = "@SPIRV_TOOLS_BINDIR@"


### PR DESCRIPTION
Various tests already declare `REQUIRES: spirv-dis`, but this feature was never enabled so those tests were always skipped as "unsupported".