### PR TITLE
[Backport to 19] add API call to display general information about the module (#2298)

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -89,9 +89,9 @@ inline constexpr std::string_view formatVersionNumber(uint32_t Version) {
   return "unknown";
 }
 
-inline bool isSPIRVVersionKnown(VersionNumber Ver) {
-  return Ver >= VersionNumber::MinimumVersion &&
-         Ver <= VersionNumber::MaximumVersion;
+inline bool isSPIRVVersionKnown(uint32_t Ver) {
+  return Ver >= static_cast<uint32_t>(VersionNumber::MinimumVersion) &&
+         Ver <= static_cast<uint32_t>(VersionNumber::MaximumVersion);
 }
 
 enum class ExtensionID : uint32_t {

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -2188,6 +2188,11 @@ SPIRVEntry *parseAndCreateSPIRVEntry(SPIRVWord &WordCount, Op &OpCode,
                 OpExt->getExtensionName() + "'")) {
       M.setInvalid();
     }
+static std::string to_string(uint32_t Version) {
+  std::string Res(formatVersionNumber(Version));
+  Res += " (" + std::to_string(Version) + ")";
+  return Res;
+}
 
     if (!M.getErrorLog().checkError(
             M.isAllowedToUseExtension(ExtID), SPIRVEC_InvalidModule,
@@ -2229,6 +2234,7 @@ std::istream &SPIRVModuleImpl::parseSPT(std::istream &I) {
     return I;
   }
 
+<<<<<<< HEAD
   if (!ErrorLog.checkError(Magic == MagicNumber, SPIRVEC_InvalidModule,
                            "invalid magic number")) {
     MI.setInvalid();
@@ -2244,6 +2250,11 @@ std::istream &SPIRVModuleImpl::parseSPT(std::istream &I) {
 
   bool SPIRVVersionIsKnown = isSPIRVVersionKnown(MI.SPIRVVersion);
   if (!ErrorLog.checkError(
+=======
+  Decoder >> MI.SPIRVVersion;
+  bool SPIRVVersionIsKnown = isSPIRVVersionKnown(MI.SPIRVVersion);
+  if (!M.getErrorLog().checkError(
+>>>>>>> 918036c6 (add API call to display general information about the module (#2298))
           SPIRVVersionIsKnown, SPIRVEC_InvalidModule,
           "unsupported SPIR-V version number '" + to_string(MI.SPIRVVersion) +
               "'. Range of supported/known SPIR-V "

--- a/test/negative/spirv_report_bad_input.spt
+++ b/test/negative/spirv_report_bad_input.spt
@@ -3,7 +3,7 @@
 ; RUN: echo "0" > %t_corrupted.spv && cat %t.spv >> %t_corrupted.spv
 ; RUN: not llvm-spirv --spirv-print-report %t_corrupted.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ;
-; CHECK-ERROR: Invalid SPIR-V binary: "InvalidMagicNumber: Invalid Magic Number."
+; CHECK-ERROR: Invalid SPIR-V binary
 
 119734787 65536 393230 10 0
 2 Capability Addresses

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -868,7 +868,7 @@ int main(int Ac, char **Av) {
     std::optional<SPIRV::SPIRVModuleReport> BinReport =
         SPIRV::getSpirvReport(IFS, ErrCode);
     if (!BinReport) {
-      std::cerr << "Invalid SPIR-V binary: \"" << SPIRV::getErrorMessage(ErrCode) << "\"\n";
+      std::cerr << "Invalid SPIR-V binary, error code is " << ErrCode << "\n";
       return -1;
     }
 


### PR DESCRIPTION
Partially load SPIR-V from the stream and decode only selected for the report instructions, needed to retrieve general information about the module: capabilities, extensions, version, memory model and addressing model.

In addition to immediately helpful for back-ends lists of capabilities and extensions declared in SPIR-V module, a general intent also is to extend report details in future by feedbacks about further potentially useful analysis, statistics, etc.