### PR TITLE
[LLVM->SPV-IR] Set an arg of __spirv_ocl_nan/shuffle/shuffle2 to unsigned

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2614,6 +2614,15 @@ public:
     case OpenCLLIB::S_Upsample:
       addUnsignedArg(1);
       break;
+    case OpenCLLIB::Nan:
+      addUnsignedArg(0);
+      break;
+    case OpenCLLIB::Shuffle:
+      addUnsignedArg(1);
+      break;
+    case OpenCLLIB::Shuffle2:
+      addUnsignedArg(2);
+      break;
     default:;
       // No special handling is needed
     }

--- a/test/transcoding/OpenCL/nan.ll
+++ b/test/transcoding/OpenCL/nan.ll
@@ -1,0 +1,33 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-SPV-IR
+
+; Check OpenCL built-in nan translation.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64"
+
+; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] nan
+
+; CHECK-LLVM: call spir_func float @_Z3nanj(
+
+; CHECK-SPV-IR: call spir_func float @_Z15__spirv_ocl_nanj(
+
+define dso_local spir_kernel void @test(ptr addrspace(1) align 4 %a, i32 %b) {
+entry:
+  %call = tail call spir_func float @_Z3nanj(i32 %b)
+  store float %call, ptr addrspace(1) %a, align 4
+  ret void
+}
+
+declare spir_func float @_Z3nanj(i32)
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}

--- a/test/transcoding/OpenCL/shuffle.ll
+++ b/test/transcoding/OpenCL/shuffle.ll
@@ -1,0 +1,46 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefixes=CHECK-SPV-IR
+
+; Check OpenCL built-in shuffle and shuffle2 translation.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64"
+
+; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] shuffle
+; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] shuffle2
+
+; CHECK-LLVM: call spir_func <2 x float> @_Z7shuffleDv2_fDv2_j(
+; CHECK-LLVM: call spir_func <4 x float> @_Z8shuffle2Dv2_fS_Dv4_j(
+
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z19__spirv_ocl_shuffleDv2_fDv2_j(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z20__spirv_ocl_shuffle2Dv2_fS_Dv4_j(
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64"
+
+define spir_kernel void @test() {
+entry:
+  %call = call spir_func <2 x float> @_Z7shuffleDv2_fDv2_j(<2 x float> zeroinitializer, <2 x i32> zeroinitializer)
+  ret void
+}
+
+declare spir_func <2 x float> @_Z7shuffleDv2_fDv2_j(<2 x float>, <2 x i32>)
+
+define spir_kernel void @test2() {
+entry:
+  %call = call spir_func <4 x float> @_Z8shuffle2Dv2_fS_Dv4_j(<2 x float> zeroinitializer, <2 x float> zeroinitializer, <4 x i32> zeroinitializer)
+  ret void
+}
+
+declare spir_func <4 x float> @_Z8shuffle2Dv2_fS_Dv4_j(<2 x float>, <2 x float>, <4 x i32>)
+
+!opencl.ocl.version = !{!0}
+
+!0 = !{i32 3, i32 0}


### PR DESCRIPTION
OpenCL built-in nan's argument type and shuffle/shuffle2's mask argument type is unsigned. DPC++ header also sets unsigned type for them. So this PR changes them to unsigned in SPV-IR.