### PR TITLE
[Backport to 17] Fix incorrect translation of calls to a builtin that returns a structure

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2259,7 +2259,7 @@ bool postProcessBuiltinReturningStruct(Function *F) {
       if (!A) {
         A = Builder.CreateAlloca(F->getReturnType());
       }
-      std::vector<Type *> ArgTys;
+      SmallVector<Type *> ArgTys;
       getFunctionTypeParameterTypes(F->getFunctionType(), ArgTys);
       ArgTys.insert(ArgTys.begin(), A->getType());
       auto *NewF =

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2248,8 +2248,9 @@ bool postProcessBuiltinReturningStruct(Function *F) {
       Builder.SetInsertPoint(CI);
       SmallVector<User *> Users(CI->users());
       Value *A = nullptr;
+      StoreInst *SI = nullptr;
       for (auto *U : Users) {
-        if (auto *SI = dyn_cast<StoreInst>(U)) {
+        if ((SI = dyn_cast<StoreInst>(U)) != nullptr) {
           A = SI->getPointerOperand();
           InstToRemove.push_back(SI);
           break;
@@ -2258,7 +2259,7 @@ bool postProcessBuiltinReturningStruct(Function *F) {
       if (!A) {
         A = Builder.CreateAlloca(F->getReturnType());
       }
-      SmallVector<Type *> ArgTys;
+      std::vector<Type *> ArgTys;
       getFunctionTypeParameterTypes(F->getFunctionType(), ArgTys);
       ArgTys.insert(ArgTys.begin(), A->getType());
       auto *NewF =
@@ -2269,12 +2270,18 @@ bool postProcessBuiltinReturningStruct(Function *F) {
       NewF->setCallingConv(F->getCallingConv());
       auto Args = getArguments(CI);
       Args.insert(Args.begin(), A);
-      CallInst *NewCI = Builder.CreateCall(NewF, Args, CI->getName());
+      CallInst *NewCI = Builder.CreateCall(
+          NewF, Args, NewF->getReturnType()->isVoidTy() ? "" : CI->getName());
       NewCI->addParamAttr(0, SretAttr);
       NewCI->setCallingConv(CI->getCallingConv());
-      SmallVector<User *> CIUsers(CI->users());
-      for (auto *CIUser : CIUsers) {
-        CIUser->replaceUsesOfWith(CI, A);
+      SmallVector<User *, 32> UsersToReplace;
+      for (auto *U : Users)
+        if (U != SI)
+          UsersToReplace.push_back(U);
+      if (UsersToReplace.size() > 0) {
+        auto *LI = Builder.CreateLoad(F->getReturnType(), A);
+        for (auto *U : UsersToReplace)
+          U->replaceUsesOfWith(CI, LI);
       }
       InstToRemove.push_back(CI);
     }

--- a/test/builtin_returns_struct.spvasm
+++ b/test/builtin_returns_struct.spvasm
@@ -1,0 +1,52 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+
+               OpCapability Kernel
+               OpCapability Addresses
+               OpCapability Int8
+               OpCapability GenericPointer
+               OpCapability Linkage
+          %1 = OpExtInstImport "OpenCL.std"
+               OpMemoryModel Physical64 OpenCL
+               OpSource OpenCL_CPP 100000
+               OpName %a "a"
+               OpName %p "p"
+               OpName %foo "foo"
+               OpName %e "e"
+               OpName %math "math"
+               OpName %ov "ov"
+               OpDecorate %foo LinkageAttributes "foo" Export
+       %uint = OpTypeInt 32 0
+      %uchar = OpTypeInt 8 0
+%_ptr_Generic_uchar = OpTypePointer Generic %uchar
+          %5 = OpTypeFunction %uint %uint %_ptr_Generic_uchar
+       %bool = OpTypeBool
+  %_struct_7 = OpTypeStruct %uint %uint
+     %uint_1 = OpConstant %uint 1
+   %uchar_42 = OpConstant %uchar 42
+         %10 = OpConstantNull %uint
+        %foo = OpFunction %uint None %5
+          %a = OpFunctionParameter %uint
+          %p = OpFunctionParameter %_ptr_Generic_uchar
+         %19 = OpLabel
+               OpBranch %20
+         %20 = OpLabel
+          %e = OpPhi %uint %a %19 %math %21
+         %16 = OpIAddCarry %_struct_7 %e %uint_1
+       %math = OpCompositeExtract %uint %16 0
+         %17 = OpCompositeExtract %uint %16 1
+         %ov = OpINotEqual %bool %17 %10
+               OpBranchConditional %ov %22 %21
+         %21 = OpLabel
+               OpStore %p %uchar_42 Aligned 1
+               OpBranch %20
+         %22 = OpLabel
+               OpReturnValue %math
+               OpFunctionEnd
+
+; CHECK: %[[#Var:]] = alloca %structtype, align 8
+; CHECK: call spir_func void @_Z17__spirv_IAddCarryii(ptr sret(%structtype) %[[#Var:]]
+; CHECK: %[[#Load:]] = load %structtype, ptr %[[#Var]], align 4
+; CHECK-2: extractvalue %structtype %[[#Load:]]


### PR DESCRIPTION
This PR fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2721
The root cause is that https://github.com/bwlodarcz/SPIRV-LLVM-Translator/blob/ca48eaf52ae791abc61cba13ef383f022e151e9f/lib/SPIRV/SPIRVUtil.cpp#L2207 doesn't preserve equivalence of values, inserting a pointer where a value of function return's type was before.

A new test case is added from the reproducer of https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/2721