### PR TITLE
Require spirv-dis in zero-length-array.ll

### DIFF
--- a/test/zero-length-array.ll
+++ b/test/zero-length-array.ll
@@ -1,3 +1,4 @@
+; REQUIRES: spirv-dis
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-dis %t.spv | FileCheck %s


### PR DESCRIPTION
We might not build spirv-dis.
