### PR TITLE
[Backport to 16][SPV_INTEL_bindless_images] Add ret type to convert-SampledImage builtin name (#2576)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3513,6 +3513,7 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   case OpCooperativeMatrixLoadKHR:
   case internal::OpCooperativeMatrixLoadCheckedINTEL:
   case internal::OpConvertHandleToImageINTEL:
+  case internal::OpConvertHandleToSampledImageINTEL:
     AddRetTypePostfix = true;
     break;
   default: {

--- a/test/extensions/INTEL/SPV_INTEL_bindless_images/bindless_images_generic.ll
+++ b/test/extensions/INTEL/SPV_INTEL_bindless_images/bindless_images_generic.ll
@@ -30,7 +30,7 @@ target triple = "spir64-unknown-unknown"
 
 ; CHECK-LLVM: call spir_func %spirv.Image._long_2_0_0_0_0_0_0 addrspace(1)* @_Z76__spirv_ConvertHandleToImageINTEL_RPU3AS133__spirv_Image__long_2_0_0_0_0_0_0m(i64 %{{.*}})
 ; CHECK-LLVM: call spir_func %spirv.Sampler addrspace(2)* @_Z35__spirv_ConvertHandleToSamplerINTELm(i64 42)
-; CHECK-LLVM: call spir_func %spirv.SampledImage._long_1_0_0_0_0_0_0 addrspace(1)* @_Z40__spirv_ConvertHandleToSampledImageINTELm(i64 43)
+; CHECK-LLVM: call spir_func %spirv.SampledImage._long_1_0_0_0_0_0_0 addrspace(1)* @_Z90__spirv_ConvertHandleToSampledImageINTEL_RPU3AS140__spirv_SampledImage__long_1_0_0_0_0_0_0m(i64 43)
 
 define spir_func void @foo(i64 %in) {
   %img = call spir_func target("spirv.Image", i64, 2, 0, 0, 0, 0, 0, 0) @_Z33__spirv_ConvertHandleToImageINTELl(i64 %in)


### PR DESCRIPTION
Similar as ConvertHandleToImageINTEL, ConvertHandleToSampledImageINTEL
builtin may have the same argument type but different return types.
So we need to add ret type as name suffix when translating to LLVM IR