### PR TITLE
Update for typeIncompatible LLVM API change

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3033,7 +3033,8 @@ void SPIRVToLLVM::transFunctionAttrs(SPIRVFunction *BF, Function *F) {
     auto *BA = BF->getArgument(I->getArgNo());
     mapValue(BA, &(*I));
     setName(&(*I), BA);
-    AttributeMask IllegalAttrs = AttributeFuncs::typeIncompatible(I->getType());
+    AttributeMask IllegalAttrs =
+        AttributeFuncs::typeIncompatible(I->getType(), I->getAttributes());
     BA->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
       // Skip this function parameter attribute as it will translated among
       // OpenCL metadata


### PR DESCRIPTION
Update after llvm-project commit c85611e8583e
("[SimplifyLibCall][Attribute] Fix bug where we may keep `range` attr with incompatible type (#112649)", 2024-10-17).