### PR TITLE
[Backport to 15] [SPIR-V 1.2] SPIRVReader: Add MaxByteOffsetId support

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3137,6 +3137,14 @@ void SPIRVToLLVM::transFunctionAttrs(SPIRVFunction *BF, Function *F) {
     SPIRVWord MaxOffset = 0;
     if (BA->hasDecorate(DecorationMaxByteOffset, 0, &MaxOffset))
       Builder.addDereferenceableAttr(MaxOffset);
+    else {
+      SPIRVId MaxOffsetId;
+      if (BA->hasDecorateId(DecorationMaxByteOffsetId, 0, &MaxOffsetId)) {
+        if (auto MaxOffsetVal = transIdAsConstant(MaxOffsetId)) {
+          Builder.addDereferenceableAttr(*MaxOffsetVal);
+        }
+      }
+    }
     if (auto Alignment = getAlignment(BA)) {
       Builder.addAlignmentAttr(*Alignment);
     }

--- a/test/MaxByteOffsetId.spvasm
+++ b/test/MaxByteOffsetId.spvasm
@@ -1,0 +1,33 @@
+; REQUIRES: spirv-as
+
+; RUN: spirv-as %s --target-env spv1.2 -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
+
+; CHECK: define spir_kernel void @testMaxByteOffsetId(
+; CHECK-SAME: i32 addrspace(1)* dereferenceable(24) %p,
+; CHECK-SAME: i32 addrspace(1)* dereferenceable(48) %q)
+
+               OpCapability Addresses
+               OpCapability Kernel
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %fn "testMaxByteOffsetId"
+               OpName %p "p"
+               OpName %q "q"
+               OpDecorateId %p MaxByteOffsetId %mbo
+               OpDecorateId %q MaxByteOffsetId %spec
+       %void = OpTypeVoid
+        %i32 = OpTypeInt 32 0
+        %ptr = OpTypePointer CrossWorkgroup %i32
+       %fnTy = OpTypeFunction %void %ptr %ptr
+        %mbo = OpConstant %i32 24
+       %spec = OpSpecConstantOp %i32 IAdd %mbo %mbo
+
+         %fn = OpFunction %void None %fnTy
+          %p = OpFunctionParameter %ptr
+          %q = OpFunctionParameter %ptr
+      %entry = OpLabel
+
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
If there is no `OpDecorate .. MaxByteOffset` in the input, see if there is an `OpDecorateId .. MaxByteOffsetId` and take the value for the LLVM `dereferenceable` attribute from the referenced constant instead.

Once `MaxByteOffsetId` has been translated to LLVM IR, it is indistinguishable from a (non-ID) `MaxByteOffset` decoration.

(cherry picked from commit 0332a1e50c3b878b0b776f41ee60890f42c75a49)