### PR TITLE
Remove unused private member from LLVMParallelAccessIndices

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1650,7 +1650,7 @@ class LLVMParallelAccessIndices {
 public:
   LLVMParallelAccessIndices(
       MDNode *Node, LLVMToSPIRVBase::LLVMToSPIRVMetadataMap &IndexGroupArrayMap)
-      : Node(Node), IndexGroupArrayMap(IndexGroupArrayMap) {
+      : Node(Node) {
 
     assert(isValid() &&
            "LLVMParallelAccessIndices initialized from an invalid MDNode");
@@ -1694,7 +1694,6 @@ public:
 
 private:
   MDNode *Node;
-  LLVMToSPIRVBase::LLVMToSPIRVMetadataMap &IndexGroupArrayMap;
   const std::string ExpectedName = "llvm.loop.parallel_access_indices";
   std::vector<SPIRVId> ArrayVariablesVec;
   unsigned SafeLen;


### PR DESCRIPTION
```
.../SPIRV-LLVM-Translator/lib/SPIRV/SPIRVWriter.cpp:1697:44: warning: private field 'IndexGroupArrayMap' is not used [-Wunused-private-field]
 1697 |   LLVMToSPIRVBase::LLVMToSPIRVMetadataMap &IndexGroupArrayMap;
      |
```
IndexGroupArrayMap is used but only during the constructor to validate and build other things.

This change happened in 4a7804bc45ada92b8365c82b99387726382b5d7d where code was moved from a separate method, into the constructor.