### PR TITLE
[Backport to 14] Add updated SPV_INTEL_bindless_images preview extension (#2559)

### DIFF
--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -195,7 +195,12 @@ void OCLTypeToSPIRVBase::adaptArgumentsBySamplerUse(Module &M) {
     StringRef DemangledName;
     if (!oclIsBuiltin(MangledName, DemangledName, false))
       continue;
-    if (DemangledName.find(kSPIRVName::SampledImage) == std::string::npos)
+    // Note: kSPIRVName::ConvertHandleToSampledImageINTEL contains
+    // kSPIRVName::SampledImage as a substring, but we still want to continue in
+    // this case.
+    if (DemangledName.find(kSPIRVName::SampledImage) == std::string::npos ||
+        DemangledName.find(kSPIRVName::ConvertHandleToSampledImageINTEL) !=
+            std::string::npos)
       continue;
 
     TraceArg(&F, 1);

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -386,6 +386,10 @@ const static char TranslateSPIRVMemOrder[] = "__translate_spirv_memory_order";
 const static char TranslateSPIRVMemScope[] = "__translate_spirv_memory_scope";
 const static char TranslateSPIRVMemFence[] = "__translate_spirv_memory_fence";
 const static char EntrypointPrefix[] = "__spirv_entry_";
+const static char ConvertHandleToImageINTEL[] = "ConvertHandleToImageINTEL";
+const static char ConvertHandleToSamplerINTEL[] = "ConvertHandleToSamplerINTEL";
+const static char ConvertHandleToSampledImageINTEL[] =
+    "ConvertHandleToSampledImageINTEL";
 } // namespace kSPIRVName
 
 namespace kSPIRVPostfix {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3328,6 +3328,7 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   case OpCooperativeMatrixLoadKHR:
   case internal::OpCooperativeMatrixLoadCheckedINTEL:
   case internal::OpConvertHandleToImageINTEL:
+  case internal::OpConvertHandleToSampledImageINTEL:
     AddRetTypePostfix = true;
     break;
   default: {

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2347,6 +2347,7 @@ public:
     }
     case internal::OpConvertHandleToImageINTEL:
     case internal::OpConvertHandleToSamplerINTEL:
+    case internal::OpConvertHandleToSampledImageINTEL:
       addUnsignedArg(0);
       break;
     default:;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4927,7 +4927,12 @@ void LLVMToSPIRVBase::oclGetMutatedArgumentTypesByBuiltin(
   StringRef Demangled;
   if (!oclIsBuiltin(F->getName(), Demangled))
     return;
-  if (Demangled.find(kSPIRVName::SampledImage) == std::string::npos)
+  // Note: kSPIRVName::ConvertHandleToSampledImageINTEL contains
+  // kSPIRVName::SampledImage as a substring, but we still want to return in
+  // this case.
+  if (Demangled.find(kSPIRVName::SampledImage) == std::string::npos ||
+      Demangled.find(kSPIRVName::ConvertHandleToSampledImageINTEL) !=
+          std::string::npos)
     return;
   if (FT->getParamType(1)->isIntegerTy())
     ChangedType[1] = getSamplerType(F->getParent());

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -3853,7 +3853,9 @@ protected:
     SPVErrLog.checkError(
         (ResTy->isTypeImage() && OC == internal::OpConvertHandleToImageINTEL) ||
             (ResTy->isTypeSampler() &&
-             OC == internal::OpConvertHandleToSamplerINTEL),
+             OC == internal::OpConvertHandleToSamplerINTEL) ||
+            (ResTy->isTypeSampledImage() &&
+             OC == internal::OpConvertHandleToSampledImageINTEL),
         SPIRVEC_InvalidInstruction,
         InstName + "\nIncorrect return type of the instruction must be "
                    "image/sampler\n");
@@ -3863,6 +3865,7 @@ protected:
   typedef SPIRVBindlessImagesInstBase<internal::Op##x> SPIRV##x;
 _SPIRV_OP(ConvertHandleToImageINTEL)
 _SPIRV_OP(ConvertHandleToSamplerINTEL)
+_SPIRV_OP(ConvertHandleToSampledImageINTEL)
 #undef _SPIRV_OP
 
 } // namespace SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVOpCodeEnumInternal.h
+++ b/lib/SPIRV/libSPIRV/SPIRVOpCodeEnumInternal.h
@@ -33,3 +33,5 @@ _SPIRV_OP_INTERNAL(ConvertHandleToImageINTEL,
                    internal::ConvertHandleToImageINTEL)
 _SPIRV_OP_INTERNAL(ConvertHandleToSamplerINTEL,
                    internal::ConvertHandleToSamplerINTEL)
+_SPIRV_OP_INTERNAL(ConvertHandleToSampledImageINTEL,
+                   internal::ConvertHandleToSampledImageINTEL)

--- a/lib/SPIRV/libSPIRV/SPIRVType.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVType.cpp
@@ -197,6 +197,10 @@ bool SPIRVType::isTypeSampler() const { return OpCode == OpTypeSampler; }
 
 bool SPIRVType::isTypeImage() const { return OpCode == OpTypeImage; }
 
+bool SPIRVType::isTypeSampledImage() const {
+  return OpCode == OpTypeSampledImage;
+}
+
 bool SPIRVType::isTypeStruct() const { return OpCode == OpTypeStruct; }
 
 bool SPIRVType::isTypeVector() const { return OpCode == OpTypeVector; }

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -93,6 +93,7 @@ public:
   bool isTypeOpaque() const;
   bool isTypePointer() const;
   bool isTypeSampler() const;
+  bool isTypeSampledImage() const;
   bool isTypeStruct() const;
   bool isTypeVector() const;
   bool isTypeJointMatrixINTEL() const;

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -82,6 +82,7 @@ enum InternalOp {
   IOpCooperativeMatrixPrefetchINTEL = 6449,
   IOpConvertHandleToImageINTEL = 6529,
   IOpConvertHandleToSamplerINTEL = 6530,
+  IOpConvertHandleToSampledImageINTEL = 6531,
   IOpPrev = OpMax - 2,
   IOpForward
 };
@@ -216,6 +217,7 @@ _SPIRV_OP(Capability, CacheControlsINTEL)
 _SPIRV_OP(Capability, BindlessImagesINTEL)
 _SPIRV_OP(Op, ConvertHandleToImageINTEL)
 _SPIRV_OP(Op, ConvertHandleToSamplerINTEL)
+_SPIRV_OP(Op, ConvertHandleToSampledImageINTEL)
 #undef _SPIRV_OP
 
 constexpr SourceLanguage SourceLanguagePython =

--- a/test/extensions/INTEL/SPV_INTEL_bindless_images/bindless_images_generic.ll
+++ b/test/extensions/INTEL/SPV_INTEL_bindless_images/bindless_images_generic.ll
@@ -18,27 +18,36 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV-DAG: TypeVoid [[#VoidTy:]]
 ; CHECK-SPIRV-DAG: TypeInt [[#Int64Ty:]] 64
 ; CHECK-SPIRV-DAG: Constant [[#Int64Ty]] [[#Const42:]] 42 0
+; CHECK-SPIRV-DAG: Constant [[#Int64Ty]] [[#Const43:]] 43 0
 ; CHECK-SPIRV-DAG: TypeImage [[#IntImgTy:]] [[#Int64Ty]]
 ; CHECK-SPIRV-DAG: TypeSampler [[#SamplerTy:]]
+; CHECK-SPIRV-DAG: TypeImage [[#IntSmpImgTy:]] [[#Int64Ty]]
+; CHECK-SPIRV-DAG: TypeSampledImage [[#SampImageTy:]] [[#IntSmpImgTy]]
 ; CHECK-SPIRV: FunctionParameter [[#Int64Ty]] [[#Input:]]
 ; CHECK-SPIRV: ConvertHandleToImageINTEL [[#IntImgTy]] [[#]] [[#Input]]
 ; CHECK-SPIRV: ConvertHandleToSamplerINTEL [[#SamplerTy]] [[#]] [[#Const42]]
+; CHECK-SPIRV: ConvertHandleToSampledImageINTEL [[#SampImageTy]] [[#]] [[#Const43]]
 
 ; CHECK-LLVM: call spir_func %spirv.Image._ulong_2_0_0_0_0_0_0 addrspace(1)* @_Z77__spirv_ConvertHandleToImageINTEL_RPU3AS134__spirv_Image__ulong_2_0_0_0_0_0_0m(i64 %{{.*}})
 ; CHECK-LLVM: call spir_func %spirv.Sampler addrspace(2)* @_Z35__spirv_ConvertHandleToSamplerINTELm(i64 42)
+; CHECK-LLVM: call spir_func %spirv.SampledImage._ulong_1_0_0_0_0_0_0
 
 %spirv.Image._long_2_0_0_0_0_0_0 = type opaque
 %spirv.Sampler = type opaque
+%spirv.SampledImage._ulong_1_0_0_0_0_0_0 = type opaque
 
 define spir_func void @foo(i64 %in) {
   %img = call spir_func %spirv.Image._long_2_0_0_0_0_0_0 addrspace(1)* @_Z33__spirv_ConvertHandleToImageINTELl(i64 %in)
   %samp = call spir_func %spirv.Sampler addrspace(2)* @_Z35__spirv_ConvertHandleToSamplerINTELl(i64 42)
+  %sampImage = call spir_func %spirv.SampledImage._ulong_1_0_0_0_0_0_0 addrspace(1)* @_Z40__spirv_ConvertHandleToSampledImageINTELl(i64 43)
   ret void
 }
 
 declare spir_func %spirv.Image._long_2_0_0_0_0_0_0 addrspace(1)* @_Z33__spirv_ConvertHandleToImageINTELl(i64)
 
 declare spir_func %spirv.Sampler addrspace(2)* @_Z35__spirv_ConvertHandleToSamplerINTELl(i64)
+
+declare spir_func %spirv.SampledImage._ulong_1_0_0_0_0_0_0 addrspace(1)* @_Z40__spirv_ConvertHandleToSampledImageINTELl(i64)
 
 !opencl.spir.version = !{!0}
 !spirv.Source = !{!1}

--- a/test/extensions/INTEL/SPV_INTEL_bindless_images/bindless_images_generic.ll
+++ b/test/extensions/INTEL/SPV_INTEL_bindless_images/bindless_images_generic.ll
@@ -30,7 +30,7 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-LLVM: call spir_func %spirv.Image._ulong_2_0_0_0_0_0_0 addrspace(1)* @_Z77__spirv_ConvertHandleToImageINTEL_RPU3AS134__spirv_Image__ulong_2_0_0_0_0_0_0m(i64 %{{.*}})
 ; CHECK-LLVM: call spir_func %spirv.Sampler addrspace(2)* @_Z35__spirv_ConvertHandleToSamplerINTELm(i64 42)
-; CHECK-LLVM: call spir_func %spirv.SampledImage._ulong_1_0_0_0_0_0_0
+; CHECK-LLVM: call spir_func %spirv.SampledImage._ulong_1_0_0_0_0_0_0 addrspace(1)* @_Z91__spirv_ConvertHandleToSampledImageINTEL_RPU3AS141__spirv_SampledImage__ulong_1_0_0_0_0_0_0m(i64 43)
 
 %spirv.Image._long_2_0_0_0_0_0_0 = type opaque
 %spirv.Sampler = type opaque

--- a/test/extensions/INTEL/SPV_INTEL_bindless_images/negative/i32-in-physical64.ll
+++ b/test/extensions/INTEL/SPV_INTEL_bindless_images/negative/i32-in-physical64.ll
@@ -11,16 +11,20 @@ target triple = "spir64-unknown-unknown"
 
 %spirv.Image._long_2_0_0_0_0_0_0 = type opaque
 %spirv.Sampler = type opaque
+%spirv.SampledImage._long_2_0_0_0_0_0_0 = type opaque
 
 define spir_func void @foo(i32 %in) {
   %img = call spir_func %spirv.Image._long_2_0_0_0_0_0_0 addrspace(1)* @_Z33__spirv_ConvertHandleToImageINTELi(i32 %in)
   %samp = call spir_func %spirv.Sampler addrspace(1)* @_Z35__spirv_ConvertHandleToSamplerINTELl(i64 42)
+  %sampImage = call spir_func %spirv.SampledImage._long_2_0_0_0_0_0_0 addrspace(1)* @_Z40__spirv_ConvertHandleToSampledImageINTELl(i64 43)
   ret void
 }
 
 declare spir_func %spirv.Image._long_2_0_0_0_0_0_0 addrspace(1)* @_Z33__spirv_ConvertHandleToImageINTELi(i32)
 
 declare spir_func %spirv.Sampler addrspace(1)* @_Z35__spirv_ConvertHandleToSamplerINTELl(i64)
+
+declare spir_func %spirv.SampledImage._long_2_0_0_0_0_0_0 addrspace(1)* @_Z40__spirv_ConvertHandleToSampledImageINTELl(i64)
 
 !opencl.spir.version = !{!0}
 !spirv.Source = !{!1}


### PR DESCRIPTION
The updated SPV_INTEL_bindless_images spec can be seen in this PR: intel/llvm#13753

(cherry picked from commit e9a9a3fc1fd3e57449ba22d0065a373eaf4b1a53)