### PR TITLE
[SPIR-V 1.2] SPIRVReader: Support LocalSizeId

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -4519,6 +4519,14 @@ bool SPIRVToLLVM::transMetadata() {
     if (auto *EM = BF->getExecutionMode(ExecutionModeLocalSize)) {
       F->setMetadata(kSPIR2MD::WGSize,
                      getMDNodeStringIntVec(Context, EM->getLiterals()));
+    } else if (auto *EM = BF->getExecutionModeId(ExecutionModeLocalSizeId)) {
+      std::vector<SPIRVWord> Values;
+      for (const auto Id : EM->getLiterals()) {
+        if (auto Val = transIdAsConstant(Id)) {
+          Values.emplace_back(static_cast<SPIRVWord>(*Val));
+        }
+      }
+      F->setMetadata(kSPIR2MD::WGSize, getMDNodeStringIntVec(Context, Values));
     }
     // Generate metadata for work_group_size_hint
     if (auto *EM = BF->getExecutionMode(ExecutionModeLocalSizeHint)) {

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -656,6 +656,7 @@ void SPIRVExecutionMode::decode(std::istream &I) {
   getDecoder(I) >> Target >> ExecMode;
   switch (static_cast<uint32_t>(ExecMode)) {
   case ExecutionModeLocalSize:
+  case ExecutionModeLocalSizeId:
   case ExecutionModeLocalSizeHint:
   case ExecutionModeMaxWorkgroupSizeINTEL:
     WordLiterals.resize(3);

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -807,6 +807,12 @@ public:
       return nullptr;
     return Loc->second;
   }
+  SPIRVExecutionModeId *getExecutionModeId(SPIRVExecutionModeKind EMK) const {
+    auto Loc = ExecModes.find(EMK);
+    if (Loc == ExecModes.end())
+      return nullptr;
+    return static_cast<SPIRVExecutionModeId *>(Loc->second);
+  }
   SPIRVExecutionModeRange
   getExecutionModeRange(SPIRVExecutionModeKind EMK) const {
     return ExecModes.equal_range(EMK);

--- a/test/LocalSizeId.spvasm
+++ b/test/LocalSizeId.spvasm
@@ -1,0 +1,27 @@
+; REQUIRES: spirv-as
+
+; RUN: spirv-as %s --target-env spv1.2 -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
+
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %fn "testLocalSizeId"
+               OpExecutionModeId %fn LocalSizeId %uint_64 %uint_1 %uint_1sco
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+    %uint_64 = OpConstant %uint 64
+  %uint_1sco = OpSpecConstantOp %uint UDiv %uint_64 %uint_64
+       %fnTy = OpTypeFunction %void
+
+; CHECK: define spir_kernel void @testLocalSizeId() {{.*}} !reqd_work_group_size ![[MD:[0-9]+]]
+; CHECK: ![[MD]] = !{i32 64, i32 1, i32 1}
+
+         %fn = OpFunction %void None %fnTy
+      %entry = OpLabel
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
If there is no `OpExecutionMode .. LocalSize` in the input, see if there is an `OpExecutionModeId .. LocalSizeId` and take the value for the `reqd_work_group_size` metadata from the referenced constants instead.

Once `LocalSizeId` has been translated to LLVM IR, it is indistinguishable from a (non-ID) `LocalSize` execution mode.