### PR TITLE
Make LLVMToSPIRVBase comply with Rule of Three.

### DIFF
--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -72,6 +72,8 @@ namespace SPIRV {
 class LLVMToSPIRVBase : protected BuiltinCallHelper {
 public:
   LLVMToSPIRVBase(SPIRVModule *SMod);
+  LLVMToSPIRVBase(const LLVMToSPIRVBase &other) = delete;
+  LLVMToSPIRVBase &operator=(const LLVMToSPIRVBase &other) = delete;
   bool runLLVMToSPIRV(Module &Mod);
 
   // This enum sets the mode used to translate the value which is


### PR DESCRIPTION
`LLVMToSPIRVBase` had a custom destructor, but no copy constructor and no copy assignment operator, so it was not complying with the Rule of Three. Explicitly add the two latter as deleted to comply.