### PR TITLE
Finish renaming of SPV_INTEL_tensor_float32_conversion

### DIFF
--- a/include/LLVMSPIRVExtensions.inc
+++ b/include/LLVMSPIRVExtensions.inc
@@ -64,7 +64,6 @@ EXT(SPV_INTEL_global_variable_fpga_decorations)
 EXT(SPV_INTEL_complex_float_mul_div)
 EXT(SPV_INTEL_split_barrier)
 EXT(SPV_INTEL_masked_gather_scatter)
-EXT(SPV_INTEL_tensor_float32_conversion) // TODO: to remove old extension
 EXT(SPV_INTEL_tensor_float32_rounding)
 EXT(SPV_EXT_relaxed_printf_string_address_space)
 EXT(SPV_INTEL_fpga_argument_interfaces)

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -4038,7 +4038,7 @@ protected:
     SPIRVType *ResCompTy = this->getType();
     if (ResCompTy->isTypeCooperativeMatrixKHR())
       this->getModule()->addExtension(ExtensionID::SPV_INTEL_joint_matrix);
-    return ExtensionID::SPV_INTEL_tensor_float32_conversion;
+    return ExtensionID::SPV_INTEL_tensor_float32_rounding;
   }
 
   void validate() const override {

--- a/test/extensions/INTEL/SPV_INTEL_joint_matrix/tf32_conversion_instructions.ll
+++ b/test/extensions/INTEL/SPV_INTEL_joint_matrix/tf32_conversion_instructions.ll
@@ -1,12 +1,12 @@
 ; RUN: llvm-as < %s -o %t.bc
-; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_cooperative_matrix,+SPV_INTEL_joint_matrix,+SPV_INTEL_tensor_float32_conversion -o %t.spv
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_cooperative_matrix,+SPV_INTEL_joint_matrix,+SPV_INTEL_tensor_float32_rounding -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_KHR_cooperative_matrix,+SPV_INTEL_tensor_float32_conversion 2>&1 \
+; RUN: not llvm-spirv %t.bc --spirv-ext=+SPV_KHR_cooperative_matrix,+SPV_INTEL_tensor_float32_rounding 2>&1 \
 ; RUN: | FileCheck %s --check-prefix=CHECK-ERROR
 
 ; CHECK-ERROR: InvalidInstruction: Can't translate llvm instruction:
@@ -16,7 +16,7 @@
 ; CHECK-SPIRV-DAG: Capability CooperativeMatrixKHR
 ; CHECK-SPIRV-DAG: Capability TensorFloat32RoundingINTEL
 ; CHECK-SPIRV-DAG: Capability JointMatrixTF32ComponentTypeINTEL
-; CHECK-SPIRV-DAG: Extension "SPV_INTEL_tensor_float32_conversion"
+; CHECK-SPIRV-DAG: Extension "SPV_INTEL_tensor_float32_rounding"
 ; CHECK-SPIRV-DAG: Extension "SPV_KHR_cooperative_matrix"
 ; CHECK-SPIRV-DAG: Extension "SPV_INTEL_joint_matrix"
 ; CHECK-SPIRV-DAG: TypeFloat [[#FP32Ty:]] 32

--- a/test/extensions/INTEL/SPV_INTEL_tensor_float32_conversion/convert_tensor_float32.ll
+++ b/test/extensions/INTEL/SPV_INTEL_tensor_float32_conversion/convert_tensor_float32.ll
@@ -1,5 +1,5 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_tensor_float32_conversion
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_tensor_float32_rounding
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %t.spv -o %t.rev.bc -r --spirv-target-env=SPV-IR
@@ -8,13 +8,13 @@
 
 ; RUN: not llvm-spirv %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; CHECK-ERROR: RequiresExtension: Feature requires the following SPIR-V extension:
-; CHECK-ERROR-NEXT: SPV_INTEL_tensor_float32_conversion
+; CHECK-ERROR-NEXT: SPV_INTEL_tensor_float32_rounding
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
 ; CHECK-SPIRV: Capability TensorFloat32RoundingINTEL
-; CHECK-SPIRV: Extension "SPV_INTEL_tensor_float32_conversion"
+; CHECK-SPIRV: Extension "SPV_INTEL_tensor_float32_rounding"
 ; CHECK-SPIRV: TypeFloat [[#FP32Ty:]] 32
 ; CHECK-SPIRV: TypeVector [[#FP32v8Ty:]] [[#FP32Ty]] 8
 ; CHECK-SPIRV: Constant [[#FP32Ty]] [[#CONST:]] 1065353216


### PR DESCRIPTION
New name is SPV_INTEL_tensor_float32_rounding. It's already recognized by older release branches of llvm-spirv.
If a frontend faces an issue with this patch, the following update is needed:
- --spirv-ext=...+SPV_INTEL_tensor_float32_conversion...
+ --spirv-ext=...+SPV_INTEL_tensor_float32_rounding...