### PR TITLE
[CI] Fix spirv-val missing features by updating dist on llvm_release_11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: cpp
 os:
   - linux
 
-# Use Ubuntu 20.04 LTS (Focal) as the Linux testing environment.
-dist: focal
+# Use Ubuntu 22.04 LTS (Jammy) as the Linux testing environment.
+dist: jammy
 
 git:
   depth: 1
@@ -25,9 +25,9 @@ before_install:
       curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
       curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
       curl -L "https://apt.kitware.com/keys/kitware-archive-latest.asc" | sudo apt-key add -
-      echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-${LLVM_VERSION} main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
-      echo "deb https://packages.lunarg.com/vulkan focal main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
-      echo "deb https://apt.kitware.com/ubuntu/ focal main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
+      echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
+      echo "deb https://packages.lunarg.com/vulkan jammy main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
+      echo "deb https://apt.kitware.com/ubuntu/ jammy main" | sudo tee -a ${TRAVIS_ROOT}/etc/apt/sources.list
       sudo apt-get update
       sudo apt-get -yq --no-install-suggests --no-install-recommends install \
         llvm-${LLVM_VERSION}-dev \


### PR DESCRIPTION
spirv-val from focal reports things like:
Invalid capability operand: 6016
where 6016 is DotProductInputAll capability
