### PR TITLE
Limit NO_INSTALL_RPATH to out-of-tree builds.

### DIFF
--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -14,10 +14,18 @@ if(SPIRV_BACKEND_FOUND)
   list(APPEND LLVM_LINK_COMPONENTS "SPIRVCodeGen")
 endif()
 
+# llvm_setup_rpath messes with the rpath making llvm-spirv not
+# executable from the build directory in out-of-tree builds
+set(add_llvm_tool_options)
+if(LLVM_SPIRV_BUILD_EXTERNAL)
+  set(add_llvm_tool_options
+    NO_INSTALL_RPATH
+  )
+endif()
+
 add_llvm_tool(llvm-spirv
   llvm-spirv.cpp
-  # llvm_setup_rpath messes with the rpath making llvm-spirv not executable from the build directory
-  NO_INSTALL_RPATH
+  ${add_llvm_tool_options}
 )
 
 setup_host_tool(llvm-spirv LLVM_SPIRV llvm-spirv_exe llvm-spirv_target)


### PR DESCRIPTION
For in-tree builds with shared libraries, setting the rpath not only works, but is required.

Fixes #2906