### PR TITLE
[Backport to 14] Emit select for out-of-range builtin var indices

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -65,6 +65,21 @@
 
 #define DEBUG_TYPE "spirv"
 
+namespace {
+
+// Return the value for when the dimension index of a builtin is out of range.
+uint64_t getBuiltinOutOfRangeValue(StringRef VarName) {
+  assert(VarName.startswith("__spirv_BuiltIn"));
+  return StringSwitch<uint64_t>(VarName)
+      .EndsWith("GlobalSize", 1)
+      .EndsWith("NumWorkgroups", 1)
+      .EndsWith("WorkgroupSize", 1)
+      .EndsWith("EnqueuedWorkgroupSize", 1)
+      .Default(0);
+}
+
+} // anonymous namespace
+
 namespace SPIRV {
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
@@ -2121,7 +2136,23 @@ bool lowerBuiltinCallsToVariables(Module *M) {
       Value *NewValue = Builder.CreateLoad(GVType, BV);
       LLVM_DEBUG(dbgs() << "Transform: " << *CI << " => " << *NewValue << '\n');
       if (IsVec) {
-        NewValue = Builder.CreateExtractElement(NewValue, CI->getArgOperand(0));
+        auto *GVVecTy = cast<FixedVectorType>(GVType);
+        ConstantInt *Bound = Builder.getInt32(GVVecTy->getNumElements());
+        // Create a select on the index first, to avoid undefined behaviour
+        // due to exceeding the vector size by the extractelement.
+        Value *IndexCmp = Builder.CreateICmpULT(CI->getArgOperand(0), Bound);
+        Constant *ZeroIndex =
+            ConstantInt::get(CI->getArgOperand(0)->getType(), 0);
+        Value *ExtractIndex =
+            Builder.CreateSelect(IndexCmp, CI->getArgOperand(0), ZeroIndex);
+
+        // Extract from builtin variable.
+        NewValue = Builder.CreateExtractElement(NewValue, ExtractIndex);
+
+        // Clamp to out-of-range value.
+        Constant *OutOfRangeVal = ConstantInt::get(
+            F.getReturnType(), getBuiltinOutOfRangeValue(BuiltinVarName));
+        NewValue = Builder.CreateSelect(IndexCmp, NewValue, OutOfRangeVal);
         LLVM_DEBUG(dbgs() << *NewValue << '\n');
       }
       NewValue->takeName(CI);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2117,16 +2117,11 @@ bool lowerBuiltinCallsToVariables(Module *M) {
     for (auto *U : F.users()) {
       auto *CI = dyn_cast<CallInst>(U);
       assert(CI && "invalid instruction");
-      const DebugLoc &DLoc = CI->getDebugLoc();
-      Instruction *NewValue = new LoadInst(GVType, BV, "", CI);
-      if (DLoc)
-        NewValue->setDebugLoc(DLoc);
+      IRBuilder<> Builder(CI);
+      Value *NewValue = Builder.CreateLoad(GVType, BV);
       LLVM_DEBUG(dbgs() << "Transform: " << *CI << " => " << *NewValue << '\n');
       if (IsVec) {
-        NewValue =
-            ExtractElementInst::Create(NewValue, CI->getArgOperand(0), "", CI);
-        if (DLoc)
-          NewValue->setDebugLoc(DLoc);
+        NewValue = Builder.CreateExtractElement(NewValue, CI->getArgOperand(0));
         LLVM_DEBUG(dbgs() << *NewValue << '\n');
       }
       NewValue->takeName(CI);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2094,9 +2094,26 @@ bool lowerBuiltinCallsToVariables(Module *M) {
     bool IsVec = F.getFunctionType()->getNumParams() > 0;
     Type *GVType =
         IsVec ? FixedVectorType::get(F.getReturnType(), 3) : F.getReturnType();
-    auto *BV = new GlobalVariable(
-        *M, GVType, /*isConstant=*/true, GlobalValue::ExternalLinkage, nullptr,
-        BuiltinVarName, 0, GlobalVariable::NotThreadLocal, SPIRAS_Input);
+    GlobalVariable *BV = nullptr;
+    // Consider the following LLVM IR:
+    // @__spirv_BuiltInLocalInvocationId = <Global constant>
+    // .....
+    // define spir_kernel void @kernel1(....) {
+    //   %3 = tail call i64 @_Z12get_local_idj(i32 0)
+    //   .....
+    //   return void
+    // }
+    // During the OCLToSPIRV pass, the opencl call will get lowered to
+    // yet another global variable with the name
+    // '@__spirv_BuiltInLocalInvocationId'. In such a case, we would want to
+    // create only a single global variable with this name.
+    if (GlobalVariable *GV = M->getGlobalVariable(BuiltinVarName))
+      BV = GV;
+    else
+      BV = new GlobalVariable(*M, GVType, /*isConstant=*/true,
+                              GlobalValue::ExternalLinkage, nullptr,
+                              BuiltinVarName, 0, GlobalVariable::NotThreadLocal,
+                              SPIRAS_Input);
     for (auto *U : F.users()) {
       auto *CI = dyn_cast<CallInst>(U);
       assert(CI && "invalid instruction");

--- a/test/DebugInfo/builtin-get-global-id.ll
+++ b/test/DebugInfo/builtin-get-global-id.ll
@@ -33,7 +33,8 @@ entry:
 ; CHECK-NEXT: [[I3:%[0-9]]] = insertelement <3 x i64> [[I1]], i64 [[I2]], i32 1, !dbg [[DBG]]
 ; CHECK-NEXT: [[I4:%[0-9]]] = call spir_func i64 @_Z13get_global_idj(i32 2) #1, !dbg [[DBG]]
 ; CHECK-NEXT: [[I5:%[0-9]]] = insertelement <3 x i64> [[I3]], i64 [[I4]], i32 2, !dbg [[DBG]]
-; CHECK-NEXT: %call = extractelement <3 x i64> [[I5]], i32 0, !dbg [[DBG]]
+; CHECK-NEXT: [[I6:%[0-9]]] = extractelement <3 x i64> [[I5]], i32 0, !dbg [[DBG]]
+; CHECK-NEXT: %call = select i1 true, i64 [[I6]], i64 0, !dbg [[DBG]]
   store i64 %call, i64* %gid, align 8, !dbg !11
   ret void, !dbg !12
 }

--- a/test/builtin_duplicate.ll
+++ b/test/builtin_duplicate.ll
@@ -1,0 +1,33 @@
+;; This test checks if we generate a single builtin variable for the following
+;; LLVM IR.
+;; @__spirv_BuiltInLocalInvocationId - A global variable
+;; %lid = tail call i64 @_Z12get_local_idj(i32 0) - A function call
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+%opencl.event_t = type opaque
+
+; CHECK-SPIRV: {{[0-9]+}} Name {{[0-9]+}} "__spirv_BuiltInLocalInvocationId"
+; CHECK-SPIRV-NOT: {{[0-9]+}} Name {{[0-9]+}} "__spirv_BuiltInLocalInvocationId.1"
+
+@__spirv_BuiltInLocalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+declare spir_func i64 @_Z12get_local_idj(i32) local_unnamed_addr
+
+; Function Attrs: nounwind
+define spir_kernel void @test_fn(i32 %a) {
+entry:
+  %lid = tail call i64 @_Z12get_local_idj(i32 0)
+  ret void
+}
+
+!spirv.Source = !{!0}
+
+!0 = !{i32 6, i32 100000}

--- a/test/get_global_size.cl
+++ b/test/get_global_size.cl
@@ -1,0 +1,38 @@
+// RUN: %clang_cc1 -triple spir64 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
+// RUN: llvm-spirv %t.bc -o %t.spv
+// RUN: spirv-val %t.spv
+// RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s
+
+// Check that out of range dimension index values are handled according to the
+// OpenCL C specification.
+
+kernel void ggs(global size_t *out, uint x) {
+  // CHECK-DAG: Constant [[#]] [[#CONST64_1:]] 1 0
+  // CHECK-DAG: Constant [[#]] [[#CONST3:]] 3
+  // CHECK-DAG: Constant [[#]] [[#CONST0:]] 0
+  // CHECK-DAG: ConstantTrue [[#]] [[#CONSTTRUE:]]
+  // CHECK-DAG: ConstantFalse [[#]] [[#CONSTFALSE:]]
+
+  // CHECK: FunctionParameter [[#]] [[#PARAMOUT:]]
+  // CHECK: FunctionParameter [[#]] [[#PARAMX:]]
+
+  // CHECK: Load [[#]] [[#LD0:]]
+  // CHECK: CompositeExtract [[#]] [[#SCAL0:]] [[#LD0]] 0
+  // CHECK: Select [[#]] [[#RES0:]] [[#CONSTTRUE]] [[#SCAL0]] [[#CONST64_1]]
+  // CHECK: Store [[#]] [[#RES0]]
+  out[0] = get_global_size(0);
+
+  // CHECK: Load [[#]] [[#LD1:]]
+  // CHECK: CompositeExtract [[#]] [[#SCAL1:]] [[#LD1]] 0
+  // CHECK: Select [[#]] [[#RES1:]] [[#CONSTFALSE]] [[#SCAL1]] [[#CONST64_1]]
+  // CHECK: Store [[#]] [[#RES1]]
+  out[1] = get_global_size(3);
+
+  // CHECK: Load [[#]] [[#LD2:]]
+  // CHECK: ULessThan [[#]] [[#CMP:]] [[#PARAMX]] [[#CONST3]]
+  // CHECK: Select [[#]] [[#SEL:]] [[#CMP]] [[#PARAMX]] [[#CONST0]]
+  // CHECK: VectorExtractDynamic 2 [[#SCAL2:]] [[#LD2:]] [[#SEL]]
+  // CHECK: Select [[#]] [[#RES2:]] [[#CMP]] [[#SCAL2]] [[#CONST64_1]]
+  // CHECK: Store [[#]] [[#RES2]]
+  out[2] = get_global_size(x);
+}

--- a/test/transcoding/OpSwitch32.ll
+++ b/test/transcoding/OpSwitch32.ll
@@ -30,7 +30,7 @@ target triple = "spir64-unknown-unknown"
 
 ;CHECK-LLVM: test_32
 ;CHECK-LLVM: entry
-;CHECK-LLVM: switch i32 %6, label %sw.epilog
+;CHECK-LLVM: switch i32 %[[#]], label %sw.epilog
 ;CHECK-LLVM: i32 0, label %sw.bb
 ;CHECK-LLVM: i32 1, label %sw.bb1
 

--- a/test/transcoding/OpSwitch64.ll
+++ b/test/transcoding/OpSwitch64.ll
@@ -33,7 +33,7 @@ target triple = "spir64-unknown-unknown"
 
 ;CHECK-LLVM: test_64
 ;CHECK-LLVM: entry
-;CHECK-LLVM: switch i64 %6, label %sw.epilog [
+;CHECK-LLVM: switch i64 %[[#]], label %sw.epilog [
 ;CHECK-LLVM: i64 0, label %sw.bb
 ;CHECK-LLVM: i64 1, label %sw.bb1
 ;CHECK-LLVM: i64 21474836481, label %sw.bb3


### PR DESCRIPTION
The behaviour for out-of-range dimension arguments to work-item functions is well defined in OpenCL C. For example, get_global_size must return 1 if its argument is larger than get_work_dim() - 1.

Ensure the generated extractelement index never exceeds the vector size and return the correct out-of-range value (which is either 0 or 1 depending on the builtin).