### PR TITLE
Update dwarf-public-names.ll after LLVM change

### DIFF
--- a/test/DebugInfo/X86/dwarf-public-names.ll
+++ b/test/DebugInfo/X86/dwarf-public-names.ll
@@ -67,7 +67,7 @@ target triple = "spir64-unknown-unknown"
 
 ; Skip the output to the header of the pubnames section.
 ; LINUX: debug_pubnames
-; LINUX-NEXT: unit_size = 0x0000012b
+; LINUX-NEXT: unit_size =
 
 ; Check for each name in the output.
 ; LINUX-DAG: "ns"


### PR DESCRIPTION
Update after llvm-project commit 7c729418d721 ("[llvm][DebugInfo] Attach object-pointer to DISubprogram declarations (#122742)", 2025-01-17).