### PR TITLE
fix possible nullptr dereference in OpBitCast pointer handling

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1096,7 +1096,7 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         unsigned TotalBitWidth =
             DstVecTy->getElementType()->getIntegerBitWidth() *
             DstVecTy->getNumElements();
-        auto *IntTy = Type::getIntNTy(BB->getContext(), TotalBitWidth);
+        auto *IntTy = Type::getIntNTy(Src->getContext(), TotalBitWidth);
         if (BB) {
           Src = CastInst::CreatePointerCast(Src, IntTy, "", BB);
         } else {
@@ -1110,7 +1110,7 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         unsigned TotalBitWidth =
             SrcVecTy->getElementType()->getIntegerBitWidth() *
             SrcVecTy->getNumElements();
-        auto *IntTy = Type::getIntNTy(BB->getContext(), TotalBitWidth);
+        auto *IntTy = Type::getIntNTy(Src->getContext(), TotalBitWidth);
         if (BB) {
           Src = CastInst::Create(Instruction::BitCast, Src, IntTy, "", BB);
         } else {


### PR DESCRIPTION
Because `BB` can be `nullptr`, we shouldn't use it to get the LLVM context.  Use `Src` instead.