### PR TITLE
[NFC] Use StringRef::operator== instead of StringRef::equals

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1035,12 +1035,11 @@ public:
       setVarArg(1);
     else if (NameRef.starts_with("write_imageui"))
       addUnsignedArg(2);
-    else if (NameRef.equals("prefetch")) {
+    else if (NameRef == "prefetch") {
       addUnsignedArg(1);
       setArgAttr(0, SPIR::ATTR_CONST);
-    } else if (NameRef.equals("get_kernel_work_group_size") ||
-               NameRef.equals(
-                   "get_kernel_preferred_work_group_size_multiple")) {
+    } else if (NameRef == "get_kernel_work_group_size" ||
+               NameRef == "get_kernel_preferred_work_group_size_multiple") {
       assert(F && "lack of necessary information");
       const size_t BlockArgIdx = 0;
       FunctionType *InvokeTy = getBlockInvokeTy(F, BlockArgIdx);
@@ -1049,8 +1048,8 @@ public:
     } else if (NameRef.starts_with("__enqueue_kernel")) {
       // clang doesn't mangle enqueue_kernel builtins
       setAsDontMangle();
-    } else if (NameRef.starts_with("get_") || NameRef.equals("nan") ||
-               NameRef.equals("mem_fence") || NameRef.starts_with("shuffle")) {
+    } else if (NameRef.starts_with("get_") || NameRef == "nan" ||
+               NameRef == "mem_fence" || NameRef.starts_with("shuffle")) {
       addUnsignedArg(-1);
       if (NameRef.starts_with(kOCLBuiltinName::GetFence)) {
         setArgAttr(0, SPIR::ATTR_CONST);
@@ -1058,10 +1057,9 @@ public:
       }
     } else if (NameRef.contains("barrier")) {
       addUnsignedArg(0);
-      if (NameRef.equals("work_group_barrier") ||
-          NameRef.equals("sub_group_barrier") ||
-          NameRef.equals("intel_work_group_barrier_arrive") ||
-          NameRef.equals("intel_work_group_barrier_wait"))
+      if (NameRef == "work_group_barrier" || NameRef == "sub_group_barrier" ||
+          NameRef == "intel_work_group_barrier_arrive" ||
+          NameRef == "intel_work_group_barrier_wait")
         setEnumArg(1, SPIR::PRIMITIVE_MEMORY_SCOPE);
     } else if (NameRef.starts_with("atomic_work_item_fence")) {
       addUnsignedArg(0);
@@ -1117,18 +1115,18 @@ public:
       NameRef = NameRef.drop_front(1);
       UnmangledName.erase(0, 1);
     } else if (NameRef.starts_with("s_")) {
-      if (NameRef.equals("s_upsample"))
+      if (NameRef == "s_upsample")
         addUnsignedArg(1);
       NameRef = NameRef.drop_front(2);
     } else if (NameRef.starts_with("u_")) {
       addUnsignedArg(-1);
       NameRef = NameRef.drop_front(2);
-    } else if (NameRef.equals("fclamp")) {
+    } else if (NameRef == "fclamp") {
       NameRef = NameRef.drop_front(1);
     }
     // handle [read|write]pipe builtins (plus two i32 literal args
     // required by SPIR 2.0 provisional specification):
-    else if (NameRef.equals("read_pipe_2") || NameRef.equals("write_pipe_2")) {
+    else if (NameRef == "read_pipe_2" || NameRef == "write_pipe_2") {
       // with 2 arguments (plus two i32 literals):
       // int read_pipe (read_only pipe gentype p, gentype *ptr)
       // int write_pipe (write_only pipe gentype p, const gentype *ptr)
@@ -1136,16 +1134,14 @@ public:
       addUnsignedArg(2);
       addUnsignedArg(3);
       // OpenCL-like representation of blocking pipes
-    } else if (NameRef.equals("read_pipe_2_bl") ||
-               NameRef.equals("write_pipe_2_bl")) {
+    } else if (NameRef == "read_pipe_2_bl" || NameRef == "write_pipe_2_bl") {
       // with 2 arguments (plus two i32 literals):
       // int read_pipe_bl (read_only pipe gentype p, gentype *ptr)
       // int write_pipe_bl (write_only pipe gentype p, const gentype *ptr)
       addVoidPtrArg(1);
       addUnsignedArg(2);
       addUnsignedArg(3);
-    } else if (NameRef.equals("read_pipe_4") ||
-               NameRef.equals("write_pipe_4")) {
+    } else if (NameRef == "read_pipe_4" || NameRef == "write_pipe_4") {
       // with 4 arguments (plus two i32 literals):
       // int read_pipe (read_only pipe gentype p, reserve_id_t reserve_id, uint
       // index, gentype *ptr) int write_pipe (write_only pipe gentype p,
@@ -1165,10 +1161,10 @@ public:
       // process [|work_group|sub_group]commit[read|write]pipe builtins
       addUnsignedArg(2);
       addUnsignedArg(3);
-    } else if (NameRef.equals("capture_event_profiling_info")) {
+    } else if (NameRef == "capture_event_profiling_info") {
       addVoidPtrArg(2);
       setEnumArg(1, SPIR::PRIMITIVE_CLK_PROFILING_INFO);
-    } else if (NameRef.equals("enqueue_marker")) {
+    } else if (NameRef == "enqueue_marker") {
       setArgAttr(2, SPIR::ATTR_CONST);
       addUnsignedArg(1);
     } else if (NameRef.starts_with("vload")) {
@@ -1529,7 +1525,7 @@ SPIRV::transSPIRVMemoryScopeIntoOCLMemoryScope(Value *MemScope,
 
   if (auto *CI = dyn_cast<CallInst>(MemScope)) {
     Function *F = CI->getCalledFunction();
-    if (F && F->getName().equals(kSPIRVName::TranslateOCLMemScope)) {
+    if (F && F->getName() == kSPIRVName::TranslateOCLMemScope) {
       // In case the SPIR-V module was created from an OpenCL program by
       // *this* SPIR-V generator, we know that the value passed to
       // __translate_ocl_memory_scope is what we should pass to the
@@ -1553,7 +1549,7 @@ SPIRV::transSPIRVMemorySemanticsIntoOCLMemoryOrder(Value *MemorySemantics,
 
   if (auto *CI = dyn_cast<CallInst>(MemorySemantics)) {
     Function *F = CI->getCalledFunction();
-    if (F && F->getName().equals(kSPIRVName::TranslateOCLMemOrder)) {
+    if (F && F->getName() == kSPIRVName::TranslateOCLMemOrder) {
       // In case the SPIR-V module was created from an OpenCL program by
       // *this* SPIR-V generator, we know that the value passed to
       // __translate_ocl_memory_order is what we should pass to the

--- a/lib/SPIRV/PassPlugin.cpp
+++ b/lib/SPIRV/PassPlugin.cpp
@@ -65,7 +65,7 @@ PassPluginLibraryInfo getSPIRVPluginInfo() {
         PB.registerPipelineParsingCallback(
             [](StringRef Name, FunctionPassManager &PM,
                ArrayRef<PassBuilder::PipelineElement>) {
-              if (Name.equals("spirv-lower-bitcast")) {
+              if (Name == "spirv-lower-bitcast") {
                 PM.addPass(
                     SPIRVLowerBitCastToNonStandardTypePass(TranslatorOpts{}));
                 return true;
@@ -75,50 +75,50 @@ PassPluginLibraryInfo getSPIRVPluginInfo() {
         PB.registerPipelineParsingCallback(
             [](StringRef Name, ModulePassManager &PM,
                ArrayRef<PassBuilder::PipelineElement>) {
-              if (Name.equals("ocl-to-spirv")) {
+              if (Name == "ocl-to-spirv") {
                 PM.addPass(OCLToSPIRVPass());
                 return true;
               }
-              if (Name.equals("llvm-to-spirv")) {
+              if (Name == "llvm-to-spirv") {
                 SPIRV::TranslatorOpts DefaultOpts;
                 DefaultOpts.enableAllExtensions();
                 SPIRVModule *BM = SPIRVModule::createSPIRVModule(DefaultOpts);
                 PM.addPass(LLVMToSPIRVPass(BM));
                 return true;
               }
-              if (Name.equals("process-metadata")) {
+              if (Name == "process-metadata") {
                 PM.addPass(PreprocessMetadataPass());
                 return true;
               }
-              if (Name.equals("spirv-lower-bool")) {
+              if (Name == "spirv-lower-bool") {
                 PM.addPass(SPIRVLowerBoolPass());
                 return true;
               }
-              if (Name.equals("spirv-lower-constexpr")) {
+              if (Name == "spirv-lower-constexpr") {
                 PM.addPass(SPIRVLowerConstExprPass());
                 return true;
               }
-              if (Name.equals("spirv-lower-memmove")) {
+              if (Name == "spirv-lower-memmove") {
                 PM.addPass(SPIRVLowerMemmovePass());
                 return true;
               }
-              if (Name.equals("spirv-lower-ocl-blocks")) {
+              if (Name == "spirv-lower-ocl-blocks") {
                 PM.addPass(SPIRVLowerOCLBlocksPass());
                 return true;
               }
-              if (Name.equals("spirv-lower-llvm-intrinsic")) {
+              if (Name == "spirv-lower-llvm-intrinsic") {
                 PM.addPass(SPIRVLowerLLVMIntrinsicPass(TranslatorOpts{}));
                 return true;
               }
-              if (Name.equals("spirv-regularize-llvm")) {
+              if (Name == "spirv-regularize-llvm") {
                 PM.addPass(SPIRVRegularizeLLVMPass());
                 return true;
               }
-              if (Name.equals("spirv-to-ocl12")) {
+              if (Name == "spirv-to-ocl12") {
                 PM.addPass(SPIRVToOCL12Pass());
                 return true;
               }
-              if (Name.equals("spirv-to-ocl20")) {
+              if (Name == "spirv-to-ocl20") {
                 PM.addPass(SPIRVToOCL20Pass());
                 return true;
               }

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -913,8 +913,7 @@ bool getRetParamSignedness(Function *F, ParamSignedness &RetSignedness,
       StringRef Arg(stringify(Name));
       if (Arg.starts_with("unsigned"))
         return ParamSignedness::Unsigned;
-      if (Arg.equals("char") || Arg.equals("short") || Arg.equals("int") ||
-          Arg.equals("long"))
+      if (Arg == "char" || Arg == "short" || Arg == "int" || Arg == "long")
         return ParamSignedness::Signed;
     }
     return ParamSignedness::Unknown;


### PR DESCRIPTION
The llvm project plans to deprecate `StringRef::equals` in favor of `StringRef::operator==`.

Most of these changes were done using `sed -i -e 's/\.equals("\([a-z0-9_\-]*\)")/ == "\1"/g'`