### PR TITLE
Translate integer dot product SPIR-V builtins to OCL builtins

### DIFF
--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1335,6 +1335,21 @@ public:
     } else if (NameRef.starts_with("bitfield_extract_signed") ||
                NameRef.starts_with("bitfield_extract_unsigned")) {
       addUnsignedArgs(1, 2);
+    } else if (NameRef.starts_with("dot_unpacked_") ||
+               NameRef.starts_with("dot_acc_sat_unpacked_")) {
+      if (NameRef.ends_with("_uu")) {
+        addUnsignedArgs(0, 1);
+        if (NameRef.starts_with("dot_acc_sat_unpacked_"))
+          addUnsignedArg(2);
+      }
+      else if (NameRef.ends_with("_su") || NameRef.ends_with("_su"))
+        addUnsignedArg(1);
+      NameRef = NameRef.drop_back(std::string("_unpacked_uu").length());
+    } else if (NameRef.starts_with("dot_4x8packed_") ||
+               NameRef.starts_with("dot_acc_sat_4x8packed_")) {
+        addUnsignedArgs(0, 1);
+      if (NameRef == "dot_acc_sat_4x8packed_uu_uint")
+        addUnsignedArg(2);
     }
 
     // Store the final version of a function name

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1341,13 +1341,12 @@ public:
         addUnsignedArgs(0, 1);
         if (NameRef.starts_with("dot_acc_sat_unpacked_"))
           addUnsignedArg(2);
-      }
-      else if (NameRef.ends_with("_su") || NameRef.ends_with("_su"))
+      } else if (NameRef.ends_with("_su") || NameRef.ends_with("_su"))
         addUnsignedArg(1);
       NameRef = NameRef.drop_back(std::string("_unpacked_uu").length());
     } else if (NameRef.starts_with("dot_4x8packed_") ||
                NameRef.starts_with("dot_acc_sat_4x8packed_")) {
-        addUnsignedArgs(0, 1);
+      addUnsignedArgs(0, 1);
       if (NameRef == "dot_acc_sat_4x8packed_uu_uint")
         addUnsignedArg(2);
     }

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -1335,20 +1335,20 @@ public:
     } else if (NameRef.starts_with("bitfield_extract_signed") ||
                NameRef.starts_with("bitfield_extract_unsigned")) {
       addUnsignedArgs(1, 2);
-    } else if (NameRef.starts_with("dot_unpacked_") ||
-               NameRef.starts_with("dot_acc_sat_unpacked_")) {
-      if (NameRef.ends_with("_uu")) {
+    } else if (NameRef.starts_with("dot_")) {
+      if (NameRef.contains("4x8packed")) {
         addUnsignedArgs(0, 1);
-        if (NameRef.starts_with("dot_acc_sat_unpacked_"))
+        if (NameRef == "dot_acc_sat_4x8packed_uu_uint")
           addUnsignedArg(2);
-      } else if (NameRef.ends_with("_su") || NameRef.ends_with("_su"))
-        addUnsignedArg(1);
-      NameRef = NameRef.drop_back(std::string("_unpacked_uu").length());
-    } else if (NameRef.starts_with("dot_4x8packed_") ||
-               NameRef.starts_with("dot_acc_sat_4x8packed_")) {
-      addUnsignedArgs(0, 1);
-      if (NameRef == "dot_acc_sat_4x8packed_uu_uint")
-        addUnsignedArg(2);
+      } else {
+        if (NameRef.ends_with("_uu")) {
+          addUnsignedArgs(0, 1);
+          if (NameRef.starts_with("dot_acc_sat"))
+            addUnsignedArg(2);
+        } else if (NameRef.ends_with("_su"))
+          addUnsignedArg(1);
+        NameRef = NameRef.drop_back(std::string("_uu").length());
+      }
     }
 
     // Store the final version of a function name

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -224,9 +224,8 @@ void SPIRVToOCLBase::visitCallInst(CallInst &CI) {
     visitCallSPIRVBFloat16Conversions(&CI, OC);
     return;
   }
-  if (OC == OpSDotKHR || OC == OpUDotKHR || OC == OpSUDotKHR ||
-      OC == OpSDotAccSatKHR || OC == OpUDotAccSatKHR ||
-      OC == OpSUDotAccSatKHR) {
+  if (OC == OpSDot || OC == OpUDot || OC == OpSUDot || OC == OpSDotAccSat ||
+      OC == OpUDotAccSat || OC == OpSUDotAccSat) {
     visitCallSPIRVDot(&CI, OC, DemangledName);
     return;
   }
@@ -951,37 +950,37 @@ void SPIRVToOCLBase::visitCallSPIRVDot(CallInst *CI, Op OC,
   bool IsPacked = !CI->getOperand(0)->getType()->isVectorTy();
   std::stringstream Name;
   switch (OC) {
-  case OpSDotKHR:
+  case OpSDot:
     if (IsPacked)
       Name << kOCLBuiltinName::Dot4x8PackedPrefix << "ss_int";
     else
       Name << kOCLBuiltinName::Dot << "_unpacked_ss";
     break;
-  case OpUDotKHR:
+  case OpUDot:
     if (IsPacked)
       Name << kOCLBuiltinName::Dot4x8PackedPrefix << "uu_uint";
     else
       Name << kOCLBuiltinName::Dot << "_unpacked_uu";
     break;
-  case OpSUDotKHR:
+  case OpSUDot:
     if (IsPacked)
       Name << kOCLBuiltinName::Dot4x8PackedPrefix << "su_int";
     else
       Name << kOCLBuiltinName::Dot << "_unpacked_su";
     break;
-  case OpSDotAccSatKHR:
+  case OpSDotAccSat:
     if (IsPacked)
       Name << kOCLBuiltinName::DotAccSat4x8PackedPrefix << "ss_int";
     else
       Name << kOCLBuiltinName::DotAccSat << "_unpacked_ss";
     break;
-  case OpUDotAccSatKHR:
+  case OpUDotAccSat:
     if (IsPacked)
       Name << kOCLBuiltinName::DotAccSat4x8PackedPrefix << "uu_uint";
     else
       Name << kOCLBuiltinName::DotAccSat << "_unpacked_uu";
     break;
-  case OpSUDotAccSatKHR:
+  case OpSUDotAccSat:
     if (IsPacked)
       Name << kOCLBuiltinName::DotAccSat4x8PackedPrefix << "su_int";
     else

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -954,37 +954,38 @@ void SPIRVToOCLBase::visitCallSPIRVDot(CallInst *CI, Op OC,
     if (IsPacked)
       Name << kOCLBuiltinName::Dot4x8PackedPrefix << "ss_int";
     else
-      Name << kOCLBuiltinName::Dot << "_unpacked_ss";
+      // Add an extra suffix to help determine signed/unsigned arguments
+      Name << kOCLBuiltinName::Dot << "_ss";
     break;
   case OpUDot:
     if (IsPacked)
       Name << kOCLBuiltinName::Dot4x8PackedPrefix << "uu_uint";
     else
-      Name << kOCLBuiltinName::Dot << "_unpacked_uu";
+      Name << kOCLBuiltinName::Dot << "_uu";
     break;
   case OpSUDot:
     if (IsPacked)
       Name << kOCLBuiltinName::Dot4x8PackedPrefix << "su_int";
     else
-      Name << kOCLBuiltinName::Dot << "_unpacked_su";
+      Name << kOCLBuiltinName::Dot << "_su";
     break;
   case OpSDotAccSat:
     if (IsPacked)
       Name << kOCLBuiltinName::DotAccSat4x8PackedPrefix << "ss_int";
     else
-      Name << kOCLBuiltinName::DotAccSat << "_unpacked_ss";
+      Name << kOCLBuiltinName::DotAccSat << "_ss";
     break;
   case OpUDotAccSat:
     if (IsPacked)
       Name << kOCLBuiltinName::DotAccSat4x8PackedPrefix << "uu_uint";
     else
-      Name << kOCLBuiltinName::DotAccSat << "_unpacked_uu";
+      Name << kOCLBuiltinName::DotAccSat << "_uu";
     break;
   case OpSUDotAccSat:
     if (IsPacked)
       Name << kOCLBuiltinName::DotAccSat4x8PackedPrefix << "su_int";
     else
-      Name << kOCLBuiltinName::DotAccSat << "_unpacked_su";
+      Name << kOCLBuiltinName::DotAccSat << "_su";
     break;
   default:
     break; // do nothing

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -258,6 +258,10 @@ public:
   // Transform FP atomic opcode to corresponding OpenCL function name
   virtual std::string mapFPAtomicName(Op OC) = 0;
 
+  /// Transform integer dot product builtins to corresponding OpenCL builtins
+  /// examples: __spirv_SDotKHR => dot, __spirv_SDotAccSatKHR => dot_acc_sat
+  void visitCallSPIRVDot(CallInst *CI, Op OC, StringRef DemangledName);
+
   void translateOpaqueTypes();
 
 private:

--- a/test/extensions/KHR/SPV_KHR_integer_dot_product/SPV_KHR_integer_dot_product-nonsat.ll
+++ b/test/extensions/KHR/SPV_KHR_integer_dot_product/SPV_KHR_integer_dot_product-nonsat.ll
@@ -44,17 +44,17 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK-LLVM: call spir_func i8 @_Z21__spirv_SDotKHR_Rchariii(
 ; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_Rshortiii(
-; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_Rintiii(
+; CHECK-LLVM: call spir_func i32 @_Z20dot_4x8packed_ss_intjj(
 ; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_Rlongiii(
 
 ; CHECK-LLVM: call spir_func i8 @_Z22__spirv_UDotKHR_Ruchariii(
 ; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_Rushortiii(
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_Ruintiii(
+; CHECK-LLVM: call spir_func i32 @_Z21dot_4x8packed_uu_uintjj(
 ; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_Rulongiii(
 
 ; CHECK-LLVM: call spir_func i8 @_Z22__spirv_SUDotKHR_Rchariii(
 ; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_Rshortiii(
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_Rintiii(
+; CHECK-LLVM: call spir_func i32 @_Z20dot_4x8packed_su_intjj(
 ; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_Rlongiii(
 
 ; CHECK-SPV-IR: call spir_func i8 @_Z21__spirv_SDotKHR_Rchariii(
@@ -112,17 +112,17 @@ define spir_kernel void @TestNonSatPacked(i32 %0, i32 %1) #0 !kernel_arg_addr_sp
 
 ; CHECK-LLVM: call spir_func i8 @_Z21__spirv_SDotKHR_RcharDv4_cS_(
 ; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_RshortDv4_cS_(
-; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_RintDv4_cS_(
+; CHECK-LLVM: call spir_func i32 @_Z3dotDv4_cS_(
 ; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_RlongDv4_cS_(
 
 ; CHECK-LLVM: call spir_func i8 @_Z22__spirv_UDotKHR_RucharDv4_cS_(
 ; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_RushortDv4_cS_(
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_RuintDv4_cS_(
+; CHECK-LLVM: call spir_func i32 @_Z3dotDv4_hS_(
 ; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_RulongDv4_cS_(
 
 ; CHECK-LLVM: call spir_func i8 @_Z22__spirv_SUDotKHR_RcharDv4_cS_(
 ; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_RshortDv4_cS_(
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_RintDv4_cS_(
+; CHECK-LLVM: call spir_func i32 @_Z3dotDv4_cDv4_h(
 ; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_RlongDv4_cS_(
 
 ; CHECK-SPV-IR: call spir_func i8 @_Z21__spirv_SDotKHR_RcharDv4_cS_(
@@ -179,15 +179,15 @@ define spir_kernel void @TestNonSatVec(<4 x i8> %0, <4 x i8> %1) #0 !kernel_arg_
 ; CHECK-SPIRV: Function
 
 ; CHECK-LLVM: call spir_func i16 @_Z22__spirv_SDotKHR_RshortDv2_sS_(
-; CHECK-LLVM: call spir_func i32 @_Z20__spirv_SDotKHR_RintDv2_sS_(
+; CHECK-LLVM: call spir_func i32 @_Z3dotDv2_sS_(
 ; CHECK-LLVM: call spir_func i64 @_Z21__spirv_SDotKHR_RlongDv2_sS_(
 
 ; CHECK-LLVM: call spir_func i16 @_Z23__spirv_UDotKHR_RushortDv2_sS_(
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_UDotKHR_RuintDv2_sS_(
+; CHECK-LLVM: call spir_func i32 @_Z3dotDv2_tS_(
 ; CHECK-LLVM: call spir_func i64 @_Z22__spirv_UDotKHR_RulongDv2_sS_(
 
 ; CHECK-LLVM: call spir_func i16 @_Z23__spirv_SUDotKHR_RshortDv2_sS_(
-; CHECK-LLVM: call spir_func i32 @_Z21__spirv_SUDotKHR_RintDv2_sS_(
+; CHECK-LLVM: call spir_func i32 @_Z3dotDv2_sDv2_t(
 ; CHECK-LLVM: call spir_func i64 @_Z22__spirv_SUDotKHR_RlongDv2_sS_(
 
 ; CHECK-SPV-IR: call spir_func i16 @_Z22__spirv_SDotKHR_RshortDv2_sS_(

--- a/test/extensions/KHR/SPV_KHR_integer_dot_product/SPV_KHR_integer_dot_product-sat.ll
+++ b/test/extensions/KHR/SPV_KHR_integer_dot_product/SPV_KHR_integer_dot_product-sat.ll
@@ -44,17 +44,17 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK-LLVM: call spir_func i8 @_Z27__spirv_SDotAccSatKHR_Rchariici(
 ; CHECK-LLVM: call spir_func i16 @_Z28__spirv_SDotAccSatKHR_Rshortiisi(
-; CHECK-LLVM: call spir_func i32 @_Z26__spirv_SDotAccSatKHR_Rintiiii(
+; CHECK-LLVM: call spir_func i32 @_Z28dot_acc_sat_4x8packed_ss_intjji(
 ; CHECK-LLVM: call spir_func i64 @_Z27__spirv_SDotAccSatKHR_Rlongiili(
 
 ; CHECK-LLVM: call spir_func i8 @_Z28__spirv_UDotAccSatKHR_Ruchariici(
 ; CHECK-LLVM: call spir_func i16 @_Z29__spirv_UDotAccSatKHR_Rushortiisi(
-; CHECK-LLVM: call spir_func i32 @_Z27__spirv_UDotAccSatKHR_Ruintiiii(
+; CHECK-LLVM: call spir_func i32 @_Z29dot_acc_sat_4x8packed_uu_uintjjj(
 ; CHECK-LLVM: call spir_func i64 @_Z28__spirv_UDotAccSatKHR_Rulongiili(
 
 ; CHECK-LLVM: call spir_func i8 @_Z28__spirv_SUDotAccSatKHR_Rchariici(
 ; CHECK-LLVM: call spir_func i16 @_Z29__spirv_SUDotAccSatKHR_Rshortiisi(
-; CHECK-LLVM: call spir_func i32 @_Z27__spirv_SUDotAccSatKHR_Rintiiii(
+; CHECK-LLVM: call spir_func i32 @_Z28dot_acc_sat_4x8packed_su_intjji(
 ; CHECK-LLVM: call spir_func i64 @_Z28__spirv_SUDotAccSatKHR_Rlongiili(
 
 ; CHECK-SPV-IR: call spir_func i8 @_Z27__spirv_SDotAccSatKHR_Rchariici(
@@ -112,17 +112,17 @@ define spir_kernel void @TestSatPacked(i32 %0, i32 %1, i8 %acc8, i16 %acc16, i32
 
 ; CHECK-LLVM: call spir_func i8 @_Z27__spirv_SDotAccSatKHR_RcharDv4_cS_c(
 ; CHECK-LLVM: call spir_func i16 @_Z28__spirv_SDotAccSatKHR_RshortDv4_cS_s(
-; CHECK-LLVM: call spir_func i32 @_Z26__spirv_SDotAccSatKHR_RintDv4_cS_i(
+; CHECK-LLVM: call spir_func i32 @_Z11dot_acc_satDv4_cS_i(
 ; CHECK-LLVM: call spir_func i64 @_Z27__spirv_SDotAccSatKHR_RlongDv4_cS_l(
 
 ; CHECK-LLVM: call spir_func i8 @_Z28__spirv_UDotAccSatKHR_RucharDv4_cS_c(
 ; CHECK-LLVM: call spir_func i16 @_Z29__spirv_UDotAccSatKHR_RushortDv4_cS_s(
-; CHECK-LLVM: call spir_func i32 @_Z27__spirv_UDotAccSatKHR_RuintDv4_cS_i(
+; CHECK-LLVM: call spir_func i32 @_Z11dot_acc_satDv4_hS_j
 ; CHECK-LLVM: call spir_func i64 @_Z28__spirv_UDotAccSatKHR_RulongDv4_cS_l(
 
 ; CHECK-LLVM: call spir_func i8 @_Z28__spirv_SUDotAccSatKHR_RcharDv4_cS_c(
 ; CHECK-LLVM: call spir_func i16 @_Z29__spirv_SUDotAccSatKHR_RshortDv4_cS_s(
-; CHECK-LLVM: call spir_func i32 @_Z27__spirv_SUDotAccSatKHR_RintDv4_cS_i(
+; CHECK-LLVM: call spir_func i32 @_Z11dot_acc_satDv4_cDv4_hi(
 ; CHECK-LLVM: call spir_func i64 @_Z28__spirv_SUDotAccSatKHR_RlongDv4_cS_l(
 
 ; CHECK-SPV-IR: call spir_func i8 @_Z27__spirv_SDotAccSatKHR_RcharDv4_cS_c(
@@ -179,15 +179,15 @@ define spir_kernel void @TestSatVec(<4 x i8> %0, <4 x i8> %1, i8 %acc8, i16 %acc
 ; CHECK-SPIRV: Function
 
 ; CHECK-LLVM: call spir_func i16 @_Z28__spirv_SDotAccSatKHR_RshortDv2_sS_s(
-; CHECK-LLVM: call spir_func i32 @_Z26__spirv_SDotAccSatKHR_RintDv2_sS_i(
+; CHECK-LLVM: call spir_func i32 @_Z11dot_acc_satDv2_sS_i(
 ; CHECK-LLVM: call spir_func i64 @_Z27__spirv_SDotAccSatKHR_RlongDv2_sS_l(
 
 ; CHECK-LLVM: call spir_func i16 @_Z29__spirv_UDotAccSatKHR_RushortDv2_sS_s(
-; CHECK-LLVM: call spir_func i32 @_Z27__spirv_UDotAccSatKHR_RuintDv2_sS_i(
+; CHECK-LLVM: call spir_func i32 @_Z11dot_acc_satDv2_tS_j(
 ; CHECK-LLVM: call spir_func i64 @_Z28__spirv_UDotAccSatKHR_RulongDv2_sS_l(
 
 ; CHECK-LLVM: call spir_func i16 @_Z29__spirv_SUDotAccSatKHR_RshortDv2_sS_s(
-; CHECK-LLVM: call spir_func i32 @_Z27__spirv_SUDotAccSatKHR_RintDv2_sS_i(
+; CHECK-LLVM: call spir_func i32 @_Z11dot_acc_satDv2_sDv2_ti(
 ; CHECK-LLVM: call spir_func i64 @_Z28__spirv_SUDotAccSatKHR_RlongDv2_sS_l(
 
 ; CHECK-SPV-IR: call spir_func i16 @_Z28__spirv_SDotAccSatKHR_RshortDv2_sS_s(


### PR DESCRIPTION
#1174 implements translating integer dot product OCL builtins to SPIR-V builtins. This pull request is to do the reverse translation.