### PR TITLE
[SPIRVToOCL20] Fix __spirv_ocl_printf translation assert error

### DIFF
--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -90,7 +90,8 @@ BuiltinCallMutator::BuiltinCallMutator(BuiltinCallMutator &&Other)
 Value *BuiltinCallMutator::doConversion() {
   assert(CI && "Need to have a call instruction to do the conversion");
   auto Mangler = makeMangler(CI, Rules);
-  for (unsigned I = 0; I < Args.size(); I++) {
+  for (unsigned I = 0, E = std::min(Args.size(), PointerTypes.size()); I < E;
+       I++) {
     Mangler->getTypeMangleInfo(I).PointerTy =
         dyn_cast<TypedPointerType>(PointerTypes[I]);
   }

--- a/test/printf-spv-ir-to-ocl.ll
+++ b/test/printf-spv-ir-to-ocl.ll
@@ -1,0 +1,14 @@
+; REQUIRES: pass-plugin
+; UNSUPPORTED: target={{.*windows.*}}
+
+; RUN: opt %load_spirv_lib -passes=spirv-to-ocl20 %s -S -o - | FileCheck %s
+
+target triple = "spir64-unknown-unknown"
+
+declare spir_func i32 @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2), ...)
+
+define spir_func void @__asan_set_shadow_dynamic_local() {
+; CHECK: call spir_func i32 (ptr addrspace(2), ...) @printf(ptr addrspace(2) null, i32 0, i32 0)
+  %call = call spir_func i32 (ptr addrspace(2), ...) @_Z18__spirv_ocl_printfPU3AS2Kcz(ptr addrspace(2) null, i32 0, i32 0)
+  ret void
+}


### PR DESCRIPTION
When SPIRVToOCL20Pass is used in OCL CPU backend to translate SPV-IR builtin to OCL builtin, __spirv_ocl_printf call has bigger number of arguments than number of parameters.