### PR TITLE
Update more llvm::PointerUnion::get calls

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -689,7 +689,7 @@ LLVMToSPIRVDbgTran::transDbgArrayTypeOpenCL(const DICompositeType *AT) {
   SPIRVWordVec LowerBounds(N);
   for (unsigned I = 0; I < N; ++I) {
     DISubrange *SR = cast<DISubrange>(AR[I]);
-    ConstantInt *Count = SR->getCount().get<ConstantInt *>();
+    ConstantInt *Count = cast<ConstantInt *>(SR->getCount());
     if (AT->isVector()) {
       assert(N == 1 && "Multidimensional vector is not expected!");
       Ops[ComponentCountIdx] = static_cast<SPIRVWord>(Count->getZExtValue());
@@ -710,7 +710,7 @@ LLVMToSPIRVDbgTran::transDbgArrayTypeOpenCL(const DICompositeType *AT) {
       if (auto *DIExprLB = dyn_cast<MDNode>(RawLB))
         LowerBounds[I] = transDbgEntry(DIExprLB)->getId();
       else {
-        ConstantInt *ConstIntLB = SR->getLowerBound().get<ConstantInt *>();
+        ConstantInt *ConstIntLB = cast<ConstantInt *>(SR->getLowerBound());
         LowerBounds[I] = SPIRVWriter->transValue(ConstIntLB, nullptr)->getId();
       }
     } else {
@@ -733,7 +733,7 @@ LLVMToSPIRVDbgTran::transDbgArrayTypeNonSemantic(const DICompositeType *AT) {
   Ops.resize(SubrangesIdx + N);
   for (unsigned I = 0; I < N; ++I) {
     DISubrange *SR = cast<DISubrange>(AR[I]);
-    ConstantInt *Count = SR->getCount().get<ConstantInt *>();
+    ConstantInt *Count = cast<ConstantInt *>(SR->getCount());
     if (AT->isVector()) {
       assert(N == 1 && "Multidimensional vector is not expected!");
       Ops[ComponentCountIdx] = static_cast<SPIRVWord>(Count->getZExtValue());
@@ -809,13 +809,13 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgSubrangeType(const DISubrange *ST) {
       ConstantInt *IntNode = nullptr;
       switch (Idx) {
       case LowerBoundIdx:
-        IntNode = ST->getLowerBound().get<ConstantInt *>();
+        IntNode = cast<ConstantInt *>(ST->getLowerBound());
         break;
       case UpperBoundIdx:
-        IntNode = ST->getUpperBound().get<ConstantInt *>();
+        IntNode = cast<ConstantInt *>(ST->getUpperBound());
         break;
       case CountIdx:
-        IntNode = ST->getCount().get<ConstantInt *>();
+        IntNode = cast<ConstantInt *>(ST->getCount());
         break;
       }
       Ops[Idx] = IntNode ? SPIRVWriter->transValue(IntNode, nullptr)->getId()
@@ -830,7 +830,7 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgSubrangeType(const DISubrange *ST) {
       Ops[StrideIdx] = transDbgEntry(Node)->getId();
     else
       Ops[StrideIdx] =
-          SPIRVWriter->transValue(ST->getStride().get<ConstantInt *>(), nullptr)
+          SPIRVWriter->transValue(cast<ConstantInt *>(ST->getStride()), nullptr)
               ->getId();
   }
   return BM->addDebugInfo(SPIRVDebug::TypeSubrange, getVoidTy(), Ops);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2644,11 +2644,11 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_200:
       if (!M->IsNewDbgInfoFormat) {
         return mapValue(
-            BV, DbgTran->transDebugIntrinsic(ExtInst, BB).get<Instruction *>());
+            BV, cast<Instruction *>(DbgTran->transDebugIntrinsic(ExtInst, BB)));
       } else {
         auto MaybeRecord = DbgTran->transDebugIntrinsic(ExtInst, BB);
         if (!MaybeRecord.isNull()) {
-          auto *Record = MaybeRecord.get<DbgRecord *>();
+          auto *Record = cast<DbgRecord *>(MaybeRecord);
           Record->setDebugLoc(
               DbgTran->transDebugScope(static_cast<SPIRVInstruction *>(BV)));
         }


### PR DESCRIPTION
Update for llvm-project commit abba01adad5d ("[ADT] Deprecate PointerUnion::{is,get} (NFC) (#122623)", 2025-01-13).