### PR TITLE
Replace SPV_INTEL_long_composites ext with the SPV_INTEL_long_composites

### DIFF
--- a/include/LLVMSPIRVExtensions.inc
+++ b/include/LLVMSPIRVExtensions.inc
@@ -44,8 +44,7 @@ EXT(SPV_INTEL_variable_length_array)
 EXT(SPV_INTEL_fp_fast_math_mode)
 EXT(SPV_INTEL_fpga_cluster_attributes)
 EXT(SPV_INTEL_loop_fuse)
-EXT(SPV_INTEL_long_constant_composite) // TODO: rename to
-                                       // SPV_INTEL_long_composites later
+EXT(SPV_INTEL_long_composites)
 EXT(SPV_EXT_optnone)
 EXT(SPV_INTEL_optnone)
 EXT(SPV_INTEL_fpga_dsp_control)

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -492,11 +492,10 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
     const size_t NumElements = ST->getNumElements();
     size_t SPIRVStructNumElements = NumElements;
     // In case number of elements is greater than maximum WordCount and
-    // SPV_INTEL_long_constant_composite is not enabled, the error will be
+    // SPV_INTEL_long_composites is not enabled, the error will be
     // emitted by validate functionality of SPIRVTypeStruct class.
     if (NumElements > MaxNumElements &&
-        BM->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_long_constant_composite)) {
+        BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_long_composites)) {
       SPIRVStructNumElements = MaxNumElements;
     }
 
@@ -504,8 +503,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
     mapType(T, Struct);
 
     if (NumElements > MaxNumElements &&
-        BM->isAllowedToUseExtension(
-            ExtensionID::SPV_INTEL_long_constant_composite)) {
+        BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_long_composites)) {
       uint64_t NumOfContinuedInstructions = NumElements / MaxNumElements - 1;
       for (uint64_t J = 0; J < NumOfContinuedInstructions; J++) {
         auto *Continued = BM->addTypeStructContinuedINTEL(MaxNumElements);
@@ -2053,7 +2051,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
         BVarInit = I->second;
     } else if (Init && !isa<UndefValue>(Init)) {
       if (!BM->isAllowedToUseExtension(
-              ExtensionID::SPV_INTEL_long_constant_composite)) {
+              ExtensionID::SPV_INTEL_long_composites)) {
         if (auto *ArrTy = dyn_cast_or_null<ArrayType>(Init->getType())) {
           // First 3 words of OpConstantComposite encode: 1) word count &
           // opcode, 2) Result Type and 3) Result Id. Max length of SPIRV

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -968,7 +968,7 @@ public:
   }
 
   std::optional<ExtensionID> getRequiredExtension() const override {
-    return ExtensionID::SPV_INTEL_long_constant_composite;
+    return ExtensionID::SPV_INTEL_long_composites;
   }
 
   SPIRVWord getNumElements() const { return Elements.size(); }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1291,10 +1291,10 @@ SPIRVValue *SPIRVModuleImpl::addCompositeConstant(
   const int NumElements = Elements.size();
 
   // In case number of elements is greater than maximum WordCount and
-  // SPV_INTEL_long_constant_composite is not enabled, the error will be emitted
+  // SPV_INTEL_long_composites is not enabled, the error will be emitted
   // by validate functionality of SPIRVCompositeConstant class.
   if (NumElements <= MaxNumElements ||
-      !isAllowedToUseExtension(ExtensionID::SPV_INTEL_long_constant_composite))
+      !isAllowedToUseExtension(ExtensionID::SPV_INTEL_long_composites))
     return addConstant(new SPIRVConstantComposite(this, Ty, getId(), Elements));
 
   auto Start = Elements.begin();
@@ -1326,10 +1326,10 @@ SPIRVValue *SPIRVModuleImpl::addSpecConstantComposite(
   const int NumElements = Elements.size();
 
   // In case number of elements is greater than maximum WordCount and
-  // SPV_INTEL_long_constant_composite is not enabled, the error will be emitted
+  // SPV_INTEL_long_composites is not enabled, the error will be emitted
   // by validate functionality of SPIRVSpecConstantComposite class.
   if (NumElements <= MaxNumElements ||
-      !isAllowedToUseExtension(ExtensionID::SPV_INTEL_long_constant_composite))
+      !isAllowedToUseExtension(ExtensionID::SPV_INTEL_long_composites))
     return addConstant(
         new SPIRVSpecConstantComposite(this, Ty, getId(), Elements));
 

--- a/test/long-constant-array.ll
+++ b/test/long-constant-array.ll
@@ -1,8 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
-; Check that everything is fine if SPV_INTEL_long_constant_composite is enabled
-; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_constant_composite %t.bc -o %t.spv
+; Check that everything is fine if SPV_INTEL_long_composites is enabled
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_composites %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
@@ -10,7 +10,7 @@
 ; RUNx: spirv-val %t.spv
 
 ; CHECK-SPIRV: Capability LongCompositesINTEL
-; CHECK-SPIRV: Extension "SPV_INTEL_long_constant_composite"
+; CHECK-SPIRV: Extension "SPV_INTEL_long_composites"
 ; CHECK-SPIRV: TypeInt [[TInt:[0-9]+]] 8
 ; CHECK-SPIRV: Constant {{[0-9]+}} [[ArrSize:[0-9]+]] 78000
 ; CHECK-SPIRV: TypeArray [[TArr:[0-9]+]] [[TInt]] [[ArrSize]]

--- a/test/long-type-struct.ll
+++ b/test/long-type-struct.ll
@@ -1,8 +1,8 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_constant_composite %t.bc -o %t.spv
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_composites %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-TYPED-PTR
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_constant_composite -spirv-text %t.rev.bc -o %t2.spt
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_composites -spirv-text %t.rev.bc -o %t2.spt
 ; RUN: FileCheck --input-file=%t2.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-TYPED-PTR
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ; TODO: run validator once it supports the extension
@@ -10,10 +10,10 @@
 
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
-; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_constant_composite,+SPV_KHR_untyped_pointers %t.bc -o %t.spv
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_composites,+SPV_KHR_untyped_pointers %t.bc -o %t.spv
 ; RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-UNTYPED-PTR
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
-; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_constant_composite,+SPV_KHR_untyped_pointers -spirv-text %t.rev.bc -o %t2.spt
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_long_composites,+SPV_KHR_untyped_pointers -spirv-text %t.rev.bc -o %t2.spt
 ; RUN: FileCheck --input-file=%t2.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-UNTYPED-PTR
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ; TODO: run validator once it supports the extension
@@ -22,7 +22,7 @@
 ; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK-SPIRV: Capability LongCompositesINTEL
-; CHECK-SPIRV: Extension "SPV_INTEL_long_constant_composite"
+; CHECK-SPIRV: Extension "SPV_INTEL_long_composites"
 ; CHECK-SPIRV: TypeInt [[TInt:[0-9]+]] 8
 ; CHECK-SPIRV-TYPED-PTR: TypePointer [[TIntPtr:[0-9]+]] 8 [[TInt]]
 ; CHECK-SPIRV-UNTYPED-PTR: TypeUntypedPointerKHR [[TIntPtr:[0-9]+]] 8


### PR DESCRIPTION
This continues #2258
All the backports with the rename has reached the backend drivers, so now it's safe to remove the old naming.