### PR TITLE
Use untyped pointers when translating pointer to structure

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2176,7 +2176,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   case OpUntypedInBoundsPtrAccessChainKHR: {
     auto *AC = static_cast<SPIRVAccessChainBase *>(BV);
     auto *Base = transValue(AC->getBase(), F, BB);
-    SPIRVType *BaseSPVTy = AC->getBase()->getType();
+    SPIRVType *BaseSPVTy = AC->getBaseType();
     if (BaseSPVTy->isTypePointer() &&
         BaseSPVTy->getPointerElementType()->isTypeCooperativeMatrixKHR()) {
       return mapValue(BV, transSPIRVBuiltinFromInst(AC, BB));
@@ -2185,7 +2185,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         BaseSPVTy->isTypeVector()
             ? transType(
                   BaseSPVTy->getVectorComponentType()->getPointerElementType())
-            : transType(BaseSPVTy->getPointerElementType());
+        : BaseSPVTy->isTypePointer()
+            ? transType(BaseSPVTy->getPointerElementType())
+            : transType(BaseSPVTy);
     auto Index = transValue(AC->getIndices(), F, BB);
     if (!AC->hasPtrIndex())
       Index.insert(Index.begin(), getInt32(M, 0));

--- a/test/CXX/global-ctor.cl
+++ b/test/CXX/global-ctor.cl
@@ -5,6 +5,12 @@
 // RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: not llvm-spirv %t.bc --spirv-max-version=1.0 2>&1 | FileCheck %s --check-prefix=CHECK-SPV10
 
+// RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_KHR_untyped_pointers
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+// RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: not llvm-spirv %t.bc --spirv-max-version=1.0 2>&1 | FileCheck %s --check-prefix=CHECK-SPV10
+
 class Something {
   public:
     Something(int a) : v(a) {}

--- a/test/EnqueueEmptyKernel.ll
+++ b/test/EnqueueEmptyKernel.ll
@@ -35,7 +35,8 @@ target triple = "spir64-unknown-unknown"
 ; CHECK-SPIRV: TypeVoid [[Void:[0-9]+]]
 ; CHECK-SPIRV-TYPED-PTR: TypePointer [[Int8PtrGen:[0-9]+]] 8 [[Int8]]
 ; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[Int8PtrGen:[0-9]+]] 8
-; CHECK-SPIRV: Variable {{[0-9]+}} [[Block:[0-9]+]]
+; CHECK-SPIRV-TYPED-PTR: Variable {{[0-9]+}} [[Block:[0-9]+]]
+; CHECK-SPIRV-UNTYPED-PTR: UntypedVariableKHR {{[0-9]+}} [[Block:[0-9]+]]
 
 ; Function Attrs: convergent nounwind
 define spir_kernel void @test_enqueue_empty() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {

--- a/test/SpecConstants/spec-constant-length-array.ll
+++ b/test/SpecConstants/spec-constant-length-array.ll
@@ -34,7 +34,7 @@
 ; CHECK-SPV-DAG: TypePointer [[#ARR_PTR_TY_1:]] [[#FUNCTION_SC]] [[#ARR_TY_1]]
 ; CHECK-SPV-DAG: TypeFloat [[#DOUBLE_TY:]] 64
 ; CHECK-SPV-DAG: TypeStruct [[#STR_TY:]] [[#DOUBLE_TY]] [[#DOUBLE_TY]]
-; CHECK-SPV-DAG: TypePointer [[#STR_PTR_TY:]] [[#FUNCTION_SC]] [[#STR_TY]]
+; CHECK-SPV-TYPED-PTR-DAG: TypePointer [[#STR_PTR_TY:]] [[#FUNCTION_SC]] [[#STR_TY]]
 ; CHECK-SPV-DAG: TypeArray [[#ARR_TY_2:]] [[#STR_TY]] [[#LENGTH_2]]
 ; CHECK-SPV-DAG: TypePointer [[#ARR_PTR_TY_2:]] [[#FUNCTION_SC]] [[#ARR_TY_2:]]
 
@@ -69,7 +69,8 @@ define spir_kernel void @test() {
   ; CHECK-LLVM: %[[VAR1:.*]] = bitcast ptr %[[ALLOCA1]] to ptr
   %scla1 = alloca i8, i32 %length1, align 2
 
-  ; CHECK-SPV: Bitcast [[#STR_PTR_TY]] [[#]] [[#SCLA_2]]
+  ; CHECK-SPV-TYPED-PTR: Bitcast [[#STR_PTR_TY]] [[#]] [[#SCLA_2]]
+  ; CHECK-SPV-UNTYPED-PTR: Bitcast [[#PTR_TY]] [[#]] [[#SCLA_2]]
 
   ; CHECK-LLVM: %[[VAR2:.*]] = bitcast ptr %[[ALLOCA2]] to ptr
   %scla2 = alloca %struct_type, i8 %length2, align 16

--- a/test/extensions/INTEL/SPV_INTEL_task_sequence/task_sequence.ll
+++ b/test/extensions/INTEL/SPV_INTEL_task_sequence/task_sequence.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_task_sequence -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
-; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-TYPED-PTR
 
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
@@ -9,7 +9,7 @@
 
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_task_sequence,+SPV_KHR_untyped_pointers -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
-; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-UNTYPED-PTR
 
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
@@ -54,12 +54,15 @@
 
 ; CHECK-SPIRV: TypeInt [[#IntTy:]] 32 0
 ; CHECK-SPIRV: TypeTaskSequenceINTEL [[#TypeTS:]]
+; CHECK-SPIRV-UNTYPED-PTR: TypeStruct [[#StructTS:]] [[#TypeTS]]
+; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[#Ptr:]] 7
 ; CHECK-SPIRV: TypeFunction [[#FuncTy:]] [[#IntTy]] [[#IntTy]] [[#IntTy]]
-; CHECK-SPIRV: TypePointer [[#PtrTS:]] 7 [[#TypeTS]]
+; CHECK-SPIRV-TYPED-PTR: TypePointer [[#PtrTS:]] 7 [[#TypeTS]]
 
 ; <id> Result Type <id> Result <id> Function Literal Pipelined Literal UseStallEnableClusters Literal GetCapacity Literal AsyncCapacity
 ; CHECK-SPIRV: TaskSequenceCreateINTEL [[#TypeTS]] [[#CreateRes:]] [[#FuncId:]] 10 4294967295 17 1
-; CHECK-SPIRV: InBoundsPtrAccessChain [[#PtrTS]] [[#GEP:]]
+; CHECK-SPIRV-TYPED-PTR: InBoundsPtrAccessChain [[#PtrTS]] [[#GEP:]]
+; CHECK-SPIRV-UNTYPED-PTR: UntypedInBoundsPtrAccessChainKHR [[#Ptr]] [[#GEP:]] [[#StructTS]]
 ; CHECK-SPIRV: Store [[#GEP]] [[#CreateRes]]
 
 ; CHECK-SPIRV: Load [[#IntTy]] [[#LoadIntVar:]]

--- a/test/extensions/INTEL/SPV_INTEL_task_sequence/task_sequence_zero_capacity_literals.ll
+++ b/test/extensions/INTEL/SPV_INTEL_task_sequence/task_sequence_zero_capacity_literals.ll
@@ -1,7 +1,7 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_task_sequence -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
-; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-TYPED-PTR
 
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
@@ -9,7 +9,7 @@
 
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_task_sequence,+SPV_KHR_untyped_pointers -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
-; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-UNTYPED-PTR
 
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
@@ -22,7 +22,8 @@
 
 ; <id> Result Type <id> Result <id> Function Literal Pipelined Literal UseStallEnableClusters Literal GetCapacity Literal AsyncCapacity
 ; CHECK-SPIRV: TaskSequenceCreateINTEL [[#TypeTS]] [[#CreateRes:]] [[#FuncId:]] 10 4294967295 0 0
-; CHECK-SPIRV: InBoundsPtrAccessChain [[#PtrTS]] [[#GEP:]]
+; CHECK-SPIRV-TYPED-PTR: InBoundsPtrAccessChain [[#PtrTS]] [[#GEP:]]
+; CHECK-SPIRV-UNTYPED-PTR: UntypedInBoundsPtrAccessChainKHR [[#]] [[#GEP:]] [[#]]
 ; CHECK-SPIRV: Store [[#GEP]] [[#CreateRes]]
 
 ; CHECK-SPIRV: Function [[#IntTy]] [[#FuncId]] 0 [[#FuncTy]]

--- a/test/extensions/KHR/SPV_KHR_untyped_pointers/untyped_ptr_access_chain.ll
+++ b/test/extensions/KHR/SPV_KHR_untyped_pointers/untyped_ptr_access_chain.ll
@@ -23,9 +23,8 @@
 ; CHECK-SPIRV: Constant [[#IntTy]] [[#Const1:]] 1 
 ; CHECK-SPIRV: TypeUntypedPointerKHR [[#UntypedPtrTy:]] 7
 ; CHECK-SPIRV: TypeStruct [[#StructTy:]] [[#IntTy]] [[#IntTy]]
-; CHECK-SPIRV: TypePointer [[#PtrStructTy:]] 7 [[#StructTy]]
 
-; CHECK-SPIRV: Variable [[#PtrStructTy]] [[#StructVarId:]] 7
+; CHECK-SPIRV: UntypedVariableKHR [[#UntypedPtrTy]] [[#StructVarId:]] 7 [[#StructTy]]
 ; CHECK-SPIRV: UntypedInBoundsPtrAccessChainKHR [[#UntypedPtrTy]] [[#]] [[#StructTy]] [[#StructVarId]] [[#Const0]] [[#Const1]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/llvm-intrinsics/memset-opaque.ll
+++ b/test/llvm-intrinsics/memset-opaque.ll
@@ -16,9 +16,9 @@
 ; CHECK-SPIRV: Constant {{[0-9]+}} [[Lenmemset21:[0-9]+]] 4
 ; CHECK-SPIRV: Constant {{[0-9]+}} [[Lenmemset0:[0-9]+]] 12
 ; CHECK-SPIRV: Constant {{[0-9]+}} [[Const21:[0-9]+]] 21
+; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[Int8Ptr:[0-9]+]] 8
 ; CHECK-SPIRV: TypeArray [[Int8x4:[0-9]+]] [[Int8]] [[Lenmemset21]]
 ; CHECK-SPIRV-TYPED-PTR: TypePointer [[Int8Ptr:[0-9]+]] 8 [[Int8]]
-; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[Int8Ptr:[0-9]+]] 8
 ; CHECK-SPIRV: TypeArray [[Int8x12:[0-9]+]] [[Int8]] [[Lenmemset0]]
 ; CHECK-SPIRV-TYPED-PTR: TypePointer [[Int8PtrConst:[0-9]+]] 0 [[Int8]]
 ; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[Int8PtrConst:[0-9]+]] 0

--- a/test/transcoding/CreatePipeFromPipeStorage.ll
+++ b/test/transcoding/CreatePipeFromPipeStorage.ll
@@ -31,11 +31,12 @@
 
 ; CHECK-SPIRV: TypePipe [[READ_PIPE:[0-9]+]] 0
 ; CHECK-SPIRV: TypeStruct [[READ_PIPE_WRAPPER:[0-9]+]] [[READ_PIPE]]
-; CHECK-SPIRV: TypePointer [[READ_PIPE_WRAPPER_PTR:[0-9]+]] 7 [[READ_PIPE_WRAPPER]]
+; CHECK-SPIRV-TYPED-PTR: TypePointer [[READ_PIPE_WRAPPER_PTR:[0-9]+]] 7 [[READ_PIPE_WRAPPER]]
+; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[PTR:[0-9]+]] 7
 ; CHECK-SPIRV: TypePipe [[WRITE_PIPE:[0-9]+]] 1
 ; CHECK-SPIRV: TypeStruct [[WRITE_PIPE_WRAPPER:[0-9]+]] [[WRITE_PIPE]]
 
-; CHECK-SPIRV: TypePointer [[WRITE_PIPE_WRAPPER_PTR:[0-9]+]] 7 [[WRITE_PIPE_WRAPPER]]
+; CHECK-SPIRV-TYPED-PTR: TypePointer [[WRITE_PIPE_WRAPPER_PTR:[0-9]+]] 7 [[WRITE_PIPE_WRAPPER]]
 
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
@@ -56,8 +57,10 @@ entry:
   ; CHECK-SPV-IR: %myrpipe = alloca %"[[CL_READ_PIPE_NAME]]", align 4
   ; CHECK-SPV-IR: %mywpipe = alloca %"[[CL_WRITE_PIPE_NAME]]", align 4
 
-  ; CHECK-SPIRV: Variable [[READ_PIPE_WRAPPER_PTR]] [[READ_PIPE_WRAPPER_ID]] 7
-  ; CHECK-SPIRV: Variable [[WRITE_PIPE_WRAPPER_PTR]] [[WRITE_PIPE_WRAPPER_ID]] 7
+  ; CHECK-SPIRV-TYPED-PTR: Variable [[READ_PIPE_WRAPPER_PTR]] [[READ_PIPE_WRAPPER_ID]] 7
+  ; CHECK-SPIRV-TYPED-PTR: Variable [[WRITE_PIPE_WRAPPER_PTR]] [[WRITE_PIPE_WRAPPER_ID]] 7
+  ; CHECK-SPIRV-UNTYPED-PTR: UntypedVariableKHR [[PTR]] [[READ_PIPE_WRAPPER_ID]] 7 [[READ_PIPE_WRAPPER]]
+  ; CHECK-SPIRV-UNTYPED-PTR: UntypedVariableKHR [[PTR]] [[WRITE_PIPE_WRAPPER_ID]] 7 [[WRITE_PIPE_WRAPPER]]
 
   %myrpipe = alloca %"class.cl::pipe<int __attribute__((ext_vector_type(4))), cl::pipe_access::read>", align 4
   %mywpipe = alloca %"class.cl::pipe<int __attribute__((ext_vector_type(4))), cl::pipe_access::write>", align 4

--- a/test/transcoding/constant-vars.ll
+++ b/test/transcoding/constant-vars.ll
@@ -40,15 +40,17 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV-UNTYPED-PTR: 8 SpecConstantOp [[AS2]] [[ASTRC:[0-9]+]] 4424 [[#]] [[ASTR]] [[I320]] [[I320]]
 ; CHECK-SPIRV: 5 SpecConstantOp [[AS1]] [[I64ARRC:[0-9]+]] 124 [[I64ARR]]
 ; CHECK-SPIRV: 5 ConstantComposite [[STRUCTTY]] [[STRUCT_INIT:[0-9]+]] [[ASTRC]] [[I64ARRC]]
-; CHECK-SPIRV: 5 Variable {{[0-9]+}} [[STRUCT:[0-9]+]] 5 [[STRUCT_INIT]]
+; CHECK-SPIRV-TYPED-PTR: 5 Variable {{[0-9]+}} [[STRUCT:[0-9]+]] 5 [[STRUCT_INIT]]
+; CHECK-SPIRV-UNTYPED-PTR: 6 UntypedVariableKHR {{[0-9]+}} [[STRUCT:[0-9]+]] 5 [[STRUCTTY]] [[STRUCT_INIT]]
 
 @array = addrspace(1) global [3 x ptr addrspace(1)] [ptr addrspace(1) @i64arr, ptr addrspace(1) @struct, ptr addrspace(1) getelementptr ([3 x i64], ptr addrspace(1) @i64arr, i64 0, i64 1) ]
 
 ; CHECK-SPIRV: 5 SpecConstantOp [[AS1]] [[I64ARRC2:[0-9]+]] 124 [[I64ARR]]
-; CHECK-SPIRV: 5 SpecConstantOp [[AS1]] [[STRUCTC:[0-9]+]] 124 [[STRUCT]]
+; CHECK-SPIRV-TYPED-PTR: 5 SpecConstantOp [[AS1]] [[STRUCTC:[0-9]+]] 124 [[STRUCT]]
 ; CHECK-SPIRV-TYPED-PTR: 7 SpecConstantOp {{[0-9]+}} [[GEP:[0-9]+]] 67 [[I64ARR]]
 ; CHECK-SPIRV-UNTYPED-PTR: 8 SpecConstantOp {{[0-9]+}} [[GEP:[0-9]+]] 4423 [[#]] [[I64ARR]]
-; CHECK-SPIRV: 6 ConstantComposite [[ARRAYTY]] [[ARRAY_INIT:[0-9]+]] [[I64ARRC2]] [[STRUCTC]] [[GEP]]
+; CHECK-SPIRV-TYPED-PTR: 6 ConstantComposite [[ARRAYTY]] [[ARRAY_INIT:[0-9]+]] [[I64ARRC2]] [[STRUCTC]] [[GEP]]
+; CHECK-SPIRV-UNTYPED-PTR: 6 ConstantComposite [[ARRAYTY]] [[ARRAY_INIT:[0-9]+]] [[I64ARRC2]] [[STRUCT]] [[GEP]]
 ; CHECK-SPIRV: 5 Variable {{[0-9]+}} [[ARRAY:[0-9]+]] 5 [[ARRAY_INIT]]
 
 ; CHECK-LLVM: %structtype = type { ptr addrspace(2), ptr addrspace(1) }

--- a/test/transcoding/kernel_query.ll
+++ b/test/transcoding/kernel_query.ll
@@ -63,8 +63,9 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: Constant [[Int32Ty]] [[ConstInt8:[0-9]+]] 8
 ; CHECK-SPIRV: TypeVoid [[VoidTy:[0-9]+]]
 ; CHECK-SPIRV: TypeStruct [[NDRangeTy:[0-9]+]] [[Int32Ty]] {{$}}
-; CHECK-SPIRV: TypePointer [[NDRangePtrTy:[0-9]+]] 7 [[NDRangeTy]]
+; CHECK-SPIRV-TYPED-PTR: TypePointer [[NDRangePtrTy:[0-9]+]] 7 [[NDRangeTy]]
 ; CHECK-SPIRV-TYPED-PTR: TypePointer [[Int8PtrGenTy:[0-9]+]] 8 [[Int8Ty]]
+; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[NDRangePtrTy:[0-9]+]] 7
 ; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[Int8PtrGenTy:[0-9]+]] 8
 ; CHECK-SPIRV: TypeFunction [[BlockKerTy:[0-9]+]] [[VoidTy]] [[Int8PtrGenTy]]
 
@@ -72,7 +73,8 @@ target triple = "spir-unknown-unknown"
 define spir_kernel void @device_side_enqueue() #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !2 !kernel_arg_type !2 !kernel_arg_base_type !2 !kernel_arg_type_qual !2 {
 entry:
 
-; CHECK-SPIRV: Variable [[NDRangePtrTy]] [[NDRange:[0-9]+]]
+; CHECK-SPIRV-TYPED-PTR: Variable [[NDRangePtrTy]] [[NDRange:[0-9]+]]
+; CHECK-SPIRV-UNTYPED-PTR: UntypedVariableKHR [[NDRangePtrTy]] [[NDRange:[0-9]+]] [[#]] [[NDRangeTy]]
 
   %ndrange = alloca %struct.ndrange_t, align 4
 


### PR DESCRIPTION
This improves SPV_KHR_untyped_pointers extension.
Removing struct type from special handling (translate as typed pointer) allowed to fix `spirv-val` error in `CXX/global-ctor.cl` test:

```
error: line 88: OpFunctionCall Argument <id> '25[%this1]'s type does not
match Function <id> '11[%_ptr_Generic_class_Something]'s parameter type.
  %30 = OpFunctionCall %void %_ZNU3AS49SomethingC2Ei %this1 %26
```

Other changes allow to translate structs in a new way without violating validation or test checks.