### PR TITLE
[Backport to 19][DebugInfo] Fix EnumClass support (#2876)

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -500,6 +500,8 @@ SPIRVWord LLVMToSPIRVDbgTran::mapDebugFlags(DINode::DIFlags DFlags) {
   if (BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200)
     if (DFlags & DINode::FlagBitField)
       Flags |= SPIRVDebug::FlagBitField;
+  if (DFlags & DINode::FlagEnumClass)
+    Flags |= SPIRVDebug::FlagIsEnumClass;
   return Flags;
 }
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -812,7 +812,7 @@ DINode *SPIRVToLLVMDbgTran::transTypeEnum(const SPIRVExtInst *DebugInst) {
       UnderlyingType = transDebugInst<DIType>(static_cast<SPIRVExtInst *>(E));
     return getDIBuilder(DebugInst).createEnumerationType(
         Scope, Name, File, LineNo, SizeInBits, AlignInBits, Enumerators,
-        UnderlyingType, 0, "", UnderlyingType);
+        UnderlyingType, 0, "", Flags & SPIRVDebug::FlagIsEnumClass);
   }
 }
 


### PR DESCRIPTION
This commit addresses issues with EnumClass handling in DebugEnumType. In reverse translation, a bug caused the EnumClass flag to be incorrectly applied to every DebugEnumType with an UnderlyingType. Additionally, in forward translation, the support for EnumClassFlag was missing entirely.