### PR TITLE
properly handle LOD values when nontemporal image operand is present

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -752,8 +752,10 @@ SPIRVToOCLBase::mutateCallImageOperands(CallInst *CI, StringRef NewFuncName,
       ConstantFP *LodVal = dyn_cast<ConstantFP>(Mutator.getArg(ImOpArgIndex));
       // If the image operand is LOD and its value is zero, drop it too.
       if (LodVal && LodVal->isNullValue() &&
-          ImOpValue == ImageOperandsMask::ImageOperandsLodMask)
+          ImOpValue & ImageOperandsMask::ImageOperandsLodMask) {
         Mutator.removeArgs(ImOpArgIndex, Mutator.arg_size() - ImOpArgIndex);
+        ImOpValue &= ~ImageOperandsMask::ImageOperandsLodMask;
+      }
     }
   }
   return Mutator;

--- a/test/image_operand_nontemporal.spvasm
+++ b/test/image_operand_nontemporal.spvasm
@@ -1,0 +1,45 @@
+; Tests the Nontemporal image operand that was added for SPIR-V 1.6.
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.6 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability ImageBasic
+               OpCapability LiteralSampler
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %kernel "read_write_image_nontemporal"
+       %uint = OpTypeInt 32 0
+       %void = OpTypeVoid
+ %read_image2d_t = OpTypeImage %void 2D 0 0 0 0 Unknown ReadOnly
+%write_image2d_t = OpTypeImage %void 2D 0 0 0 0 Unknown WriteOnly
+  %sampler_t = OpTypeSampler
+ %kernel_sig = OpTypeFunction %void %read_image2d_t %write_image2d_t
+%sampledimage_t = OpTypeSampledImage %read_image2d_t
+     %v2uint = OpTypeVector %uint 2
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+    %sampler = OpConstantSampler %sampler_t None 0 Nearest
+  %coord_0_0 = OpConstantNull %v2uint
+    %float_0 = OpConstant %float 0
+     %kernel = OpFunction %void None %kernel_sig
+        %src = OpFunctionParameter %read_image2d_t
+        %dst = OpFunctionParameter %write_image2d_t
+      %entry = OpLabel
+         %si = OpSampledImage %sampledimage_t %src %sampler
+      %data0 = OpImageSampleExplicitLod %v4float %si %coord_0_0 Lod %float_0
+               OpImageWrite %dst %coord_0_0 %data0
+      %data1 = OpImageSampleExplicitLod %v4float %si %coord_0_0 Lod|Nontemporal %float_0
+               OpImageWrite %dst %coord_0_0 %data1 Nontemporal
+               OpReturn
+               OpFunctionEnd
+
+; CHECK-LLVM: define spir_kernel void @read_write_image_nontemporal
+; CHECK-LLVM: call spir_func <4 x float> [[READ_IMAGEF:@[a-zA-Z0-9_]+]](
+; CHECK-LLVM: call spir_func void [[WRITE_IMAGEF:@[a-zA-Z0-9_]+]](
+; CHECK-LLVM: call spir_func <4 x float> [[READ_IMAGEF]](
+; CHECK-LLVM: call spir_func void [[WRITE_IMAGEF]](


### PR DESCRIPTION
Instead of checking that the image operands are equal to the LOD mask, check that the LOD bit is in the image operands.  This way an LOD value of zero may be ignored even when image operands contains bits other than the LOD bit, such as for the SPIR-V 1.6 nontemporal image operand.

fixes #3049