### PR TITLE
Update calls to PointerType::get with opaque equivalent

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1127,8 +1127,8 @@ LLVMToSPIRVDbgTran::transDbgTemplateParameter(const DITemplateParameter *TP) {
       Constant *C = cast<ConstantAsMetadata>(TVVal)->getValue();
       Ops[ValueIdx] = SPIRVWriter->transValue(C, nullptr)->getId();
     } else {
-      SPIRVType *TyPtr = SPIRVWriter->transType(
-          PointerType::get(Type::getInt8Ty(M->getContext()), 0));
+      SPIRVType *TyPtr =
+          SPIRVWriter->transType(PointerType::get(M->getContext(), 0));
       Ops[ValueIdx] = BM->addNullConstant(TyPtr)->getId();
     }
   }

--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -1491,8 +1491,8 @@ void OCLToSPIRVBase::visitCallEnqueueKernel(CallInst *CI,
   // If no event arguments in original call, add dummy ones
   if (!HasEvents) {
     Args.push_back(getInt32(M, 0)); // dummy num events
-    Value *Null = Constant::getNullValue(PointerType::get(
-        getSPIRVType(OpTypeDeviceEvent, true), SPIRAS_Generic));
+    Value *Null = Constant::getNullValue(
+        PointerType::get(CI->getContext(), SPIRAS_Generic));
     Args.push_back(Null); // dummy wait events
     Args.push_back(Null); // dummy ret event
   }

--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -99,7 +99,7 @@ Value *BuiltinCallMutator::doConversion() {
 
   // Sanitize the return type, in case it's a TypedPointerType.
   if (auto *TPT = dyn_cast<TypedPointerType>(ReturnTy))
-    ReturnTy = PointerType::get(TPT->getElementType(), TPT->getAddressSpace());
+    ReturnTy = PointerType::get(CI->getContext(), TPT->getAddressSpace());
 
   CallInst *NewCall =
       Builder.Insert(addCallInst(CI->getModule(), FuncName, ReturnTy, Args,
@@ -238,7 +238,7 @@ Value *BuiltinCallHelper::addSPIRVCall(IRBuilder<> &Builder, spv::Op Opcode,
                                        const Twine &Name) {
   // Sanitize the return type, in case it's a TypedPointerType.
   if (auto *TPT = dyn_cast<TypedPointerType>(ReturnTy))
-    ReturnTy = PointerType::get(TPT->getElementType(), TPT->getAddressSpace());
+    ReturnTy = PointerType::get(Builder.getContext(), TPT->getAddressSpace());
 
   // Copy the types into the mangling info.
   BuiltinFuncMangleInfo BtnInfo;
@@ -352,7 +352,7 @@ Type *BuiltinCallHelper::getSPIRVType(spv::Op TypeOpcode,
     STy = StructType::create(M->getContext(), FullName);
 
   unsigned AddrSpace = getOCLOpaqueTypeAddrSpace(TypeOpcode);
-  return UseRealType ? (Type *)PointerType::get(STy, AddrSpace)
+  return UseRealType ? (Type *)PointerType::get(M->getContext(), AddrSpace)
                      : TypedPointerType::get(STy, AddrSpace);
 }
 

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -86,7 +86,8 @@ static Value *removeBitCasts(Value *OldValue, Type *NewTy, NFIRBuilder &Builder,
 
   if (auto *ASCI = dyn_cast<AddrSpaceCastInst>(OldValue)) {
     Builder.SetInsertPoint(ASCI);
-    Type *NewSrcTy = PointerType::get(NewTy, ASCI->getSrcAddressSpace());
+    Type *NewSrcTy =
+        PointerType::get(Builder.getContext(), ASCI->getSrcAddressSpace());
     Value *Pointer = removeBitCasts(ASCI->getPointerOperand(), NewSrcTy,
                                     Builder, InstsToErase);
     return RauwBitcasts(ASCI, Builder.CreateAddrSpaceCast(Pointer, NewTy));

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -381,7 +381,7 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     Type *ElementTy = transType(T->getPointerElementType(), UseTPT);
     if (UseTPT)
       return TypedPointerType::get(ElementTy, AS);
-    return mapType(T, PointerType::get(ElementTy, AS));
+    return mapType(T, PointerType::get(*Context, AS));
   }
   case OpTypeUntypedPointerKHR: {
     unsigned AS = SPIRSPIRVAddrSpaceMap::rmap(T->getPointerStorageClass());
@@ -461,7 +461,7 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     if (UseTPT) {
       return mapType(T, TypedPointerType::get(STy, 1));
     }
-    return mapType(T, PointerType::get(STy, 1));
+    return mapType(T, PointerType::get(*Context, 1));
   }
   case OpTypeVmeImageINTEL: {
     auto *VT = static_cast<SPIRVTypeVmeImageINTEL *>(T)->getImageType();
@@ -646,8 +646,7 @@ SPIRVToLLVM::transTypeVector(const std::vector<SPIRVType *> &BT, bool UseTPT) {
 
 static Type *opaquifyType(Type *Ty) {
   if (auto *TPT = dyn_cast<TypedPointerType>(Ty)) {
-    Ty = PointerType::get(opaquifyType(TPT->getElementType()),
-                          TPT->getAddressSpace());
+    Ty = PointerType::get(Ty->getContext(), TPT->getAddressSpace());
   }
   return Ty;
 }
@@ -3032,7 +3031,8 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
   std::vector<Value *> Args;
   Args.reserve(8);
   if (RetTy->getIntegerBitWidth() > 64) {
-    llvm::PointerType *RetPtrTy = llvm::PointerType::get(RetTy, SPIRAS_Generic);
+    llvm::PointerType *RetPtrTy =
+        llvm::PointerType::get(*Context, SPIRAS_Generic);
     Value *Alloca =
         new AllocaInst(RetTy, M->getDataLayout().getAllocaAddrSpace(), "", BB);
     Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
@@ -3156,7 +3156,8 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
   std::vector<Value *> Args;
 
   if (RetTy->getIntegerBitWidth() > 64) {
-    llvm::PointerType *RetPtrTy = llvm::PointerType::get(RetTy, SPIRAS_Generic);
+    llvm::PointerType *RetPtrTy =
+        llvm::PointerType::get(*Context, SPIRAS_Generic);
     ArgTys.push_back(RetPtrTy);
     Value *Alloca =
         new AllocaInst(RetTy, M->getDataLayout().getAllocaAddrSpace(), "", BB);
@@ -4503,8 +4504,7 @@ void SPIRVToLLVM::createCXXStructor(const char *ListName,
 
   // Type of a structor entry: { i32, void ()*, i8* }
   Type *PriorityTy = Type::getInt32Ty(*Context);
-  PointerType *CtorTy = PointerType::getUnqual(
-      FunctionType::get(Type::getVoidTy(*Context), false));
+  PointerType *CtorTy = PointerType::getUnqual(*Context);
   PointerType *ComdatTy = PointerType::getUnqual(*Context);
   StructType *StructorTy = StructType::get(PriorityTy, CtorTy, ComdatTy);
 

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -643,7 +643,7 @@ void SPIRVToOCLBase::visitCallGenericCastToPtrBuiltIn(CallInst *CI, Op OC) {
   Value *PtrArg = CI->getArgOperand(0);
   auto AddrSpace =
       static_cast<SPIRAddressSpace>(CI->getType()->getPointerAddressSpace());
-  Type *NewTy = PointerType::get(PtrArg->getType(), AddrSpace);
+  Type *NewTy = PointerType::get(CI->getContext(), AddrSpace);
   Value *ASC = Builder.CreateAddrSpaceCast(PtrArg, NewTy);
   CI->replaceAllUsesWith(ASC);
   CI->eraseFromParent();

--- a/lib/SPIRV/SPIRVToOCL20.cpp
+++ b/lib/SPIRV/SPIRVToOCL20.cpp
@@ -176,7 +176,7 @@ CallInst *SPIRVToOCL20Base::mutateCommonAtomicArguments(CallInst *CI, Op OC) {
     if (auto *TypedPtrTy = dyn_cast<TypedPointerType>(PtrArgTy)) {
       if (TypedPtrTy->getAddressSpace() != SPIRAS_Generic) {
         Type *ElementTy = TypedPtrTy->getElementType();
-        Type *FixedPtr = PointerType::get(ElementTy, SPIRAS_Generic);
+        Type *FixedPtr = PointerType::get(CI->getContext(), SPIRAS_Generic);
         PtrArg = Builder.CreateAddrSpaceCast(PtrArg, FixedPtr,
                                              PtrArg->getName() + ".as");
         PtrArgTy = TypedPointerType::get(ElementTy, SPIRAS_Generic);
@@ -222,7 +222,8 @@ void SPIRVToOCL20Base::visitCallSPIRVAtomicCmpExchg(CallInst *CI) {
               [=](IRBuilder<> &Builder, Value *Expected) {
                 Builder.CreateStore(Expected, PExpected);
                 unsigned AddrSpc = SPIRAS_Generic;
-                Type *PtrTyAS = PointerType::get(PExpected->getType(), AddrSpc);
+                Type *PtrTyAS =
+                    PointerType::get(Expected->getContext(), AddrSpc);
                 Value *V = Builder.CreateAddrSpaceCast(
                     PExpected, PtrTyAS, PExpected->getName() + ".as");
                 return std::make_pair(V, TypedPointerType::get(MemTy, AddrSpc));

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -633,7 +633,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
 }
 
 SPIRVType *LLVMToSPIRVBase::transPointerType(Type *ET, unsigned AddrSpc) {
-  Type *T = PointerType::get(ET, AddrSpc);
+  Type *T = PointerType::get(ET->getContext(), AddrSpc);
   if (ET->isFunctionTy() &&
       !BM->checkExtension(ExtensionID::SPV_INTEL_function_pointers,
                           SPIRVEC_FunctionPointers, toString(T)))


### PR DESCRIPTION
Update after llvm-project commit 146ad71bc71a ("[IR] Deprecate PointerType::get/getUnqual pointee type overload (#134517)", 2025-04-06).