### PR TITLE
[NFC] Enable spirv-val testing

### DIFF
--- a/test/transcoding/BuiltinPrintf.cl
+++ b/test/transcoding/BuiltinPrintf.cl
@@ -3,8 +3,7 @@
 // RUN: %clang_cc1 -triple spir-unknown-unknown -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
-// Change TODO to RUN when spirv-val allows array of 8-bit ints for format
-// TODO: spirv-val %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/test/transcoding/Printf.cl
+++ b/test/transcoding/Printf.cl
@@ -3,8 +3,7 @@
 // RUN: %clang_cc1 -triple spir-unknown-unknown -emit-llvm-bc %s -o %t.bc -finclude-default-header
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv
-// Change TODO to RUN when spirv-val allows array of 8-bit ints for format
-// TODO: spirv-val %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 


### PR DESCRIPTION
spirv-val allows non-constant and array of 8-bit ints for printf fmt strings after https://github.com/KhronosGroup/SPIRV-Tools/pull/5677.  Enable spirv-val testing of this new functionality.