### PR TITLE
Fix string to bool conversion warnings in some asserts

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -513,13 +513,14 @@ void prepareCacheControlsTranslation(Metadata *MD, Instruction *Inst) {
   for (unsigned I = 0, E = ArgDecoMD->getNumOperands(); I != E; ++I) {
     auto *DecoMD = dyn_cast<MDNode>(ArgDecoMD->getOperand(I));
     if (!DecoMD) {
-      assert(!"Decoration does not name metadata");
+      assert(false && "Decoration does not name metadata");
       return;
     }
 
     constexpr size_t CacheControlsNumOps = 4;
     if (DecoMD->getNumOperands() != CacheControlsNumOps) {
-      assert(!"Cache controls metadata on instruction must have 4 operands");
+      assert(false &&
+             "Cache controls metadata on instruction must have 4 operands");
       return;
     }
 
@@ -532,7 +533,7 @@ void prepareCacheControlsTranslation(Metadata *MD, Instruction *Inst) {
             ->getZExtValue();
     Value *PtrInstOp = Inst->getOperand(TargetArgNo);
     if (!PtrInstOp->getType()->isPointerTy()) {
-      assert(!"Cache controls must decorate a pointer");
+      assert(false && "Cache controls must decorate a pointer");
       return;
     }
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5459,7 +5459,7 @@ void LLVMToSPIRVBase::transGlobalAnnotation(GlobalVariable *V) {
 
     StringRef AnnotationString;
     if (!getConstantStringInfo(GV, AnnotationString)) {
-      assert(!"Annotation string missing");
+      assert(false && "Annotation string missing");
       return;
     }
     DecorationsInfoVec Decorations =


### PR DESCRIPTION
```
/SPIRV-LLVM-Translator/lib/SPIRV/SPIRVRegularizeLLVM.cpp:535:15: warning: implicit conversion turns string literal into bool: 'const char[39]' to 'bool' [-Wstring-conversion]
  535 |       assert(!"Cache controls must decorate a pointer");
      |              ~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/assert.h:93:27: note: expanded from macro 'assert'
   93 |      (static_cast <bool> (expr)                                         \
      |                           ^~~~
```
The original code is not wrong but `false &&` is only a few characters more and does the same thing without warning.