### PR TITLE
Update header.ll DebugInfo test after LLVM change

### DIFF
--- a/test/DebugInfo/X86/header.ll
+++ b/test/DebugInfo/X86/header.ll
@@ -19,7 +19,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK:       .text
 ; CHECK-NEXT: .file	"<stdin>"
 ; CHECK-NEXT: .globl	f
-; CHECK-NEXT: .p2align	4, 0x90
+; CHECK-NEXT: .p2align	4
 ; CHECK-NEXT: .type	f,@function
 ; CHECK-NEXT: f:                                      # @f
 


### PR DESCRIPTION
Update a test after llvm commit e6bf48d11047 ("[X86] Don't request 0x90 nop filling in p2align directives (#110134)", 2024-10-02).