### PR TITLE
Prevent invalid cast.

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -159,8 +159,10 @@ void SPIRVToLLVMDbgTran::transDbgInfo(const SPIRVValue *SV, Value *V) {
     return;
 
   if (Instruction *I = dyn_cast<Instruction>(V)) {
-    const SPIRVInstruction *SI = static_cast<const SPIRVInstruction *>(SV);
-    I->setDebugLoc(transDebugScope(SI));
+    if (SV->isInst()) {
+      const SPIRVInstruction *SI = static_cast<const SPIRVInstruction *>(SV);
+      I->setDebugLoc(transDebugScope(SI));
+    }
   }
 }
 


### PR DESCRIPTION
Not all `SPIRVValue` are `SPIRVInstruction`. For example, a `SPIRVType` is a `SPIRVValue` but not a `SPIRVInstruction`, so the cast is undefined behavior. Prevent invalid casts by checking if `SV` is indeed a `SPIRVInstruction` before doing the cast.