### PR TITLE
[CI] Fix code style checks by installing libllvmlibc

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -69,6 +69,7 @@ jobs:
         sudo apt-get install -yqq \
             clang-format-${{ env.LLVM_VERSION }} clang-tidy-${{ env.LLVM_VERSION }} \
             llvm-${{ env.LLVM_VERSION }}-dev libomp-${{ env.LLVM_VERSION }}-dev \
+            libllvmlibc-${{ env.LLVM_VERSION }}-dev \
             mlir-${{ env.LLVM_VERSION }}-tools \
 
     - name: Generate compile command database


### PR DESCRIPTION
LLVMExports.cmake from already installed packages references files from the libllvmlibc package.