### PR TITLE
Add translation for Intrinsic::atan2

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1853,6 +1853,7 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
   case Intrinsic::acos:
   case Intrinsic::asin:
   case Intrinsic::atan:
+  case Intrinsic::atan2:
   case Intrinsic::ceil:
   case Intrinsic::copysign:
   case Intrinsic::cos:

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4004,6 +4004,8 @@ static SPIRVWord getBuiltinIdForIntrinsic(Intrinsic::ID IID) {
     return OpenCLLIB::Asin;
   case Intrinsic::atan:
     return OpenCLLIB::Atan;
+  case Intrinsic::atan2:
+    return OpenCLLIB::Atan2;
   case Intrinsic::ceil:
     return OpenCLLIB::Ceil;
   case Intrinsic::copysign:
@@ -4260,6 +4262,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
                           BB);
   }
   // Binary FP intrinsics
+  case Intrinsic::atan2:
   case Intrinsic::copysign:
   case Intrinsic::pow:
   case Intrinsic::powi:

--- a/test/llvm-intrinsics/fp-intrinsics.ll
+++ b/test/llvm-intrinsics/fp-intrinsics.ll
@@ -422,3 +422,17 @@ entry:
 }
 
 declare float @llvm.tanh.f32(float)
+
+; CHECK: Function
+; CHECK: FunctionParameter {{[0-9]+}} [[x:[0-9]+]]
+; CHECK: FunctionParameter {{[0-9]+}} [[y:[0-9]+]]
+; CHECK: ExtInst [[var1]] {{[0-9]+}} [[extinst_id]] atan2 [[y]] [[x]]
+; CHECK: FunctionEnd
+
+define spir_func float @TestAtan2(float %x, float %y) {
+entry:
+  %t = tail call float @llvm.atan2.f32(float %y, float %x)
+  ret float %t
+}
+
+declare float @llvm.atan2.f32(float, float)


### PR DESCRIPTION
Add translation for atan2 LLVM
intrinsic which is mapped to corresponding OpenCL extended
instructions.