### PR TITLE
Generate memcpy for OpCopyLogical

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2991,7 +2991,8 @@ void SPIRVToLLVM::transFunctionAttrs(SPIRVFunction *BF, Function *F) {
     auto *BA = BF->getArgument(I->getArgNo());
     mapValue(BA, &(*I));
     setName(&(*I), BA);
-    AttributeMask IllegalAttrs = AttributeFuncs::typeIncompatible(I->getType());
+    AttributeMask IllegalAttrs =
+        AttributeFuncs::typeIncompatible(I->getType(), I->getAttributes());
     BA->foreachAttr([&](SPIRVFuncParamAttrKind Kind) {
       // Skip this function parameter attribute as it will translated among
       // OpenCL metadata

--- a/test/OpCopyLogical.spvasm
+++ b/test/OpCopyLogical.spvasm
@@ -22,4 +22,6 @@
                OpReturn
                OpFunctionEnd
 
-; CHECK-LLVM: @_Z19__spirv_CopyLogical12structtype.0(ptr sret(%structtype) %[[#]], %structtype.0 zeroinitializer)
+; CHECK-LLVM: [[SRC_ALLOCA:%[a-z0-9.]+]] = alloca [[SRC_TYPE:%[a-z0-9.]+]], align 8
+; CHECK-LLVM: [[DST_ALLOCA:%[a-z0-9.]+]] = alloca [[DST_TYPE:%[a-z0-9.]+]], align 8
+; CHECK-LLVM: call void @llvm.memcpy.p0.p0.i64(ptr align 8 [[DST_ALLOCA]], ptr align 8 [[SRC_ALLOCA]], i64 0, i1 false)


### PR DESCRIPTION
fixes #2768 

Generate an LLVM memcpy for OpCopyLogical, rather than a call to an OpCopyLogical function.