### PR TITLE
Update tests after LLVM IR splat syntax change

### DIFF
--- a/test/ExtendBitBoolArg.ll
+++ b/test/ExtendBitBoolArg.ll
@@ -16,8 +16,8 @@
 ; CHECK: %[[#LSHR:]] = lshr i32 %[[#ExtBase]], %[[#ExtShift]]
 ; CHECK: and i32 %[[#LSHR]], 1
 
-; CHECK: %[[#ExtVecBase:]] = select <2 x i1> %vec1, <2 x i32> <i32 1, i32 1>, <2 x i32> zeroinitializer
-; CHECK: %[[#ExtVecShift:]] = select <2 x i1> %vec2, <2 x i32> <i32 1, i32 1>, <2 x i32> zeroinitializer
+; CHECK: %[[#ExtVecBase:]] = select <2 x i1> %vec1, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
+; CHECK: %[[#ExtVecShift:]] = select <2 x i1> %vec2, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
 ; CHECK: lshr <2 x i32> %[[#ExtVecBase]], %[[#ExtVecShift]]
 
 ; ModuleID = 'source.bc'

--- a/test/SpecConstants/specconstantop-init.spvasm
+++ b/test/SpecConstants/specconstantop-init.spvasm
@@ -32,7 +32,7 @@
 ; CHECK: @var_bitand = addrspace(1) global i32 52
 ; CHECK: @var_vecshuf = addrspace(1) global <2 x i32> <i32 4, i32 53>
 ; CHECK: @var_compext = addrspace(1) global i32 53
-; CHECK: @var_compins = addrspace(1) global <2 x i32> <i32 53, i32 53>
+; CHECK: @var_compins = addrspace(1) global <2 x i32> splat (i32 53)
 ; CHECK: @var_logor = addrspace(1) global i1 true
 ; CHECK: @var_logand = addrspace(1) global i1 false
 ; CHECK: @var_lognot = addrspace(1) global i1 false

--- a/test/complex-constexpr-vector.ll
+++ b/test/complex-constexpr-vector.ll
@@ -44,14 +44,14 @@ entry:
 ; CHECK-LLVM: #dbg_value(
 ; CHECK-LLVM-SAME:   <4 x i8> <
 ; CHECK-LLVM-SAME:   i8 add (
-; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 0),
-; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 0)),
+; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> splat (i32 65793) to <8 x i8>), i32 0),
+; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> splat (i32 131586) to <8 x i8>), i32 0)),
 ; CHECK-LLVM-SAME:   i8 add (
-; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 1),
-; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 1)),
+; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> splat (i32 65793) to <8 x i8>), i32 1),
+; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> splat (i32 131586) to <8 x i8>), i32 1)),
 ; CHECK-LLVM-SAME:   i8 add (
-; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 2),
-; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 2)),
+; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> splat (i32 65793) to <8 x i8>), i32 2),
+; CHECK-LLVM-SAME:     i8 extractelement (<8 x i8> bitcast (<2 x i32> splat (i32 131586) to <8 x i8>), i32 2)),
 ; CHECK-LLVM-SAME:   i8 undef>,
 ; CHECK-LLVM-SAME:   ![[#]], !DIExpression(), ![[#]])
   call void @llvm.dbg.value(

--- a/test/extensions/INTEL/SPV_INTEL_masked_gather_scatter/intel-gather-scatter.ll
+++ b/test/extensions/INTEL/SPV_INTEL_masked_gather_scatter/intel-gather-scatter.ll
@@ -43,7 +43,7 @@
 ; CHECK-LLVM: %[[#VECGATHER:]] = load <4 x ptr addrspace(4)>, ptr
 ; CHECK-LLVM: %[[#VECSCATTER:]] = load <4 x ptr addrspace(4)>, ptr
 ; CHECK-LLVM: %[[GATHER:[a-z0-9]+]] = call <4 x i32> @llvm.masked.gather.v4i32.v4p4(<4 x ptr addrspace(4)> %[[#VECGATHER]], i32 4, <4 x i1> <i1 true, i1 false, i1 true, i1 true>, <4 x i32> <i32 4, i32 0, i32 1, i32 0>)
-; CHECK-LLVM: call void @llvm.masked.scatter.v4i32.v4p4(<4 x i32> %[[GATHER]], <4 x ptr addrspace(4)> %[[#VECSCATTER]], i32 4, <4 x i1> <i1 true, i1 true, i1 true, i1 true>)
+; CHECK-LLVM: call void @llvm.masked.scatter.v4i32.v4p4(<4 x i32> %[[GATHER]], <4 x ptr addrspace(4)> %[[#VECSCATTER]], i32 4, <4 x i1> splat (i1 true))
 
 ; CHECK-LLVM-DAG: declare <4 x i32> @llvm.masked.gather.v4i32.v4p4(<4 x ptr addrspace(4)>, i32 immarg, <4 x i1>, <4 x i32>)
 ; CHECK-LLVM-DAG: declare void @llvm.masked.scatter.v4i32.v4p4(<4 x i32>, <4 x ptr addrspace(4)>, i32 immarg, <4 x i1>)
@@ -59,7 +59,7 @@ entry:
   %0 = load <4 x ptr addrspace(4)>, ptr %arg0
   %1 = load <4 x ptr addrspace(4)>, ptr %arg1
   %res = call <4 x i32> @llvm.masked.gather.v4i32.v4p4(<4 x ptr addrspace(4)> %0, i32 4, <4 x i1> <i1 true, i1 false, i1 true, i1 true>, <4 x i32> <i32 4, i32 0, i32 1, i32 0>)
-  call void @llvm.masked.scatter.v4i32.v4p4(<4 x i32> %res, <4 x ptr addrspace(4)> %1, i32 4, <4 x i1> <i1 true, i1 true, i1 true, i1 true>)
+  call void @llvm.masked.scatter.v4i32.v4p4(<4 x i32> %res, <4 x ptr addrspace(4)> %1, i32 4, <4 x i1> splat (i1 true))
   ret void
 }
 

--- a/test/lshr_shl_i1_regularize.ll
+++ b/test/lshr_shl_i1_regularize.ll
@@ -43,8 +43,8 @@ entry:
 define spir_func void @test_shl_vec_i1(<8 x i1> %a, <8 x i1> %b) {
 entry:
   %0 = shl <8 x i1> %a, %b
-; CHECK-LLVM: [[AI32_2:%[0-9]+]] = select <8 x i1> %a, <8 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>, <8 x i32> zeroinitializer
-; CHECK-LLVM: [[BI32_2:%[0-9]+]] = select <8 x i1> %b, <8 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1, i32 1>, <8 x i32> zeroinitializer
+; CHECK-LLVM: [[AI32_2:%[0-9]+]] = select <8 x i1> %a, <8 x i32> splat (i32 1), <8 x i32> zeroinitializer
+; CHECK-LLVM: [[BI32_2:%[0-9]+]] = select <8 x i1> %b, <8 x i32> splat (i32 1), <8 x i32> zeroinitializer
 ; CHECK-LLVM: [[LSHR32_2:%[0-9]+]] = lshr <8 x i32> [[AI32_2]], [[BI32_2]]
 ; CHECK-LLVM: [[TRUNC_2:%[0-9]+]] = icmp ne <8 x i32> [[LSHR32_2]], zeroinitializer
   %1 = zext <8 x i1> %0 to <8 x i32>

--- a/test/transcoding/relationals_select.ll
+++ b/test/transcoding/relationals_select.ll
@@ -75,31 +75,31 @@ entry:
 ; CHECK: [[DATA10:%.*]] = call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> [[ARG1:%.*]]) #0
 ; CHECK-NEXT: [[DATA11:%.*]] = trunc <4 x i32> [[DATA10]] to <4 x i8>
 ; CHECK-NEXT: [[DATA12:%.*]] = trunc <4 x i8> [[DATA11]] to <4 x i1>
-; CHECK-NEXT: [[CALL5:%.*]] = select <4 x i1> [[DATA12]], <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>, <4 x i32> zeroinitializer
+; CHECK-NEXT: [[CALL5:%.*]] = select <4 x i1> [[DATA12]], <4 x i32> splat (i32 -1), <4 x i32> zeroinitializer
   %call7 = tail call spir_func <4 x i32> @_Z8isnormalDv4_f(<4 x float> noundef %v) #2
 
 ; CHECK: [[DATA13:%.*]] = call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> [[ARG1]]) #0
 ; CHECK-NEXT: [[DATA14:%.*]] = trunc <4 x i32> [[DATA13]] to <4 x i8>
 ; CHECK-NEXT: [[DATA15:%.*]] = trunc <4 x i8> [[DATA14]] to <4 x i1>
-; CHECK-NEXT: [[CALL6:%.*]] = select <4 x i1> [[DATA15]], <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>, <4 x i32> zeroinitializer
+; CHECK-NEXT: [[CALL6:%.*]] = select <4 x i1> [[DATA15]], <4 x i32> splat (i32 -1), <4 x i32> zeroinitializer
   %call8 = tail call spir_func <4 x i32> @_Z8isfiniteDv4_f(<4 x float> noundef %v) #2
 
 ; CHECK: [[DATA16:%.*]] = call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> [[ARG1]]) #0
 ; CHECK-NEXT: [[DATA17:%.*]] = trunc <4 x i32> [[DATA16]] to <4 x i8>
 ; CHECK-NEXT: [[DATA18:%.*]] = trunc <4 x i8> [[DATA17]] to <4 x i1>
-; CHECK-NEXT: [[CALL7:%.*]] = select <4 x i1> [[DATA18]], <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>, <4 x i32> zeroinitializer
+; CHECK-NEXT: [[CALL7:%.*]] = select <4 x i1> [[DATA18]], <4 x i32> splat (i32 -1), <4 x i32> zeroinitializer
   %call9 = tail call spir_func <4 x i32> @_Z5isnanDv4_f(<4 x float> noundef %v) #2
 
 ; CHECK: [[DATA19:%.*]] = call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> [[ARG1]]) #0
 ; CHECK-NEXT: [[DATA20:%.*]] = trunc <4 x i32> [[DATA19]] to <4 x i8>
 ; CHECK-NEXT: [[DATA21:%.*]] = trunc <4 x i8> [[DATA20]] to <4 x i1>
-; CHECK-NEXT: [[CALL8:%.*]] = select <4 x i1> [[DATA21]], <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>, <4 x i32> zeroinitializer
+; CHECK-NEXT: [[CALL8:%.*]] = select <4 x i1> [[DATA21]], <4 x i32> splat (i32 -1), <4 x i32> zeroinitializer
   %call10 = tail call spir_func <4 x i32> @_Z5isinfDv4_f(<4 x float> noundef %v) #2
 
 ; CHECK: [[DATA22:%.*]] = call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> [[ARG1]]) #0
 ; CHECK-NEXT: [[DATA23:%.*]] = trunc <4 x i32> [[DATA22]] to <4 x i8>
 ; CHECK-NEXT: [[DATA24:%.*]] = trunc <4 x i8> [[DATA23]] to <4 x i1>
-; CHECK-NEXT: [[CALL9:%.*]] = select <4 x i1> [[DATA24]], <4 x i32> <i32 -1, i32 -1, i32 -1, i32 -1>, <4 x i32> zeroinitializer
+; CHECK-NEXT: [[CALL9:%.*]] = select <4 x i1> [[DATA24]], <4 x i32> splat (i32 -1), <4 x i32> zeroinitializer
   %call11 = tail call spir_func <4 x i32> @_Z7signbitDv4_f(<4 x float> noundef %v) #2
   ret void
 }

--- a/test/uitofp-with-bool.ll
+++ b/test/uitofp-with-bool.ll
@@ -114,16 +114,16 @@ entry:
 ; LLVM-DAG: %s4 = select i1 %i1s, i64 -1, i64 0
   %s4 = sext i1 %i1s to i64
 ; SPV-DAG: Select [[vec_8]] [[s5]] [[i1v]] [[mones_8]] [[zeros_8]]
-; LLVM-DAG: %s5 = select <2 x i1> %i1v, <2 x i8> <i8 -1, i8 -1>, <2 x i8> zeroinitializer
+; LLVM-DAG: %s5 = select <2 x i1> %i1v, <2 x i8> splat (i8 -1), <2 x i8> zeroinitializer
   %s5 = sext <2 x i1> %i1v to <2 x i8>
 ; SPV-DAG: Select [[vec_16]] [[s6]] [[i1v]] [[mones_16]] [[zeros_16]]
-; LLVM-DAG: %s6 = select <2 x i1> %i1v, <2 x i16> <i16 -1, i16 -1>, <2 x i16> zeroinitializer
+; LLVM-DAG: %s6 = select <2 x i1> %i1v, <2 x i16> splat (i16 -1), <2 x i16> zeroinitializer
   %s6 = sext <2 x i1> %i1v to <2 x i16>
 ; SPV-DAG: Select [[vec_32]] [[s7]] [[i1v]] [[mones_32]] [[zeros_32]]
-; LLVM-DAG: %s7 = select <2 x i1> %i1v, <2 x i32> <i32 -1, i32 -1>, <2 x i32> zeroinitializer
+; LLVM-DAG: %s7 = select <2 x i1> %i1v, <2 x i32> splat (i32 -1), <2 x i32> zeroinitializer
   %s7 = sext <2 x i1> %i1v to <2 x i32>
 ; SPV-DAG: Select [[vec_64]] [[s8]] [[i1v]] [[mones_64]] [[zeros_64]]
-; LLVM-DAG: %s8 = select <2 x i1> %i1v, <2 x i64> <i64 -1, i64 -1>, <2 x i64> zeroinitializer
+; LLVM-DAG: %s8 = select <2 x i1> %i1v, <2 x i64> splat (i64 -1), <2 x i64> zeroinitializer
   %s8 = sext <2 x i1> %i1v to <2 x i64>
 ; SPV-DAG: Select [[int_8]] [[z1]] [[i1s]] [[one_8]] [[zero_8]]
 ; LLVM-DAG: %z1 = select i1 %i1s, i8 1, i8 0
@@ -138,16 +138,16 @@ entry:
 ; LLVM-DAG: %z4 = select i1 %i1s, i64 1, i64 0
   %z4 = zext i1 %i1s to i64
 ; SPV-DAG: Select [[vec_8]] [[z5]] [[i1v]] [[ones_8]] [[zeros_8]]
-; LLVM-DAG: %z5 = select <2 x i1> %i1v, <2 x i8> <i8 1, i8 1>, <2 x i8> zeroinitializer
+; LLVM-DAG: %z5 = select <2 x i1> %i1v, <2 x i8> splat (i8 1), <2 x i8> zeroinitializer
   %z5 = zext <2 x i1> %i1v to <2 x i8>
 ; SPV-DAG: Select [[vec_16]] [[z6]] [[i1v]] [[ones_16]] [[zeros_16]]
-; LLVM-DAG: %z6 = select <2 x i1> %i1v, <2 x i16> <i16 1, i16 1>, <2 x i16> zeroinitializer
+; LLVM-DAG: %z6 = select <2 x i1> %i1v, <2 x i16> splat (i16 1), <2 x i16> zeroinitializer
   %z6 = zext <2 x i1> %i1v to <2 x i16>
 ; SPV-DAG: Select [[vec_32]] [[z7]] [[i1v]] [[ones_32]] [[zeros_32]]
-; LLVM-DAG: %z7 = select <2 x i1> %i1v, <2 x i32> <i32 1, i32 1>, <2 x i32> zeroinitializer
+; LLVM-DAG: %z7 = select <2 x i1> %i1v, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
   %z7 = zext <2 x i1> %i1v to <2 x i32>
 ; SPV-DAG: Select [[vec_64]] [[z8]] [[i1v]] [[ones_64]] [[zeros_64]]
-; LLVM-DAG: %z8 = select <2 x i1> %i1v, <2 x i64> <i64 1, i64 1>, <2 x i64> zeroinitializer
+; LLVM-DAG: %z8 = select <2 x i1> %i1v, <2 x i64> splat (i64 1), <2 x i64> zeroinitializer
   %z8 = zext <2 x i1> %i1v to <2 x i64>
 ; SPV-DAG: Select [[int_32]] [[ufp1_res:[0-9]+]] [[i1s]] [[one_32]] [[zero_32]]
 ; SPV-DAG: ConvertUToF [[float]] [[ufp1]] [[ufp1_res]]
@@ -156,7 +156,7 @@ entry:
   %ufp1 = uitofp i1 %i1s to float
 ; SPV-DAG: Select [[vec_32]] [[ufp2_res:[0-9]+]] [[i1v]] [[ones_32]] [[zeros_32]]
 ; SPV-DAG: ConvertUToF [[vec_float]] [[ufp2]] [[ufp2_res]]
-; LLVM-DAG: %[[ufp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> <i32 1, i32 1>, <2 x i32> zeroinitializer
+; LLVM-DAG: %[[ufp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
 ; LLVM-DAG: %ufp2 = uitofp <2 x i32> %[[ufp2_res_llvm]] to <2 x float>
   %ufp2 = uitofp <2 x i1> %i1v to <2 x float>
 ; SPV-DAG: Select [[int_32]] [[sfp1_res:[0-9]+]] [[i1s]] [[one_32]] [[zero_32]]
@@ -166,7 +166,7 @@ entry:
   %sfp1 = sitofp i1 %i1s to float
 ; SPV-DAG: Select [[vec_32]] [[sfp2_res:[0-9]+]] [[i1v]] [[ones_32]] [[zeros_32]]
 ; SPV-DAG: ConvertSToF [[vec_float]] [[sfp2]] [[sfp2_res]]
-; LLVM-DAG: %[[sfp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> <i32 1, i32 1>, <2 x i32> zeroinitializer
+; LLVM-DAG: %[[sfp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
 ; LLVM-DAG: %sfp2 = sitofp <2 x i32> %[[sfp2_res_llvm]] to <2 x float>
   %sfp2 = sitofp <2 x i1> %i1v to <2 x float>
   ret void


### PR DESCRIPTION
Update for LLVM commit 38fffa630ee8 ("[LLVM][IR] Use splat syntax when printing Constant[Data]Vector. (#112548)", 2024-11-06).