### PR TITLE
Add a new flag "--no-entry"

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -227,7 +227,7 @@ ModulePass *
 createSPIRVLowerLLVMIntrinsicLegacy(const SPIRV::TranslatorOpts &Opts);
 
 /// Create a pass for regularize LLVM module to be translated to SPIR-V.
-ModulePass *createSPIRVRegularizeLLVMLegacy();
+ModulePass *createSPIRVRegularizeLLVMLegacy(const SPIRV::TranslatorOpts &Opts);
 
 /// Create a pass for translating SPIR-V Instructions to desired
 /// representation in LLVM IR (OpenCL built-ins, SPIR-V Friendly IR, etc.)

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -233,6 +233,14 @@ public:
     PreserveOCLKernelArgTypeMetadataThroughString = Value;
   }
 
+  void setGenerateKernelEntryPoints(bool Value) noexcept {
+    GenerateEntryPoints = Value;
+  }
+
+  bool getGenerateKernelEntryPoints() const noexcept {
+    return GenerateEntryPoints;
+  }
+
   void setBuiltinFormat(BuiltinFormat Value) noexcept {
     SPIRVBuiltinFormat = Value;
   }
@@ -280,6 +288,8 @@ private:
   // Add a workaround to preserve OpenCL kernel_arg_type and
   // kernel_arg_type_qual metadata through OpString
   bool PreserveOCLKernelArgTypeMetadataThroughString = false;
+
+  bool GenerateEntryPoints = true;
 
   bool PreserveAuxData = false;
 

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -500,7 +500,8 @@ void regularizeWithOverflowInstrinsics(StringRef MangledName, CallInst *Call,
 /// Remove entities not representable by SPIR-V
 bool SPIRVRegularizeLLVMBase::regularize() {
   eraseUselessFunctions(M);
-  addKernelEntryPoint(M);
+  if (Opts.getGenerateKernelEntryPoints())
+    addKernelEntryPoint(M);
   expandSYCLTypeUsing(M);
   cleanupConversionToNonStdIntegers(M);
 
@@ -767,6 +768,6 @@ void SPIRVRegularizeLLVMBase::addKernelEntryPoint(Module *M) {
 INITIALIZE_PASS(SPIRVRegularizeLLVMLegacy, "spvregular",
                 "Regularize LLVM for SPIR-V", false, false)
 
-ModulePass *llvm::createSPIRVRegularizeLLVMLegacy() {
-  return new SPIRVRegularizeLLVMLegacy();
+ModulePass *llvm::createSPIRVRegularizeLLVMLegacy(const TranslatorOpts &Opts) {
+  return new SPIRVRegularizeLLVMLegacy(Opts);
 }

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -45,7 +45,8 @@ namespace SPIRV {
 
 class SPIRVRegularizeLLVMBase {
 public:
-  SPIRVRegularizeLLVMBase() : M(nullptr), Ctx(nullptr) {}
+  SPIRVRegularizeLLVMBase(const TranslatorOpts& TOpts)
+      : M(nullptr), Ctx(nullptr), Opts(TOpts) {}
 
   bool runRegularizeLLVM(llvm::Module &M);
   // Lower functions
@@ -116,12 +117,15 @@ public:
 private:
   llvm::Module *M;
   llvm::LLVMContext *Ctx;
+  const TranslatorOpts &Opts;
 };
 
 class SPIRVRegularizeLLVMPass
     : public llvm::PassInfoMixin<SPIRVRegularizeLLVMPass>,
       public SPIRVRegularizeLLVMBase {
 public:
+  SPIRVRegularizeLLVMPass(const TranslatorOpts &TOpts)
+      : SPIRVRegularizeLLVMBase(TOpts) {}
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM) {
     return runRegularizeLLVM(M) ? llvm::PreservedAnalyses::none()
@@ -134,7 +138,8 @@ public:
 class SPIRVRegularizeLLVMLegacy : public llvm::ModulePass,
                                   public SPIRVRegularizeLLVMBase {
 public:
-  SPIRVRegularizeLLVMLegacy() : ModulePass(ID) {
+  SPIRVRegularizeLLVMLegacy(const TranslatorOpts &TOpts)
+      : ModulePass(ID), SPIRVRegularizeLLVMBase(TOpts) {
     initializeSPIRVRegularizeLLVMLegacyPass(*PassRegistry::getPassRegistry());
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -578,6 +578,10 @@ public:
     return TranslationOpts.getDesiredBIsRepresentation();
   }
 
+  bool getGenerateKernelEntryPoints() const {
+    return TranslationOpts.getGenerateKernelEntryPoints();
+  }
+
   // I/O functions
   friend spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M);
   friend std::istream &operator>>(std::istream &I, SPIRVModule &M);

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -278,6 +278,10 @@ static cl::opt<SPIRV::BuiltinFormat> SPIRVBuiltinFormat(
         clEnumValN(SPIRV::BuiltinFormat::Global, "global",
                    "Use globals to represent SPIR-V builtin variables")));
 
+static cl::opt<bool>
+    NoEntry("no-entry", cl::init(false),
+                  cl::desc("Disable kernel entry point generation. This is a workaround for some OpenCL drivers that are incompatible with entry points, leading them to have twice the number of kernel arguments. See https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1486 for more details."));
+
 static std::string removeExt(const std::string &FileName) {
   size_t Pos = FileName.find_last_of(".");
   if (Pos != std::string::npos)
@@ -819,6 +823,8 @@ int main(int Ac, char **Av) {
 
   if (PreserveOCLKernelArgTypeMetadataThroughString.getNumOccurrences() != 0)
     Opts.setPreserveOCLKernelArgTypeMetadataThroughString(true);
+
+  Opts.setGenerateKernelEntryPoints(!NoEntry);
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
   if (ToText && (ToBinary || IsReverse || IsRegularization)) {


### PR DESCRIPTION
Add a new flag "--no-entry" which disables kernel entry point generation. This is a workaround for some OpenCL drivers that are incompatible with entry points, leading them to have twice the number of kernel arguments. See https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/1486 for more details.

Adding this option allows a single toolchain to be used when compiling kernels for all devices. Some real world instances of this problem:
https://community.intel.com/t5/GPU-Compute-Software/OpenCL-CL-INVALID-KERNEL-ARGS-with-driver-gt-30-0-101-1340/td-p/1420021
https://community.intel.com/t5/GPU-Compute-Software/OpenCL-Kernel-Name-appends-quot-1-quot/m-p/1419720#M644

The workaround is to use ocloc but that adds another toolchain to dev environments and it doesn't have CLC++ support in master just yet.