### PR TITLE
[NFC] Stop using IRBuilder::CreatePointerBitCastOrAddrSpaceCast

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -961,7 +961,7 @@ void OCLToSPIRVBase::transBuiltin(CallInst *CI, OCLBuiltinTransInfo &Info) {
           if (Info.RetTy->isIntegerTy() && OldRetTy->isIntegerTy()) {
             return Builder.CreateIntCast(NewCI, OldRetTy, false);
           }
-          return Builder.CreatePointerBitCastOrAddrSpaceCast(NewCI, OldRetTy);
+          return Builder.CreateAddrSpaceCast(NewCI, OldRetTy);
         });
   }
 }

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -584,7 +584,7 @@ void SPIRVToOCLBase::visitCallSPIRVPipeBuiltin(CallInst *CI, Op OC) {
       assert(isa<PointerType>(T));
       auto *NewTy = Builder.getPtrTy(SPIRAS_Generic);
       if (T != NewTy) {
-        P = Builder.CreatePointerBitCastOrAddrSpaceCast(P, NewTy);
+        P = Builder.CreateAddrSpaceCast(P, NewTy);
       }
       return std::make_pair(
           P, TypedPointerType::get(Builder.getInt8Ty(), SPIRAS_Generic));


### PR DESCRIPTION
With opaque pointers, this is equivalent to calling `IRBuilder::CreateAddrSpaceCast`.