### PR TITLE
Remove unecessary include that require c++20

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -50,7 +50,6 @@
 #include "llvm/IR/DebugProgramInstruction.h"
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
-#include <bit>
 
 using namespace std;
 using namespace SPIRVDebug::Operand;


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/aab92ecc22e2f1e fix the usage ibut did not remove the include.
