### PR TITLE
Add missing requirements spirv-val to tests

### DIFF
--- a/test/CXX/global-ctor.cl
+++ b/test/CXX/global-ctor.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -cl-std=clc++ -emit-llvm-bc -triple spir -O0 %s -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/ComparePointers.cl
+++ b/test/ComparePointers.cl
@@ -8,6 +8,7 @@ kernel void test(int global *in, int global *in2) {
   if (in < in2)
     return;
 }
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir64 -x cl -cl-std=CL2.0 -O0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc --spirv-max-version=1.3 -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/FPFastMathModeNotNaNFast.spvasm
+++ b/test/FPFastMathModeNotNaNFast.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/GEPOperator.spvasm
+++ b/test/GEPOperator.spvasm
@@ -1,7 +1,7 @@
 ; It's possible that access to builtin variable is represented by
 ; GetElementPtrConstantExpr rather than GetElementPtrInst. This
 ; test case presents a pattern that results into a ConstantExpr.
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/GroupAndSubgroupInstructions.spvasm
+++ b/test/GroupAndSubgroupInstructions.spvasm
@@ -61,7 +61,7 @@
 ; llvm-spirv tmp.bc --spirv-ext=+all,-SPV_KHR_untyped_pointers -o tmp.spv
 ; spirv-dis tmp.spv -o llvm-spirv/test/GroupAndSubgroupInstructions.spvasm
 
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as %s --target-env spv1.3 -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv --spirv-target-env=CL1.2 -o %t.bc

--- a/test/OpConstantNull.spvasm
+++ b/test/OpConstantNull.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpConvertPtrToU_narrowing.spvasm
+++ b/test/OpConvertPtrToU_narrowing.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpConvertPtrToU_widening.spvasm
+++ b/test/OpConvertPtrToU_widening.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpConvertUToPtr_narrowing.spvasm
+++ b/test/OpConvertUToPtr_narrowing.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpConvertUToPtr_widening.spvasm
+++ b/test/OpConvertUToPtr_widening.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpCopyLogical.spvasm
+++ b/test/OpCopyLogical.spvasm
@@ -1,6 +1,6 @@
 ; Check support of OpCopyLogical instruction that was added in SPIR-V 1.4
 
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.4 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/OpDecorateString_UserSemantic.spvasm
+++ b/test/OpDecorateString_UserSemantic.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.4 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpDecorateString_UserSemantic_Builtin.spvasm
+++ b/test/OpDecorateString_UserSemantic_Builtin.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.4 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o - | llvm-dis | FileCheck --check-prefix=CHECK-OCL %s

--- a/test/OpFMod_f32.spvasm
+++ b/test/OpFMod_f32.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpFMod_v2f16.spvasm
+++ b/test/OpFMod_v2f16.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpGroupIAdd.spt
+++ b/test/OpGroupIAdd.spt
@@ -30,6 +30,7 @@
 ; to _Z21work_group_reduce_addj, instead.  Remove this test and update
 ; test/transcoding/group_ops.cl when fixing this.
 ; XFAIL: *
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/OpIAdd.spvasm
+++ b/test/OpIAdd.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpIMul.spvasm
+++ b/test/OpIMul.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpISub.spvasm
+++ b/test/OpISub.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpLogicalAnd.spvasm
+++ b/test/OpLogicalAnd.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpLogicalEqual.spvasm
+++ b/test/OpLogicalEqual.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpLogicalNot.spvasm
+++ b/test/OpLogicalNot.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpLogicalNotEqual.spvasm
+++ b/test/OpLogicalNotEqual.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpLogicalOr.spvasm
+++ b/test/OpLogicalOr.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpLoopMergeNone.spt
+++ b/test/OpLoopMergeNone.spt
@@ -79,6 +79,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/OpMemberDecorateString_UserSemantic.spvasm
+++ b/test/OpMemberDecorateString_UserSemantic.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.4 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpNoLine.spvasm
+++ b/test/OpNoLine.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpNop.spvasm
+++ b/test/OpNop.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpNot.spvasm
+++ b/test/OpNot.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpSMod_i32.spvasm
+++ b/test/OpSMod_i32.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpSMod_v2i16.spvasm
+++ b/test/OpSMod_v2i16.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpSNegate.spvasm
+++ b/test/OpSNegate.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpShiftLeftLogical.spvasm
+++ b/test/OpShiftLeftLogical.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpVectorShuffle.spvasm
+++ b/test/OpVectorShuffle.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/OpenCL.std/acos.spvasm
+++ b/test/OpenCL.std/acos.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s --check-prefixes=CHECK,CHECK-SPV-IR

--- a/test/OpenCL.std/printf.spvasm
+++ b/test/OpenCL.std/printf.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o %t.rev.bc

--- a/test/OpenCL.std/upsample.spvasm
+++ b/test/OpenCL.std/upsample.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s --check-prefixes=CHECK,CHECK-SPV-IR

--- a/test/OpenCL.std/vload_half.spvasm
+++ b/test/OpenCL.std/vload_half.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s --check-prefixes=CHECK,CHECK-SPV-IR

--- a/test/OpenCL.std/vload_halfn.spvasm
+++ b/test/OpenCL.std/vload_halfn.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s --check-prefixes=CHECK,CHECK-SPV-IR

--- a/test/OpenCL.std/vloada_halfn.spvasm
+++ b/test/OpenCL.std/vloada_halfn.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s --check-prefixes=CHECK,CHECK-SPV-IR

--- a/test/OpenCL.std/vloadn.spvasm
+++ b/test/OpenCL.std/vloadn.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s --check-prefixes=CHECK,CHECK-SPV-IR

--- a/test/OpenCL.std/vstore_half.spvasm
+++ b/test/OpenCL.std/vstore_half.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o %t.rev.bc

--- a/test/OpenCL.std/vstore_halfn.spvasm
+++ b/test/OpenCL.std/vstore_halfn.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o %t.rev.bc

--- a/test/OpenCL.std/vstorea_halfn.spvasm
+++ b/test/OpenCL.std/vstorea_halfn.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o %t.rev.bc

--- a/test/OpenCL.std/vstoren.spvasm
+++ b/test/OpenCL.std/vstoren.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -r --spirv-target-env=SPV-IR -o %t.rev.bc

--- a/test/SpecConstants/OpSpecConstantComposite.spvasm
+++ b/test/SpecConstants/OpSpecConstantComposite.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 

--- a/test/SpecConstants/specconstantop-arraylength.spvasm
+++ b/test/SpecConstants/specconstantop-arraylength.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 

--- a/test/SpecConstants/specconstantop-copymemsized.spvasm
+++ b/test/SpecConstants/specconstantop-copymemsized.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 

--- a/test/atomic_explicit_arguments.spt
+++ b/test/atomic_explicit_arguments.spt
@@ -29,6 +29,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc

--- a/test/barrier_explicit_arguments.spt
+++ b/test/barrier_explicit_arguments.spt
@@ -24,6 +24,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.bc

--- a/test/builtin_returns_struct.spvasm
+++ b/test/builtin_returns_struct.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/composite_construct_array_non_constant.spvasm
+++ b/test/composite_construct_array_non_constant.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/composite_construct_struct.spt
+++ b/test/composite_construct_struct.spt
@@ -47,6 +47,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/composite_construct_struct_non_constant.spt
+++ b/test/composite_construct_struct_non_constant.spt
@@ -1,3 +1,4 @@
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/composite_construct_vector.spt
+++ b/test/composite_construct_vector.spt
@@ -41,6 +41,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/composite_construct_vector_non_constant.spvasm
+++ b/test/composite_construct_vector_non_constant.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/copy_object.spt
+++ b/test/copy_object.spt
@@ -38,6 +38,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/event_no_group_cap.cl
+++ b/test/event_no_group_cap.cl
@@ -2,6 +2,7 @@ __kernel void test_fn( const __global char *src)
 {
 	wait_group_events(0, NULL);
 }
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir64 -x cl -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -O0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s

--- a/test/extensions/EXT/SPV_EXT_image_raw10_raw12/reader.spvasm
+++ b/test/extensions/EXT/SPV_EXT_image_raw10_raw12/reader.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/extensions/INTEL/SPV_INTEL_media_block_io/SPV_INTEL_media_block_io.cl
+++ b/test/extensions/INTEL/SPV_INTEL_media_block_io/SPV_INTEL_media_block_io.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv --spirv-ext=+SPV_INTEL_media_block_io %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/extensions/KHR/SPV_KHR_cooperative_matrix/length.spvasm
+++ b/test/extensions/KHR/SPV_KHR_cooperative_matrix/length.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/extensions/KHR/SPV_KHR_shader_clock/shader_clock.cl
+++ b/test/extensions/KHR/SPV_KHR_shader_clock/shader_clock.cl
@@ -1,4 +1,4 @@
-// REQUIRES: spirv-dis
+// REQUIRES: spirv-dis, spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_shader_clock -o %t.spv
 // RUN: spirv-dis %t.spv -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/extensions/KHR/SPV_KHR_untyped_pointers/untyped_var.spvasm
+++ b/test/extensions/KHR/SPV_KHR_untyped_pointers/untyped_var.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.6 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 

--- a/test/float_atomic_spv_to_ocl12.spt
+++ b/test/float_atomic_spv_to_ocl12.spt
@@ -72,6 +72,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc --spirv-target-env="CL1.2"

--- a/test/ignore-builtin-linkage-name.spt
+++ b/test/ignore-builtin-linkage-name.spt
@@ -47,6 +47,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -spirv-target-env=SPV-IR -o - | llvm-dis | FileCheck %s -check-prefix=CHECK-LLVM

--- a/test/image-unoptimized.cl
+++ b/test/image-unoptimized.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 %s -triple spir -O0 -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s

--- a/test/image_without_access_qualifier.spt
+++ b/test/image_without_access_qualifier.spt
@@ -64,6 +64,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/linkage-name.spt
+++ b/test/linkage-name.spt
@@ -23,6 +23,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/matrix_times_matrix.spt
+++ b/test/matrix_times_matrix.spt
@@ -1,3 +1,4 @@
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/matrix_times_scalar.spt
+++ b/test/matrix_times_scalar.spt
@@ -1,3 +1,4 @@
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/matrix_times_vector.spt
+++ b/test/matrix_times_vector.spt
@@ -33,6 +33,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/matrix_transpose.spt
+++ b/test/matrix_transpose.spt
@@ -1,3 +1,4 @@
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/mem_fence_explicit_arguments.spt
+++ b/test/mem_fence_explicit_arguments.spt
@@ -26,6 +26,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/negative/InvalidAtomicBuiltins.cl
+++ b/test/negative/InvalidAtomicBuiltins.cl
@@ -1,6 +1,7 @@
 // Check that translator doesn't generate atomic instructions for atomic builtins
 // which are not defined in the spec.
 
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir -O1 -cl-std=cl2.0 -fdeclare-opencl-builtins -finclude-default-header %s -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/opundef.spt
+++ b/test/opundef.spt
@@ -38,6 +38,7 @@
 
 1 FunctionEnd 
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/phi-multiple-predecessors.spvasm
+++ b/test/phi-multiple-predecessors.spvasm
@@ -1,4 +1,4 @@
-; REQUIRES: spirv-as
+; REQUIRES: spirv-as, spirv-val
 ; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s

--- a/test/read_image.cl
+++ b/test/read_image.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir64 -fdeclare-opencl-builtins -finclude-default-header -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv --spirv-max-version=1.3 %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/redundant_word.spt
+++ b/test/redundant_word.spt
@@ -27,7 +27,7 @@
 
 1 FunctionEnd 
 
-
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/right_shift.spt
+++ b/test/right_shift.spt
@@ -42,6 +42,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/sampler-variable.spt
+++ b/test/sampler-variable.spt
@@ -21,6 +21,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; Reverse translation shouldn't crash:

--- a/test/selection_merge.spt
+++ b/test/selection_merge.spt
@@ -65,6 +65,7 @@
 1 Return
 
 1 FunctionEnd
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt

--- a/test/spirv-extensions-control.spt
+++ b/test/spirv-extensions-control.spt
@@ -39,6 +39,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; The purpose of this test is to check that SPIR-V file that uses extensions is

--- a/test/spirv-ocl-builtins-version.spt
+++ b/test/spirv-ocl-builtins-version.spt
@@ -30,6 +30,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 

--- a/test/spirv-version-controls.spt
+++ b/test/spirv-version-controls.spt
@@ -27,6 +27,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv --spirv-max-version=1.1 -o %t

--- a/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
+++ b/test/transcoding/AtomicCompareExchangeExplicit_cl20.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/BuiltinPrintf.cl
+++ b/test/transcoding/BuiltinPrintf.cl
@@ -1,5 +1,6 @@
 // Ensure __builtin_printf is translated to a SPIRV printf instruction
 
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/ConvertPtr.cl
+++ b/test/transcoding/ConvertPtr.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/DivRem.cl
+++ b/test/transcoding/DivRem.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/GenericCastToPtr.cl
+++ b/test/transcoding/GenericCastToPtr.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -emit-llvm-bc -fdeclare-opencl-builtins -finclude-default-header %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/OpImageSampleExplicitLod_arg.cl
+++ b/test/transcoding/OpImageSampleExplicitLod_arg.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -O1 -triple spir-unknown-unknown -cl-std=CL2.0 %s -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/OpenCL/atomic_cmpxchg.cl
+++ b/test/transcoding/OpenCL/atomic_cmpxchg.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -emit-llvm-bc -fdeclare-opencl-builtins -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/OpenCL/atomic_legacy.cl
+++ b/test/transcoding/OpenCL/atomic_legacy.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -emit-llvm-bc -fdeclare-opencl-builtins -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/OpenCL/atomic_work_item_fence.cl
+++ b/test/transcoding/OpenCL/atomic_work_item_fence.cl
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 //
+// REQUIRES: spirv-val
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/OpenCL/barrier.cl
+++ b/test/transcoding/OpenCL/barrier.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/OpenCL/mem_fence.cl
+++ b/test/transcoding/OpenCL/mem_fence.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 %s -triple spir -cl-std=CL1.2 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/OpenCL/sub_group_barrier.cl
+++ b/test/transcoding/OpenCL/sub_group_barrier.cl
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 //
+// REQUIRES: spirv-val
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/OpenCL/sub_group_mask.cl
+++ b/test/transcoding/OpenCL/sub_group_mask.cl
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 
+// REQUIRES: spirv-val
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/OpenCL/work_group_barrier.cl
+++ b/test/transcoding/OpenCL/work_group_barrier.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 %s -triple spir -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/Printf.cl
+++ b/test/transcoding/Printf.cl
@@ -1,5 +1,6 @@
 // Ensure printf is translated to a SPIRV printf instruction
 
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -emit-llvm-bc %s -o %t.bc -finclude-default-header
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/RelationalOperators.cl
+++ b/test/transcoding/RelationalOperators.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/SampledImage.cl
+++ b/test/transcoding/SampledImage.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir -cl-std=CL2.0 %s -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
 // RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/TransFNeg.cl
+++ b/test/transcoding/TransFNeg.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O0 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/atomic_flag.cl
+++ b/test/transcoding/atomic_flag.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/atomics.spt
+++ b/test/transcoding/atomics.spt
@@ -50,7 +50,7 @@
 
 1 FunctionEnd 
 
-
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t1.spv
 ; RUN: spirv-val %t1.spv
 ; RUN: llvm-spirv -r %t1.spv -o %t1.bc --spirv-target-env="CL1.2"

--- a/test/transcoding/atomics_int64.spt
+++ b/test/transcoding/atomics_int64.spt
@@ -50,6 +50,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv --to-binary %s -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv --spirv-target-env=CL1.2 -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/transcoding/bit_ops.cl
+++ b/test/transcoding/bit_ops.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/block_w_struct_return.cl
+++ b/test/transcoding/block_w_struct_return.cl
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -triple spir -cl-std=cl2.0 -disable-llvm-passes -fdeclare-opencl-builtins -finclude-default-header %s -emit-llvm-bc -o %t.bc
 
+// REQUIRES: spirv-val
 // RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV1_1,CHECK-SPIRV
 // RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spirv1.1.spv
 // RUN: spirv-val --target-env spv1.1 %t.spirv1.1.spv

--- a/test/transcoding/clk_event_t.cl
+++ b/test/transcoding/clk_event_t.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/enqueue_kernel.cl
+++ b/test/transcoding/enqueue_kernel.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 // RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/enqueue_marker.cl
+++ b/test/transcoding/enqueue_marker.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -fdeclare-opencl-builtins -finclude-default-header -O0 -cl-std=CL2.0 -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spv.txt
 // RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/explicit-conversions.cl
+++ b/test/transcoding/explicit-conversions.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/global_block.cl
+++ b/test/transcoding/global_block.cl
@@ -5,6 +5,7 @@
 
 // RUN: %clang_cc1 -O0 -triple spir-unknown-unknown -cl-std=CL2.0 -x cl %s -emit-llvm-bc -o %t.bc
 
+// REQUIRES: spirv-val
 // RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spirv1.1.spv
 // RUN: spirv-val --target-env spv1.1 %t.spirv1.1.spv

--- a/test/transcoding/group_ops.cl
+++ b/test/transcoding/group_ops.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/ldexp.cl
+++ b/test/transcoding/ldexp.cl
@@ -1,4 +1,5 @@
 // Check that translator converts scalar arg to vector for ldexp math instructions
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -o %t.spv
 // RUN: spirv-val %t.spv

--- a/test/transcoding/pipe_builtins.cl
+++ b/test/transcoding/pipe_builtins.cl
@@ -1,5 +1,6 @@
 // Pipe built-ins are mangled accordingly to SPIR2.0/C++ ABI.
 
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -x cl -cl-std=CL2.0 -triple spir64-unknown-unknown -emit-llvm-bc -fdeclare-opencl-builtins -finclude-default-header -Dcl_khr_subgroups %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/transcoding/subgroup_spirv_1_5.cl
+++ b/test/transcoding/subgroup_spirv_1_5.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: not llvm-spirv --spirv-max-version=1.4 %t.bc 2>&1 | FileCheck --check-prefix=CHECK-ERROR %s
 // RUN: llvm-spirv %t.bc -o %t.spv

--- a/test/transcoding/vec_type_hint.cl
+++ b/test/transcoding/vec_type_hint.cl
@@ -1,3 +1,4 @@
+// REQUIRES: spirv-val
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -x cl -cl-std=CL2.0 -O0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc -spirv-text -o %t.spt
 // RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV

--- a/test/vector_times_matrix.spt
+++ b/test/vector_times_matrix.spt
@@ -33,6 +33,7 @@
 
 1 FunctionEnd
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc

--- a/test/vector_times_scalar.spt
+++ b/test/vector_times_scalar.spt
@@ -49,6 +49,7 @@
 
 1 FunctionEnd 
 
+; REQUIRES: spirv-val
 ; RUN: llvm-spirv %s -to-binary -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.bc


### PR DESCRIPTION
There is a feature that checks if spirv-val exists, but no test that uses spirv-val requires that it exists.