### PR TITLE
Add return type for OpReadClockKHR SPIR-V friendly IR

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3370,6 +3370,7 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   case OpSDotAccSatKHR:
   case OpUDotAccSatKHR:
   case OpSUDotAccSatKHR:
+  case OpReadClockKHR:
   case internal::OpJointMatrixLoadINTEL:
   case OpCooperativeMatrixLoadKHR:
   case internal::OpCooperativeMatrixLoadCheckedINTEL:
@@ -3391,6 +3392,7 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   case OpUConvert:
   case OpUDotKHR:
   case OpUDotAccSatKHR:
+  case OpReadClockKHR:
     IsRetSigned = false;
     break;
   case OpImageRead:

--- a/test/extensions/KHR/SPV_KHR_shader_clock/shader_clock.ll
+++ b/test/extensions/KHR/SPV_KHR_shader_clock/shader_clock.ll
@@ -24,8 +24,8 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV: ReadClockKHR [[#I32v2Ty]] [[#]] [[I32ValId]]
 ; CHECK-SPIRV: ReadClockKHR [[#I64Ty]] [[#]] [[I32ValId]]
 
-; CHECK-LLVM: call spir_func <2 x i32> @_Z20__spirv_ReadClockKHR
-; CHECK-LLVM: call spir_func i64 @_Z20__spirv_ReadClockKHR
+; CHECK-LLVM: call spir_func <2 x i32> @_Z27__spirv_ReadClockKHR_Ruint2i(
+; CHECK-LLVM: call spir_func i64 @_Z27__spirv_ReadClockKHR_Rulongi(
 
 define spir_func void @_Z7read_types(i32 %a) {
   %1 = tail call spir_func <2 x i32> @_Z20__spirv_ReadClockKHRIDv2_jET_j(i32 %a)


### PR DESCRIPTION
`OpReadClockKHR` can return unsigned `i64` or `<2 x i32>`.  Include the return type in the SPIR-V friendly IR function name, to be able to distinguish between both versions.