### PR TITLE
Centralise & tweak handling of SyncScope to SPIR-V translation

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -715,14 +715,6 @@ bool SPIRVRegularizeLLVMBase::regularize() {
           // %1 = insertvalue { i32, i1 } undef, i32 %cmpxchg.res, 0
           // %2 = insertvalue { i32, i1 } %1, i1 %cmpxchg.success, 1
 
-          // To get memory scope argument we use Cmpxchg->getSyncScopeID()
-          // but LLVM's cmpxchg instruction is not aware of OpenCL(or SPIR-V)
-          // memory scope enumeration. If the scope is not set and assuming the
-          // produced SPIR-V module will be consumed in an OpenCL environment,
-          // we can use the same memory scope as OpenCL atomic functions that do
-          // not have memory_scope argument, i.e. memory_scope_device. See the
-          // OpenCL C specification p6.13.11. Atomic Functions
-
           // cmpxchg LLVM instruction returns a pair {i32, i1}: the original
           // value and a flag indicating success (true) or failure (false).
           // OpAtomicCompareExchange SPIR-V instruction returns only the
@@ -733,15 +725,9 @@ bool SPIRVRegularizeLLVMBase::regularize() {
           // comparator, which matches with semantics of the flag returned by
           // cmpxchg.
           Value *Ptr = Cmpxchg->getPointerOperand();
-          SmallVector<StringRef> SSIDs;
-          Cmpxchg->getContext().getSyncScopeNames(SSIDs);
 
-          spv::Scope S;
-          // Fill unknown syncscope value to default Device scope.
-          if (!OCLStrMemScopeMap::find(SSIDs[Cmpxchg->getSyncScopeID()].str(),
-                                       &S)) {
-            S = ScopeDevice;
-          }
+          spv::Scope S = toSPIRVScope(Cmpxchg->getContext(),
+                                      Cmpxchg->getSyncScopeID());
           Value *MemoryScope = getInt32(M, S);
           auto SuccessOrder = static_cast<OCLMemOrderKind>(
               llvm::toCABI(Cmpxchg->getSuccessOrdering()));

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -726,8 +726,8 @@ bool SPIRVRegularizeLLVMBase::regularize() {
           // cmpxchg.
           Value *Ptr = Cmpxchg->getPointerOperand();
 
-          spv::Scope S = toSPIRVScope(Cmpxchg->getContext(),
-                                      Cmpxchg->getSyncScopeID());
+          spv::Scope S =
+              toSPIRVScope(Cmpxchg->getContext(), Cmpxchg->getSyncScopeID());
           Value *MemoryScope = getInt32(M, S);
           auto SuccessOrder = static_cast<OCLMemOrderKind>(
               llvm::toCABI(Cmpxchg->getSuccessOrdering()));

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1901,14 +1901,7 @@ static int transAtomicOrdering(llvm::AtomicOrdering Ordering) {
 
 SPIRVValue *LLVMToSPIRVBase::transAtomicStore(StoreInst *ST,
                                               SPIRVBasicBlock *BB) {
-  SmallVector<StringRef> SSIDs;
-  ST->getContext().getSyncScopeNames(SSIDs);
-
-  spv::Scope S;
-  // Fill unknown syncscope value to default Device scope.
-  if (!OCLStrMemScopeMap::find(SSIDs[ST->getSyncScopeID()].str(), &S)) {
-    S = ScopeDevice;
-  }
+  spv::Scope S = toSPIRVScope(ST->getContext(), ST->getSyncScopeID());
 
   std::vector<Value *> Ops{ST->getPointerOperand(), getUInt32(M, S),
                            getUInt32(M, transAtomicOrdering(ST->getOrdering())),
@@ -1921,14 +1914,7 @@ SPIRVValue *LLVMToSPIRVBase::transAtomicStore(StoreInst *ST,
 
 SPIRVValue *LLVMToSPIRVBase::transAtomicLoad(LoadInst *LD,
                                              SPIRVBasicBlock *BB) {
-  SmallVector<StringRef> SSIDs;
-  LD->getContext().getSyncScopeNames(SSIDs);
-
-  spv::Scope S;
-  // Fill unknown syncscope value to default Device scope.
-  if (!OCLStrMemScopeMap::find(SSIDs[LD->getSyncScopeID()].str(), &S)) {
-    S = ScopeDevice;
-  }
+  spv::Scope S = toSPIRVScope(LD->getContext(), LD->getSyncScopeID());
 
   std::vector<Value *> Ops{
       LD->getPointerOperand(), getUInt32(M, S),
@@ -2587,21 +2573,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     auto MemSem = OCLMemOrderMap::map(static_cast<OCLMemOrderKind>(Ordering));
     std::vector<Value *> Operands(4);
     Operands[0] = ARMW->getPointerOperand();
-    // To get the memory scope argument we use ARMW->getSyncScopeID(), but
-    // atomicrmw LLVM instruction is not aware of OpenCL(or SPIR-V) memory scope
-    // enumeration. If the scope is not set and assuming the produced SPIR-V
-    // module will be consumed in an OpenCL environment, we can use the same
-    // memory scope as OpenCL atomic functions that don't have memory_scope
-    // argument i.e. memory_scope_device. See the OpenCL C specification
-    // p6.13.11. "Atomic Functions"
-    SmallVector<StringRef> SSIDs;
-    ARMW->getContext().getSyncScopeNames(SSIDs);
-
-    spv::Scope S;
-    // Fill unknown syncscope value to default Device scope.
-    if (!OCLStrMemScopeMap::find(SSIDs[ARMW->getSyncScopeID()].str(), &S)) {
-      S = ScopeDevice;
-    }
+    spv::Scope S = toSPIRVScope(ARMW->getContext(), ARMW->getSyncScopeID());
     Operands[1] = getUInt32(M, S);
     Operands[2] = getUInt32(M, MemSem);
     Operands[3] = ARMW->getValOperand();
@@ -5211,13 +5183,7 @@ SPIRVValue *LLVMToSPIRVBase::transFenceInst(FenceInst *FI,
   }
 
   Module *M = FI->getParent()->getModule();
-  SmallVector<StringRef> SSIDs;
-  FI->getContext().getSyncScopeNames(SSIDs);
-  spv::Scope S;
-  // Treat all llvm.fence instructions as having CrossDevice scope by default
-  if (!OCLStrMemScopeMap::find(SSIDs[FI->getSyncScopeID()].str(), &S)) {
-    S = ScopeCrossDevice;
-  }
+  spv::Scope S = toSPIRVScope(FI->getContext(), FI->getSyncScopeID());
 
   SPIRVValue *RetScope = transConstant(getUInt32(M, S));
   SPIRVValue *Val = transConstant(getUInt32(M, MemorySemantics));

--- a/test/AtomicCompareExchange.ll
+++ b/test/AtomicCompareExchange.ll
@@ -4,7 +4,7 @@
 ; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-SPIRV: Constant [[Int]] [[MemScope_Device:[0-9]+]] 1
+; CHECK-SPIRV: Constant [[Int]] [[MemScope_CrossDevice:[0-9]+]] 0
 ; CHECK-SPIRV: Constant [[Int]] [[MemSemEqual_SeqCst:[0-9]+]] 16
 ; CHECK-SPIRV: Constant [[Int]] [[MemSemUnequal_Acquire:[0-9]+]] 2
 ; CHECK-SPIRV: Constant [[Int]] [[Constant_456:[0-9]+]] 456
@@ -18,7 +18,7 @@
 ; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[Comparator:[0-9]+]]
 
 ; CHECK-SPIRV: Load [[Int]] [[Value:[0-9]+]] [[Value_ptr]]
-; CHECK-SPIRV: AtomicCompareExchange [[Int]] [[Res:[0-9]+]] [[Pointer]] [[MemScope_Device]]
+; CHECK-SPIRV: AtomicCompareExchange [[Int]] [[Res:[0-9]+]] [[Pointer]] [[MemScope_CrossDevice]]
 ; CHECK-SPIRV-SAME:                  [[MemSemEqual_SeqCst]] [[MemSemUnequal_Acquire]] [[Value]] [[Comparator]]
 ; CHECK-SPIRV: IEqual {{[0-9]+}} [[Success:[0-9]+]] [[Res]] [[Comparator]]
 ; CHECK-SPIRV: CompositeInsert [[Struct]] [[Composite_0:[0-9]+]] [[Res]] [[UndefStruct]] 0
@@ -48,7 +48,7 @@ cmpxchg.continue:                                 ; preds = %cmpxchg.store_expec
 ; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[Ptr:[0-9]+]]
 ; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[Store_ptr:[0-9]+]]
 
-; CHECK-SPIRV: AtomicCompareExchange [[Int]] [[Res_1:[0-9]+]] [[Ptr]] [[MemScope_Device]]
+; CHECK-SPIRV: AtomicCompareExchange [[Int]] [[Res_1:[0-9]+]] [[Ptr]] [[MemScope_CrossDevice]]
 ; CHECK-SPIRV-SAME:                  [[MemSemEqual_SeqCst]] [[MemSemUnequal_Acquire]] [[Constant_456]] [[Constant_128]]
 ; CHECK-SPIRV: IEqual {{[0-9]+}} [[Success_1:[0-9]+]] [[Res_1]] [[Constant_128]]
 ; CHECK-SPIRV: CompositeInsert [[Struct]] [[Composite:[0-9]+]] [[Res_1]] [[UndefStruct]] 0

--- a/test/atomic-load-store.ll
+++ b/test/atomic-load-store.ll
@@ -3,11 +3,10 @@
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s
 
-; CHECK-DAG: Constant [[#]] [[#Relaxed:]] 0
-; CHECK-DAG: Constant [[#]] [[#DeviceScope:]] 1
-; CHECK-DAG: Constant [[#]] [[#Acquire:]] 2
+; CHECK-DAG: Constant [[#]] [[#CrossDeviceScope:]] 0
 ; CHECK-DAG: Constant [[#]] [[#Release:]] 4
 ; CHECK-DAG: Constant [[#]] [[#SequentiallyConsistent:]] 16
+; CHECK-DAG: Constant [[#]] [[#Acquire:]] 2
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"
@@ -18,18 +17,18 @@ entry:
 ; CHECK: Variable [[#]] [[#PTR:]]
   %0 = alloca i32
 
-; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#Relaxed]] [[#]]
+; CHECK: AtomicStore [[#PTR]] [[#CrossDeviceScope]] {{.+}} [[#]]
   store atomic i32 0, ptr %0 monotonic, align 4
-; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#Release]] [[#]]
+; CHECK: AtomicStore [[#PTR]] [[#CrossDeviceScope]] [[#Release]] [[#]]
   store atomic i32 0, ptr %0 release, align 4
-; CHECK: AtomicStore [[#PTR]] [[#DeviceScope]] [[#SequentiallyConsistent]] [[#]]
+; CHECK: AtomicStore [[#PTR]] [[#CrossDeviceScope]] [[#SequentiallyConsistent]] [[#]]
   store atomic i32 0, ptr %0 seq_cst, align 4
 
-; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#Relaxed]]
+; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#CrossDeviceScope]] {{.+}}
   %1 = load atomic i32, ptr %0 monotonic, align 4
-; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#Acquire]]
+; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#CrossDeviceScope]] [[#Acquire]]
   %2 = load atomic i32, ptr %0 acquire, align 4
-; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#DeviceScope]] [[#SequentiallyConsistent]]
+; CHECK: AtomicLoad [[#]] [[#]] [[#PTR]] [[#CrossDeviceScope]] [[#SequentiallyConsistent]]
   %3 = load atomic i32, ptr %0 seq_cst, align 4
   ret void
 }

--- a/test/atomicrmw.ll
+++ b/test/atomicrmw.ll
@@ -4,7 +4,6 @@
 ; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s
 
 ; CHECK: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-DAG: Constant [[Int]] [[Scope_Device:[0-9]+]] 1 {{$}}
 ; CHECK-DAG: Constant [[Int]] [[MemSem_Relaxed:[0-9]+]] 0
 ; CHECK-DAG: Constant [[Int]] [[MemSem_Acquire:[0-9]+]] 2
 ; CHECK-DAG: Constant [[Int]] [[MemSem_Release:[0-9]+]] 4 {{$}}
@@ -26,37 +25,37 @@ target triple = "spir64"
 define dso_local spir_func void @test_atomicrmw() local_unnamed_addr #0 {
 entry:
   %0 = atomicrmw xchg ptr addrspace(1) @ui, i32 42 acq_rel
-; CHECK: AtomicExchange [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_AcquireRelease]] [[Value]]
+; CHECK: AtomicExchange [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_AcquireRelease]] [[Value]]
 
   %1 = atomicrmw xchg ptr addrspace(1) @f, float 42.000000e+00 seq_cst
-; CHECK: AtomicExchange [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[FPValue]]
+; CHECK: AtomicExchange [[Float]] {{[0-9]+}} [[FPPointer]] {{.+}} [[MemSem_SequentiallyConsistent]] [[FPValue]]
 
   %2 = atomicrmw add ptr addrspace(1) @ui, i32 42 monotonic
-; CHECK: AtomicIAdd [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Relaxed]] [[Value]]
+; CHECK: AtomicIAdd [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_Relaxed]] [[Value]]
 
   %3 = atomicrmw sub ptr addrspace(1) @ui, i32 42 acquire
-; CHECK: AtomicISub [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Acquire]] [[Value]]
+; CHECK: AtomicISub [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_Acquire]] [[Value]]
 
   %4 = atomicrmw or ptr addrspace(1) @ui, i32 42 release
-; CHECK: AtomicOr [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Release]] [[Value]]
+; CHECK: AtomicOr [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_Release]] [[Value]]
 
   %5 = atomicrmw xor ptr addrspace(1) @ui, i32 42 acq_rel
-; CHECK: AtomicXor [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_AcquireRelease]] [[Value]]
+; CHECK: AtomicXor [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_AcquireRelease]] [[Value]]
 
   %6 = atomicrmw and ptr addrspace(1) @ui, i32 42 seq_cst
-; CHECK: AtomicAnd [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[Value]]
+; CHECK: AtomicAnd [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_SequentiallyConsistent]] [[Value]]
 
   %7 = atomicrmw max ptr addrspace(1) @ui, i32 42 monotonic
-; CHECK: AtomicSMax [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Relaxed]] [[Value]]
+; CHECK: AtomicSMax [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_Relaxed]] [[Value]]
 
   %8 = atomicrmw min ptr addrspace(1) @ui, i32 42 acquire
-; CHECK: AtomicSMin [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Acquire]] [[Value]]
+; CHECK: AtomicSMin [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_Acquire]] [[Value]]
 
   %9 = atomicrmw umax ptr addrspace(1) @ui, i32 42 release
-; CHECK: AtomicUMax [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_Release]] [[Value]]
+; CHECK: AtomicUMax [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_Release]] [[Value]]
 
   %10 = atomicrmw umin ptr addrspace(1) @ui, i32 42 acq_rel
-; CHECK: AtomicUMin [[Int]] {{[0-9]+}} [[Pointer]] [[Scope_Device]] [[MemSem_AcquireRelease]] [[Value]]
+; CHECK: AtomicUMin [[Int]] {{[0-9]+}} [[Pointer]] {{.+}} [[MemSem_AcquireRelease]] [[Value]]
 
   ret void
 }

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fadd_double.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fadd_double.ll
@@ -6,7 +6,7 @@
 ; CHECK-DAG: Extension "SPV_EXT_shader_atomic_float_add"
 ; CHECK-DAG: Capability AtomicFloat64AddEXT
 ; CHECK: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-DAG: Constant [[Int]] [[Scope_Device:[0-9]+]] 1 {{$}}
+; CHECK-DAG: Constant [[Int]] [[Scope_CrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-DAG: Constant [[Int]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK: TypeFloat [[Double:[0-9]+]] 64
 ; CHECK: Variable {{[0-9]+}} [[DoublePointer:[0-9]+]]
@@ -21,7 +21,7 @@ target triple = "spir64"
 define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fadd ptr addrspace(1) @f, double 42.000000e+00 seq_cst
-; CHECK: AtomicFAddEXT [[Double]] {{[0-9]+}} [[DoublePointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[DoubleValue]]
+; CHECK: AtomicFAddEXT [[Double]] {{[0-9]+}} [[DoublePointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[DoubleValue]]
 
   ret void
 }

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fadd_float.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fadd_float.ll
@@ -6,7 +6,7 @@
 ; CHECK-DAG: Extension "SPV_EXT_shader_atomic_float_add"
 ; CHECK-DAG: Capability AtomicFloat32AddEXT
 ; CHECK: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-DAG: Constant [[Int]] [[Scope_Device:[0-9]+]] 1 {{$}}
+; CHECK-DAG: Constant [[Int]] [[Scope_CrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-DAG: Constant [[Int]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK: TypeFloat [[Float:[0-9]+]] 32
 ; CHECK: Variable {{[0-9]+}} [[FPPointer:[0-9]+]]
@@ -21,7 +21,7 @@ target triple = "spir64"
 define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fadd ptr addrspace(1) @f, float 42.000000e+00 seq_cst
-; CHECK: AtomicFAddEXT [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[FPValue]]
+; CHECK: AtomicFAddEXT [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[FPValue]]
 
   ret void
 }

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fadd_half.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fadd_half.ll
@@ -7,7 +7,7 @@
 ; CHECK-DAG: Extension "SPV_EXT_shader_atomic_float_add"
 ; CHECK-DAG: Capability AtomicFloat16AddEXT
 ; CHECK: TypeInt [[TypeIntID:[0-9]+]] 32 0
-; CHECK-DAG: Constant [[TypeIntID]] [[ScopeDevice:[0-9]+]] 1 {{$}}
+; CHECK-DAG: Constant [[TypeIntID]] [[ScopeCrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-DAG: Constant [[TypeIntID]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK: TypeFloat [[TypeFloatHalfID:[0-9]+]] 16
 ; CHECK: Variable {{[0-9]+}} [[HalfPointer:[0-9]+]]
@@ -22,7 +22,7 @@ target triple = "spir64"
 define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fadd ptr addrspace(1) @f, half 42.000000e+00 seq_cst
-; CHECK: AtomicFAddEXT [[TypeFloatHalfID]] {{[0-9]+}} [[HalfPointer]] [[ScopeDevice]] [[MemSem_SequentiallyConsistent]] [[HalfValue]]
+; CHECK: AtomicFAddEXT [[TypeFloatHalfID]] {{[0-9]+}} [[HalfPointer]] [[ScopeCrossDevice]] [[MemSem_SequentiallyConsistent]] [[HalfValue]]
 
   ret void
 }

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fsub_double.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fsub_double.ll
@@ -9,7 +9,7 @@
 ; CHECK-SPIRV-DAG: Extension "SPV_EXT_shader_atomic_float_add"
 ; CHECK-SPIRV-DAG: Capability AtomicFloat64AddEXT
 ; CHECK-SPIRV: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-SPIRV-DAG: Constant [[Int]] [[Scope_Device:[0-9]+]] 1 {{$}}
+; CHECK-SPIRV-DAG: Constant [[Int]] [[Scope_CrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-SPIRV-DAG: Constant [[Int]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK-SPIRV: TypeFloat [[Double:[0-9]+]] 64
 ; CHECK-SPIRV: Variable {{[0-9]+}} [[DoublePointer:[0-9]+]]
@@ -25,7 +25,7 @@ define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fsub ptr addrspace(1) @f, double 42.000000e+00 seq_cst
 ; CHECK-SPIRV: FNegate [[Double]] [[NegateValue:[0-9]+]] [[DoubleValue]]
-; CHECK-SPIRV: AtomicFAddEXT [[Double]] {{[0-9]+}} [[DoublePointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[NegateValue]]
+; CHECK-SPIRV: AtomicFAddEXT [[Double]] {{[0-9]+}} [[DoublePointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[NegateValue]]
 ; CHECK-LLVM: [[FNegateLLVM:%[0-9]+]] = fneg double 4.200000e+01
 ; CHECK-LLVM: call spir_func double {{.*}}atomic_add{{.*}}(ptr addrspace(1) @f, double [[FNegateLLVM]])
   ret void

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fsub_float.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fsub_float.ll
@@ -9,7 +9,7 @@
 ; CHECK-SPIRV-DAG: Extension "SPV_EXT_shader_atomic_float_add"
 ; CHECK-SPIRV-DAG: Capability AtomicFloat32AddEXT
 ; CHECK-SPIRV: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-SPIRV-DAG: Constant [[Int]] [[Scope_Device:[0-9]+]] 1 {{$}}
+; CHECK-SPIRV-DAG: Constant [[Int]] [[Scope_CrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-SPIRV-DAG: Constant [[Int]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK-SPIRV: TypeFloat [[Float:[0-9]+]] 32
 ; CHECK-SPIRV: Variable {{[0-9]+}} [[FPPointer:[0-9]+]]
@@ -25,7 +25,7 @@ define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fsub ptr addrspace(1) @f, float 42.000000e+00 seq_cst
 ; CHECK-SPIRV: FNegate [[Float]] [[NegateValue:[0-9]+]] [[FPValue]]
-; CHECK-SPIRV: AtomicFAddEXT [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[NegateValue]]
+; CHECK-SPIRV: AtomicFAddEXT [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[NegateValue]]
 ; CHECK-LLVM: [[FNegateLLVM:%[0-9]+]] = fneg float 4.200000e+01
 ; CHECK-LLVM: call spir_func float {{.*}}atomic_add{{.*}}(ptr addrspace(1) @f, float [[FNegateLLVM]])
   ret void

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fsub_half.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_/atomicrmw_fsub_half.ll
@@ -10,7 +10,7 @@
 ; CHECK-SPIRV-DAG: Extension "SPV_EXT_shader_atomic_float_add"
 ; CHECK-SPIRV-DAG: Capability AtomicFloat16AddEXT
 ; CHECK-SPIRV: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-SPIRV-DAG: Constant [[Int]] [[ScopeDevice:[0-9]+]] 1 {{$}}
+; CHECK-SPIRV-DAG: Constant [[Int]] [[ScopeCrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-SPIRV-DAG: Constant [[Int]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK-SPIRV: TypeFloat [[Half:[0-9]+]] 16
 ; CHECK-SPIRV: Variable {{[0-9]+}} [[HalfPointer:[0-9]+]]
@@ -26,7 +26,7 @@ define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fsub ptr addrspace(1) @f, half 1.0e+00 seq_cst
 ; CHECK-SPIRV: FNegate [[Half]] [[NegateValue:[0-9]+]] [[HalfValue]]
-; CHECK-SPIRV: AtomicFAddEXT [[Half]] {{[0-9]+}} [[HalfPointer]] [[ScopeDevice]] [[MemSem_SequentiallyConsistent]] [[NegateValue]]
+; CHECK-SPIRV: AtomicFAddEXT [[Half]] {{[0-9]+}} [[HalfPointer]] [[ScopeCrossDevice]] [[MemSem_SequentiallyConsistent]] [[NegateValue]]
 ; CHECK-LLVM: [[FNegateLLVM:%[0-9]+]] = fneg half 0xH3C00
 ; CHECK-LLVM: call spir_func half {{.*}}atomic_add{{.*}}(ptr addrspace(1) @f, half [[FNegateLLVM]])
   ret void

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_min_max/atomicrmw_fminfmax_double.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_min_max/atomicrmw_fminfmax_double.ll
@@ -6,7 +6,7 @@
 ; CHECK-DAG: Extension "SPV_EXT_shader_atomic_float_min_max"
 ; CHECK-DAG: Capability AtomicFloat64MinMaxEXT
 ; CHECK: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-DAG: Constant [[Int]] [[Scope_Device:[0-9]+]] 1 {{$}}
+; CHECK-DAG: Constant [[Int]] [[Scope_CrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-DAG: Constant [[Int]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK: TypeFloat [[Double:[0-9]+]] 64
 ; CHECK: Variable {{[0-9]+}} [[DoublePointer:[0-9]+]]
@@ -21,9 +21,9 @@ target triple = "spir64"
 define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fmin ptr addrspace(1) @f, double 42.000000e+00 seq_cst
-; CHECK: AtomicFMinEXT [[Double]] {{[0-9]+}} [[DoublePointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[DoubleValue]]
+; CHECK: AtomicFMinEXT [[Double]] {{[0-9]+}} [[DoublePointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[DoubleValue]]
  %1 = atomicrmw fmax ptr addrspace(1) @f, double 42.000000e+00 seq_cst
-; CHECK: AtomicFMaxEXT [[Double]] {{[0-9]+}} [[DoublePointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[DoubleValue]]
+; CHECK: AtomicFMaxEXT [[Double]] {{[0-9]+}} [[DoublePointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[DoubleValue]]
 
   ret void
 }

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_min_max/atomicrmw_fminfmax_float.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_min_max/atomicrmw_fminfmax_float.ll
@@ -6,7 +6,7 @@
 ; CHECK-DAG: Extension "SPV_EXT_shader_atomic_float_min_max"
 ; CHECK-DAG: Capability AtomicFloat32MinMaxEXT
 ; CHECK: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-DAG: Constant [[Int]] [[Scope_Device:[0-9]+]] 1 {{$}}
+; CHECK-DAG: Constant [[Int]] [[Scope_CrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-DAG: Constant [[Int]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK: TypeFloat [[Float:[0-9]+]] 32
 ; CHECK: Variable {{[0-9]+}} [[FPPointer:[0-9]+]]
@@ -21,9 +21,9 @@ target triple = "spir64"
 define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fmin ptr addrspace(1) @f, float 42.000000e+00 seq_cst
-; CHECK: AtomicFMinEXT [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[FPValue]]
+; CHECK: AtomicFMinEXT [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[FPValue]]
  %1 = atomicrmw fmax ptr addrspace(1) @f, float 42.000000e+00 seq_cst
-; CHECK: AtomicFMaxEXT [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[FPValue]]
+; CHECK: AtomicFMaxEXT [[Float]] {{[0-9]+}} [[FPPointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[FPValue]]
 
   ret void
 }

--- a/test/extensions/EXT/SPV_EXT_shader_atomic_float_min_max/atomicrmw_fminfmax_half.ll
+++ b/test/extensions/EXT/SPV_EXT_shader_atomic_float_min_max/atomicrmw_fminfmax_half.ll
@@ -6,7 +6,7 @@
 ; CHECK-DAG: Extension "SPV_EXT_shader_atomic_float_min_max"
 ; CHECK-DAG: Capability AtomicFloat16MinMaxEXT
 ; CHECK: TypeInt [[Int:[0-9]+]] 32 0
-; CHECK-DAG: Constant [[Int]] [[Scope_Device:[0-9]+]] 1 {{$}}
+; CHECK-DAG: Constant [[Int]] [[Scope_CrossDevice:[0-9]+]] 0 {{$}}
 ; CHECK-DAG: Constant [[Int]] [[MemSem_SequentiallyConsistent:[0-9]+]] 16
 ; CHECK: TypeFloat [[Half:[0-9]+]] 16
 ; CHECK: Variable {{[0-9]+}} [[HalfPointer:[0-9]+]]
@@ -21,9 +21,9 @@ target triple = "spir64"
 define dso_local spir_func void @test_atomicrmw_fadd() local_unnamed_addr #0 {
 entry:
  %0 = atomicrmw fmin ptr addrspace(1) @f, half 42.000000e+00 seq_cst
-; CHECK: AtomicFMinEXT [[Half]] {{[0-9]+}} [[HalfPointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[HalfValue]]
+; CHECK: AtomicFMinEXT [[Half]] {{[0-9]+}} [[HalfPointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[HalfValue]]
  %1 = atomicrmw fmax ptr addrspace(1) @f, half 42.000000e+00 seq_cst
-; CHECK: AtomicFMaxEXT [[Half]] {{[0-9]+}} [[HalfPointer]] [[Scope_Device]] [[MemSem_SequentiallyConsistent]] [[HalfValue]]
+; CHECK: AtomicFMaxEXT [[Half]] {{[0-9]+}} [[HalfPointer]] [[Scope_CrossDevice]] [[MemSem_SequentiallyConsistent]] [[HalfValue]]
 
   ret void
 }

--- a/test/transcoding/OpenCL/atomic_syncscope_test.ll
+++ b/test/transcoding/OpenCL/atomic_syncscope_test.ll
@@ -37,12 +37,12 @@ target triple = "spir64"
 ; AtomicLoad ResTypeId ResId PtrId MemScopeId MemSemanticsId
 ; CHECK-SPIRV: AtomicLoad [[#]] [[#]] [[#]] [[#ConstInt2]] [[#SequentiallyConsistent]]
 ; CHECK-SPIRV: AtomicLoad [[#]] [[#]] [[#]] [[#ConstInt1]] [[#SequentiallyConsistent]]
-; CHECK-SPIRV: AtomicLoad [[#]] [[#]] [[#]] [[#ConstInt1]] [[#SequentiallyConsistent]]
+; CHECK-SPIRV: AtomicLoad [[#]] [[#]] [[#]] [[#ConstInt0]] [[#SequentiallyConsistent]]
 ; CHECK-SPIRV: AtomicLoad [[#]] [[#]] [[#]] [[#ConstInt3]] [[#SequentiallyConsistent]]
 
 ; CHECK-LLVM: call spir_func i32 @_Z20atomic_load_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(ptr{{.*}}, i32 5, i32 1)
 ; CHECK-LLVM: call spir_func i32 @_Z20atomic_load_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(ptr{{.*}}, i32 5, i32 2)
-; CHECK-LLVM: call spir_func i32 @_Z20atomic_load_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(ptr{{.*}}, i32 5, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z20atomic_load_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(ptr{{.*}}, i32 5, i32 3)
 ; CHECK-LLVM: call spir_func i32 @_Z20atomic_load_explicitPU3AS4VU7_Atomici12memory_order12memory_scope(ptr{{.*}}, i32 5, i32 4)
 
 define dso_local void @fi1(ptr addrspace(4) nocapture noundef readonly %i) local_unnamed_addr #0 {
@@ -70,13 +70,13 @@ entry:
 ; Atomic* ResTypeId ResId PtrId MemScopeId MemSemanticsId ValueId
 ; CHECK-SPIRV: AtomicAnd [[#]] [[#]] [[#]] [[#ConstInt4]] [[#SequentiallyConsistent]] [[#ConstInt1]]
 ; CHECK-SPIRV: AtomicSMin [[#]] [[#]] [[#]] [[#ConstInt0]] [[#SequentiallyConsistent]] [[#ConstInt1]]
-; CHECK-SPIRV: AtomicSMax [[#]] [[#]] [[#]] [[#ConstInt1]] [[#SequentiallyConsistent]] [[#ConstInt1]]
+; CHECK-SPIRV: AtomicSMax [[#]] [[#]] [[#]] [[#ConstInt0]] [[#SequentiallyConsistent]] [[#ConstInt1]]
 ; CHECK-SPIRV: AtomicUMin [[#]] [[#]] [[#]] [[#ConstInt2]] [[#SequentiallyConsistent]] [[#ConstInt1]]
 ; CHECK-SPIRV: AtomicUMax [[#]] [[#]] [[#]] [[#ConstInt2]] [[#SequentiallyConsistent]] [[#ConstInt1]]
 
 ; CHECK-LLVM: call spir_func i32 @_Z25atomic_fetch_and_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(ptr{{.*}}, i32 1, i32 5, i32 0)
 ; CHECK-LLVM: call spir_func i32 @_Z25atomic_fetch_min_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(ptr{{.*}}, i32 1, i32 5, i32 3)
-; CHECK-LLVM: call spir_func i32 @_Z25atomic_fetch_max_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(ptr{{.*}}, i32 1, i32 5, i32 2)
+; CHECK-LLVM: call spir_func i32 @_Z25atomic_fetch_max_explicitPU3AS4VU7_Atomicii12memory_order12memory_scope(ptr{{.*}}, i32 1, i32 5, i32 3)
 ; CHECK-LLVM: call spir_func i32 @_Z25atomic_fetch_min_explicitPU3AS4VU7_Atomicjj12memory_order12memory_scope(ptr{{.*}}, i32 1, i32 5, i32 1)
 ; CHECK-LLVM: call spir_func i32 @_Z25atomic_fetch_max_explicitPU3AS4VU7_Atomicjj12memory_order12memory_scope(ptr{{.*}}, i32 1, i32 5, i32 1)
 

--- a/test/transcoding/fence_inst.ll
+++ b/test/transcoding/fence_inst.ll
@@ -23,7 +23,7 @@
 ; CHECK-SPIRV: MemoryBarrier [[#CD]] [[#ID1]]
 ; CHECK-SPIRV: MemoryBarrier [[#CD]] [[#ID2]]
 ; CHECK-SPIRV: MemoryBarrier [[#CD]] [[#ID3]]
-; CHECK-SPIRV: MemoryBarrier [[#CD]] [[#ID4]]
+; CHECK-SPIRV: MemoryBarrier [[#ID2]] [[#ID4]]
 ; CHECK-SPIRV: MemoryBarrier [[#ID1]] [[#ID2]]
 
 


### PR DESCRIPTION
This patch collects the mapping from LLVM SyncScope ID, which was spread out across multiple sites, into a single utility function. Furthermore, it realigns the mapping to match LLVM conventions, namely it defaults to `System` / `CrossDevice` (please see <https://github.com/llvm/llvm-project/pull/106429>) for more context for the proposed changes.