### PR TITLE
[Backport to 15] [CI] Do not run check-in-tree after pushes to llvm_release_*

### DIFF
--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -9,8 +9,8 @@ name: In-tree build & tests
 on:
   push:
     branches:
+      # This check is expensive; do not run it after pushes to llvm_release_*
       - main
-      - llvm_release_*
     paths-ignore: # no need to check build for:
       - 'docs/**' # documentation
       - '**.md'   # README


### PR DESCRIPTION
The check-in-tree tests take about 50 minutes to run compared to <5 minutes for check-out-of-tree.  This causes considerable congestion on the runners when backports get merged to several llvm_release_* branches around the same time.

Since the value of these post-push checks is relatively low, disable them; they will still run on pull requests.

(cherry picked from commit 196bbc97bdde04578084c8ea4c47f4be01194f0e)