### PR TITLE
Allow llvm-spirv to be built natively in LLVM cross builds.

### DIFF
--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -16,6 +16,8 @@ add_llvm_tool(llvm-spirv
   NO_INSTALL_RPATH
 )
 
+setup_host_tool(llvm-spirv LLVM_SPIRV llvm-spirv_exe llvm-spirv_target)
+
 if (LLVM_SPIRV_BUILD_EXTERNAL OR LLVM_LINK_LLVM_DYLIB)
   target_link_libraries(llvm-spirv PRIVATE LLVMSPIRVLib)
 endif()


### PR DESCRIPTION
When llvm-spirv is built in-tree as part of LLVM, and the LLVM build also includes libclc, libclc will require a native version of llvm-spirv to be built. To accommodate this, call setup_host_tool. This change by itself is intended to have no effect at the moment, but enables a future LLVM change.