### PR TITLE
[Backport to 20] [SPIR-V 1.6] Allow UniformDecoration capability for Uniform

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -83,6 +83,10 @@ public:
       BuiltIn BI = static_cast<BuiltIn>(Literals.back());
       return getCapability(BI);
     }
+    case DecorationUniform:
+      if (Module->isAllowedToUseVersion(VersionNumber::SPIRV_1_6))
+        return getVec(CapabilityUniformDecoration);
+      return getVec(CapabilityShader);
 
     default:
       return getCapability(Dec);

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -396,7 +396,6 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationSample, {CapabilitySampleRateShading});
   ADD_VEC_INIT(DecorationInvariant, {CapabilityShader});
   ADD_VEC_INIT(DecorationConstant, {CapabilityKernel});
-  ADD_VEC_INIT(DecorationUniform, {CapabilityShader});
   ADD_VEC_INIT(DecorationSaturatedConversion, {CapabilityKernel});
   ADD_VEC_INIT(DecorationStream, {CapabilityGeometryStreams});
   ADD_VEC_INIT(DecorationLocation, {CapabilityShader});

--- a/test/DecorateUniform.spvasm
+++ b/test/DecorateUniform.spvasm
@@ -1,0 +1,26 @@
+; REQUIRES: spirv-as
+
+; RUN: spirv-as %s --target-env spv1.6 -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -to-text -o - %t.spv | FileCheck %s
+
+; Check that the translator does not add the Shader/Matrix capability
+; requirements for SPIR-V 1.6.
+
+; CHECK-NOT: Capability Matrix
+; CHECK-NOT: Capability Shader
+
+               OpCapability Addresses
+               OpCapability Kernel
+               OpCapability UniformDecoration
+               OpMemoryModel Physical64 OpenCL
+               OpEntryPoint Kernel %2 "test"
+               OpDecorate %uint_0 Uniform
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+       %void = OpTypeVoid
+          %1 = OpTypeFunction %void
+          %2 = OpFunction %void None %1
+          %3 = OpLabel
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
Starting from SPIR-V 1.6, the `UniformDecoration` capability also enables the `Uniform` decoration (in addition to the `Shader` capability). llvm-spirv was not aware of this, and would always add the `Shader` (and implied `Matrix`) capabilities when consuming a SPIR-V module with a `Uniform` decoration.

(cherry picked from commit e17f4b4f34a330fbb75d04c3db64fdcb551d0844)