### PR TITLE
[Backport to 15][DebugInfo] Backporting 3 patches to LLVM 15

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -776,7 +776,7 @@ LLVMToSPIRVDbgTran::transDbgArrayTypeDynamic(const DICompositeType *AT) {
 
 SPIRVEntry *LLVMToSPIRVDbgTran::transDbgSubrangeType(const DISubrange *ST) {
   using namespace SPIRVDebug::Operand::TypeSubrange;
-  SPIRVWordVec Ops(OperandCount);
+  SPIRVWordVec Ops(MinOperandCount);
   auto TransOperand = [&Ops, this, ST](int Idx) -> void {
     Metadata *RawNode = nullptr;
     switch (Idx) {
@@ -788,9 +788,6 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgSubrangeType(const DISubrange *ST) {
       break;
     case CountIdx:
       RawNode = ST->getRawCountNode();
-      break;
-    case StrideIdx:
-      RawNode = ST->getRawStride();
       break;
     }
     if (!RawNode) {
@@ -819,8 +816,17 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgSubrangeType(const DISubrange *ST) {
                          : getDebugInfoNoneId();
     }
   };
-  for (int Idx = CountIdx; Idx < OperandCount; ++Idx)
+  for (int Idx = 0; Idx < MinOperandCount; ++Idx)
     TransOperand(Idx);
+  if (auto *RawNode = ST->getRawStride()) {
+    Ops.resize(MaxOperandCount);
+    if (auto *Node = dyn_cast<MDNode>(RawNode))
+      Ops[StrideIdx] = transDbgEntry(Node)->getId();
+    else
+      Ops[StrideIdx] =
+          SPIRVWriter->transValue(ST->getStride().get<ConstantInt *>(), nullptr)
+              ->getId();
+  }
   return BM->addDebugInfo(SPIRVDebug::TypeSubrange, getVoidTy(), Ops);
 }
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1102,8 +1102,8 @@ MDNode *SPIRVToLLVMDbgTran::transEntryPoint(const SPIRVExtInst *DebugInst) {
   std::string Producer = getString(Ops[CompilerSignatureIdx]);
   std::string CLArgs = getString(Ops[CommandLineArgsIdx]);
 
-  [[maybe_unused]] DICompileUnit *C =
-      transCompilationUnit(CU, Producer, CLArgs);
+  DICompileUnit *C = transCompilationUnit(CU, Producer, CLArgs); // NOLINT
+  DebugInstCache[CU] = C;
 
   return transFunction(EP, true /*IsMainSubprogram*/);
 }

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -607,8 +607,9 @@ DISubrange *
 SPIRVToLLVMDbgTran::transTypeSubrange(const SPIRVExtInst *DebugInst) {
   using namespace SPIRVDebug::Operand::TypeSubrange;
   const SPIRVWordVec &Ops = DebugInst->getArguments();
-  assert(Ops.size() == OperandCount && "Invalid number of operands");
-  std::vector<Metadata *> TranslatedOps(OperandCount, nullptr);
+  assert((Ops.size() == MinOperandCount || Ops.size() == MaxOperandCount) &&
+         "Invalid number of operands");
+  std::vector<Metadata *> TranslatedOps(MaxOperandCount, nullptr);
   auto TransOperand = [&Ops, &TranslatedOps, this](int Idx) -> void {
     if (!getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[Idx])) {
       if (auto *GlobalVar = getDbgInst<SPIRVDebug::GlobalVariable>(Ops[Idx])) {
@@ -627,10 +628,11 @@ SPIRVToLLVMDbgTran::transTypeSubrange(const SPIRVExtInst *DebugInst) {
       }
     }
   };
-  for (int Idx = CountIdx; Idx < OperandCount; ++Idx)
+  for (size_t Idx = 0; Idx < Ops.size(); ++Idx)
     TransOperand(Idx);
   return getDIBuilder(DebugInst).getOrCreateSubrange(
-      TranslatedOps[0], TranslatedOps[1], TranslatedOps[2], TranslatedOps[3]);
+      TranslatedOps[CountIdx], TranslatedOps[LowerBoundIdx],
+      TranslatedOps[UpperBoundIdx], TranslatedOps[StrideIdx]);
 }
 
 DIStringType *

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -211,7 +211,7 @@ SPIRVToLLVMDbgTran::transCompilationUnit(const SPIRVExtInst *DebugInst,
   // Do nothing in case we have already translated the CU (e.g. during
   // DebugEntryPoint translation)
   if (BuilderMap[DebugInst->getId()])
-    return nullptr;
+    return cast<DICompileUnit>(DebugInstCache[DebugInst]);
 
   const SPIRVWordVec &Ops = DebugInst->getArguments();
 

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -396,11 +396,12 @@ namespace TypeVector = TypeArray;
 
 namespace TypeSubrange {
 enum {
-  CountIdx        = 0,
-  LowerBoundIdx   = 1,
-  UpperBoundIdx   = 2,
+  LowerBoundIdx   = 0,
+  UpperBoundIdx   = 1,
+  CountIdx        = 2,
   StrideIdx       = 3,
-  OperandCount    = 4
+  MinOperandCount = 3,
+  MaxOperandCount = 4
 };
 }
 

--- a/test/DebugInfo/NonSemantic/Shader200/DebugInfoSubrange.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugInfoSubrange.ll
@@ -28,12 +28,12 @@
 ; CHECK-SPIRV: [[#DebugFuncId:]] [[#EISId]] DebugFunction
 ; CHECK-SPIRV: [[#LocalVarId:]] [[#EISId]] DebugLocalVariable [[#LocalVarNameId]] [[#]] [[#]] [[#]] [[#]] [[#DebugFuncId]]
 ; CHECK-SPIRV: [[#DebugTypeTemplate:]] [[#EISId]] DebugTypeTemplate [[#DebugFuncId]]
-; CHECK-SPIRV: [[#EISId]] DebugTypeSubrange [[#DINoneId]] [[#Constant1Id]] [[#LocalVarId]]  [[#DINoneId]]
+; CHECK-SPIRV: [[#EISId]] DebugTypeSubrange [[#Constant1Id]] [[#LocalVarId]]  [[#DINoneId]] {{$}}
 
 ; CHECK-SPIRV: [[#DIExprId:]] [[#EISId]] DebugExpression
-; CHECK-SPIRV: [[#EISId]] DebugTypeSubrange [[#DINoneId]] [[#DIExprId]] [[#DIExprId]] [[#DINoneId]]
+; CHECK-SPIRV: [[#EISId]] DebugTypeSubrange [[#DIExprId]] [[#DIExprId]] [[#DINoneId]] {{$}}
 
-; CHECK-SPIRV: [[#EISId]] DebugTypeSubrange [[#Constant1000Id]] [[#Constant1Id]] [[#DINoneId]] [[#DINoneId]]
+; CHECK-SPIRV: [[#EISId]] DebugTypeSubrange [[#Constant1Id]] [[#DINoneId]] [[#Constant1000Id]] {{$}}
 
 ; CHECK-SPIRV: [[#EISId]] DebugLine [[#]] [[#Constant15Id]] [[#Constant15Id]] [[#Constant67Id]] [[#Constant68Id]]
 ; CHECK-SPIRV: [[#EISId]] DebugLine [[#]] [[#Constant27Id]] [[#Constant27Id]] [[#Constant24Id]] [[#Constant25Id]]

--- a/test/DebugInfo/NonSemantic/Shader200/DebugTypeDef.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugTypeDef.ll
@@ -1,0 +1,52 @@
+; This test covers assertion "Typedef should have a parent scope"
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-200 -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
+; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV: String [[#TestStr:]] "test.cpp"
+; CHECK-SPIRV: String [[#StdStr:]] "stddef.h"
+; CHECK-SPIRV: [[#SourceCpp:]] [[#]] DebugSource [[#TestStr]]
+; CHECK-SPIRV: [[#Scope:]] [[#]] DebugCompilationUnit [[#]] [[#]] [[#SourceCpp]]
+; CHECK-SPIRV: [[#SourceHeader:]] [[#]] DebugSource [[#StdStr]]
+; CHECK-SPIRV: DebugTypedef [[#]] [[#]] [[#SourceHeader]] [[#]] [[#]] [[#Scope]]
+; CHECK-SPIRV: DebugEntryPoint [[#]] [[#Scope]]
+
+; CHECK-LLVM: DW_TAG_typedef
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64"
+
+$_ZTSZ4mainEUlvE_ = comdat any
+
+; Function Attrs: convergent mustprogress norecurse nounwind
+define weak_odr dso_local spir_kernel void @_ZTSZ4mainEUlvE_() #0 comdat !dbg !14 {
+entry:
+  ret void
+}
+
+attributes #0 = { convergent mustprogress norecurse nounwind }
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!10, !11, !12, !13}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang based compiler", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, imports: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "test.cpp", directory: "")
+!2 = !{}
+!3 = !{!4}
+!4 = !DIGlobalVariableExpression(var: !5, expr: !DIExpression(DW_OP_constu, 175, DW_OP_stack_value))
+!5 = distinct !DIGlobalVariable(name: "N", scope: !0, file: !1, line: 7, type: !6, isLocal: true, isDefinition: true)
+!6 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+!7 = !DIDerivedType(tag: DW_TAG_typedef, name: "size_t", file: !8, line: 62, baseType: !9)
+!8 = !DIFile(filename: "stddef.h", directory: "")
+!9 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
+!10 = !{i32 7, !"Dwarf Version", i32 4}
+!11 = !{i32 2, !"Debug Info Version", i32 3}
+!12 = !{i32 1, !"wchar_size", i32 4}
+!13 = !{i32 7, !"frame-pointer", i32 2}
+!14 = distinct !DISubprogram(name: "_ZTSZ4mainEUlvE_", scope: !1, file: !1, line: 24, type: !15, flags: DIFlagArtificial | DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!15 = !DISubroutineType(cc: DW_CC_nocall, types: !16)
+!16 = !{null}

--- a/test/DebugInfo/NonSemantic/Shader200/DebugTypeDef.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugTypeDef.ll
@@ -4,7 +4,7 @@
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-200 -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
-; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
@@ -50,3 +50,7 @@ attributes #0 = { convergent mustprogress norecurse nounwind }
 !14 = distinct !DISubprogram(name: "_ZTSZ4mainEUlvE_", scope: !1, file: !1, line: 24, type: !15, flags: DIFlagArtificial | DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
 !15 = !DISubroutineType(cc: DW_CC_nocall, types: !16)
 !16 = !{null}
+!17 = !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !18, entity: !19, file: !1, line: 58)
+!18 = !DINamespace(name: "std", scope: null)
+!19 = !DIDerivedType(tag: DW_TAG_typedef, name: "max_align_t", file: !1, baseType: !20)
+!20 = !DICompositeType(tag: DW_TAG_structure_type, file: !8, line: 19, size: 256, flags: DIFlagFwdDecl, elements: !2, identifier: "_ZTS11max_align_t")

--- a/test/DebugInfo/NonSemantic/Shader200/FortranDynamicArrayExpr.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/FortranDynamicArrayExpr.ll
@@ -25,8 +25,8 @@
 ; CHECK-SPIRV: ExtInst [[#VoidT]] [[#DbgExprAssociated:]] [[#Import]] DebugExpression [[#]] [[#]] [[#]] [[#]] {{$}}
 ; CHECK-SPIRV: ExtInst [[#VoidT]] [[#DbgExprLowerBound:]] [[#Import]] DebugExpression [[#]] [[#]] [[#]] {{$}}
 ; CHECK-SPIRV: ExtInst [[#VoidT]] [[#DbgExprUpperBound:]] [[#Import]] DebugExpression [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] [[#]] {{$}}
-; CHECK-SPIRV: ExtInst [[#VoidT]] [[#DbgExprCount:]] [[#Import]] DebugExpression [[#]] [[#]] [[#]] {{$}}
-; CHECK-SPIRV: ExtInst [[#VoidT]] [[#DbgSubRangeId:]] [[#Import]] DebugTypeSubrange [[#DbgInfoNone]] [[#DbgExprLowerBound]] [[#DbgExprUpperBound]] [[#DbgExprCount]]
+; CHECK-SPIRV: ExtInst [[#VoidT]] [[#DbgExprStride:]] [[#Import]] DebugExpression [[#]] [[#]] [[#]] {{$}}
+; CHECK-SPIRV: ExtInst [[#VoidT]] [[#DbgSubRangeId:]] [[#Import]] DebugTypeSubrange [[#DbgExprLowerBound]] [[#DbgExprUpperBound]] [[#DbgInfoNone]] [[#DbgExprStride]]
 ; CHECK-SPIRV: ExtInst [[#VoidT]] [[#DbgArrayId:]] [[#Import]] DebugTypeArrayDynamic [[#ArrayBasicT]] [[#DbgExprLocation]] [[#DbgExprAssociated]] [[#DbgInfoNone]] [[#DbgInfoNone]] [[#DbgSubRangeId]]
 
 ; CHECK-LLVM: %[[#Array:]] = alloca


### PR DESCRIPTION
1)
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/450b9dff870214a5b484e720f51b9a2b33dab8b7

[Backport to 15][DebugInfo] Cache CU value translated outside of usual flow Compilation unit can be translated earlier, e.g. in `transEntryPoint()`. We should save the translated LLVM value to be used further.

2)
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/9f0117bb9d719ea50bc551dc029ac0ae02fd30d1

[Backport to 15][DebugInfo] Correctly use cached DICompilationUnit Followup for
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2072

3)
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/commit/0f835cc0ab44c1c15ced28b06ef3aa01b263cc95

[Backport to 15][DebugInfo] Fix DebugTypeSubrange parameters order Count should be the 3rd parameter.