### PR TITLE
[CI] Move away from deprecated set-output

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -54,7 +54,7 @@ jobs:
           # perform or skip further steps, i.e. there is no sense to install
           # clang-format if PR hasn't changed .cpp files at all
           # See [workflow-commands] for reference
-          echo '::set-output name=HAS_CHANGES::true'
+          echo 'HAS_CHANGES=true' >> "$GITHUB_OUTPUT"
         fi
 
     - name: Install dependencies


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/