### PR TITLE
Emit select for out-of-range builtin var indices

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -606,6 +606,21 @@ static Type *parsePrimitiveType(LLVMContext &Ctx, StringRef Name) {
 
 } // namespace SPIRV
 
+namespace {
+
+// Return the value for when the dimension index of a builtin is out of range.
+uint64_t getBuiltinOutOfRangeValue(StringRef VarName) {
+  assert(VarName.starts_with("__spirv_BuiltIn"));
+  return StringSwitch<uint64_t>(VarName)
+      .EndsWith("GlobalSize", 1)
+      .EndsWith("NumWorkgroups", 1)
+      .EndsWith("WorkgroupSize", 1)
+      .EndsWith("EnqueuedWorkgroupSize", 1)
+      .Default(0);
+}
+
+} // anonymous namespace
+
 // The demangler node hierarchy doesn't use LLVM's RTTI helper functions (as it
 // also needs to live in libcxxabi). By specializing this implementation here,
 // we can add support for these functions.
@@ -2188,7 +2203,23 @@ bool lowerBuiltinCallsToVariables(Module *M) {
       Value *NewValue = Builder.CreateLoad(GVType, BV);
       LLVM_DEBUG(dbgs() << "Transform: " << *CI << " => " << *NewValue << '\n');
       if (IsVec) {
-        NewValue = Builder.CreateExtractElement(NewValue, CI->getArgOperand(0));
+        auto *GVVecTy = cast<FixedVectorType>(GVType);
+        ConstantInt *Bound = Builder.getInt32(GVVecTy->getNumElements());
+        // Create a select on the index first, to avoid undefined behaviour
+        // due to exceeding the vector size by the extractelement.
+        Value *IndexCmp = Builder.CreateICmpULT(CI->getArgOperand(0), Bound);
+        Constant *ZeroIndex =
+            ConstantInt::get(CI->getArgOperand(0)->getType(), 0);
+        Value *ExtractIndex =
+            Builder.CreateSelect(IndexCmp, CI->getArgOperand(0), ZeroIndex);
+
+        // Extract from builtin variable.
+        NewValue = Builder.CreateExtractElement(NewValue, ExtractIndex);
+
+        // Clamp to out-of-range value.
+        Constant *OutOfRangeVal = ConstantInt::get(
+            F.getReturnType(), getBuiltinOutOfRangeValue(BuiltinVarName));
+        NewValue = Builder.CreateSelect(IndexCmp, NewValue, OutOfRangeVal);
         LLVM_DEBUG(dbgs() << *NewValue << '\n');
       }
       NewValue->takeName(CI);

--- a/test/DebugInfo/builtin-get-global-id.ll
+++ b/test/DebugInfo/builtin-get-global-id.ll
@@ -33,7 +33,8 @@ entry:
 ; CHECK-NEXT: [[I3:%[0-9]]] = insertelement <3 x i64> [[I1]], i64 [[I2]], i32 1, !dbg [[DBG]]
 ; CHECK-NEXT: [[I4:%[0-9]]] = call spir_func i64 @_Z13get_global_idj(i32 2) #1, !dbg [[DBG]]
 ; CHECK-NEXT: [[I5:%[0-9]]] = insertelement <3 x i64> [[I3]], i64 [[I4]], i32 2, !dbg [[DBG]]
-; CHECK-NEXT: %call = extractelement <3 x i64> [[I5]], i32 0, !dbg [[DBG]]
+; CHECK-NEXT: [[I6:%[0-9]]] = extractelement <3 x i64> [[I5]], i32 0, !dbg [[DBG]]
+; CHECK-NEXT: %call = select i1 true, i64 [[I6]], i64 0, !dbg [[DBG]]
   store i64 %call, ptr %gid, align 8, !dbg !11
   ret void, !dbg !12
 }

--- a/test/get_global_size.cl
+++ b/test/get_global_size.cl
@@ -10,19 +10,21 @@ kernel void ggs(global size_t *out, uint x) {
   // CHECK-DAG: Constant [[#]] [[#CONST64_1:]] 1 0
   // CHECK-DAG: Constant [[#]] [[#CONST3:]] 3
   // CHECK-DAG: Constant [[#]] [[#CONST0:]] 0
+  // CHECK-DAG: ConstantTrue [[#]] [[#CONSTTRUE:]]
+  // CHECK-DAG: ConstantFalse [[#]] [[#CONSTFALSE:]]
 
   // CHECK: FunctionParameter [[#]] [[#PARAMOUT:]]
   // CHECK: FunctionParameter [[#]] [[#PARAMX:]]
 
   // CHECK: Load [[#]] [[#LD0:]]
   // CHECK: CompositeExtract [[#]] [[#SCAL0:]] [[#LD0]] 0
-  // CHECK: Select [[#]] [[#RES0:]] [[#]] [[#SCAL0]] [[#CONST64_1]]
+  // CHECK: Select [[#]] [[#RES0:]] [[#CONSTTRUE]] [[#SCAL0]] [[#CONST64_1]]
   // CHECK: Store [[#]] [[#RES0]]
   out[0] = get_global_size(0);
 
   // CHECK: Load [[#]] [[#LD1:]]
   // CHECK: CompositeExtract [[#]] [[#SCAL1:]] [[#LD1]] 0
-  // CHECK: Select [[#]] [[#RES1:]] [[#]] [[#SCAL1]] [[#CONST64_1]]
+  // CHECK: Select [[#]] [[#RES1:]] [[#CONSTFALSE]] [[#SCAL1]] [[#CONST64_1]]
   // CHECK: Store [[#]] [[#RES1]]
   out[1] = get_global_size(3);
 
@@ -30,7 +32,7 @@ kernel void ggs(global size_t *out, uint x) {
   // CHECK: ULessThan [[#]] [[#CMP:]] [[#PARAMX]] [[#CONST3]]
   // CHECK: Select [[#]] [[#SEL:]] [[#CMP]] [[#PARAMX]] [[#CONST0]]
   // CHECK: VectorExtractDynamic 2 [[#SCAL2:]] [[#LD2:]] [[#SEL]]
-  // CHECK: Select [[#]] [[#RES2:]] [[#]] [[#SCAL2]] [[#CONST64_1]]
+  // CHECK: Select [[#]] [[#RES2:]] [[#CMP]] [[#SCAL2]] [[#CONST64_1]]
   // CHECK: Store [[#]] [[#RES2]]
   out[2] = get_global_size(x);
 }

--- a/test/get_global_size.cl
+++ b/test/get_global_size.cl
@@ -1,0 +1,36 @@
+// RUN: %clang_cc1 -triple spir64 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+
+// Check that out of range dimension index values are handled according to the
+// OpenCL C specification.
+
+kernel void ggs(global size_t *out, uint x) {
+  // CHECK-DAG: Constant [[#]] [[#CONST64_1:]] 1 0
+  // CHECK-DAG: Constant [[#]] [[#CONST3:]] 3
+  // CHECK-DAG: Constant [[#]] [[#CONST0:]] 0
+
+  // CHECK: FunctionParameter [[#]] [[#PARAMOUT:]]
+  // CHECK: FunctionParameter [[#]] [[#PARAMX:]]
+
+  // CHECK: Load [[#]] [[#LD0:]]
+  // CHECK: CompositeExtract [[#]] [[#SCAL0:]] [[#LD0]] 0
+  // CHECK: Select [[#]] [[#RES0:]] [[#]] [[#SCAL0]] [[#CONST64_1]]
+  // CHECK: Store [[#]] [[#RES0]]
+  out[0] = get_global_size(0);
+
+  // CHECK: Load [[#]] [[#LD1:]]
+  // CHECK: CompositeExtract [[#]] [[#SCAL1:]] [[#LD1]] 0
+  // CHECK: Select [[#]] [[#RES1:]] [[#]] [[#SCAL1]] [[#CONST64_1]]
+  // CHECK: Store [[#]] [[#RES1]]
+  out[1] = get_global_size(3);
+
+  // CHECK: Load [[#]] [[#LD2:]]
+  // CHECK: ULessThan [[#]] [[#CMP:]] [[#PARAMX]] [[#CONST3]]
+  // CHECK: Select [[#]] [[#SEL:]] [[#CMP]] [[#PARAMX]] [[#CONST0]]
+  // CHECK: VectorExtractDynamic 2 [[#SCAL2:]] [[#LD2:]] [[#SEL]]
+  // CHECK: Select [[#]] [[#RES2:]] [[#]] [[#SCAL2]] [[#CONST64_1]]
+  // CHECK: Store [[#]] [[#RES2]]
+  out[2] = get_global_size(x);
+}


### PR DESCRIPTION
The behaviour for out-of-range dimension arguments to work-item functions is well defined in OpenCL C.  For example, `get_global_size` must return 1 if its argument is larger than `get_work_dim() - 1`.

Ensure the generated `extractelement` index never exceeds the vector size and return the correct out-of-range value (which is either 0 or 1 depending on the builtin).

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2638 .