### PR TITLE
Fix reverse translation of `OpPtrDiff` with untyped pointers

### DIFF
--- a/test/transcoding/ptr_diff.ll
+++ b/test/transcoding/ptr_diff.ll
@@ -5,7 +5,16 @@
 
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
-; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-TYPED-PTR
+; RUN: spirv-val %t.spv
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_KHR_untyped_pointers
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-UNTYPED-PTR
 ; RUN: spirv-val %t.spv
 
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
@@ -19,9 +28,11 @@
 ; CHECK-SPIRV: 66560
 ; CHECK-SPIRV: TypeInt [[#TypeInt:]] 32 0
 ; CHECK-SPIRV: TypeFloat [[#TypeFloat:]] 32
-; CHECK-SPIRV: TypePointer [[#TypePointer:]] [[#]] [[#TypeFloat]]
+; CHECK-SPIRV-TYPED-PTR: TypePointer [[#TypePointer:]] [[#]] [[#TypeFloat]]
+; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[#TypePointer:]] [[#]]
 
-; CHECK-SPIRV: Variable [[#TypePointer]] [[#Var:]]
+; CHECK-SPIRV-TYPED-PTR: Variable [[#TypePointer]] [[#Var:]]
+; CHECK-SPIRV-UNTYPED-PTR: UntypedVariableKHR [[#TypePointer]] [[#Var:]] [[#]] [[#TypeFloat]]
 ; CHECK-SPIRV: PtrDiff [[#TypeInt]] [[#]] [[#Var]] [[#Var]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
We should not lose operand type when `SPV_KHR_untyped_pointers` is used.