### PR TITLE
[Backport to 16] [CI] Upgrade out-of-tree job to Ubuntu 22.04

### DIFF
--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -38,14 +38,14 @@ jobs:
       matrix:
         build_type: [Release, Debug]
       fail-fast: false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies
         run: |
           curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
           curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
-          echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-16 main" | sudo tee -a /etc/apt/sources.list
-          echo "deb https://packages.lunarg.com/vulkan focal main" | sudo tee -a /etc/apt/sources.list
+          echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" | sudo tee -a /etc/apt/sources.list
+          echo "deb https://packages.lunarg.com/vulkan jammy main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \


### PR DESCRIPTION
(cherry picked from commit b8ee72df7cb2e0e9991f379101ad3462b4e30969)