### PR TITLE
Add an option to translate LLVM IR to SPIR-V using the LLVM SPIRV Backend target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,16 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
   )
   include(AddLLVM)
   include(HandleLLVMOptions)
+  include(LLVM-Config)
 
   message(STATUS "Found LLVM: ${LLVM_VERSION}")
+
+  is_llvm_target_library("SPIRV" spirv_present_result INCLUDED_TARGETS)
+  if(spirv_present_result)
+    message(STATUS "Found SPIR-V Backend")
+    set(SPIRV_BACKEND_FOUND TRUE)
+    add_compile_definitions(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
+  endif()
 
   option(CCACHE_ALLOWED "allow use of ccache" TRUE)
   find_program(CCACHE_EXE_FOUND ccache)

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -149,6 +149,9 @@ public:
       ExtStatusMap[Extension] = Allow;
   }
 
+  std::vector<std::string>
+  getAllowedSPIRVExtensionNames(std::function<bool(ExtensionID)> &Filter) const;
+
   VersionNumber getMaxVersion() const { return MaxVersion; }
 
   bool isGenArgNameMDEnabled() const { return GenKernelArgNameMD; }

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -241,11 +241,11 @@ public:
   }
   BuiltinFormat getBuiltinFormat() const noexcept { return SPIRVBuiltinFormat; }
 
-  void useLLVMSPIRVBackendTarget(bool Flag) noexcept {
-    UseLLVMSPIRVBackendTarget = Flag;
+  void useLLVMTarget(bool Flag) noexcept {
+    UseLLVMTarget = Flag;
   }
   bool getUseLLVMSPIRVBackendTarget() const noexcept {
-    return UseLLVMSPIRVBackendTarget;
+    return UseLLVMTarget;
   }
 
 private:
@@ -296,7 +296,7 @@ private:
   BuiltinFormat SPIRVBuiltinFormat = BuiltinFormat::Function;
 
   // Convert LLVM to SPIR-V using the LLVM SPIR-V Backend target
-  bool UseLLVMSPIRVBackendTarget = false;
+  bool UseLLVMTarget = false;
 };
 
 } // namespace SPIRV

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -241,12 +241,8 @@ public:
   }
   BuiltinFormat getBuiltinFormat() const noexcept { return SPIRVBuiltinFormat; }
 
-  void useLLVMTarget(bool Flag) noexcept {
-    UseLLVMTarget = Flag;
-  }
-  bool getUseLLVMSPIRVBackendTarget() const noexcept {
-    return UseLLVMTarget;
-  }
+  void useLLVMTarget(bool Flag) noexcept { UseLLVMTarget = Flag; }
+  bool getUseLLVMSPIRVBackendTarget() const noexcept { return UseLLVMTarget; }
 
 private:
   // Common translation options

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -242,7 +242,7 @@ public:
   BuiltinFormat getBuiltinFormat() const noexcept { return SPIRVBuiltinFormat; }
 
   void setUseLLVMTarget(bool Flag) noexcept { UseLLVMTarget = Flag; }
-  bool getUseLLVMSPIRVBackendTarget() const noexcept { return UseLLVMTarget; }
+  bool getUseLLVMTarget() const noexcept { return UseLLVMTarget; }
 
 private:
   // Common translation options

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -241,6 +241,13 @@ public:
   }
   BuiltinFormat getBuiltinFormat() const noexcept { return SPIRVBuiltinFormat; }
 
+  void useLLVMSPIRVBackendTarget(bool Flag) noexcept {
+    UseLLVMSPIRVBackendTarget = Flag;
+  }
+  bool getUseLLVMSPIRVBackendTarget() const noexcept {
+    return UseLLVMSPIRVBackendTarget;
+  }
+
 private:
   // Common translation options
   VersionNumber MaxVersion = VersionNumber::MaximumVersion;
@@ -287,6 +294,9 @@ private:
   bool PreserveAuxData = false;
 
   BuiltinFormat SPIRVBuiltinFormat = BuiltinFormat::Function;
+
+  // Convert LLVM to SPIR-V using the LLVM SPIR-V Backend target
+  bool UseLLVMSPIRVBackendTarget = false;
 };
 
 } // namespace SPIRV

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -241,7 +241,7 @@ public:
   }
   BuiltinFormat getBuiltinFormat() const noexcept { return SPIRVBuiltinFormat; }
 
-  void useLLVMTarget(bool Flag) noexcept { UseLLVMTarget = Flag; }
+  void setUseLLVMTarget(bool Flag) noexcept { UseLLVMTarget = Flag; }
   bool getUseLLVMSPIRVBackendTarget() const noexcept { return UseLLVMTarget; }
 
 private:

--- a/lib/SPIRV/LLVMSPIRVOpts.cpp
+++ b/lib/SPIRV/LLVMSPIRVOpts.cpp
@@ -40,6 +40,7 @@
 
 #include "LLVMSPIRVOpts.h"
 
+#include "SPIRVEnum.h"
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 #include <llvm/IR/IntrinsicInst.h>
@@ -73,4 +74,18 @@ bool TranslatorOpts::isSPIRVAllowUnknownIntrinsicsEnabled() const noexcept {
 void TranslatorOpts::setSPIRVAllowUnknownIntrinsics(
     TranslatorOpts::ArgList IntrinsicPrefixList) noexcept {
   SPIRVAllowUnknownIntrinsics = IntrinsicPrefixList;
+}
+
+std::vector<std::string> TranslatorOpts::getAllowedSPIRVExtensionNames(
+    std::function<bool(SPIRV::ExtensionID)> &Filter) const {
+  std::vector<std::string> AllowExtNames;
+  AllowExtNames.reserve(ExtStatusMap.size());
+  for (const auto &It : ExtStatusMap) {
+    if (!It.second || !Filter(It.first))
+      continue;
+    std::string ExtName;
+    SPIRVMap<ExtensionID, std::string>::find(It.first, &ExtName);
+    AllowExtNames.push_back(ExtName);
+  }
+  return AllowExtNames;
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6934,6 +6934,12 @@ bool llvm::writeSpirv(Module *M, std::ostream &OS, std::string &ErrMsg) {
 
 bool llvm::writeSpirv(Module *M, const SPIRV::TranslatorOpts &Opts,
                       std::ostream &OS, std::string &ErrMsg) {
+#if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
+  // Check if a user asks to convert LLVM to SPIR-V using the LLVM SPIR-V
+  // Backend target
+  if (Opts.getUseLLVMSPIRVBackendTarget())
+    return runSpirvBackend(M, &OS, ErrMsg, Opts);
+#endif
   return runSpirvWriterPasses(M, &OS, ErrMsg, Opts);
 }
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6965,7 +6965,7 @@ bool llvm::writeSpirv(Module *M, const SPIRV::TranslatorOpts &Opts,
 #if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
   // Check if a user asks to convert LLVM to SPIR-V using the LLVM SPIR-V
   // Backend target
-  if (Opts.getUseLLVMSPIRVBackendTarget()) {
+  if (Opts.getUseLLVMTarget()) {
 #if !defined(_SPIRV_SUPPORT_TEXT_FMT)
     return runSpirvBackend(M, &OS, ErrMsg, Opts);
 #else

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6821,7 +6821,7 @@ bool runSpirvBackend(Module *M, std::string &Result, std::string &ErrMsg,
       SPIRV::ExtensionID::SPV_KHR_non_semantic_info};
   // The fallback for the Triple value.
   static const std::string DefaultTriple = "spirv64-unknown-unknown";
-  // SPIR-V BE uses the following command line options to conform with
+  // SPIR-V backend uses the following command line options to conform with
   // Translator's way to generate SPIR-V or with requirements of the Compute
   // flavor of SPIR-V. This list is subject to changes and may become empty
   // eventually.

--- a/test/spirvbackend-usage.ll
+++ b/test/spirvbackend-usage.ll
@@ -1,0 +1,41 @@
+; This test is to ensure that SPIR-V Backend is able to generate SPIR-V code
+; for Translator, and the code can be translated back to LLVM IR. The source
+; code contains instructions which require the SPV_KHR_uniform_group_instructions
+; extension.
+
+; If LLVM is built without SPIR-V Backend support this test must pass as well.
+
+; RUN: llvm-as %s -o %t.bc
+
+; The following is to test that 
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt -spirv-ext=+SPV_KHR_uniform_group_instructions --spirv-use-llvm-backend-target
+; RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv %t.bc -o %t.spv -spirv-ext=+SPV_KHR_uniform_group_instructions --spirv-use-llvm-backend-target
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM-SPV
+
+; CHECK-SPIRV: Capability GroupUniformArithmeticKHR
+; CHECK-SPIRV: Extension "SPV_KHR_uniform_group_instructions"
+; CHECK-SPIRV: GroupBitwiseAndKHR
+
+; CHECK-LLVM-SPV: @test1()
+; CHECK-LLVM-SPV: @test2()
+
+target triple = "spir64-unknown-unknown"
+
+define dso_local spir_func void @test1() {
+entry:
+  %res1 = tail call spir_func i32 @_Z26__spirv_GroupBitwiseAndKHR(i32 2, i32 0, i32 0)
+  ret void
+}
+
+define dso_local spir_func void @test2() {
+entry:
+  %res1 = tail call spir_func i32  @_Z21work_group_reduce_andi(i32 0)
+  ret void
+}
+
+declare dso_local spir_func i32  @_Z26__spirv_GroupBitwiseAndKHR(i32, i32, i32)
+declare dso_local spir_func i32  @_Z21work_group_reduce_andi(i32)

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -10,6 +10,10 @@ set(LLVM_LINK_COMPONENTS
   TransformUtils
 )
 
+if(SPIRV_BACKEND_FOUND)
+  list(APPEND LLVM_LINK_COMPONENTS "SPIRVCodeGen")
+endif()
+
 add_llvm_tool(llvm-spirv
   llvm-spirv.cpp
   # llvm_setup_rpath messes with the rpath making llvm-spirv not executable from the build directory

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -273,7 +273,9 @@ static cl::opt<SPIRV::BuiltinFormat> SPIRVBuiltinFormat(
 
 static cl::opt<bool> SPIRVUseLLVMSPIRVBackendTarget(
     "spirv-use-llvm-backend-target",
-    cl::desc("Convert LLVM to SPIR-V using the LLVM SPIR-V Backend target"),
+    cl::desc("Convert LLVM to SPIR-V using the LLVM SPIR-V Backend target if "
+             "it's available. Otherwise has no effect. Default behavior is to "
+             "don't use the LLVM SPIR-V Backend target."),
     cl::init(false));
 
 static std::string removeExt(const std::string &FileName) {
@@ -741,7 +743,7 @@ int main(int Ac, char **Av) {
 
   SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, ExtensionsStatus);
 #if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
-  Opts.useLLVMTarget(SPIRVUseLLVMSPIRVBackendTarget);
+  Opts.setUseLLVMTarget(SPIRVUseLLVMSPIRVBackendTarget);
 #endif
 
   if (ExtInst.getNumOccurrences() != 0) {

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -116,22 +116,6 @@ static cl::opt<VersionNumber> MaxSPIRVVersion(
                clEnumValN(VersionNumber::SPIRV_1_6, "1.6", "SPIR-V 1.6")),
     cl::init(VersionNumber::MaximumVersion));
 
-#if !defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
-// There is one conflict in command line argument names between SPIR-V Backend
-// and LLVM/SPIRV Translator: "spirv-ext". In order to avoid the inconsistency
-// in registered CommandLine options we register this command line option
-// globally only if SPIR-V Backend is unavailable and so the conflict doesn't
-// materialize. Otherwise we address the conflict in main() before parsing
-// command line options by renaming the instance of "spirv-ext" inserted in
-// SPIR-V Backend, and then adding the instance of "spirv-ext" required by
-// LLVM/SPIRV Translator from the corresponding auto variable.
-static cl::list<std::string>
-    SPVExt("spirv-ext", cl::CommaSeparated,
-           cl::desc("Specify list of allowed/disallowed extensions"),
-           cl::value_desc("+SPV_extenstion1_name,-SPV_extension2_name"),
-           cl::ValueRequired);
-#endif
-
 static cl::list<std::string> SPIRVAllowUnknownIntrinsics(
     "spirv-allow-unknown-intrinsics", cl::CommaSeparated,
     cl::desc("Unknown intrinsics that begin with any prefix from the "
@@ -734,12 +718,12 @@ int main(int Ac, char **Av) {
     OptToDisable->setArgStr("spirv-ext-coming-from-spirv-backend");
     OptToDisable->setHiddenFlag(cl::Hidden);
   }
+#endif
   cl::list<std::string> SPVExt(
       "spirv-ext", cl::CommaSeparated,
       cl::desc("Specify list of allowed/disallowed extensions"),
       cl::value_desc("+SPV_extenstion1_name,-SPV_extension2_name"),
       cl::ValueRequired);
-#endif
 
   cl::ParseCommandLineOptions(Ac, Av, "LLVM/SPIR-V translator");
 
@@ -757,7 +741,7 @@ int main(int Ac, char **Av) {
 
   SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, ExtensionsStatus);
 #if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
-  Opts.useLLVMSPIRVBackendTarget(SPIRVUseLLVMSPIRVBackendTarget);
+  Opts.useLLVMTarget(SPIRVUseLLVMSPIRVBackendTarget);
 #endif
 
   if (ExtInst.getNumOccurrences() != 0) {

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -116,11 +116,21 @@ static cl::opt<VersionNumber> MaxSPIRVVersion(
                clEnumValN(VersionNumber::SPIRV_1_6, "1.6", "SPIR-V 1.6")),
     cl::init(VersionNumber::MaximumVersion));
 
+#if !defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
+// There is one conflict in command line argument names between SPIR-V Backend
+// and LLVM/SPIRV Translator: "spirv-ext". In order to avoid the inconsistency
+// in registered CommandLine options we register this command line option
+// globally only if SPIR-V Backend is unavailable and so the conflict doesn't
+// materialize. Otherwise we address the conflict in main() before parsing
+// command line options by renaming the instance of "spirv-ext" inserted in
+// SPIR-V Backend, and then adding the instance of "spirv-ext" required by
+// LLVM/SPIRV Translator from the corresponding auto variable.
 static cl::list<std::string>
     SPVExt("spirv-ext", cl::CommaSeparated,
            cl::desc("Specify list of allowed/disallowed extensions"),
            cl::value_desc("+SPV_extenstion1_name,-SPV_extension2_name"),
            cl::ValueRequired);
+#endif
 
 static cl::list<std::string> SPIRVAllowUnknownIntrinsics(
     "spirv-allow-unknown-intrinsics", cl::CommaSeparated,
@@ -276,6 +286,11 @@ static cl::opt<SPIRV::BuiltinFormat> SPIRVBuiltinFormat(
                    "Use functions to represent SPIR-V builtin variables"),
         clEnumValN(SPIRV::BuiltinFormat::Global, "global",
                    "Use globals to represent SPIR-V builtin variables")));
+
+static cl::opt<bool> SPIRVUseLLVMSPIRVBackendTarget(
+    "spirv-use-llvm-backend-target",
+    cl::desc("Convert LLVM to SPIR-V using the LLVM SPIR-V Backend target"),
+    cl::init(false));
 
 static std::string removeExt(const std::string &FileName) {
   size_t Pos = FileName.find_last_of(".");
@@ -509,6 +524,7 @@ static int regularizeLLVM(SPIRV::TranslatorOpts &Opts) {
 }
 
 static int parseSPVExtOption(
+    cl::list<std::string> &SPVExtList,
     SPIRV::TranslatorOpts::ExtensionsStatusMap &ExtensionsStatus) {
   // Map name -> id for known extensions
   std::map<std::string, ExtensionID> ExtensionNamesMap;
@@ -531,11 +547,11 @@ static int parseSPVExtOption(
   for (const auto &It : ExtensionNamesMap)
     ExtensionsStatus[It.second] = DefaultVal;
 
-  if (SPVExt.empty())
+  if (SPVExtList.empty())
     return 0; // Nothing to do
 
-  for (unsigned i = 0; i < SPVExt.size(); ++i) {
-    const std::string &ExtString = SPVExt[i];
+  for (unsigned i = 0; i < SPVExtList.size(); ++i) {
+    const std::string &ExtString = SPVExtList[i];
     if (ExtString.empty() ||
         ('+' != ExtString.front() && '-' != ExtString.front())) {
       errs() << "Invalid value of --spirv-ext, expected format is:\n"
@@ -704,6 +720,27 @@ int main(int Ac, char **Av) {
   sys::PrintStackTraceOnErrorSignal(Av[0]);
   PrettyStackTraceProgram X(Ac, Av);
 
+#if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
+  // SPIR-V Backend is available, and so we have a clash of command line
+  // argument names, because both products use "spirv-ext" name. Let's rename
+  // the command line option coming from SPIR-V Backend, as it's not supposed to
+  // be used by a user anyway. After that we may safely add the instance of
+  // "spirv-ext" required by LLVM/SPIRV Translator from the corresponding auto
+  // variable (SPVExt).
+  StringMap<llvm::cl::Option *> &RegisteredOptions =
+      llvm::cl::getRegisteredOptions();
+  if (RegisteredOptions.count("spirv-ext") == 1) {
+    llvm::cl::Option *OptToDisable = RegisteredOptions["spirv-ext"];
+    OptToDisable->setArgStr("spirv-ext-coming-from-spirv-backend");
+    OptToDisable->setHiddenFlag(cl::Hidden);
+  }
+  cl::list<std::string> SPVExt(
+      "spirv-ext", cl::CommaSeparated,
+      cl::desc("Specify list of allowed/disallowed extensions"),
+      cl::value_desc("+SPV_extenstion1_name,-SPV_extension2_name"),
+      cl::ValueRequired);
+#endif
+
   cl::ParseCommandLineOptions(Ac, Av, "LLVM/SPIR-V translator");
 
   if (InputFile != "-" && isFileEmpty(InputFile)) {
@@ -714,11 +751,14 @@ int main(int Ac, char **Av) {
   SPIRV::TranslatorOpts::ExtensionsStatusMap ExtensionsStatus;
   // ExtensionsStatus will be properly initialized and update according to
   // values passed via --spirv-ext option in parseSPVExtOption function.
-  int Ret = parseSPVExtOption(ExtensionsStatus);
+  int Ret = parseSPVExtOption(SPVExt, ExtensionsStatus);
   if (0 != Ret)
     return Ret;
 
   SPIRV::TranslatorOpts Opts(MaxSPIRVVersion, ExtensionsStatus);
+#if defined(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
+  Opts.useLLVMSPIRVBackendTarget(SPIRVUseLLVMSPIRVBackendTarget);
+#endif
 
   if (ExtInst.getNumOccurrences() != 0) {
     if (ExtInst.getNumOccurrences() > 1) {


### PR DESCRIPTION
This PR adds an option to translate LLVM IR to SPIR-V using the LLVM SPIRV Backend target:
* cmake is modified to search for the LLVM SPIRV Backend target while configuring the project,
* if LLVM is built with SPIRV Backend support, we may use the interface exposed by SPIRV BE to translate Module to SPIR-V code if a user explicitly asks for this way of LLVM IR transaformation.