### PR TITLE
Fix unannotated fall-through warning in SPIRVWriter.cpp

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3713,6 +3713,7 @@ void addAnnotationDecorations(SPIRVEntry *E, DecorationsInfoVec &Decorations) {
         E->addDecorate(new SPIRVDecorateCacheControlLoadINTEL(
             E, CacheLevel, static_cast<LoadCacheControl>(CacheControl)));
       }
+      break;
     }
 
     default:


### PR DESCRIPTION
By adding the missing `break`.
```
SPIRV-LLVM-Translator/lib/SPIRV/SPIRVWriter.cpp:3718:5: warning: unannotated fall-through between switch labels [-Wimplicit-fallthrough]
 3718 |     default:
      |     ^
SPIRV-LLVM-Translator/lib/SPIRV/SPIRVWriter.cpp:3718:5: note: insert 'break;' to avoid fall-through
 3718 |     default:
      |     ^
      |     break;
```
As the default case was just `break`, the behaviour is the same but this should prevent future mistakes here.