### PR TITLE
Support for record debug format

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -61,6 +61,7 @@
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/IR/AttributeMask.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DebugProgramInstruction.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Dominators.h"
 #include "llvm/IR/IRBuilder.h"
@@ -2438,7 +2439,13 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     case SPIRVEIS_OpenCL_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_200:
-      return mapValue(BV, DbgTran->transDebugIntrinsic(ExtInst, BB));
+      if (!M->IsNewDbgInfoFormat) {
+        auto *X = mapValue(
+            BV, DbgTran->transDebugIntrinsic(ExtInst, BB).get<Instruction *>());
+        return X;
+      }
+      DbgTran->transDebugIntrinsic(ExtInst, BB);
+      return mapValue(BV, nullptr);
     default:
       llvm_unreachable("Unknown extended instruction set!");
     }
@@ -5068,7 +5075,7 @@ llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM,
   std::unique_ptr<Module> M(new Module("", C));
   // TODO: Migrate to the new debug record format.  Until then, keep using the
   // old format.
-  M->setNewDbgInfoFormatFlag(false);
+  M->setNewDbgInfoFormatFlag(true);
 
   SPIRVToLLVM BTL(M.get(), &BM);
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2440,19 +2440,17 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_200:
       if (!M->IsNewDbgInfoFormat) {
-        auto *X = mapValue(
+        return mapValue(
             BV, DbgTran->transDebugIntrinsic(ExtInst, BB).get<Instruction *>());
-        return X;
-      }
-      {
+      } else {
         auto MaybeRecord = DbgTran->transDebugIntrinsic(ExtInst, BB);
         if (!MaybeRecord.isNull()) {
-          auto *Rcrd = MaybeRecord.get<DbgRecord *>();
-          Rcrd->setDebugLoc(
+          auto *Record = MaybeRecord.get<DbgRecord *>();
+          Record->setDebugLoc(
               DbgTran->transDebugScope(static_cast<SPIRVInstruction *>(BV)));
         }
+        return mapValue(BV, nullptr);
       }
-      return mapValue(BV, nullptr);
     default:
       llvm_unreachable("Unknown extended instruction set!");
     }

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -5078,9 +5078,6 @@ llvm::convertSpirvToLLVM(LLVMContext &C, SPIRVModule &BM,
                          const SPIRV::TranslatorOpts &Opts,
                          std::string &ErrMsg) {
   std::unique_ptr<Module> M(new Module("", C));
-  // TODO: Migrate to the new debug record format.  Until then, keep using the
-  // old format.
-  M->setNewDbgInfoFormatFlag(true);
 
   SPIRVToLLVM BTL(M.get(), &BM);
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2444,7 +2444,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
             BV, DbgTran->transDebugIntrinsic(ExtInst, BB).get<Instruction *>());
         return X;
       }
-      DbgTran->transDebugIntrinsic(ExtInst, BB);
+      {
+        auto MaybeRecord = DbgTran->transDebugIntrinsic(ExtInst, BB);
+        if (!MaybeRecord.isNull()) {
+          auto *Rcrd = MaybeRecord.get<DbgRecord *>();
+          Rcrd->setDebugLoc(
+              DbgTran->transDebugScope(static_cast<SPIRVInstruction *>(BV)));
+        }
+      }
       return mapValue(BV, nullptr);
     default:
       llvm_unreachable("Unknown extended instruction set!");

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1573,6 +1573,7 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
   case SPIRVDebug::Declare: {
     using namespace SPIRVDebug::Operand::DebugDeclare;
     auto LocalVar = GetLocalVar(Ops[DebugLocalVarIdx]);
+    DIBuilder &DIB = getDIBuilder(DebugInst);
     if (getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[VariableIdx])) {
       // If we don't have the variable(e.g. alloca might be promoted by mem2reg)
       // we should generate the following IR:
@@ -1582,17 +1583,15 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
       // parameter. To work around this limitation we create a dummy temp
       // alloca, use it to create llvm.dbg.declare, and then remove the alloca.
       auto *AI = new AllocaInst(Type::getInt8Ty(M->getContext()), 0, "tmp", BB);
-      DbgInstPtr DbgDeclare = getDIBuilder(DebugInst).insertDeclare(
+      DbgInstPtr DbgDeclare = DIB.insertDeclare(
           AI, LocalVar.first, GetExpression(Ops[ExpressionIdx]),
           LocalVar.second, BB);
       AI->eraseFromParent();
       return DbgDeclare;
     }
-    DIBuilder &DIB = getDIBuilder(DebugInst);
-    DbgInstPtr Tmp = DIB.insertDeclare(
-        GetValue(Ops[VariableIdx]), LocalVar.first,
-        GetExpression(Ops[ExpressionIdx]), LocalVar.second, BB);
-    return Tmp;
+    return DIB.insertDeclare(GetValue(Ops[VariableIdx]), LocalVar.first,
+                             GetExpression(Ops[ExpressionIdx]), LocalVar.second,
+                             BB);
   }
   case SPIRVDebug::Value: {
     using namespace SPIRVDebug::Operand::DebugValue;
@@ -1608,8 +1607,13 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
     }
     if (!MDs.empty()) {
       DIArgList *AL = DIArgList::get(M->getContext(), MDs);
-      cast<DbgVariableIntrinsic>(DbgValIntr.get<Instruction *>())
-          ->setRawLocation(AL);
+      if (M->IsNewDbgInfoFormat) {
+        cast<DbgVariableRecord>(DbgValIntr.get<DbgRecord *>())
+            ->setRawLocation(AL);
+      } else {
+        cast<DbgVariableIntrinsic>(DbgValIntr.get<Instruction *>())
+            ->setRawLocation(AL);
+      }
     }
     return DbgValIntr;
   }

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -84,8 +84,7 @@ public:
     return static_cast<T *>(Res);
   }
 
-  Instruction *transDebugIntrinsic(const SPIRVExtInst *DebugInst,
-                                   BasicBlock *BB);
+  DbgInstPtr transDebugIntrinsic(const SPIRVExtInst *DebugInst, BasicBlock *BB);
   void finalize();
 
 private:

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -86,6 +86,7 @@ public:
 
   DbgInstPtr transDebugIntrinsic(const SPIRVExtInst *DebugInst, BasicBlock *BB);
   void finalize();
+  llvm::DebugLoc transDebugScope(const SPIRVInstruction *Inst);
 
 private:
   DIFile *getFile(const SPIRVId SourceId);
@@ -102,8 +103,6 @@ private:
   DIType *transNonNullDebugType(const SPIRVExtInst *DebugInst);
 
   llvm::DebugLoc transDebugLocation(const SPIRVExtInst *DebugInst);
-
-  llvm::DebugLoc transDebugScope(const SPIRVInstruction *Inst);
 
   MDNode *transDebugInlined(const SPIRVExtInst *Inst);
   MDNode *transDebugInlinedNonSemanticShader200(const SPIRVExtInst *Inst);


### PR DESCRIPTION
Recently, LLVM migrated to new debug format replacing debug intrinsics with so-called records. The DIBuilder api supports both formats now with grace deprecation period for intrinsics. Currently Translator during reverse translation have new format disabled by flag and still supports only old one.
Documentation for the migration: https://llvm.org/docs/RemoveDIsDebugInfo.html