### PR TITLE
[Backport to 15] [NFC] Use hasAlignment helper (#2856)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3115,7 +3115,7 @@ void SPIRVToLLVM::transFunctionAttrs(SPIRVFunction *BF, Function *F) {
     if (BA->hasDecorate(DecorationMaxByteOffset, 0, &MaxOffset))
       Builder.addDereferenceableAttr(MaxOffset);
     SPIRVWord AlignmentBytes = 0;
-    if (BA->hasDecorate(DecorationAlignment, 0, &AlignmentBytes))
+    if (BA->hasAlignment(&AlignmentBytes))
       Builder.addAlignmentAttr(AlignmentBytes);
     I->addAttrs(Builder);
   }


### PR DESCRIPTION
Handle all queries of `Alignment` decorations through one and the same helper function.

(cherry picked from commit 67685320c1192af7f8bb18c674064ac7f5888952)