### PR TITLE
UnXFAIL untyped_var test after spirv-tools update

### DIFF
--- a/test/extensions/KHR/SPV_KHR_untyped_pointers/untyped_var.spvasm
+++ b/test/extensions/KHR/SPV_KHR_untyped_pointers/untyped_var.spvasm
@@ -1,6 +1,3 @@
-; TODO: enable back once spirv-tools are updated.
-; XFAIL: *
-
 ; REQUIRES: spirv-as
 ; RUN: spirv-as --target-env spv1.6 -o %t.spv %s
 ; RUN: spirv-val %t.spv


### PR DESCRIPTION
With the latest release of spirv-tools (1.3.296) this test now passes.