### PR TITLE
[Backport to 19] Emit alloca for all OpVariables with Function storage

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1645,9 +1645,18 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       return transValue(Init, F, BB);
     }
 
-    if (BS == StorageClassFunction && !Init) {
-      assert(BB && "Invalid BB");
-      return mapValue(BV, new AllocaInst(Ty, 0, BV->getName(), BB));
+    if (BS == StorageClassFunction) {
+      // A Function storage class variable needs storage for each dynamic
+      // execution instance, so emit an alloca instead of a global.
+      assert(BB && "OpVariable with Function storage class requires BB");
+      IRBuilder<> Builder(BB);
+      AllocaInst *AI = Builder.CreateAlloca(Ty, 0, BV->getName());
+      if (Init) {
+        auto *Src = transValue(Init, F, BB);
+        const bool IsVolatile = BVar->hasDecorate(DecorationVolatile);
+        Builder.CreateStore(Src, AI, IsVolatile);
+      }
+      return mapValue(BV, AI);
     }
 
     SPIRAddressSpace AddrSpace;

--- a/test/OpCopyMemory.spvasm
+++ b/test/OpCopyMemory.spvasm
@@ -46,6 +46,6 @@
                OpFunctionEnd
 
 ; CHECK-LABEL: define spir_kernel void @copymemory(ptr addrspace(1) %dstShort, ptr addrspace(1) %dstInt, ptr addrspace(1) %dstStruct)
-; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstShort, ptr @pShort, i64 2, i1 false)
-; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstInt, ptr @pInt, i64 4, i1 false)
-; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstStruct, ptr @pStruct, i64 12, i1 false)
+; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstShort, ptr %pShort, i64 2, i1 false)
+; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstInt, ptr %pInt, i64 4, i1 false)
+; CHECK: call void @llvm.memcpy.p1.p0.i64(ptr addrspace(1) %dstStruct, ptr %pStruct, i64 12, i1 false)

--- a/test/var_function_init.spvasm
+++ b/test/var_function_init.spvasm
@@ -1,0 +1,34 @@
+; Check translation of OpVariable with Function storage and initializer.
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
+
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability Int64
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "test"
+               OpName %pvalue "pvalue"
+       %uint = OpTypeInt 32 0
+      %ulong = OpTypeInt 64 0
+       %void = OpTypeVoid
+   %gptr_int = OpTypePointer CrossWorkgroup %uint
+   %pptr_int = OpTypePointer Function %uint
+ %kernel_sig = OpTypeFunction %void %gptr_int
+    %uint_42 = OpConstant %uint 42
+    %ulong_4 = OpConstant %ulong 4
+     %kernel = OpFunction %void None %kernel_sig
+        %dst = OpFunctionParameter %gptr_int
+      %entry = OpLabel
+     %pvalue = OpVariable %pptr_int Function %uint_42
+               OpCopyMemorySized %dst %pvalue %ulong_4 Volatile
+               OpReturn
+               OpFunctionEnd
+
+; CHECK-LABEL: define spir_kernel void @test
+; CHECK: %pvalue = alloca i32, align 4
+; CHECK: store i32 42, ptr %pvalue, align 4
+; CHECK: call void @llvm.memcpy.p1.p0.i64


### PR DESCRIPTION
A Function storage class variable needs storage for each dynamic execution instance, so emit an alloca instead of a global.  The SPIR-V Reader was already doing so for OpVariables without an initializer, but when an initializer is present it would still emit a global.

Co-authored-by: Ben Watkins <ben.watkins@arm.com>
(cherry picked from commit 648654da1d135e582dd7aeaec85855d48310109e)