### PR TITLE
[Backport to 19] Fix element type when reading OpPtrDiff (#2683)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2185,7 +2185,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto *BC = static_cast<SPIRVBinary *>(BV);
     auto Ops = transValue(BC->getOperands(), F, BB);
     IRBuilder<> Builder(BB);
-    Value *V = Builder.CreatePtrDiff(transType(BC->getType()), Ops[0], Ops[1]);
+    Type *ElemTy =
+        transType(BC->getOperands()[0]->getType()->getPointerElementType());
+    Value *V = Builder.CreatePtrDiff(ElemTy, Ops[0], Ops[1]);
     return mapValue(BV, V);
   }
 

--- a/test/transcoding/ptr_diff.ll
+++ b/test/transcoding/ptr_diff.ll
@@ -35,7 +35,7 @@ entry:
 ; CHECK-LLVM: %[[#Arg1:]] = ptrtoint ptr %[[#]] to i64
 ; CHECK-LLVM: %[[#Arg2:]] = ptrtoint ptr %[[#]] to i64
 ; CHECK-LLVM: %[[#Sub:]] = sub i64 %[[#Arg1]], %[[#Arg2]]
-; CHECK-LLVM: sdiv exact i64 %[[#Sub]], ptrtoint (ptr getelementptr (i32, ptr null, i32 1) to i64)
+; CHECK-LLVM: sdiv exact i64 %[[#Sub]], ptrtoint (ptr getelementptr (float, ptr null, i32 1) to i64)
   %1 = call spir_func noundef i32 @_Z15__spirv_PtrDiff(ptr %0, ptr %0)
   ret void
 }


### PR DESCRIPTION
The first argument to IRBuilder's `CreatePtrDiff` must be the element type, not the pointer type; otherwise the resulting difference will be scaled incorrectly.

(cherry picked from commit b5938f0f5e80dbe764b733c7d935c3cafc56a3df)