### PR TITLE
Update DebugInfo test after LLVM change

### DIFF
--- a/test/DebugInfo/X86/inline-seldag-test.ll
+++ b/test/DebugInfo/X86/inline-seldag-test.ll
@@ -34,8 +34,8 @@ target triple = "spir64-unknown-unknown"
 ; Make sure the condition test is attributed to the inline function, not the
 ; location of the test's operands within the caller.
 
-; ASM: # inline-seldag-test.c:2:0
-; ASM-NOT: .loc
+; ASM: # inline-seldag-test.c:
+; ASM: .loc 1 2 0 # inline-seldag-test.c:2 @[ inline-seldag-test.c:6
 ; ASM: testl
 
 ; Function Attrs: nounwind uwtable


### PR DESCRIPTION
Update the pattern after llvm-project commit da0f9e75d858 ("Reland: [MC] output inlined-at debug info (#106230) (#130306)", 2025-03-11).