### PR TITLE
Ensure that PHI node has an incoming value per each predecessor instance even if the input SPIR-V module is invalid

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3163,7 +3163,10 @@ static void validatePhiPredecessors(Function *F) {
     for (PHINode &Phi : BB.phis()) {
       SmallVector<Value *> Vs;
       SmallVector<BasicBlock *> Bs;
+      SmallPtrSet<BasicBlock *, 8> UsedB;
       for (auto [V, B] : zip(Phi.incoming_values(), Phi.blocks())) {
+        if (!UsedB.insert(B).second)
+          continue;
         unsigned N = PredsCnt[B];
         Vs.insert(Vs.end(), N, V);
         Bs.insert(Bs.end(), N, B);

--- a/test/phi-multiple-predecessors-invalid-input.spvasm
+++ b/test/phi-multiple-predecessors-invalid-input.spvasm
@@ -1,0 +1,41 @@
+; The goal of the test case is to ensure that PHI node has an incoming value per each predecessor
+; instance even if the input SPIR-V module is invalid as reported by spirv-val.
+
+; We don't run spirv-val on this module therefore.
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+
+               OpCapability Kernel
+               OpCapability Addresses
+               OpCapability Int64
+               OpCapability Linkage
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource OpenCL_CPP 100000
+               OpName %foo "foo"
+               OpName %get "get"
+               OpDecorate %foo LinkageAttributes "foo" Export
+               OpDecorate %get LinkageAttributes "get" Import
+       %uint = OpTypeInt 32 0
+          %3 = OpTypeFunction %uint
+      %ulong = OpTypeInt 64 0
+     %uint_2 = OpConstant %uint 2
+     %uint_4 = OpConstant %uint 4
+        %get = OpFunction %uint None %3
+               OpFunctionEnd
+        %foo = OpFunction %uint None %3
+         %11 = OpLabel
+          %9 = OpFunctionCall %uint %get
+               OpSwitch %9 %12 10 %13 4 %13 0 %13 42 %13
+         %12 = OpLabel
+               OpBranch %13
+         %13 = OpLabel
+         %10 = OpPhi %uint %uint_4 %11 %uint_4 %11 %uint_4 %11 %uint_4 %11 %uint_2 %12
+         %14 = OpPhi %uint %uint_2 %12 %uint_4 %11 %uint_4 %11 %uint_4 %11 %uint_4 %11
+               OpReturnValue %14
+               OpFunctionEnd
+
+; CHECK: phi i32 [ 4, %0 ], [ 4, %0 ], [ 4, %0 ], [ 4, %0 ], [ 2, %2 ]
+; CHECK: phi i32 [ 2, %2 ], [ 4, %0 ], [ 4, %0 ], [ 4, %0 ], [ 4, %0 ]


### PR DESCRIPTION
The goal of the PR is to ensure that PHI node has an incoming value per each predecessor instance even if the input SPIR-V module is invalid as reported by spirv-val.

This PR fixes solution https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2736 intended to fix https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2702
This previous version https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2736 works well for valid SPIR-V modules, but fails to produce correct LLVM IR if a SPIR-V input is incorrect in terms of OpPhi's number of incoming blocks does not match block's predecessor count.
