### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -1,0 +1,42 @@
+name: Automated release
+
+on:
+  push:
+    branches:
+        - llvm_release_*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+      - name: Get latest tag
+        run: |
+            echo "LATEST_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+            echo "LLVM_VERSION=$(git describe --tags --abbrev=0)" | \
+                sed -E 's/(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/' >> $GITHUB_ENV
+      - name: Get patch version
+        run: |
+            echo "PATCH=$(git rev-list ${LLVM_VERSION}..HEAD --count)" >> $GITHUB_ENV
+      - name: Get current version
+        run: |
+            echo "RELEASE_VERSION=${LLVM_VERSION}.${PATCH}" >> $GITHUB_ENV
+      - name: Get latest llvm_release branch
+        run: echo "LATEST_BRANCH=llvm_release_$(git branch -r | grep 'llvm_release_' | sed -E 's/.*\/llvm_release_([0-9]+)/\1/' | sort -n -r | head -1)" >> $GITHUB_ENV 
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+            # Setting tag to have format:
+            # %latest llvm version%.%number of commits since that tag%
+            tag_name: ${{ env.RELEASE_VERSION }}
+            # We have to set this so tag is set on the branch that triggered
+            # a PR
+            target_commitish: ${{ github.sha }}
+            # We don't want to mark patch releases latest unless it is latest
+            # major version
+            make_latest: ${{ env.LATEST_BRANCH == github.ref_name }}
+            name: SPIR-V LLVM translator based on LLVM ${{ env.LLVM_VERSION }}
+            body: 'Full Changelog: ${{ github.server_url }}/${{ github.repository }}/compare/${{ env.LATEST_VERSION }}...${{ env.RELEASE_VERSION }}'

--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       latest_branch: ${{steps.latest_branch.outputs.latest_branch}}
-      branches_json: ${{steps.relase_branches.outputs.branches_json}}
+      branches_json: ${{steps.release_branches.outputs.branches_json}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
           | xargs printf "latest_branch=llvm_release_%s" \
           >> $GITHUB_OUTPUT
       - name: Get branch list
-        id: relase_branches
+        id: release_branches
         run: |
           git branch -r \
           | grep "origin/llvm_release_" \
@@ -71,10 +71,9 @@ jobs:
         if: ${{ steps.versions.outputs.commits_since_last_release != 0 }}
         with:
             # Setting tag to have format:
-            # %latest llvm version%.%number of commits since that tag%
+            # %latest llvm version%.%latest patch + 1%
             tag_name: ${{ steps.versions.outputs.release_version }}
-            # We have to set this so tag is set on the branch that triggered
-            # a PR
+            # We have to set this so tag is set on the branch we are releasing
             target_commitish: ${{ steps.versions.outputs.last_commit }}
             # We don't want to mark patch releases latest unless it is latest
             # major version

--- a/.github/workflows/patch-release.yaml
+++ b/.github/workflows/patch-release.yaml
@@ -1,42 +1,89 @@
 name: Automated release
 
 on:
-  push:
-    branches:
-        - llvm_release_*
+  workflow_dispatch:
+  schedule:
+    # First day of every month
+    - cron: '0 0 1 * *'
 
 jobs:
-  release:
+  setup:
     runs-on: ubuntu-latest
+    outputs:
+      latest_branch: ${{steps.latest_branch.outputs.latest_branch}}
+      branches_json: ${{steps.relase_branches.outputs.branches_json}}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
             fetch-depth: 0
-      - name: Get latest tag
-        run: |
-            echo "LATEST_VERSION=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
-            echo "LLVM_VERSION=$(git describe --tags --abbrev=0)" | \
-                sed -E 's/(v[0-9]+\.[0-9]+\.[0-9]+).*/\1/' >> $GITHUB_ENV
-      - name: Get patch version
-        run: |
-            echo "PATCH=$(git rev-list ${LLVM_VERSION}..HEAD --count)" >> $GITHUB_ENV
-      - name: Get current version
-        run: |
-            echo "RELEASE_VERSION=${LLVM_VERSION}.${PATCH}" >> $GITHUB_ENV
       - name: Get latest llvm_release branch
-        run: echo "LATEST_BRANCH=llvm_release_$(git branch -r | grep 'llvm_release_' | sed -E 's/.*\/llvm_release_([0-9]+)/\1/' | sort -n -r | head -1)" >> $GITHUB_ENV 
+        id: latest_branch
+        run: |
+          git branch -r \
+          | grep 'llvm_release_' \
+          | sed -E 's/.*\/llvm_release_([0-9]+)/\1/' \
+          | sort -n -r \
+          | head -1 \
+          | xargs printf "latest_branch=llvm_release_%s" \
+          >> $GITHUB_OUTPUT
+      - name: Get branch list
+        id: relase_branches
+        run: |
+          git branch -r \
+          | grep "origin/llvm_release_" \
+          | sed -E 's/\ *origin\/([^\ ]*)/\"\1\"/' \
+          | paste -sd',' \
+          | xargs -0 -d"\n" printf 'branches_json={"branch":[%s]}' \
+          >> $GITHUB_OUTPUT
+  release:
+    runs-on: ubuntu-latest
+    needs: setup
+    strategy:
+      matrix: ${{fromJson(needs.setup.outputs.branches_json)}}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+            ref: ${{ matrix.branch }}
+            fetch-depth: 0
+      - name: Get commits info
+        id: versions
+        run: |
+            export LATEST_VERSION=\
+            "$(git describe --tags --abbrev=0 --match 'v*')"
+            export LLVM_VERSION=$(echo $LATEST_VERSION \
+            | sed -E 's/(v[0-9]+\.[0-9]+)\.([0-9]+).*/\1/')
+            export PATCH=$(echo $LATEST_VERSION \
+            | sed -E 's/(v[0-9]+\.[0-9]+)\.([0-9]+).*/\2/')
+
+            echo "llvm_version=$LLVM_VERSION" >> $GITHUB_OUTPUT
+            echo "patch=$PATCH" >> $GITHUB_OUTPUT
+            echo "latest_version=${LATEST_VERSION}" >> $GITHUB_OUTPUT
+            echo "release_version=${LLVM_VERSION}.$((${PATCH}+1))" \
+            >> $GITHUB_OUTPUT
+
+            git rev-list ${LATEST_VERSION}..HEAD --count \
+            | xargs printf "commits_since_last_release=%d\n" >> $GITHUB_OUTPUT
+            git rev-parse HEAD | xargs printf "last_commit=%s\n" >> $GITHUB_OUTPUT
       - name: Release
         uses: softprops/action-gh-release@v2
+        if: ${{ steps.versions.outputs.commits_since_last_release != 0 }}
         with:
             # Setting tag to have format:
             # %latest llvm version%.%number of commits since that tag%
-            tag_name: ${{ env.RELEASE_VERSION }}
+            tag_name: ${{ steps.versions.outputs.release_version }}
             # We have to set this so tag is set on the branch that triggered
             # a PR
-            target_commitish: ${{ github.sha }}
+            target_commitish: ${{ steps.versions.outputs.last_commit }}
             # We don't want to mark patch releases latest unless it is latest
             # major version
-            make_latest: ${{ env.LATEST_BRANCH == github.ref_name }}
-            name: SPIR-V LLVM translator based on LLVM ${{ env.LLVM_VERSION }}
-            body: 'Full Changelog: ${{ github.server_url }}/${{ github.repository }}/compare/${{ env.LATEST_VERSION }}...${{ env.RELEASE_VERSION }}'
+            make_latest: >-
+              ${{ needs.setup.outputs.latest_branch == matrix.branch }}
+            name: >
+              SPIR-V LLVM translator based on LLVM
+              ${{ steps.versions.outputs.llvm_version }}
+            body: "Full Changelog: ${{ github.server_url }}/\
+              ${{ github.repository }}/compare/\
+              ${{ steps.versions.outputs.latest_version }}...\
+              ${{ steps.versions.outputs.release_version }}"

--- a/README.md
+++ b/README.md
@@ -256,3 +256,9 @@ LLVM/Clang release and there are no objections from the maintainer(s). There
 is no guarantee that older release branches are proactively kept up to date
 with main, but you can request specific commits on older release branches by
 creating a pull request or raising an issue on GitHub.
+
+## Releasing strategy
+
+As mentioned earlier there are branches `llvm_release_*` that get backported
+changes. Those changes if exists are released automatically by github CI on
+monthly basis in a format `<llvm_major>.<llvm_minor>.<latest patch +1>`.


### PR DESCRIPTION
Some of the upstream PRs are getting backported to the `llvm_release_*` branches, but those changes are never released. That prevents them from distributing as precompiled packages in various distributions like `conda-forge` and others. This PR targets this issue by creating automated workflow that is triggered once a month and generates automated releases for each such branch if there were changes since last release.

### This PR

- Adds workflow to generate releases every month from `llvm_release_*` branches in the format `%llvm_major%.%llvm_minor%.%latest patch version +1%`. For example:
   - v18.1.1
   - v17.0.2
   - v17.0.1
   - v14.0.1
   - etc
- Release description matches as close as possible to current releases. The only difference is that llvm versions is represented by two numbers, instead of three, because it is impossible to recover exact version. You can check out example of generated versions here (there are few releases from the original proposal): https://github.com/ZzEeKkAa/SPIRV-LLVM-Translator/releases
- Workflow is set to be triggered once a month. It is also possible to trigger it manually from github actions UI.

### Merge process

- Merge the PR to main
- Trigger workflow manually

### Note

There is no need to backport changes to all branches, since workflow dispatch on schedule basis can be performed only from main branch.

# Original proposal

I want to create this PR as a DRAFT and initial discussion about automated release. So I would like to hear feedback before merging the PR.

This PR:
- Adds workflow to generate releases on every push to `llvm_release_*` branches in the format `%llvm_version%.%commits since tag%`. For example:
   - v18.1.0.14
   - v17.0.0.29
   - v17.0.0.28
   - v14.0.0.196
   - etc
- Release description matches as close as possible to current releases. You can check out example of generated versions here: https://github.com/ZzEeKkAa/SPIRV-LLVM-Translator/releases

Merge process:
- Merge the PR to main
- Backport the PR to all `llvm_release_*` branches

Open questions:
1. How often should we do releases? On every push, weekly, bi-weekly, monthly, quarterly?
2. Are we okay with proposed version system?
3. [Kind of out of scope] Do we need to tag minor releases of llvm (like '14.0.6', etc)
4. Is release description is okay?

Fixes: #1898
Fixes: #1508