### PR TITLE
Experiment with new form of SPIR-V friendly decoration representation

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -102,6 +102,8 @@ public:
   // non-standard integer types.
   void cleanupConversionToNonStdIntegers(llvm::Module *M);
 
+  void promoteCacheControlBuiltin(llvm::Module *M);
+
   // According to the specification, the operands of a shift instruction must be
   // a scalar/vector of integer. When LLVM-IR contains a shift instruction with
   // i1 operands, they are treated as a bool. We need to extend them to i32 to

--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -1025,6 +1025,14 @@ void SPIRVTypeScavenger::correctUseTypes(Instruction &I) {
       });
       Value *CastedValue =
           Builder.Insert(CastInst::CreatePointerCast(U, U->getType()));
+      if (isa<Instruction>(U)) {
+        if (auto *MDNode =
+            cast<Instruction>(U)->getMetadata("spirv.Decorations")) {
+          Instruction *BitCast = cast<Instruction>(CastedValue);
+          BitCast->setMetadata("spirv.Decorations", MDNode);
+          cast<Instruction>(U)->dropUnknownNonDebugMetadata();
+        }
+      }
       DeducedTypes[CastedValue] = UsedTy;
       U.set(CastedValue);
     }

--- a/test/extensions/INTEL/SPV_INTEL_cache_controls/basic_load_store_triton.ll
+++ b/test/extensions/INTEL/SPV_INTEL_cache_controls/basic_load_store_triton.ll
@@ -1,0 +1,75 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_cache_controls -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_cache_controls %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: TypeInt [[#Int32:]] 32 0
+; CHECK-SPIRV-DAG: Constant [[#Int32]] [[#Zero:]] 0
+; CHECK-SPIRV-DAG: Decorate [[#Load1Ptr:]] CacheControlLoadINTEL 0 1
+; CHECK-SPIRV-DAG: Decorate [[#Load2Ptr:]] CacheControlLoadINTEL 1 1
+; CHECK-SPIRV-DAG: Decorate [[#Store1Ptr:]] CacheControlStoreINTEL 0 1
+; CHECK-SPIRV-DAG: Decorate [[#Store2Ptr:]] CacheControlStoreINTEL 1 1
+
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#Load1GEPPtr:]] [[#]] [[#Zero]]
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#Load2GEPPtr:]] [[#]] [[#Zero]]
+; CHECK-SPIRV: Bitcast [[#]] [[#Load1Ptr]] [[#Load1GEPPtr]]
+; CHECK-SPIRV: Load [[#]] [[#]] [[#Load1Ptr]]
+; CHECK-SPIRV: Bitcast [[#]] [[#Load2Ptr]] [[#Load2GEPPtr]]
+; CHECK-SPIRV: Load [[#]] [[#]] [[#Load2Ptr]]
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#Store1GEPPtr:]] [[#]] [[#Zero]]
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#Store2GEPPtr:]] [[#]] [[#Zero]]
+; CHECK-SPIRV: Bitcast [[#]] [[#Store1Ptr]] [[#Store1GEPPtr]]
+; CHECK-SPIRV: Store [[#Store1Ptr]]
+; CHECK-SPIRV: Bitcast [[#]] [[#Store2Ptr]] [[#Store2GEPPtr]]
+; CHECK-SPIRV: Store [[#Store2Ptr]]
+
+; CHECK-LLVM: %[[#GEPLoad1:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[#]], i32 0
+; CHECK-LLVM: %[[#GEPLoad2:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[#]], i32 0
+; CHECK-LLVM: %[[#LoadPtr1:]] = bitcast ptr addrspace(1) %[[#GEPLoad1]] to ptr addrspace(1), !spirv.Decorations ![[#Cache1:]]
+; CHECK-LLVM: load i32, ptr addrspace(1) %[[#LoadPtr1]], align 4
+; CHECK-LLVM: %[[#LoadPtr2:]] = bitcast ptr addrspace(1) %[[#GEPLoad2:]] to ptr addrspace(1), !spirv.Decorations ![[#Cache2:]]
+; CHECK-LLVM: load i32, ptr addrspace(1) %[[#LoadPtr2]], align 4
+; CHECK-LLVM: %[[#GEPStore1:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[#]], i32 0
+; CHECK-LLVM: %[[#GEPStore2:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[#]], i32 0
+; CHECK-LLVM: %[[#StorePtr1:]] = bitcast ptr addrspace(1) %[[#GEPStore1]] to ptr addrspace(1), !spirv.Decorations ![[#Cache3:]]
+; CHECK-LLVM: store i32 %[[#]], ptr addrspace(1) %[[#StorePtr1]], align 4
+; CHECK-LLVM: [[#StorePtr2:]] = bitcast ptr addrspace(1) %[[#GEPStore2]] to ptr addrspace(1), !spirv.Decorations ![[#Cache4:]]
+; CHECK-LLVM: store i32 %[[#]], ptr addrspace(1) %[[#StorePtr2]], align 4
+; CHECK-LLVM: ![[#Cache1]] = !{![[#DecLoad1:]]}
+; CHECK-LLVM: ![[#DecLoad1]] = !{i32 6442, i32 0, i32 1}
+; CHECK-LLVM: ![[#Cache2]] = !{![[#DecLoad2:]]}
+; CHECK-LLVM: ![[#DecLoad2]] = !{i32 6442, i32 1, i32 1}
+; CHECK-LLVM: ![[#Cache3:]] = !{![[#DecStore1:]]}
+; CHECK-LLVM: ![[#DecStore1]] = !{i32 6443, i32 0, i32 1}
+; CHECK-LLVM: ![[#Cache4:]] = !{![[#DecStore2:]]}
+; CHECK-LLVM: ![[#DecStore2]] = !{i32 6443, i32 1, i32 1}
+
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %buffer) {
+entry:
+  %arrayidx = getelementptr inbounds i32, ptr addrspace(1) %buffer, i64 1
+  %arrayidx_ann_1 = call ptr addrspace(1) @__spirv_DecorationCacheControlLoadINTEL(ptr addrspace(1) %arrayidx, i32 0, i32 1)
+  %arrayidx_ann_2 = call ptr addrspace(1) @__spirv_DecorationCacheControlLoadINTEL(ptr addrspace(1) %arrayidx, i32 1, i32 1)
+  %0 = load i32, ptr addrspace(1) %arrayidx_ann_1, align 4
+  %1 = load i32, ptr addrspace(1) %arrayidx_ann_2, align 4
+  %arrayidx1 = getelementptr inbounds i32, ptr addrspace(1) %buffer, i64 0
+  %arrayidx1_ann_1 = call ptr addrspace(1) @__spirv_DecorationCacheControlStoreINTEL(ptr addrspace(1) %arrayidx1, i32 0, i32 1)
+  %arrayidx1_ann_2 = call ptr addrspace(1) @__spirv_DecorationCacheControlStoreINTEL(ptr addrspace(1) %arrayidx1, i32 1, i32 1)
+  store i32 %0, ptr addrspace(1) %arrayidx1_ann_1, align 4
+  store i32 %1, ptr addrspace(1) %arrayidx1_ann_2, align 4
+  ret void
+}
+
+declare ptr @__spirv_DecorationCacheControlLoadINTEL(ptr addrspace(1), i32, i32)
+
+declare ptr @__spirv_DecorationCacheControlStoreINTEL(ptr addrspace(1), i32, i32)
+
+!spirv.MemoryModel = !{!0}
+!spirv.Source = !{!1}
+!opencl.spir.version = !{!2}
+!opencl.ocl.version = !{!2}
+
+!0 = !{i32 2, i32 2}
+!1 = !{i32 3, i32 102000}
+!2 = !{i32 1, i32 2}


### PR DESCRIPTION
spirv.Decorations metadata and annotation intrinsics have a drawback that they can be optimized out. This patch adds experimental approach of preserving decorations with an external function call with __spirv_Decoration prefix. To start with Intel Cache Controls decorations are being added.

SPIRVRegularizeLLVM pass will replace such call with it's argument aka value to decorate and add spirv.Decorations metadata to be recognized by the SPIRVWriter.

That is experimental approach, so we are not ready to document it yet.

