### PR TITLE
Do not pass -DLLVM_EXTERNAL_PROJECTS="SPIRV-Headers" for an out of tree build

### DIFF
--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -80,7 +80,6 @@ jobs:
             -DCMAKE_CXX_FLAGS="-Werror" \
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_EXTERNAL_LIT="/usr/lib/llvm-${{ env.LLVM_VERSION }}/build/utils/lit/lit.py" \
-            -DLLVM_EXTERNAL_PROJECTS="SPIRV-Headers" \
             -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${{ github.workspace }}/SPIRV-Headers \
             -G "Unix Makefiles"
       - name: Build


### PR DESCRIPTION
As per the CI logs:
```
CMake Warning:
  Manually-specified variables were not used by the project:

    LLVM_EXTERNAL_PROJECTS


-- Build files have been written to: /home/runner/work/SPIRV-LLVM-Translator/SPIRV-LLVM-Translator/build
```

According to https://reviews.llvm.org/D20838 it looks like this is only relevant for in-tree builds, so no need to pass it here.