### PR TITLE
Set DEBUG_TYPE after all includes

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -36,7 +36,6 @@
 // friendly IR form for further translation into SPIR-V
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "ocl-to-spv"
 
 #include "OCLToSPIRV.h"
 #include "OCLTypeToSPIRV.h"
@@ -54,6 +53,8 @@
 #include <algorithm>
 #include <regex>
 #include <set>
+
+#define DEBUG_TYPE "ocl-to-spv"
 
 using namespace llvm;
 using namespace PatternMatch;

--- a/lib/SPIRV/OCLTypeToSPIRV.cpp
+++ b/lib/SPIRV/OCLTypeToSPIRV.cpp
@@ -38,7 +38,6 @@
 // propagates the mapping to the uses of the kernel arguments.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "cltytospv"
 
 #include "OCLTypeToSPIRV.h"
 #include "OCLUtil.h"
@@ -49,6 +48,8 @@
 
 #include <iterator>
 #include <set>
+
+#define DEBUG_TYPE "cltytospv"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -35,7 +35,6 @@
 // This file implements OCL utility functions.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "oclutil"
 
 #include "OCLUtil.h"
 #include "SPIRVEntry.h"
@@ -49,6 +48,8 @@
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "oclutil"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/PreprocessMetadata.cpp
+++ b/lib/SPIRV/PreprocessMetadata.cpp
@@ -36,7 +36,6 @@
 // further translation to SPIR-V.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "clmdtospv"
 
 #include "PreprocessMetadata.h"
 #include "OCLUtil.h"
@@ -50,6 +49,8 @@
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/TargetParser/Triple.h"
+
+#define DEBUG_TYPE "clmdtospv"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -35,13 +35,14 @@
 // This file implements lowering instructions with bool operands.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spvbool"
 
 #include "SPIRVLowerBool.h"
 #include "SPIRVInternal.h"
 #include "libSPIRV/SPIRVDebug.h"
 
 #include "llvm/IR/IRBuilder.h"
+
+#define DEBUG_TYPE "spvbool"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/lib/SPIRV/SPIRVLowerConstExpr.cpp
@@ -35,7 +35,6 @@
 // This file implements regularization of LLVM module for SPIR-V.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spv-lower-const-expr"
 
 #include "SPIRVLowerConstExpr.h"
 #include "OCLUtil.h"
@@ -55,6 +54,8 @@
 
 #include <list>
 #include <set>
+
+#define DEBUG_TYPE "spv-lower-const-expr"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerLLVMIntrinsic.cpp
+++ b/lib/SPIRV/SPIRVLowerLLVMIntrinsic.cpp
@@ -27,7 +27,6 @@
 // into basic LLVM operations.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spv-lower-llvm_intrinsic"
 
 #include "SPIRVLowerLLVMIntrinsic.h"
 #include "LLVMBitreverse.h"
@@ -43,6 +42,8 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/Support/SourceMgr.h"
+
+#define DEBUG_TYPE "spv-lower-llvm_intrinsic"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -35,7 +35,6 @@
 // This file implements lowering llvm.memmove into several llvm.memcpys.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spvmemmove"
 
 #include "SPIRVLowerMemmove.h"
 #include "SPIRVInternal.h"
@@ -44,6 +43,8 @@
 #include "llvm/Analysis/TargetTransformInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Transforms/Utils/LowerMemIntrinsics.h"
+
+#define DEBUG_TYPE "spvmemmove"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.cpp
@@ -53,7 +53,6 @@
 // with null pointers.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spv-lower-ocl-blocks"
 
 #include "SPIRVLowerOCLBlocks.h"
 #include "SPIRVInternal.h"
@@ -62,6 +61,8 @@
 #include "llvm/IR/PassManager.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/Regex.h"
+
+#define DEBUG_TYPE "spv-lower-ocl-blocks"
 
 using namespace llvm;
 

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -35,7 +35,6 @@
 // This file implements regularization of LLVM module for SPIR-V.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spvregular"
 
 #include "SPIRVRegularizeLLVM.h"
 #include "OCLUtil.h"
@@ -54,6 +53,8 @@
 
 #include <set>
 #include <vector>
+
+#define DEBUG_TYPE "spvregular"
 
 using namespace llvm;
 using namespace SPIRV;

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -39,12 +39,13 @@
 // in this pass as a common functionality for both versions.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spvtocl"
 
 #include "SPIRVToOCL.h"
 #include "llvm/IR/TypedPointerType.h"
 #include "llvm/IR/Verifier.h"
 #include "llvm/Support/CommandLine.h"
+
+#define DEBUG_TYPE "spvtocl"
 
 namespace SPIRV {
 

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -35,11 +35,12 @@
 // This file implements transform SPIR-V builtins to OCL 2.0 builtins.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spvtocl20"
 
 #include "OCLUtil.h"
 #include "SPIRVToOCL.h"
 #include "llvm/IR/Verifier.h"
+
+#define DEBUG_TYPE "spvtocl20"
 
 namespace SPIRV {
 


### PR DESCRIPTION
The LLVM Programmer's Manual states that `DEBUG_TYPE` should be set after the includes.