### PR TITLE
Add cmake option to enable --spirv-tools-dis feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,9 @@ if (NOT SPIRV_TOOLS_FOUND)
   endif()
 endif()
 
-if (NOT SPIRV_TOOLS_FOUND)
+option(LLVM_SPIRV_ENABLE_LIBSPIRV_DIS "Enable --spirv-tools-dis support.")
+
+if (NOT SPIRV_TOOLS_FOUND AND LLVM_SPIRV_ENABLE_LIBSPIRV_DIS)
   message(STATUS "SPIRV-Tools not found; project will be built without "
           "--spirv-tools-dis support.")
 endif()

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Building clang from sources takes time and resources and it can be avoided:
 ### Build with SPIRV-Tools
 
 The translator can use [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools) to generate assembly with widely adopted syntax.
+This feature can be enabled by passing `-DLLVM_SPIRV_ENABLE_LIBSPIRV_DIS=ON` option.
 If SPIRV-Tools have been installed prior to the build it will be detected and
 used automatically. However it is also possible to enable use of SPIRV-Tools
 from a custom location using the following instructions:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,9 @@ if(SPIRV_TOOLS_FOUND AND NOT SPIRV-Tools-tools_FOUND)
   endif()
 
   set(SPIRV_TOOLS_BINDIR "${SPIRV_TOOLS_PREFIX}/bin")
+  if (LLVM_SPIRV_ENABLE_LIBSPIRV_DIS)
+    set(SPIRV_ENABLE_LIBSPIRV_DIS ON)
+  endif()
 elseif(SPIRV-Tools-tools_FOUND)
   # we found SPIRV-Tools via cmake targets
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -21,7 +21,7 @@ config.suffixes = ['.cl', '.ll', '.spt', '.spvasm']
 # excludes: A list of directories  and fles to exclude from the testsuite.
 config.excludes = ['CMakeLists.txt']
 
-if config.spirv_tools_found:
+if config.libspirv_dis:
     config.available_features.add('libspirv_dis')
 
 if not config.spirv_skip_debug_info_tests:

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -19,6 +19,7 @@ config.host_arch = "@HOST_ARCH@"
 config.python_executable = "@PYTHON_EXECUTABLE@"
 config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
 config.spirv_tools_found = "@SPIRV_TOOLS_FOUND@"
+config.libspirv_dis = "@SPIRV_ENABLE_LIBSPIRV_DIS@"
 config.spirv_tools_have_spirv_as = @SPIRV_TOOLS_SPIRV_AS_FOUND@
 config.spirv_tools_have_spirv_dis = @SPIRV_TOOLS_SPIRV_DIS_FOUND@
 config.spirv_tools_have_spirv_link = @SPIRV_TOOLS_SPIRV_LINK_FOUND@

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -32,8 +32,8 @@ target_include_directories(llvm-spirv
     ${LLVM_SPIRV_INCLUDE_DIRS}
 )
 
-if(SPIRV_TOOLS_FOUND)
+if(SPIRV_TOOLS_FOUND AND LLVM_SPIRV_ENABLE_LIBSPIRV_DIS)
   target_compile_definitions(llvm-spirv PRIVATE LLVM_SPIRV_HAVE_SPIRV_TOOLS=1)
   target_include_directories(llvm-spirv PRIVATE ${SPIRV_TOOLS_INCLUDE_DIRS})
   target_link_libraries(llvm-spirv PRIVATE ${SPIRV_TOOLS_LDFLAGS})
-endif(SPIRV_TOOLS_FOUND)
+endif()


### PR DESCRIPTION
Currently, when making spirv-tools available to the translator two things happen:

1. Tests requiring spirv-tools binaries such as `spirv-as` or `spirv-dis` can run.
2. `llvm-spirv` is linked against spirv-tools libraries to enable `--spirv-tools-dis` option.

This patch separates (2.) into a different option (`LLVM_SPIRV_ENABLE_LIBSPIRV_DIS`), so that we can still run tests requiring spirv-tools binaries even if we don't want to link `llvm-spirv` against spirv-tools libraries.