### PR TITLE
Handle constant sized array allocations using no extension

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2260,14 +2260,14 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       SPIRVValue *Length = transValue(Alc->getArraySize(), BB);
       assert(Length && "Couldn't translate array size!");
 
-      if (isSpecConstantOpCode(Length->getOpCode())) {
-        // SPIR-V arrays length can be expressed using a specialization
-        // constant.
+      if (isConstantOpCode(Length->getOpCode())) {
+        // Length can be any constant instruction, either a specialization
+        // constant or a non-specialization constant.
         //
-        // Spec Constant Length Arrays need special treatment, as the allocation
-        // type will be 'OpTypePointer(Function, OpTypeArray(ElementType,
-        // Length))', we need to bitcast the obtained pointer to the expected
-        // type: 'OpTypePointer(Function, ElementType).
+        // Array allocations need special treatment: as the allocation type will
+        // be 'OpTypePointer(Function, OpTypeArray(ElementType, Length))', we
+        // need to bitcast the obtained pointer to the expected type:
+        // 'OpTypePointer(Function, ElementType).
         SPIRVType *AllocationType = BM->addPointerType(
             StorageClassFunction,
             BM->addArrayType(transType(Alc->getAllocatedType()), Length));

--- a/test/array-alloca.ll
+++ b/test/array-alloca.ll
@@ -27,7 +27,7 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-SPIRV: Function [[#VOID]] {{.*}} [[#FUNCTY]]
 ; CHECK-SPIRV: Variable [[#ARRPTRTY]] [[#ARR]] [[#FUNCSTORAGE]]
-; CHECK-SPIRV: Bitcast [[#PTRTY]] {{.*}} [[#ARR]]
+; CHECK-SPIRV: Bitcast [[#PTRTY]] [[#BITARR]] [[#ARR]]
 
 ; CHECK-LLVM:  define spir_func void @test_array_alloca()
 ; CHECK-LLVM:    %[[#ALLOC:]] = alloca [4 x i32], align 4

--- a/test/array-alloca.ll
+++ b/test/array-alloca.ll
@@ -29,6 +29,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV: Variable [[#ARRPTRTY]] [[#ARR]] [[#FUNCSTORAGE]]
 ; CHECK-SPIRV: Bitcast [[#PTRTY]] [[#BITARR]] [[#ARR]]
 
+; Generated LLVM is different, but equivalent as an array type is allocated.
 ; CHECK-LLVM:  define spir_func void @test_array_alloca()
 ; CHECK-LLVM:    %[[#ALLOC:]] = alloca [4 x i32], align 4
 ; CHECK-LLVM:    %{{.*}} = bitcast ptr %[[#ALLOC]] to ptr

--- a/test/array-alloca.ll
+++ b/test/array-alloca.ll
@@ -1,0 +1,51 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+
+; Validation test.
+; RUN: spirv-val %t.spv
+
+; SPIR-V codegen test.
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+; Roundtrip test.
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV: Decorate [[#ARR:]] Alignment 4
+; CHECK-SPIRV: Decorate [[#BITARR:]] Alignment 4
+
+; CHECK-SPIRV: TypeInt [[#I32:]] 32 0
+; CHECK-SPIRV: TypeInt [[#I64:]] 64 0
+; CHECK-SPIRV: Constant [[#I64]] [[#SIZE:]] 4 0
+; CHECK-SPIRV: TypeVoid [[#VOID:]]
+; CHECK-SPIRV: TypeFunction [[#FUNCTY:]] [[#VOID]]
+; CHECK-SPIRV: TypePointer [[#PTRTY:]] [[#FUNCSTORAGE:]] [[#I32]]
+; CHECK-SPIRV: TypeArray [[#ARRTY:]] [[#I32]] [[#SIZE]]
+; CHECK-SPIRV: TypePointer [[#ARRPTRTY:]] [[#FUNCSTORAGE]] [[#ARRTY]]
+
+; CHECK-SPIRV: Function [[#VOID]] {{.*}} [[#FUNCTY]]
+; CHECK-SPIRV: Variable [[#ARRPTRTY]] [[#ARR]] [[#FUNCSTORAGE]]
+; CHECK-SPIRV: Bitcast [[#PTRTY]] {{.*}} [[#ARR]]
+
+; CHECK-LLVM:  define spir_func void @test_array_alloca()
+; CHECK-LLVM:    %[[#ALLOC:]] = alloca [4 x i32], align 4
+; CHECK-LLVM:    %{{.*}} = bitcast ptr %[[#ALLOC]] to ptr
+define dso_local void @test_array_alloca() #0 {
+  %arr = alloca i32, i64 4, align 4
+  ret void
+}
+
+attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!1}
+!opencl.ocl.version = !{!1}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!3}
+!opencl.compiler.options = !{!2}
+
+!1 = !{i32 1, i32 2}
+!2 = !{}
+!3 = !{}

--- a/test/simple.ll
+++ b/test/simple.ll
@@ -126,13 +126,6 @@ entry:
   ret void
 }
 
-; CHECK: "test_array_alloca"
-; Function Attrs: nounwind
-define dso_local void @test_array_alloca() #0 {
-  %arr = alloca i32, i64 4, align 4
-  ret void
-}
-
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { nounwind readnone }

--- a/test/simple.ll
+++ b/test/simple.ll
@@ -126,6 +126,57 @@ entry:
   ret void
 }
 
+; CHECK: "test_array_alloca"
+; Function Attrs: nounwind
+define dso_local void @test_array_alloca(ptr noundef %0, ptr noundef %1) #0 {
+  %3 = alloca ptr, align 8
+  %4 = alloca ptr, align 8
+  %5 = alloca i32, i64 4, align 4
+  store ptr %0, ptr %3, align 8
+  store ptr %1, ptr %4, align 8
+  %6 = load ptr, ptr %3, align 8
+  %7 = getelementptr inbounds i32, ptr %6, i64 0
+  %8 = load i32, ptr %7, align 4
+  %9 = getelementptr inbounds i32, ptr %5, i64 0
+  store i32 %8, ptr %9, align 16
+  %10 = load ptr, ptr %3, align 8
+  %11 = getelementptr inbounds i32, ptr %10, i64 1
+  %12 = load i32, ptr %11, align 4
+  %13 = getelementptr inbounds i32, ptr %5, i64 1
+  store i32 %12, ptr %13, align 4
+  %14 = load ptr, ptr %3, align 8
+  %15 = getelementptr inbounds i32, ptr %14, i64 2
+  %16 = load i32, ptr %15, align 4
+  %17 = getelementptr inbounds i32, ptr %5, i64 2
+  store i32 %16, ptr %17, align 8
+  %18 = load ptr, ptr %3, align 8
+  %19 = getelementptr inbounds i32, ptr %18, i64 3
+  %20 = load i32, ptr %19, align 4
+  %21 = getelementptr inbounds i32, ptr %5, i64 3
+  store i32 %20, ptr %21, align 4
+  %22 = getelementptr inbounds i32, ptr %5, i64 0
+  %23 = load i32, ptr %22, align 16
+  %24 = load ptr, ptr %4, align 8
+  %25 = getelementptr inbounds i32, ptr %24, i64 0
+  store i32 %23, ptr %25, align 4
+  %26 = getelementptr inbounds i32, ptr %5, i64 1
+  %27 = load i32, ptr %26, align 4
+  %28 = load ptr, ptr %4, align 8
+  %29 = getelementptr inbounds i32, ptr %28, i64 1
+  store i32 %27, ptr %29, align 4
+  %30 = getelementptr inbounds i32, ptr %5, i64 2
+  %31 = load i32, ptr %30, align 8
+  %32 = load ptr, ptr %4, align 8
+  %33 = getelementptr inbounds i32, ptr %32, i64 2
+  store i32 %31, ptr %33, align 4
+  %34 = getelementptr inbounds i32, ptr %5, i64 3
+  %35 = load i32, ptr %34, align 4
+  %36 = load ptr, ptr %4, align 8
+  %37 = getelementptr inbounds i32, ptr %36, i64 3
+  store i32 %35, ptr %37, align 4
+  ret void
+}
+
 attributes #0 = { nounwind "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #1 = { nounwind readnone "less-precise-fpmad"="false" "no-frame-pointer-elim"="false" "no-infs-fp-math"="false" "no-nans-fp-math"="false" "no-realign-stack" "stack-protector-buffer-size"="8" "unsafe-fp-math"="false" "use-soft-float"="false" }
 attributes #2 = { nounwind readnone }

--- a/test/simple.ll
+++ b/test/simple.ll
@@ -128,52 +128,8 @@ entry:
 
 ; CHECK: "test_array_alloca"
 ; Function Attrs: nounwind
-define dso_local void @test_array_alloca(ptr noundef %0, ptr noundef %1) #0 {
-  %3 = alloca ptr, align 8
-  %4 = alloca ptr, align 8
-  %5 = alloca i32, i64 4, align 4
-  store ptr %0, ptr %3, align 8
-  store ptr %1, ptr %4, align 8
-  %6 = load ptr, ptr %3, align 8
-  %7 = getelementptr inbounds i32, ptr %6, i64 0
-  %8 = load i32, ptr %7, align 4
-  %9 = getelementptr inbounds i32, ptr %5, i64 0
-  store i32 %8, ptr %9, align 16
-  %10 = load ptr, ptr %3, align 8
-  %11 = getelementptr inbounds i32, ptr %10, i64 1
-  %12 = load i32, ptr %11, align 4
-  %13 = getelementptr inbounds i32, ptr %5, i64 1
-  store i32 %12, ptr %13, align 4
-  %14 = load ptr, ptr %3, align 8
-  %15 = getelementptr inbounds i32, ptr %14, i64 2
-  %16 = load i32, ptr %15, align 4
-  %17 = getelementptr inbounds i32, ptr %5, i64 2
-  store i32 %16, ptr %17, align 8
-  %18 = load ptr, ptr %3, align 8
-  %19 = getelementptr inbounds i32, ptr %18, i64 3
-  %20 = load i32, ptr %19, align 4
-  %21 = getelementptr inbounds i32, ptr %5, i64 3
-  store i32 %20, ptr %21, align 4
-  %22 = getelementptr inbounds i32, ptr %5, i64 0
-  %23 = load i32, ptr %22, align 16
-  %24 = load ptr, ptr %4, align 8
-  %25 = getelementptr inbounds i32, ptr %24, i64 0
-  store i32 %23, ptr %25, align 4
-  %26 = getelementptr inbounds i32, ptr %5, i64 1
-  %27 = load i32, ptr %26, align 4
-  %28 = load ptr, ptr %4, align 8
-  %29 = getelementptr inbounds i32, ptr %28, i64 1
-  store i32 %27, ptr %29, align 4
-  %30 = getelementptr inbounds i32, ptr %5, i64 2
-  %31 = load i32, ptr %30, align 8
-  %32 = load ptr, ptr %4, align 8
-  %33 = getelementptr inbounds i32, ptr %32, i64 2
-  store i32 %31, ptr %33, align 4
-  %34 = getelementptr inbounds i32, ptr %5, i64 3
-  %35 = load i32, ptr %34, align 4
-  %36 = load ptr, ptr %4, align 8
-  %37 = getelementptr inbounds i32, ptr %36, i64 3
-  store i32 %35, ptr %37, align 4
+define dso_local void @test_array_alloca() #0 {
+  %arr = alloca i32, i64 4, align 4
   ret void
 }
 


### PR DESCRIPTION
In LLVM, array allocations might have constant size:

```llvm
%array = alloca i32, i64 4, align 4
```

Represent this kind of allocations using `OpVariable + OpBitcast`.

Before this patch, the `SPV_INTEL_variable_length_array` extension was used.