### PR TITLE
[Backport to 19] SPIRVReader: Support OpConstantComposite for cooperative matrix

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1504,6 +1504,21 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
       return mapValue(BV, ConstantStruct::get(BCCTy, CV));
     }
+    case OpTypeCooperativeMatrixKHR: {
+      assert(CV.size() == 1 &&
+             "expecting exactly one operand for cooperative matrix types");
+      llvm::Type *RetTy = transType(BCC->getType());
+      llvm::Type *EltTy = transType(
+          static_cast<const SPIRVTypeCooperativeMatrixKHR *>(BV->getType())
+              ->getCompType());
+      auto *FTy = FunctionType::get(RetTy, {EltTy}, false);
+      FunctionCallee Func =
+          M->getOrInsertFunction(getSPIRVFuncName(OC, RetTy), FTy);
+      IRBuilder<> Builder(BB);
+      CallInst *Call = Builder.CreateCall(Func, CV.front());
+      Call->setCallingConv(CallingConv::SPIR_FUNC);
+      return Call;
+    }
     default:
       llvm_unreachable("not implemented");
       return nullptr;

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -153,8 +153,10 @@ SPIRVToLLVMDbgTran::getStringSourceContinued(const SPIRVId Id,
 }
 
 void SPIRVToLLVMDbgTran::transDbgInfo(const SPIRVValue *SV, Value *V) {
-  // A constant sampler does not have a corresponding SPIRVInstruction.
-  if (SV->getOpCode() == OpConstantSampler)
+  // Constant samplers and composites do not have a corresponding
+  // SPIRVInstruction, but they may be mapped to an LLVM Instruction.
+  if (SV->getOpCode() == OpConstantSampler ||
+      SV->getOpCode() == OpConstantComposite)
     return;
 
   if (Instruction *I = dyn_cast<Instruction>(V)) {

--- a/test/extensions/KHR/SPV_KHR_cooperative_matrix/constant_composite.spvasm
+++ b/test/extensions/KHR/SPV_KHR_cooperative_matrix/constant_composite.spvasm
@@ -1,0 +1,30 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; TODO: re-enable spirv-val
+; R/U/N: spirv-val %t.spv
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+
+OpCapability Addresses
+OpCapability Kernel
+OpCapability CooperativeMatrixKHR
+OpExtension "SPV_KHR_cooperative_matrix"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %1 "testCoopMat"
+%void = OpTypeVoid
+%uint = OpTypeInt 32 0
+%_ptr_CrossWorkgroup_uint = OpTypePointer CrossWorkgroup %uint
+%fnTy = OpTypeFunction %void %_ptr_CrossWorkgroup_uint
+%uint_0 = OpConstant %uint 0
+%uint_3 = OpConstant %uint 3
+%uint_8 = OpConstant %uint 8
+%uint_42 = OpConstant %uint 42
+%matTy = OpTypeCooperativeMatrixKHR %uint %uint_3 %uint_8 %uint_8 %uint_0
+%matConst = OpConstantComposite %matTy %uint_42
+%1 = OpFunction %void None %fnTy
+%outPtr = OpFunctionParameter %_ptr_CrossWorkgroup_uint
+%2 = OpLabel
+OpCooperativeMatrixStoreKHR %outPtr %matConst %uint_0 %uint_8
+OpReturn
+OpFunctionEnd
+
+; CHECK: call spir_func target("spirv.CooperativeMatrixKHR", i32, 3, 8, 8, 0) @__spirv_ConstantComposite_RPU3AS142__spirv_CooperativeMatrixKHR__uint_3_8_8_0(i32 42)


### PR DESCRIPTION
This was hitting a "not implemented UNREACHABLE".
Like the other cooperative matrix operations, map this construct to a SPIR-V friendly IR function call.

Let `transDbgInfo` skip over `OpConstantComposite` because we're mapping `OpConstantComposite` to an LLVM `Instruction` without having a corresponding `SPIRVInstruction`.

(cherry picked from commit 04b546550077c4fb51535022af6bf76dcb59362d)