### PR TITLE
[Backport to 14][OCLToSPIRV] Translate floating-point atomic_compare_exchange as integer (#2668)

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -472,10 +472,24 @@ CallInst *OCLToSPIRVBase::visitCallAtomicCmpXchg(CallInst *CI) {
   mutateCallInstOCL(
       M, CI,
       [&](CallInst *CI, std::vector<Value *> &Args, Type *&RetTy) {
-        Expected = Args[1]; // temporary save second argument.
-        Args[1] = new LoadInst(Args[1]->getType()->getPointerElementType(),
-                               Args[1], "exp", false, CI);
         RetTy = Args[2]->getType();
+        if (RetTy->isFloatTy() || RetTy->isDoubleTy()) {
+          RetTy = RetTy->isFloatTy() ? Type::getInt32Ty(*Ctx)
+                                     : Type::getInt64Ty(*Ctx);
+          Args[0] = new BitCastInst(
+              Args[0],
+              PointerType::get(RetTy,
+                               Args[0]->getType()->getPointerAddressSpace()),
+              "", CI);
+          Args[1] = new BitCastInst(
+              Args[1],
+              PointerType::get(RetTy,
+                               Args[1]->getType()->getPointerAddressSpace()),
+              "", CI);
+          Args[2] = new BitCastInst(Args[2], RetTy, "", CI);
+        }
+        Expected = Args[1]; // temporary save second argument.
+        Args[1] = new LoadInst(RetTy, Args[1], "exp", false, CI);
         assert(Args[0]->getType()->getPointerElementType()->isIntegerTy() &&
                Args[1]->getType()->isIntegerTy() &&
                Args[2]->getType()->isIntegerTy() &&

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
@@ -6,46 +6,127 @@
 // RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.rev.bc
 // RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-__kernel void testAtomicCompareExchangeExplicit_cl20(
-    volatile global atomic_int* object,
-    global int* expected,
-    int desired)
-{
-  // Values of memory order and memory scope arguments correspond to SPIR-2.0 spec.
-  atomic_compare_exchange_strong_explicit(object, expected, desired,
-                                          memory_order_release, // 3
-                                          memory_order_relaxed  // 0
-                                         ); // by default, assume device scope = 2
-  atomic_compare_exchange_strong_explicit(object, expected, desired,
-                                          memory_order_acq_rel,   // 4
-                                          memory_order_relaxed,   // 0
-                                          memory_scope_work_group // 1
-                                         );
-  atomic_compare_exchange_weak_explicit(object, expected, desired,
-                                        memory_order_release, // 3
-                                        memory_order_relaxed  // 0
-                                         ); // by default, assume device scope = 2
-  atomic_compare_exchange_weak_explicit(object, expected, desired,
-                                        memory_order_acq_rel,   // 4
-                                        memory_order_relaxed,   // 0
-                                        memory_scope_work_group // 1
-                                       );
+#define DEFINE_KERNEL(TYPE)                                                            \
+__kernel void testAtomicCompareExchangeExplicit_cl20_##TYPE(                           \
+    volatile global atomic_##TYPE* object,                                             \
+    global TYPE* expected,                                                             \
+    TYPE desired)                                                                      \
+{                                                                                      \
+  /* Values of memory order and memory scope arguments correspond to SPIR-2.0 spec. */ \
+  atomic_compare_exchange_strong_explicit(object, expected, desired,                   \
+                                          memory_order_release, /* 3 */                \
+                                          memory_order_relaxed  /* 0 */                \
+                                         ); /* by default, assume device scope = 2 */  \
+  atomic_compare_exchange_strong_explicit(object, expected, desired,                   \
+                                          memory_order_acq_rel,   /* 4 */              \
+                                          memory_order_relaxed,   /* 0 */              \
+                                          memory_scope_work_group /* 1 */              \
+                                         );                                            \
+  atomic_compare_exchange_weak_explicit(object, expected, desired,                     \
+                                        memory_order_release, /* 3 */                  \
+                                        memory_order_relaxed  /* 0 */                  \
+                                         ); /* by default, assume device scope = 2 */  \
+  atomic_compare_exchange_weak_explicit(object, expected, desired,                     \
+                                        memory_order_acq_rel,   /* 4 */                \
+                                        memory_order_relaxed,   /* 0 */                \
+                                        memory_scope_work_group /* 1 */                \
+                                       );                                              \
 }
 
-//CHECK-SPIRV: TypeInt [[int:[0-9]+]] 32 0
+DEFINE_KERNEL(int)
+DEFINE_KERNEL(float)
+DEFINE_KERNEL(double)
+
+//CHECK-SPIRV: TypeInt [[int32:[0-9]+]] 32 0
+//CHECK-SPIRV: TypeInt [[int64:[0-9]+]] 64 0
 //; Constants below correspond to the SPIR-V spec
-//CHECK-SPIRV-DAG: Constant [[int]] [[DeviceScope:[0-9]+]] 1
-//CHECK-SPIRV-DAG: Constant [[int]] [[WorkgroupScope:[0-9]+]] 2
-//CHECK-SPIRV-DAG: Constant [[int]] [[ReleaseMemSem:[0-9]+]] 4
-//CHECK-SPIRV-DAG: Constant [[int]] [[RelaxedMemSem:[0-9]+]] 0
-//CHECK-SPIRV-DAG: Constant [[int]] [[AcqRelMemSem:[0-9]+]] 8
+//CHECK-SPIRV-DAG: Constant [[int32]] [[DeviceScope:[0-9]+]] 1
+//CHECK-SPIRV-DAG: Constant [[int32]] [[WorkgroupScope:[0-9]+]] 2
+//CHECK-SPIRV-DAG: Constant [[int32]] [[ReleaseMemSem:[0-9]+]] 4
+//CHECK-SPIRV-DAG: Constant [[int32]] [[RelaxedMemSem:[0-9]+]] 0
+//CHECK-SPIRV-DAG: Constant [[int32]] [[AcqRelMemSem:[0-9]+]] 8
 
-//CHECK-SPIRV: AtomicCompareExchange {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
-//CHECK-SPIRV: AtomicCompareExchange {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
-//CHECK-SPIRV: AtomicCompareExchangeWeak {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
-//CHECK-SPIRV: AtomicCompareExchangeWeak {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchange [[int32]] {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchange [[int32]] {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchangeWeak [[int32]] {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchangeWeak [[int32]] {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
 
-//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected1.as, i32 %desired, i32 3, i32 0, i32 2)
-//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected3.as, i32 %desired, i32 4, i32 0, i32 1)
-//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected5.as, i32 %desired, i32 3, i32 0, i32 2)
-//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected7.as, i32 %desired, i32 4, i32 0, i32 1)
+//CHECK-SPIRV: AtomicCompareExchange [[int32]] {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchange [[int32]] {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchangeWeak [[int32]] {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchangeWeak [[int32]] {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
+
+//CHECK-SPIRV: AtomicCompareExchange [[int64]] {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchange [[int64]] {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchangeWeak [[int64]] {{[0-9]+}} {{[0-9]+}} [[DeviceScope]] [[ReleaseMemSem]] [[RelaxedMemSem]]
+//CHECK-SPIRV: AtomicCompareExchangeWeak [[int64]] {{[0-9]+}} {{[0-9]+}} [[WorkgroupScope]] [[AcqRelMemSem]] [[RelaxedMemSem]]
+
+//CHECK-LLVM-LABEL: define spir_kernel void @testAtomicCompareExchangeExplicit_cl20_int(
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected{{.*}}, i32 %desired, i32 3, i32 0, i32 2)
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected{{.*}}, i32 %desired, i32 4, i32 0, i32 1)
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected{{.*}}, i32 %desired, i32 3, i32 0, i32 2)
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* %0, i32 addrspace(4)* %expected{{.*}}, i32 %desired, i32 4, i32 0, i32 1)
+
+//CHECK-LLVM-LABEL: define spir_kernel void @testAtomicCompareExchangeExplicit_cl20_float(
+//CHECK-LLVM: [[OBJECT:%[0-9]+]] = addrspacecast float addrspace(1)* %object to float addrspace(4)*
+//CHECK-LLVM: [[EXPECTED:%[0-9]+]] = addrspacecast float addrspace(1)* %expected to float addrspace(4)*
+//CHECK-LLVM: [[OBJECT_BC:%[0-9]+]] = bitcast float addrspace(4)* [[OBJECT]] to i32 addrspace(4)*
+//CHECK-LLVM: [[EXPECTED_BC:%[0-9]+]] = bitcast float addrspace(4)* [[EXPECTED]] to i32 addrspace(4)*
+//CHECK-LLVM: [[DESIRED_CAST:%[0-9]+]] = bitcast float %desired to i32
+//CHECK-LLVM: %exp = load i32, i32 addrspace(4)* [[EXPECTED_BC]], align 4
+//CHECK-LLVM: store i32 %exp, i32* [[EXPECTED_ALLOCA:%expected[0-9]+]], align 4
+//CHECK-LLVM: [[EXPECTED_AS:%expected.*]] = addrspacecast i32* [[EXPECTED_ALLOCA]] to i32 addrspace(4)*
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* [[OBJECT_BC]], i32 addrspace(4)* [[EXPECTED_AS]], i32 [[DESIRED_CAST]], i32 3, i32 0, i32 2)
+//CHECK-LLVM: [[OBJECT_BC:%[0-9]+]] = bitcast float addrspace(4)* [[OBJECT]] to i32 addrspace(4)*
+//CHECK-LLVM: [[EXPECTED_BC:%[0-9]+]] = bitcast float addrspace(4)* [[EXPECTED]] to i32 addrspace(4)*
+//CHECK-LLVM: [[DESIRED_CAST:%[0-9]+]] = bitcast float %desired to i32
+//CHECK-LLVM: [[LOAD:%exp[0-9]+]] = load i32, i32 addrspace(4)* [[EXPECTED_BC]], align 4
+//CHECK-LLVM: store i32 [[LOAD]], i32* [[EXPECTED_ALLOCA:%expected[0-9]+]], align 4
+//CHECK-LLVM: [[EXPECTED_AS:%expected.*]] = addrspacecast i32* [[EXPECTED_ALLOCA]] to i32 addrspace(4)*
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* [[OBJECT_BC]], i32 addrspace(4)* [[EXPECTED_AS]], i32 [[DESIRED_CAST]], i32 4, i32 0, i32 1)
+//CHECK-LLVM: [[OBJECT_BC:%[0-9]+]] = bitcast float addrspace(4)* [[OBJECT]] to i32 addrspace(4)*
+//CHECK-LLVM: [[EXPECTED_BC:%[0-9]+]] = bitcast float addrspace(4)* [[EXPECTED]] to i32 addrspace(4)*
+//CHECK-LLVM: [[DESIRED_CAST:%[0-9]+]] = bitcast float %desired to i32
+//CHECK-LLVM: [[LOAD:%exp[0-9]+]] = load i32, i32 addrspace(4)* [[EXPECTED_BC]], align 4
+//CHECK-LLVM: store i32 [[LOAD]], i32* [[EXPECTED_ALLOCA:%expected[0-9]+]], align 4
+//CHECK-LLVM: [[EXPECTED_AS:%expected.*]] = addrspacecast i32* [[EXPECTED_ALLOCA]] to i32 addrspace(4)*
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* [[OBJECT_BC]], i32 addrspace(4)* [[EXPECTED_AS]], i32 [[DESIRED_CAST]], i32 3, i32 0, i32 2)
+//CHECK-LLVM: [[OBJECT_BC:%[0-9]+]] = bitcast float addrspace(4)* [[OBJECT]] to i32 addrspace(4)*
+//CHECK-LLVM: [[EXPECTED_BC:%[0-9]+]] = bitcast float addrspace(4)* [[EXPECTED]] to i32 addrspace(4)*
+//CHECK-LLVM: [[DESIRED_CAST:%[0-9]+]] = bitcast float %desired to i32
+//CHECK-LLVM: [[LOAD:%exp[0-9]+]] = load i32, i32 addrspace(4)* [[EXPECTED_BC]], align 4
+//CHECK-LLVM: store i32 [[LOAD]], i32* [[EXPECTED_ALLOCA:%expected[0-9]+]], align 4
+//CHECK-LLVM: [[EXPECTED_AS:%expected.*]] = addrspacecast i32* [[EXPECTED_ALLOCA]] to i32 addrspace(4)*
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 addrspace(4)* [[OBJECT_BC]], i32 addrspace(4)* [[EXPECTED_AS]], i32 [[DESIRED_CAST]], i32 4, i32 0, i32 1)
+
+//CHECK-LLVM-LABEL: define spir_kernel void @testAtomicCompareExchangeExplicit_cl20_double(
+//CHECK-LLVM: [[OBJECT:%[0-9]+]] = addrspacecast double addrspace(1)* %object to double addrspace(4)*
+//CHECK-LLVM: [[EXPECTED:%[0-9]+]] = addrspacecast double addrspace(1)* %expected to double addrspace(4)*
+//CHECK-LLVM: [[OBJECT_BC:%[0-9]+]] = bitcast double addrspace(4)* [[OBJECT]] to i64 addrspace(4)*
+//CHECK-LLVM: [[EXPECTED_BC:%[0-9]+]] = bitcast double addrspace(4)* [[EXPECTED]] to i64 addrspace(4)*
+//CHECK-LLVM: [[DESIRED_CAST:%[0-9]+]] = bitcast double %desired to i64
+//CHECK-LLVM: %exp = load i64, i64 addrspace(4)* [[EXPECTED_BC]], align 8
+//CHECK-LLVM: store i64 %exp, i64* [[EXPECTED_ALLOCA:%expected[0-9]+]], align 8
+//CHECK-LLVM: [[EXPECTED_AS:%expected.*]] = addrspacecast i64* [[EXPECTED_ALLOCA]] to i64 addrspace(4)*
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiclPU3AS4ll12memory_orderS4_12memory_scope(i64 addrspace(4)* [[OBJECT_BC]], i64 addrspace(4)* [[EXPECTED_AS]], i64 [[DESIRED_CAST]], i32 3, i32 0, i32 2)
+//CHECK-LLVM: [[OBJECT_BC:%[0-9]+]] = bitcast double addrspace(4)* [[OBJECT]] to i64 addrspace(4)*
+//CHECK-LLVM: [[EXPECTED_BC:%[0-9]+]] = bitcast double addrspace(4)* [[EXPECTED]] to i64 addrspace(4)*
+//CHECK-LLVM: [[DESIRED_CAST:%[0-9]+]] = bitcast double %desired to i64
+//CHECK-LLVM: [[LOAD:%exp[0-9]+]] = load i64, i64 addrspace(4)* [[EXPECTED_BC]], align 8
+//CHECK-LLVM: store i64 [[LOAD]], i64* [[EXPECTED_ALLOCA:%expected[0-9]+]], align 8
+//CHECK-LLVM: [[EXPECTED_AS:%expected.*]] = addrspacecast i64* [[EXPECTED_ALLOCA]] to i64 addrspace(4)*
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiclPU3AS4ll12memory_orderS4_12memory_scope(i64 addrspace(4)* [[OBJECT_BC]], i64 addrspace(4)* [[EXPECTED_AS]], i64 [[DESIRED_CAST]], i32 4, i32 0, i32 1)
+//CHECK-LLVM: [[OBJECT_BC:%[0-9]+]] = bitcast double addrspace(4)* [[OBJECT]] to i64 addrspace(4)*
+//CHECK-LLVM: [[EXPECTED_BC:%[0-9]+]] = bitcast double addrspace(4)* [[EXPECTED]] to i64 addrspace(4)*
+//CHECK-LLVM: [[DESIRED_CAST:%[0-9]+]] = bitcast double %desired to i64
+//CHECK-LLVM: [[LOAD:%exp[0-9]+]] = load i64, i64 addrspace(4)* [[EXPECTED_BC]], align 8
+//CHECK-LLVM: store i64 [[LOAD]], i64* [[EXPECTED_ALLOCA:%expected[0-9]+]], align 8
+//CHECK-LLVM: [[EXPECTED_AS:%expected.*]] = addrspacecast i64* [[EXPECTED_ALLOCA]] to i64 addrspace(4)*
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiclPU3AS4ll12memory_orderS4_12memory_scope(i64 addrspace(4)* [[OBJECT_BC]], i64 addrspace(4)* [[EXPECTED_AS]], i64 [[DESIRED_CAST]], i32 3, i32 0, i32 2)
+//CHECK-LLVM: [[OBJECT_BC:%[0-9]+]] = bitcast double addrspace(4)* [[OBJECT]] to i64 addrspace(4)*
+//CHECK-LLVM: [[EXPECTED_BC:%[0-9]+]] = bitcast double addrspace(4)* [[EXPECTED]] to i64 addrspace(4)*
+//CHECK-LLVM: [[DESIRED_CAST:%[0-9]+]] = bitcast double %desired to i64
+//CHECK-LLVM: [[LOAD:%exp[0-9]+]] = load i64, i64 addrspace(4)* [[EXPECTED_BC]], align 8
+//CHECK-LLVM: store i64 [[LOAD]], i64* [[EXPECTED_ALLOCA:%expected[0-9]+]], align 8
+//CHECK-LLVM: [[EXPECTED_AS:%expected.*]] = addrspacecast i64* [[EXPECTED_ALLOCA]] to i64 addrspace(4)*
+//CHECK-LLVM: call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiclPU3AS4ll12memory_orderS4_12memory_scope(i64 addrspace(4)* [[OBJECT_BC]], i64 addrspace(4)* [[EXPECTED_AS]], i64 [[DESIRED_CAST]], i32 4, i32 0, i32 1)

--- a/test/transcoding/AtomicCompareExchange_cl20.ll
+++ b/test/transcoding/AtomicCompareExchange_cl20.ll
@@ -26,6 +26,26 @@ target triple = "spir-unknown-unknown"
 ; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}(i32 {{.*}}* %object, i32 {{.*}}* [[PTR_STRONG]].as, i32 %desired, i32 5, i32 5, i32 2)
 ; CHECK:         load i32, i32 addrspace(4)* [[PTR_STRONG]].as
 
+; CHECK-LABEL:   define spir_func void @test_strong_float
+; CHECK-NEXT:    entry:
+; CHECK:         [[PTR_STRONG:%expected[0-9]*]] = alloca i32, align 4
+; CHECK:         [[OBJECT_CAST:%[0-9]+]] = bitcast float addrspace(4)* %object to i32 addrspace(4)*
+; CHECK:         [[DESIRED_CAST:%[0-9]*]] = bitcast float %desired to i32
+; CHECK:         store i32 {{.*}}, i32* [[PTR_STRONG]]
+; CHECK:         [[PTR_STRONG]].as = addrspacecast i32* [[PTR_STRONG]] to i32 addrspace(4)*
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}(i32 {{.*}}* [[OBJECT_CAST]], i32 {{.*}}* [[PTR_STRONG]].as, i32 [[DESIRED_CAST]], i32 5, i32 5, i32 2)
+; CHECK:         load i32, i32 addrspace(4)* [[PTR_STRONG]].as
+
+; CHECK-LABEL:   define spir_func void @test_strong_double
+; CHECK-NEXT:    entry:
+; CHECK:         [[PTR_STRONG:%expected[0-9]*]] = alloca i64, align 8
+; CHECK:         [[OBJECT_CAST:%[0-9]+]] = bitcast double addrspace(4)* %object to i64 addrspace(4)*
+; CHECK:         [[DESIRED_CAST:%[0-9]*]] = bitcast double %desired to i64
+; CHECK:         store i64 {{.*}}, i64* [[PTR_STRONG]]
+; CHECK:         [[PTR_STRONG]].as = addrspacecast i64* [[PTR_STRONG]] to i64 addrspace(4)*
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicit{{.*}}(i64 {{.*}}* [[OBJECT_CAST]], i64 {{.*}}* [[PTR_STRONG]].as, i64 [[DESIRED_CAST]], i32 5, i32 5, i32 2)
+; CHECK:         load i64, i64 addrspace(4)* [[PTR_STRONG]].as
+
 ; CHECK-LABEL:   define spir_func void @test_weak
 ; CHECK-NEXT:    entry:
 ; CHECK:         [[PTR_WEAK:%expected[0-9]*]] = alloca i32, align 4
@@ -33,6 +53,26 @@ target triple = "spir-unknown-unknown"
 ; CHECK:         [[PTR_WEAK]].as = addrspacecast i32* [[PTR_WEAK]] to i32 addrspace(4)*
 ; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope{{.*}}(i32 {{.*}}* %object, i32 {{.*}}* [[PTR_WEAK]].as, i32 %desired, i32 5, i32 5, i32 2)
 ; CHECK:         load i32, i32 addrspace(4)* [[PTR_WEAK]].as
+
+; CHECK-LABEL:   define spir_func void @test_weak_float
+; CHECK-NEXT:    entry:
+; CHECK:         [[PTR_WEAK:%expected[0-9]*]] = alloca i32, align 4
+; CHECK:         [[OBJECT_CAST:%[0-9]+]] = bitcast float addrspace(4)* %object to i32 addrspace(4)*
+; CHECK:         [[DESIRED_CAST:%[0-9]*]] = bitcast float %desired to i32
+; CHECK:         store i32 {{.*}}, i32* [[PTR_WEAK]]
+; CHECK:         [[PTR_WEAK]].as = addrspacecast i32* [[PTR_WEAK]] to i32 addrspace(4)*
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiciPU3AS4ii12memory_orderS4_12memory_scope(i32 {{.*}}* [[OBJECT_CAST]], i32 {{.*}}* [[PTR_WEAK]].as, i32 [[DESIRED_CAST]], i32 5, i32 5, i32 2)
+; CHECK:         load i32, i32 addrspace(4)* [[PTR_WEAK]].as
+
+; CHECK-LABEL:   define spir_func void @test_weak_double
+; CHECK-NEXT:    entry:
+; CHECK:         [[PTR_WEAK:%expected[0-9]*]] = alloca i64, align 8
+; CHECK:         [[OBJECT_CAST:%[0-9]+]] = bitcast double addrspace(4)* %object to i64 addrspace(4)*
+; CHECK:         [[DESIRED_CAST:%[0-9]*]] = bitcast double %desired to i64
+; CHECK:         store i64 {{.*}}, i64* [[PTR_WEAK]]
+; CHECK:         [[PTR_WEAK]].as = addrspacecast i64* [[PTR_WEAK]] to i64 addrspace(4)*
+; CHECK:         call spir_func i1 @_Z39atomic_compare_exchange_strong_explicitPU3AS4VU7_AtomiclPU3AS4ll12memory_orderS4_12memory_scope(i64 {{.*}}* [[OBJECT_CAST]], i64 {{.*}}* [[PTR_WEAK]].as, i64 [[DESIRED_CAST]], i32 5, i32 5, i32 2)
+; CHECK:         load i64, i64 addrspace(4)* [[PTR_WEAK]].as
 
 ; Check that alloca for atomic_compare_exchange is being created in the entry block.
 
@@ -52,6 +92,22 @@ entry:
 
 declare spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)*, i32 addrspace(4)*, i32) #1
 
+define spir_func void @test_strong_float(float addrspace(4)* %object, float addrspace(4)* %expected, float %desired) #0 {
+entry:
+  %call = call spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPU3AS1VU7_AtomicfPU3AS1ff(float addrspace(4)* %object, float addrspace(4)* %expected, float %desired) #2
+  ret void
+}
+
+declare spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPU3AS1VU7_AtomicfPU3AS1ff(float addrspace(4)*, float addrspace(4)*, float)
+
+define spir_func void @test_strong_double(double addrspace(4)* %object, double addrspace(4)* %expected, double %desired) #0 {
+entry:
+  %call = call spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPU3AS1VU7_AtomicdPU3AS1dd(double addrspace(4)* %object, double addrspace(4)* %expected, double %desired) #2
+  ret void
+}
+
+declare spir_func zeroext i1 @_Z30atomic_compare_exchange_strongPU3AS1VU7_AtomicdPU3AS1dd(double addrspace(4)*, double addrspace(4)*, double)
+
 ; Function Attrs: nounwind
 define spir_func void @test_weak(i32 addrspace(4)* %object, i32 addrspace(4)* %expected, i32 %desired) #0 {
 entry:
@@ -60,6 +116,22 @@ entry:
 }
 
 declare spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)*, i32 addrspace(4)*, i32) #1
+
+define spir_func void @test_weak_float(float addrspace(4)* %object, float addrspace(4)* %expected, float %desired) #0 {
+entry:
+  %call = call spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPU3AS1VU7_AtomicfPU3AS1ff(float addrspace(4)* %object, float addrspace(4)* %expected, float %desired) #2
+  ret void
+}
+
+declare spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPU3AS1VU7_AtomicfPU3AS1ff(float addrspace(4)*, float addrspace(4)*, float)
+
+define spir_func void @test_weak_double(double addrspace(4)* %object, double addrspace(4)* %expected, double %desired) #0 {
+entry:
+  %call = call spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPU3AS1VU7_AtomicdPU3AS1dd(double addrspace(4)* %object, double addrspace(4)* %expected, double %desired) #2
+  ret void
+}
+
+declare spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPU3AS1VU7_AtomicdPU3AS1dd(double addrspace(4)*, double addrspace(4)*, double)
 
 ; Function Attrs: nounwind
 define spir_kernel void @atomic_in_loop(i32 addrspace(1)* %destMemory, i32 addrspace(1)* %oldValues) #0 {


### PR DESCRIPTION
OpenCL spec supports atomic_float/atomic_double type for atomic_compare_exchange* functions. However, value and return type in OpAtomicCompareExchange in SPIR-V spec must be integer type. Therefore, in OCLToSPIRV translation we need to translate floating-point type to corresponding integer variant that has the same type size. Floating-point value is bitcasted so that bits remain the same.

(cherry picked from commit e5544014fba77d3ae1d1ce294f8255b5b9e0d36a)