### PR TITLE
handle OpBitcast between pointers and non-pointers

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1088,7 +1088,7 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
   case OpBitcast:
     CO = Instruction::BitCast;
     if (Src->getType()->isPointerTy() && !Dst->isPointerTy()) {
-      if (auto* DstVecTy = dyn_cast<FixedVectorType>(Dst)) {
+      if (auto *DstVecTy = dyn_cast<FixedVectorType>(Dst)) {
         assert(DstVecTy->getElementType()->isIntegerTy(32) &&
                DstVecTy->getNumElements() == 2 &&
                "Expected vector of two 32-bit integer components");
@@ -1102,7 +1102,7 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         CO = Instruction::PtrToInt;
       }
     } else if (!Src->getType()->isPointerTy() && Dst->isPointerTy()) {
-      if (auto* SrcVecTy = dyn_cast<FixedVectorType>(Src->getType())) {
+      if (auto *SrcVecTy = dyn_cast<FixedVectorType>(Src->getType())) {
         assert(SrcVecTy->getElementType()->isIntegerTy(32) &&
                SrcVecTy->getNumElements() == 2 &&
                "Expected vector of two 32-bit integer components");

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1086,6 +1086,10 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
     CO = IsExt ? Instruction::FPExt : Instruction::FPTrunc;
     break;
   case OpBitcast:
+    // OpBitcast need to be handled as a special-case when the source is a
+    // pointer and the destination is not a pointer, and where the source is not
+    // a pointer and the destination is a pointer. This is supported by the
+    // SPIR-V bitcast, but not by the LLVM bitcast.
     CO = Instruction::BitCast;
     if (Src->getType()->isPointerTy() && !Dst->isPointerTy()) {
       if (auto *DstVecTy = dyn_cast<FixedVectorType>(Dst)) {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1085,6 +1085,15 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
   case OpFConvert:
     CO = IsExt ? Instruction::FPExt : Instruction::FPTrunc;
     break;
+  case OpBitcast:
+    if (Src->getType()->isPointerTy() && !Dst->isPointerTy()) {
+      CO = Instruction::PtrToInt;
+    } else if (!Src->getType()->isPointerTy() && Dst->isPointerTy()) {
+      CO = Instruction::IntToPtr;
+    } else {
+      CO = Instruction::BitCast;
+    }
+    break;
   default:
     CO = static_cast<CastInst::CastOps>(OpCodeMap::rmap(BC->getOpCode()));
   }

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1089,28 +1089,28 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
     CO = Instruction::BitCast;
     if (Src->getType()->isPointerTy() && !Dst->isPointerTy()) {
       if (auto *DstVecTy = dyn_cast<FixedVectorType>(Dst)) {
-        assert(DstVecTy->getElementType()->isIntegerTy(32) &&
-               DstVecTy->getNumElements() == 2 &&
-               "Expected vector of two 32-bit integer components");
-        auto *Int64Ty = Type::getInt64Ty(BB->getContext());
+        unsigned TotalBitWidth =
+            DstVecTy->getElementType()->getIntegerBitWidth() *
+            DstVecTy->getNumElements();
+        auto *IntTy = Type::getIntNTy(BB->getContext(), TotalBitWidth);
         if (BB) {
-          Src = CastInst::CreatePointerCast(Src, Int64Ty, "", BB);
+          Src = CastInst::CreatePointerCast(Src, IntTy, "", BB);
         } else {
-          Src = ConstantExpr::getPointerCast(dyn_cast<Constant>(Src), Int64Ty);
+          Src = ConstantExpr::getPointerCast(dyn_cast<Constant>(Src), IntTy);
         }
       } else {
         CO = Instruction::PtrToInt;
       }
     } else if (!Src->getType()->isPointerTy() && Dst->isPointerTy()) {
       if (auto *SrcVecTy = dyn_cast<FixedVectorType>(Src->getType())) {
-        assert(SrcVecTy->getElementType()->isIntegerTy(32) &&
-               SrcVecTy->getNumElements() == 2 &&
-               "Expected vector of two 32-bit integer components");
-        auto *Int64Ty = Type::getInt64Ty(BB->getContext());
+        unsigned TotalBitWidth =
+            SrcVecTy->getElementType()->getIntegerBitWidth() *
+            SrcVecTy->getNumElements();
+        auto *IntTy = Type::getIntNTy(BB->getContext(), TotalBitWidth);
         if (BB) {
-          Src = CastInst::Create(Instruction::BitCast, Src, Int64Ty, "", BB);
+          Src = CastInst::Create(Instruction::BitCast, Src, IntTy, "", BB);
         } else {
-          Src = ConstantExpr::getBitCast(dyn_cast<Constant>(Src), Int64Ty);
+          Src = ConstantExpr::getBitCast(dyn_cast<Constant>(Src), IntTy);
         }
       }
       CO = Instruction::IntToPtr;

--- a/test/OpBitcast_ptr_scalar.spvasm
+++ b/test/OpBitcast_ptr_scalar.spvasm
@@ -1,0 +1,31 @@
+; Check support of OpBitcast with pointer operands
+; Converts to scalar integers, which is supported by all SPIR-V versions
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int64
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test"
+       %uint = OpTypeInt 32 0
+      %ulong = OpTypeInt 64 0
+       %void = OpTypeVoid
+   %pptr_int = OpTypePointer Function %uint
+ %kernel_sig = OpTypeFunction %void
+     %kernel = OpFunction %void None %kernel_sig
+      %entry = OpLabel
+     %srcptr = OpVariable %pptr_int Function
+     %dstint = OpBitcast %ulong %srcptr
+     %dstptr = OpBitcast %pptr_int %dstint
+               OpReturn
+               OpFunctionEnd
+
+
+; CHECK-LLVM: [[SRCPTR:%[a-z0-9.]+]] = alloca i32, align 4
+; CHECK-LLVM: [[DSTINT:%[a-z0-9.]+]] = ptrtoint ptr [[SRCPTR]] to i64
+; CHECK-LLVM: [[DSTPTR:%[a-z0-9.]+]] = inttoptr i64 [[DSTINT]] to ptr

--- a/test/OpBitcast_ptr_vector.spvasm
+++ b/test/OpBitcast_ptr_vector.spvasm
@@ -1,0 +1,34 @@
+; Check support of OpBitcast with pointer operands
+; Converts to vectors of integers, which is supported by SPIR-V 1.5
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.5 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int64
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test"
+       %uint = OpTypeInt 32 0
+      %ulong = OpTypeInt 64 0
+      %uint2 = OpTypeVector %uint 2
+       %void = OpTypeVoid
+   %pptr_int = OpTypePointer Function %uint
+ %kernel_sig = OpTypeFunction %void
+     %kernel = OpFunction %void None %kernel_sig
+      %entry = OpLabel
+     %srcptr = OpVariable %pptr_int Function
+    %dstint2 = OpBitcast %uint2 %srcptr
+     %dstptr = OpBitcast %pptr_int %dstint2
+               OpReturn
+               OpFunctionEnd
+
+
+; CHECK-LLVM: [[SRCPTR:%[a-z0-9.]+]] = alloca i32, align 4
+; CHECK-LLVM: [[TMPLONG0:%[a-z0-9.]+]] = ptrtoint ptr [[SRCPTR]] to i64
+; CHECK-LLVM: [[DSTINT2:%[a-z0-9.]+]] = bitcast i64 [[TMPLONG0]] to <2 x i32>
+; CHECK-LLVM: [[TMPLONG1:%[a-z0-9.]+]] = bitcast <2 x i32> [[DSTINT2]] to i64
+; CHECK-LLVM: [[DSTPTR:%[a-z0-9.]+]] = inttoptr i64 [[TMPLONG1]] to ptr

--- a/test/OpBitcast_ptr_vector.spvasm
+++ b/test/OpBitcast_ptr_vector.spvasm
@@ -13,7 +13,6 @@
                OpMemoryModel Physical64 OpenCL
                OpEntryPoint Kernel %kernel "test"
        %uint = OpTypeInt 32 0
-      %ulong = OpTypeInt 64 0
       %uint2 = OpTypeVector %uint 2
        %void = OpTypeVoid
    %pptr_int = OpTypePointer Function %uint


### PR DESCRIPTION
Adds support for SPIR-V [OpBitcast](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpBitcast) instructions where the source is a pointer and the destination is not a pointer, and where the source is not a pointer and the destination is a pointer.  This needs to be handled as a special case because the LLVM [bitcast](https://llvm.org/docs/LangRef.html#bitcast-to-instruction) instruction does not support this.

Handles bitcasts between pointers and scalar integers, which is supported by all SPIR-V versions, and pointers and vectors of integers, which is supported by SPIR-V 1.5 (though only for vectors of 32-bit integers).