### PR TITLE
SPIRVReader: Add OpCopyMemory support

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1822,8 +1822,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         BC->getSrcAlignment() ? MaybeAlign(BC->getSrcAlignment()) : Align;
     Type *EltTy =
         transType(BC->getSource()->getType()->getPointerElementType());
-    uint64_t Size =
-        M->getDataLayout().getTypeSizeInBits(EltTy).getFixedValue() / 8;
+    uint64_t Size = M->getDataLayout().getTypeStoreSize(EltTy).getFixedValue();
     bool IsVolatile = BC->SPIRVMemoryAccess::isVolatile();
     IRBuilder<> Builder(BB);
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1814,21 +1814,40 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     return mapValue(BV, LI);
   }
 
+  case OpCopyMemory:
   case OpCopyMemorySized: {
-    SPIRVCopyMemorySized *BC = static_cast<SPIRVCopyMemorySized *>(BV);
-    CallInst *CI = nullptr;
-    llvm::Value *Dst = transValue(BC->getTarget(), F, BB);
-    MaybeAlign Align(BC->getAlignment());
-    MaybeAlign SrcAlign =
-        BC->getSrcAlignment() ? MaybeAlign(BC->getSrcAlignment()) : Align;
-    llvm::Value *Size = transValue(BC->getSize(), F, BB);
-    bool IsVolatile = BC->SPIRVMemoryAccess::isVolatile();
-    IRBuilder<> Builder(BB);
-
-    if (!CI) {
-      llvm::Value *Src = transValue(BC->getSource(), F, BB);
-      CI = Builder.CreateMemCpy(Dst, Align, Src, SrcAlign, Size, IsVolatile);
+    llvm::Value *Src = nullptr;
+    llvm::Value *Dst = nullptr;
+    llvm::Value *Size = nullptr;
+    SPIRVMemoryAccess *MA = nullptr;
+    if (OC == OpCopyMemory) {
+      auto *BC = static_cast<SPIRVCopyMemory *>(BV);
+      Src = transValue(BC->getSource(), F, BB);
+      Dst = transValue(BC->getTarget(), F, BB);
+      Type *EltTy =
+          transType(BC->getSource()->getType()->getPointerElementType());
+      Size = ConstantExpr::getSizeOf(EltTy);
+      MA = static_cast<SPIRVMemoryAccess *>(BC);
+    } else {
+      assert(OC == OpCopyMemorySized);
+      auto *BC = static_cast<SPIRVCopyMemorySized *>(BV);
+      Src = transValue(BC->getSource(), F, BB);
+      Dst = transValue(BC->getTarget(), F, BB);
+      Size = transValue(BC->getSize(), F, BB);
+      MA = static_cast<SPIRVMemoryAccess *>(BC);
     }
+    assert(Src);
+    assert(Dst);
+    assert(Size);
+    assert(MA);
+    MaybeAlign Align(MA->getAlignment());
+    MaybeAlign SrcAlign =
+        MA->getSrcAlignment() ? MaybeAlign(MA->getSrcAlignment()) : Align;
+    bool IsVolatile = MA->SPIRVMemoryAccess::isVolatile();
+
+    IRBuilder<> Builder(BB);
+    CallInst *CI =
+        Builder.CreateMemCpy(Dst, Align, Src, SrcAlign, Size, IsVolatile);
     if (isFuncNoUnwind())
       CI->getFunction()->addFnAttr(Attribute::NoUnwind);
     return mapValue(BV, CI);

--- a/test/OpCopyMemory.spvasm
+++ b/test/OpCopyMemory.spvasm
@@ -11,31 +11,41 @@
                OpCapability Kernel
                OpMemoryModel Physical64 OpenCL
                OpEntryPoint Kernel %kernel "copymemory"
+               OpName %pStruct "pStruct"
+               OpName %dstStruct "dstStruct"
                OpName %pShort "pShort"
                OpName %dstShort "dstShort"
                OpName %pInt "pInt"
                OpName %dstInt "dstInt"
      %ushort = OpTypeInt 16 0
        %uint = OpTypeInt 32 0
+     %struct = OpTypeStruct %ushort %uint %ushort
        %void = OpTypeVoid
+%gptr_struct = OpTypePointer CrossWorkgroup %struct
+%pptr_struct = OpTypePointer Function %struct
  %gptr_short = OpTypePointer CrossWorkgroup %ushort
  %pptr_short = OpTypePointer Function %ushort
    %gptr_int = OpTypePointer CrossWorkgroup %uint
    %pptr_int = OpTypePointer Function %uint
- %kernel_sig = OpTypeFunction %void %gptr_short %gptr_int
+ %kernel_sig = OpTypeFunction %void %gptr_short %gptr_int %gptr_struct
   %ushort_42 = OpConstant %ushort 42
   %uint_4242 = OpConstant %uint 4242
+%struct_init = OpConstantComposite %struct %ushort_42 %uint_4242 %ushort_42
      %kernel = OpFunction %void None %kernel_sig
    %dstShort = OpFunctionParameter %gptr_short
      %dstInt = OpFunctionParameter %gptr_int
+  %dstStruct = OpFunctionParameter %gptr_struct
       %entry = OpLabel
      %pShort = OpVariable %pptr_short Function %ushort_42
        %pInt = OpVariable %pptr_int Function %uint_4242
+    %pStruct = OpVariable %pptr_struct Function %struct_init
                OpCopyMemory %dstShort %pShort
                OpCopyMemory %dstInt %pInt
+               OpCopyMemory %dstStruct %pStruct
                OpReturn
                OpFunctionEnd
 
-; CHECK-LABEL: define spir_kernel void @copymemory(ptr addrspace(1) %dstShort, ptr addrspace(1) %dstInt)
-; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstShort, ptr @pShort, i64 ptrtoint (ptr getelementptr (i16, ptr null, i32 1) to i64), i1 false)
-; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstInt, ptr @pInt, i64 ptrtoint (ptr getelementptr (i32, ptr null, i32 1) to i64), i1 false)
+; CHECK-LABEL: define spir_kernel void @copymemory(ptr addrspace(1) %dstShort, ptr addrspace(1) %dstInt, ptr addrspace(1) %dstStruct)
+; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstShort, ptr @pShort, i64 2, i1 false)
+; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstInt, ptr @pInt, i64 4, i1 false)
+; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstStruct, ptr @pStruct, i64 12, i1 false)

--- a/test/OpCopyMemory.spvasm
+++ b/test/OpCopyMemory.spvasm
@@ -1,0 +1,41 @@
+; Check SPIRVReader support for OpCopyMemory.
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
+
+               OpCapability Addresses
+               OpCapability Int16
+               OpCapability Kernel
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "copymemory"
+               OpName %pShort "pShort"
+               OpName %dstShort "dstShort"
+               OpName %pInt "pInt"
+               OpName %dstInt "dstInt"
+     %ushort = OpTypeInt 16 0
+       %uint = OpTypeInt 32 0
+       %void = OpTypeVoid
+ %gptr_short = OpTypePointer CrossWorkgroup %ushort
+ %pptr_short = OpTypePointer Function %ushort
+   %gptr_int = OpTypePointer CrossWorkgroup %uint
+   %pptr_int = OpTypePointer Function %uint
+ %kernel_sig = OpTypeFunction %void %gptr_short %gptr_int
+  %ushort_42 = OpConstant %ushort 42
+  %uint_4242 = OpConstant %uint 4242
+     %kernel = OpFunction %void None %kernel_sig
+   %dstShort = OpFunctionParameter %gptr_short
+     %dstInt = OpFunctionParameter %gptr_int
+      %entry = OpLabel
+     %pShort = OpVariable %pptr_short Function %ushort_42
+       %pInt = OpVariable %pptr_int Function %uint_4242
+               OpCopyMemory %dstShort %pShort
+               OpCopyMemory %dstInt %pInt
+               OpReturn
+               OpFunctionEnd
+
+; CHECK-LABEL: define spir_kernel void @copymemory(ptr addrspace(1) %dstShort, ptr addrspace(1) %dstInt)
+; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstShort, ptr @pShort, i64 ptrtoint (ptr getelementptr (i16, ptr null, i32 1) to i64), i1 false)
+; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstInt, ptr @pInt, i64 ptrtoint (ptr getelementptr (i32, ptr null, i32 1) to i64), i1 false)


### PR DESCRIPTION
Add support for translating `OpCopyMemory` into `llvm.memcpy`.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2769