### PR TITLE
[Backport to 20] [SPIR-V 1.6] Support reverse translation of FPFastMathMode

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1225,6 +1225,7 @@ Value *SPIRVToLLVM::transCmpInst(SPIRVValue *BV, BasicBlock *BB, Function *F) {
   else if (BT->isTypeVectorOrScalarFloat())
     Inst = Builder.CreateFCmp(CmpMap::rmap(OP), Op0, Op1);
   assert(Inst && "not implemented");
+  applyFPFastMathModeDecorations(BV, static_cast<Instruction *>(Inst));
   return Inst;
 }
 

--- a/test/transcoding/fcmp.ll
+++ b/test/transcoding/fcmp.ll
@@ -9,7 +9,7 @@
 ; RUN: llvm-spirv %t.bc --spirv-max-version=1.6 -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.rev.ll
-; FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM-16
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM-16
 
 ; CHECK-SPIRV: 3 Name [[#r1:]] "r1"
 ; CHECK-SPIRV: 3 Name [[#r2:]] "r2"

--- a/test/transcoding/fneg.ll
+++ b/test/transcoding/fneg.ll
@@ -5,7 +5,7 @@
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; RUN: llvm-spirv -spirv-text %t.bc --spirv-max-version=1.6
-; FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-16
+; RUN: FileCheck < %t.spt %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-16
 ; RUN: llvm-spirv %t.bc --spirv-max-version=1.6 -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM-16


### PR DESCRIPTION
... decoration for `fcmp` instruction (#3108)