### PR TITLE
Add support for multiple Intel cache controls on a single argument

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -558,7 +558,7 @@ void prepareCacheControlsTranslation(Metadata *MD, Instruction *Inst) {
       }
     }
     IRBuilder Builder(Inst);
-    Type *GEPTy = Builder.getInt8Ty();;
+    Type *GEPTy = Builder.getInt8Ty();
     if (auto *LI = dyn_cast<LoadInst>(Inst))
       GEPTy = LI->getType();
     else if (auto *SI = dyn_cast<StoreInst>(Inst))

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -545,14 +545,10 @@ void prepareCacheControlsTranslation(Metadata *MD, Instruction *Inst) {
       if (GEP->hasAllZeroIndices()) {
         MDs.push_back(MDNode::get(Inst->getContext(), OPs));
         // If the existing GEP has SPIRV_MD_DECORATIONS metadata - copy it
-        auto *OldMD = GEP->getMetadata(SPIRV_MD_DECORATIONS);
-        if (OldMD) {
-          for (unsigned I = 0, E = OldMD->getNumOperands(); I != E; ++I) {
-            auto *DecoMD = dyn_cast<MDNode>(OldMD->getOperand(I));
-            if (DecoMD)
+        if (auto *OldMD = GEP->getMetadata(SPIRV_MD_DECORATIONS))
+          for (unsigned I = 0, E = OldMD->getNumOperands(); I != E; ++I)
+            if (auto *DecoMD = dyn_cast<MDNode>(OldMD->getOperand(I)))
               MDs.push_back(DecoMD);
-          }
-        }
         MDNode *MDList = MDNode::get(Inst->getContext(), MDs);
         GEP->setMetadata(SPIRV_MD_DECORATIONS, MDList);
         return;

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -558,7 +558,7 @@ void prepareCacheControlsTranslation(Metadata *MD, Instruction *Inst) {
       }
     }
     IRBuilder Builder(Inst);
-    Type *GEPTy = PtrInstOp->getType();
+    Type *GEPTy = Builder.getInt8Ty();;
     if (auto *LI = dyn_cast<LoadInst>(Inst))
       GEPTy = LI->getType();
     else if (auto *SI = dyn_cast<StoreInst>(Inst))

--- a/test/extensions/INTEL/SPV_INTEL_cache_controls/call_inst_arg_dec.ll
+++ b/test/extensions/INTEL/SPV_INTEL_cache_controls/call_inst_arg_dec.ll
@@ -11,8 +11,8 @@
 ; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP2]] [[#]] [[#Zero]]
 ; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#GEP1]] [[#GEP2]]
 
-; CHECK-LLVM: %[[#GEP1:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %{{.*}}, i32 0, !spirv.Decorations ![[#Cache1:]]
-; CHECK-LLVM: %[[#GEP2:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %{{.*}}, i32 0, !spirv.Decorations ![[#Cache2:]]
+; CHECK-LLVM: %[[#GEP1:]] = getelementptr i8, ptr addrspace(1) %{{.*}}, i32 0, !spirv.Decorations ![[#Cache1:]]
+; CHECK-LLVM: %[[#GEP2:]] = getelementptr i8, ptr addrspace(1) %{{.*}}, i32 0, !spirv.Decorations ![[#Cache2:]]
 ; CHECK-LLVM: call spir_func void @foo(ptr addrspace(1) %[[#GEP1]], ptr addrspace(1) %[[#GEP2]])
 ; CHECK-LLVM: ![[#Cache1]] = !{![[#LoadCache:]]}
 ; CHECK-LLVM: ![[#LoadCache]] = !{i32 6442, i32 0, i32 1}

--- a/test/extensions/INTEL/SPV_INTEL_cache_controls/multiple-decoration-single-arg.ll
+++ b/test/extensions/INTEL/SPV_INTEL_cache_controls/multiple-decoration-single-arg.ll
@@ -20,16 +20,18 @@
 ; CHECK-SPIRV: Function [[#]] [[#FuncGEP]]
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#Buffer:]]
 ; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP3:]] [[#Buffer]] [[#Zero]]
-; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP2]] [[#GEP3]] [[#Zero]]
+; CHECK-SPIRV: Bitcast [[#]] [[#BitCast:]] [[#GEP3]]
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP2]] [[#BitCast:]] [[#Zero]]
 ; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#GEP2]]
 
-; CHECK-LLVM: define spir_kernel void @test(ptr addrspace(1) %[[Param:[a-z0-9_.]+]])
-; CHECK-LLVM: %[[#GEP:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[Param]], i32 0, !spirv.Decorations ![[#MD:]]
+; CHECK-LLVM: define spir_kernel void @test(ptr addrspace(1) %[[Param1:[a-z0-9_.]+]])
+; CHECK-LLVM: %[[#GEP:]] = getelementptr i8, ptr addrspace(1) %[[Param1]], i32 0, !spirv.Decorations ![[#MD:]]
 ; CHECK-LLVM: call spir_func void @foo(ptr addrspace(1) %[[#GEP:]])
 
-; CHECK-LLVM: define spir_kernel void @test_gep(ptr addrspace(1) %[[Param:[a-z0-9_.]+]])
-; CHECK-LLVM: %[[#GEP1:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[Param]], i32 0
-; CHECK-LLVM: %[[#GEP2:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[#GEP1]], i32 0, !spirv.Decorations ![[#MD]]
+; CHECK-LLVM: define spir_kernel void @test_gep(ptr addrspace(1) %[[Param2:[a-z0-9_.]+]])
+; CHECK-LLVM: %[[#GEP1:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[Param2]], i32 0
+; CHECK-LLVM: %[[#BitCast:]] = bitcast ptr addrspace(1) %[[#GEP1]] to ptr addrspace(1)
+; CHECK-LLVM: %[[#GEP2:]] = getelementptr i8, ptr addrspace(1) %[[#BitCast]], i32 0, !spirv.Decorations ![[#MD]]
 ; CHECK-LLVM: call spir_func void @foo(ptr addrspace(1) %[[#GEP2:]])
 
 ; CHECK-LLVM: ![[#MD]] = !{![[#Dec1:]], ![[#Dec2:]]}

--- a/test/extensions/INTEL/SPV_INTEL_cache_controls/multiple-decoration-single-arg.ll
+++ b/test/extensions/INTEL/SPV_INTEL_cache_controls/multiple-decoration-single-arg.ll
@@ -4,19 +4,34 @@
 ; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV-DAG: Name [[#Func:]] "test"
+; CHECK-SPIRV-DAG: Name [[#FuncGEP:]] "test_gep"
 ; CHECK-SPIRV-DAG: TypeInt [[#Int32:]] 32 0
 ; CHECK-SPIRV-DAG: Constant [[#Int32]] [[#Zero:]] 0
-; CHECK-SPIRV-DAG: Decorate [[#GEP:]] CacheControlLoadINTEL 1 1
-; CHECK-SPIRV-DAG: Decorate [[#GEP]] CacheControlLoadINTEL 0 3
+; CHECK-SPIRV-DAG: Decorate [[#GEP1:]] CacheControlLoadINTEL 1 1
+; CHECK-SPIRV-DAG: Decorate [[#GEP1]] CacheControlLoadINTEL 0 3
+; CHECK-SPIRV-DAG: Decorate [[#GEP2:]] CacheControlLoadINTEL 1 1
+; CHECK-SPIRV-DAG: Decorate [[#GEP2]] CacheControlLoadINTEL 0 3
 
 ; CHECK-SPIRV: Function [[#]] [[#Func]]
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#Buffer:]]
-; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP]] [[#Buffer]] [[#Zero]]
-; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#GEP]]
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP1]] [[#Buffer]] [[#Zero]]
+; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#GEP1]]
+
+; CHECK-SPIRV: Function [[#]] [[#FuncGEP]]
+; CHECK-SPIRV: FunctionParameter [[#]] [[#Buffer:]]
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP3:]] [[#Buffer]] [[#Zero]]
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP2]] [[#GEP3]] [[#Zero]]
+; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#GEP2]]
 
 ; CHECK-LLVM: define spir_kernel void @test(ptr addrspace(1) %[[Param:[a-z0-9_.]+]])
 ; CHECK-LLVM: %[[#GEP:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[Param]], i32 0, !spirv.Decorations ![[#MD:]]
 ; CHECK-LLVM: call spir_func void @foo(ptr addrspace(1) %[[#GEP:]])
+
+; CHECK-LLVM: define spir_kernel void @test_gep(ptr addrspace(1) %[[Param:[a-z0-9_.]+]])
+; CHECK-LLVM: %[[#GEP1:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[Param]], i32 0
+; CHECK-LLVM: %[[#GEP2:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[#GEP1]], i32 0, !spirv.Decorations ![[#MD]]
+; CHECK-LLVM: call spir_func void @foo(ptr addrspace(1) %[[#GEP2:]])
+
 ; CHECK-LLVM: ![[#MD]] = !{![[#Dec1:]], ![[#Dec2:]]}
 ; CHECK-LLVM: ![[#Dec1]] = !{i32 6442, i32 1, i32 1}
 ; CHECK-LLVM: ![[#Dec2]] = !{i32 6442, i32 0, i32 3}
@@ -26,6 +41,13 @@ target triple = "spir64-unknown-unknown"
 define spir_kernel void @test(ptr addrspace(1) %buffer1) {
 entry:
   call void @foo(ptr addrspace(1) %buffer1), !spirv.DecorationCacheControlINTEL !3
+  ret void
+}
+
+define spir_kernel void @test_gep(ptr addrspace(1) %buffer1) {
+entry:
+  %0 = getelementptr ptr addrspace(1), ptr addrspace(1) %buffer1, i32 0
+  call void @foo(ptr addrspace(1) %0), !spirv.DecorationCacheControlINTEL !3
   ret void
 }
 

--- a/test/extensions/INTEL/SPV_INTEL_cache_controls/multiple-decoration-single-arg.ll
+++ b/test/extensions/INTEL/SPV_INTEL_cache_controls/multiple-decoration-single-arg.ll
@@ -1,0 +1,44 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_cache_controls -spirv-text %t.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_cache_controls %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: Name [[#Func:]] "test"
+; CHECK-SPIRV-DAG: TypeInt [[#Int32:]] 32 0
+; CHECK-SPIRV-DAG: Constant [[#Int32]] [[#Zero:]] 0
+; CHECK-SPIRV-DAG: Decorate [[#GEP:]] CacheControlLoadINTEL 1 1
+; CHECK-SPIRV-DAG: Decorate [[#GEP]] CacheControlLoadINTEL 0 3
+
+; CHECK-SPIRV: Function [[#]] [[#Func]]
+; CHECK-SPIRV: FunctionParameter [[#]] [[#Buffer:]]
+; CHECK-SPIRV: PtrAccessChain [[#]] [[#GEP]] [[#Buffer]] [[#Zero]]
+; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[#]] [[#GEP]]
+
+; CHECK-LLVM: define spir_kernel void @test(ptr addrspace(1) %[[Param:[a-z0-9_.]+]])
+; CHECK-LLVM: %[[#GEP:]] = getelementptr ptr addrspace(1), ptr addrspace(1) %[[Param]], i32 0, !spirv.Decorations ![[#MD:]]
+; CHECK-LLVM: call spir_func void @foo(ptr addrspace(1) %[[#GEP:]])
+; CHECK-LLVM: ![[#MD]] = !{![[#Dec1:]], ![[#Dec2:]]}
+; CHECK-LLVM: ![[#Dec1]] = !{i32 6442, i32 1, i32 1}
+; CHECK-LLVM: ![[#Dec2]] = !{i32 6442, i32 0, i32 3}
+
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @test(ptr addrspace(1) %buffer1) {
+entry:
+  call void @foo(ptr addrspace(1) %buffer1), !spirv.DecorationCacheControlINTEL !3
+  ret void
+}
+
+declare void @foo(ptr addrspace(1))
+
+!spirv.MemoryModel = !{!0}
+!spirv.Source = !{!1}
+!opencl.spir.version = !{!2}
+!opencl.ocl.version = !{!2}
+
+!0 = !{i32 2, i32 2}
+!1 = !{i32 3, i32 102000}
+!2 = !{i32 1, i32 2}
+!3 = !{!4, !5}
+!4 = !{i32 6442, i32 0, i32 3, i32 0}
+!5 = !{i32 6442, i32 1, i32 1, i32 0}


### PR DESCRIPTION
In this case zero GEP will be created a single time, all the decorations will be attached to it.