### PR TITLE
[Backport to 15][SPV_INTEL_bindless_images] Add ret type to convert-SampledImage builtin name (#2576)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3613,6 +3613,7 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   case OpCooperativeMatrixLoadKHR:
   case internal::OpCooperativeMatrixLoadCheckedINTEL:
   case internal::OpConvertHandleToImageINTEL:
+  case internal::OpConvertHandleToSampledImageINTEL:
     AddRetTypePostfix = true;
     break;
   default: {

--- a/test/extensions/INTEL/SPV_INTEL_bindless_images/bindless_images_generic.ll
+++ b/test/extensions/INTEL/SPV_INTEL_bindless_images/bindless_images_generic.ll
@@ -30,7 +30,7 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-LLVM: call spir_func %spirv.Image._ulong_2_0_0_0_0_0_0 addrspace(1)* @_Z77__spirv_ConvertHandleToImageINTEL_RPU3AS134__spirv_Image__ulong_2_0_0_0_0_0_0m(i64 %{{.*}})
 ; CHECK-LLVM: call spir_func %spirv.Sampler addrspace(2)* @_Z35__spirv_ConvertHandleToSamplerINTELm(i64 42)
-; CHECK-LLVM: call spir_func %spirv.SampledImage._ulong_1_0_0_0_0_0_0 addrspace(1)* @_Z40__spirv_ConvertHandleToSampledImageINTELm(i64 43)
+; CHECK-LLVM: call spir_func %spirv.SampledImage._ulong_1_0_0_0_0_0_0 addrspace(1)* @_Z91__spirv_ConvertHandleToSampledImageINTEL_RPU3AS141__spirv_SampledImage__ulong_1_0_0_0_0_0_0m(i64 43)
 
 %spirv.Image._long_2_0_0_0_0_0_0 = type opaque
 %spirv.Sampler = type opaque


### PR DESCRIPTION
Similar as ConvertHandleToImageINTEL, ConvertHandleToSampledImageINTEL
builtin may have the same argument type but different return types.
So we need to add ret type as name suffix when translating to LLVM IR.