### PR TITLE
[Backport to 18] Fix SPV_INTEL_runtime_aligned implementation part 1

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -199,19 +199,19 @@ static void addRuntimeAlignedMetadata(
     LLVMContext *Context, SPIRVFunction *BF, llvm::Function *Fn,
     std::function<Metadata *(SPIRVFunctionParameter *)> ForeachFnArg) {
   std::vector<Metadata *> ValueVec;
-  bool DecorationFound = false;
+  bool RuntimeAlignedFound = false;
+  [[maybe_unused]] llvm::Metadata *DefaultNode =
+      ConstantAsMetadata::get(ConstantInt::get(Type::getInt1Ty(*Context), 0));
   BF->foreachArgument([&](SPIRVFunctionParameter *Arg) {
-    if (Arg->getType()->isTypePointer() &&
+    if (Arg->hasAttr(FunctionParameterAttributeRuntimeAlignedINTEL) ||
         Arg->hasDecorate(internal::DecorationRuntimeAlignedINTEL)) {
-      DecorationFound = true;
+      RuntimeAlignedFound = true;
       ValueVec.push_back(ForeachFnArg(Arg));
     } else {
-      llvm::Metadata *DefaultNode = ConstantAsMetadata::get(
-          ConstantInt::get(Type::getInt1Ty(*Context), 0));
       ValueVec.push_back(DefaultNode);
     }
   });
-  if (DecorationFound)
+  if (RuntimeAlignedFound)
     Fn->setMetadata("kernel_arg_runtime_aligned",
                     MDNode::get(*Context, ValueVec));
 }
@@ -3043,6 +3043,10 @@ void SPIRVToLLVM::transFunctionAttrs(SPIRVFunction *BF, Function *F) {
     setName(&(*I), BA);
     AttributeMask IllegalAttrs = AttributeFuncs::typeIncompatible(I->getType());
     BA->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
+      // Skip this function parameter attribute as it will translated among
+      // OpenCL metadata
+      if (Kind == FunctionParameterAttributeRuntimeAlignedINTEL)
+        return;
       Attribute::AttrKind LLVMKind = SPIRSPIRVFuncParamAttrMap::rmap(Kind);
       if (IllegalAttrs.contains(LLVMKind))
         return;
@@ -4499,13 +4503,8 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
   });
   // Generate metadata for kernel_arg_runtime_aligned
   addRuntimeAlignedMetadata(Context, BF, F, [=](SPIRVFunctionParameter *Arg) {
-    auto Literals =
-        Arg->getDecorationLiterals(internal::DecorationRuntimeAlignedINTEL);
-    assert(Literals.size() == 1 &&
-           "RuntimeAlignedINTEL decoration shall have 1 ID literal");
-
     return ConstantAsMetadata::get(
-        ConstantInt::get(Type::getInt1Ty(*Context), Literals[0]));
+        ConstantInt::get(Type::getInt1Ty(*Context), 1));
   });
   // Generate metadata for spirv.ParameterDecorations
   addKernelArgumentMetadata(Context, SPIRV_MD_PARAMETER_DECORATIONS, BF, F,

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -949,12 +949,19 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
       // Order of integer numbers in MD node follows the order of function
       // parameters on which we shall attach the appropriate decoration. Add
       // decoration only if MD value is 1.
-      int LocID = 0;
+      int IsRuntimeAligned = 0;
       if (!isa<MDString>(RuntimeAligned->getOperand(ArgNo)) &&
           !isa<MDNode>(RuntimeAligned->getOperand(ArgNo)))
-        LocID = getMDOperandAsInt(RuntimeAligned, ArgNo);
-      if (LocID == 1)
-        BA->addDecorate(internal::DecorationRuntimeAlignedINTEL, LocID);
+        IsRuntimeAligned = getMDOperandAsInt(RuntimeAligned, ArgNo);
+      if (IsRuntimeAligned == 1) {
+        // TODO: to replace non-conformant to the spec decoration generation
+        // with:
+        // BM->addExtension(ExtensionID::SPV_INTEL_runtime_aligned);
+        // BM->addCapability(CapabilityRuntimeAlignedAttributeINTEL);
+        // BA->addAttr(FunctionParameterAttributeRuntimeAlignedINTEL);
+        BA->addDecorate(internal::DecorationRuntimeAlignedINTEL,
+                        IsRuntimeAligned);
+      }
     }
   }
   if (Attrs.hasRetAttr(Attribute::ZExt))

--- a/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVIsValidEnum.h
@@ -171,6 +171,7 @@ inline bool isValid(spv::FunctionParameterAttribute V) {
   case FunctionParameterAttributeNoCapture:
   case FunctionParameterAttributeNoWrite:
   case FunctionParameterAttributeNoReadWrite:
+  case FunctionParameterAttributeRuntimeAlignedINTEL:
     return true;
   default:
     return false;

--- a/test/extensions/INTEL/SPV_INTEL_runtime_aligned/RuntimeAligned.spt
+++ b/test/extensions/INTEL/SPV_INTEL_runtime_aligned/RuntimeAligned.spt
@@ -1,0 +1,68 @@
+; RUN: llvm-spirv -spirv-text -r %s -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: define spir_kernel void @test{{.*}} !kernel_arg_runtime_aligned ![[RTALIGN_MD:[0-9]+]] {{.*}}
+; CHECK-LLVM: ![[RTALIGN_MD]] = !{i1 true, i1 false, i1 true, i1 false, i1 false}
+
+119734787 65536 393230 22 0 
+2 Capability Addresses 
+2 Capability Linkage 
+2 Capability Kernel 
+2 Capability Int8 
+2 Capability RuntimeAlignedAttributeINTEL 
+8 Extension "SPV_INTEL_runtime_aligned" 
+5 ExtInstImport 1 "OpenCL.std" 
+3 MemoryModel 2 2 
+5 EntryPoint 6 14 "test" 
+3 Source 0 0 
+4 Name 7 "test" 
+3 Name 8 "a" 
+3 Name 9 "b" 
+3 Name 10 "c" 
+3 Name 11 "d" 
+3 Name 12 "e" 
+4 Name 13 "entry" 
+3 Name 15 "a" 
+3 Name 16 "b" 
+3 Name 17 "c" 
+3 Name 18 "d" 
+3 Name 19 "e" 
+
+6 Decorate 7 LinkageAttributes "test" Export 
+4 Decorate 8 FuncParamAttr 5940 
+4 Decorate 10 FuncParamAttr 5940 
+4 Decorate 15 FuncParamAttr 5940 
+4 Decorate 17 FuncParamAttr 5940 
+4 TypeInt 3 8 0 
+4 TypeInt 5 32 0 
+2 TypeVoid 2 
+4 TypePointer 4 5 3 
+8 TypeFunction 6 2 4 4 4 5 5 
+
+
+
+5 Function 2 7 0 6 
+3 FunctionParameter 4 8 
+3 FunctionParameter 4 9 
+3 FunctionParameter 4 10 
+3 FunctionParameter 5 11 
+3 FunctionParameter 5 12 
+
+2 Label 13 
+1 Return 
+
+1 FunctionEnd 
+
+5 Function 2 14 0 6 
+3 FunctionParameter 4 15 
+3 FunctionParameter 4 16 
+3 FunctionParameter 4 17 
+3 FunctionParameter 5 18 
+3 FunctionParameter 5 19 
+
+2 Label 20 
+9 FunctionCall 2 21 7 15 16 17 18 19 
+1 Return 
+
+1 FunctionEnd 
+


### PR DESCRIPTION
It was implemented via new decoration, which is not correct. Instead it should be Function Parameter Attribute decoration.

In this commit starts fixing this in step-by-step manner.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>
Co-authored-by: Maksimova, Viktoria <viktoria.maksimova@intel.com>

(This is a cherry-pick of 0db0f98)