### PR TITLE
[Backport to 19] Generate load and store for OpCopyLogical (#2825)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2174,7 +2174,22 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
   case OpCopyLogical: {
     SPIRVCopyLogical *CL = static_cast<SPIRVCopyLogical *>(BV);
-    return mapValue(BV, transSPIRVBuiltinFromInst(CL, BB));
+
+    auto *SrcTy = transType(CL->getOperand()->getType());
+    auto *DstTy = transType(CL->getType());
+
+    assert(M->getDataLayout().getTypeStoreSize(SrcTy).getFixedValue() ==
+               M->getDataLayout().getTypeStoreSize(DstTy).getFixedValue() &&
+           "Size mismatch in OpCopyLogical");
+
+    IRBuilder<> Builder(BB);
+
+    auto *SrcAI = Builder.CreateAlloca(SrcTy);
+    Builder.CreateAlignedStore(transValue(CL->getOperand(), F, BB), SrcAI,
+                               SrcAI->getAlign());
+
+    auto *LI = Builder.CreateAlignedLoad(DstTy, SrcAI, SrcAI->getAlign());
+    return mapValue(BV, LI);
   }
 
   case OpAccessChain:

--- a/test/OpCopyLogical.spvasm
+++ b/test/OpCopyLogical.spvasm
@@ -22,4 +22,6 @@
                OpReturn
                OpFunctionEnd
 
-; CHECK-LLVM: @_Z19__spirv_CopyLogical12structtype.0(ptr sret(%structtype) %[[#]], %structtype.0 zeroinitializer)
+; CHECK-LLVM: [[ALLOCA:%[a-z0-9.]+]] = alloca [[SRC_TYPE:%[a-z0-9.]+]], align 8
+; CHECK-LLVM: store [[SRC_TYPE]] zeroinitializer, ptr [[ALLOCA]], align 8
+; CHECK-LLVM: [[DST:%[a-z0-9.]+]] = load [[DST_TYPE:%[a-z0-9.]+]], ptr [[ALLOCA]], align 8


### PR DESCRIPTION
fixes #2768

Generate an LLVM memcpy for OpCopyLogical, rather than a call to an OpCopyLogical function.

(cherry picked from commit 1a1bf17d9e8684cd826e4278e78f63aa80e2e2ca)