### PR TITLE
[Backport to 15] Don't add initializer to local variables with external linkage. 

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1674,7 +1674,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     else if (LinkageTy == GlobalValue::CommonLinkage)
       // In LLVM, variables with common linkage type must be initialized to 0.
       Initializer = Constant::getNullValue(Ty);
-    else if (BS == SPIRVStorageClassKind::StorageClassWorkgroup)
+    else if (BS == SPIRVStorageClassKind::StorageClassWorkgroup &&
+             LinkageTy != GlobalValue::ExternalLinkage)
       Initializer = dyn_cast<Constant>(UndefValue::get(Ty));
     else if ((LinkageTy != GlobalValue::ExternalLinkage) &&
              (BS == SPIRVStorageClassKind::StorageClassCrossWorkgroup))

--- a/test/local_var_keeps_external.ll
+++ b/test/local_var_keeps_external.ll
@@ -1,0 +1,10 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck < %t.rev.ll %s --check-prefix CHECK-LLVM
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+@__LocalVar = external addrspace(3) global ptr addrspace(1)
+; CHECK-LLVM:@__LocalVar = external addrspace(3) global ptr addrspace(1)

--- a/test/local_var_keeps_external.ll
+++ b/test/local_var_keeps_external.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc -opaque-pointers
 ; RUN: llvm-spirv %t.bc -o %t.spv -opaque-pointers
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc -opaque-pointers
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc -emit-opaque-pointers
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll -opaque-pointers
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix CHECK-LLVM
 

--- a/test/local_var_keeps_external.ll
+++ b/test/local_var_keeps_external.ll
@@ -1,6 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv
-; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-spirv %t.bc -o %t.spv -opaque-pointers
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc -opaque-pointers
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix CHECK-LLVM
 

--- a/test/local_var_keeps_external.ll
+++ b/test/local_var_keeps_external.ll
@@ -1,7 +1,7 @@
-; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-as %s -o %t.bc -opaque-pointers
 ; RUN: llvm-spirv %t.bc -o %t.spv -opaque-pointers
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc -opaque-pointers
-; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll -opaque-pointers
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix CHECK-LLVM
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"


### PR DESCRIPTION
If a variable is external, it will be defined during linking, the translator should not do it.