### PR TITLE
[DebugInfo] Continue fixing translation of debug info for mem2reged vars

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2676,7 +2676,12 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         return mapValue(
             BV, cast<Instruction *>(DbgTran->transDebugIntrinsic(ExtInst, BB)));
       } else {
-        DbgTran->transDebugIntrinsic(ExtInst, BB);
+        auto MaybeRecord = DbgTran->transDebugIntrinsic(ExtInst, BB);
+        if (!MaybeRecord.isNull()) {
+          auto *Record = cast<DbgRecord *>(MaybeRecord);
+          Record->setDebugLoc(
+              DbgTran->transDebugScope(static_cast<SPIRVInstruction *>(BV)));
+        }
         return mapValue(BV, nullptr);
       }
     default:

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2676,12 +2676,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         return mapValue(
             BV, cast<Instruction *>(DbgTran->transDebugIntrinsic(ExtInst, BB)));
       } else {
-        auto MaybeRecord = DbgTran->transDebugIntrinsic(ExtInst, BB);
-        if (!MaybeRecord.isNull()) {
-          auto *Record = cast<DbgRecord *>(MaybeRecord);
-          Record->setDebugLoc(
-              DbgTran->transDebugScope(static_cast<SPIRVInstruction *>(BV)));
-        }
+        DbgTran->transDebugIntrinsic(ExtInst, BB);
         return mapValue(BV, nullptr);
       }
     default:

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1592,8 +1592,9 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
       AI->eraseFromParent();
       return DbgDeclare;
     }
+    DebugLoc Loc = transDebugScope(DebugInst);
     return DIB.insertDeclare(GetValue(Ops[VariableIdx]), LocalVar.first,
-                             GetExpression(Ops[ExpressionIdx]), LocalVar.second,
+                             GetExpression(Ops[ExpressionIdx]), Loc,
                              BB);
   }
   case SPIRVDebug::Value: {
@@ -1601,8 +1602,9 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
     auto LocalVar = GetLocalVar(Ops[DebugLocalVarIdx]);
     Value *Val = GetValue(Ops[ValueIdx]);
     DIExpression *Expr = GetExpression(Ops[ExpressionIdx]);
+    DebugLoc Loc = transDebugScope(DebugInst);
     DbgInstPtr DbgValIntr = getDIBuilder(DebugInst).insertDbgValueIntrinsic(
-        Val, LocalVar.first, Expr, LocalVar.second, BB);
+        Val, LocalVar.first, Expr, Loc, BB);
 
     std::vector<ValueAsMetadata *> MDs;
     for (size_t I = 0; I != Expr->getNumLocationOperands(); ++I) {

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1582,8 +1582,7 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
       auto *Null =
           ConstantPointerNull::get(PointerType::get(M->getContext(), 0));
       DbgInstPtr DbgDeclare = DIB.insertDeclare(
-          Null, LocalVar.first, GetExpression(Ops[ExpressionIdx]),
-          Loc, BB);
+          Null, LocalVar.first, GetExpression(Ops[ExpressionIdx]), Loc, BB);
       return DbgDeclare;
     }
     return DIB.insertDeclare(GetValue(Ops[VariableIdx]), LocalVar.first,

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1574,25 +1574,18 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
   case SPIRVDebug::Declare: {
     using namespace SPIRVDebug::Operand::DebugDeclare;
     auto LocalVar = GetLocalVar(Ops[DebugLocalVarIdx]);
+    DebugLoc Loc = transDebugScope(DebugInst);
+    if (!Loc)
+      Loc = LocalVar.second;
     DIBuilder &DIB = getDIBuilder(DebugInst);
     if (getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[VariableIdx])) {
-      // If we don't have the variable(e.g. alloca might be promoted by mem2reg)
-      // we should generate the following IR:
-      // call void @llvm.dbg.declare(metadata !4, metadata !14, metadata !5)
-      // !4 = !{}
-      // DIBuilder::insertDeclare doesn't allow to pass nullptr for the Storage
-      // parameter. To work around this limitation we create a dummy temp
-      // alloca, use it to create llvm.dbg.declare, and then remove the alloca.
-      auto *AI =
-          new AllocaInst(Type::getInt8Ty(M->getContext()),
-                         M->getDataLayout().getAllocaAddrSpace(), "tmp", BB);
+      auto *Null =
+          ConstantPointerNull::get(PointerType::get(M->getContext(), 0));
       DbgInstPtr DbgDeclare = DIB.insertDeclare(
-          AI, LocalVar.first, GetExpression(Ops[ExpressionIdx]),
-          LocalVar.second, BB);
-      AI->eraseFromParent();
+          Null, LocalVar.first, GetExpression(Ops[ExpressionIdx]),
+          Loc, BB);
       return DbgDeclare;
     }
-    DebugLoc Loc = transDebugScope(DebugInst);
     return DIB.insertDeclare(GetValue(Ops[VariableIdx]), LocalVar.first,
                              GetExpression(Ops[ExpressionIdx]), Loc,
                              BB);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1592,9 +1592,8 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
       AI->eraseFromParent();
       return DbgDeclare;
     }
-    DebugLoc Loc = transDebugScope(DebugInst);
     return DIB.insertDeclare(GetValue(Ops[VariableIdx]), LocalVar.first,
-                             GetExpression(Ops[ExpressionIdx]), Loc,
+                             GetExpression(Ops[ExpressionIdx]), LocalVar.second,
                              BB);
   }
   case SPIRVDebug::Value: {
@@ -1602,9 +1601,8 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
     auto LocalVar = GetLocalVar(Ops[DebugLocalVarIdx]);
     Value *Val = GetValue(Ops[ValueIdx]);
     DIExpression *Expr = GetExpression(Ops[ExpressionIdx]);
-    DebugLoc Loc = transDebugScope(DebugInst);
     DbgInstPtr DbgValIntr = getDIBuilder(DebugInst).insertDbgValueIntrinsic(
-        Val, LocalVar.first, Expr, Loc, BB);
+        Val, LocalVar.first, Expr, LocalVar.second, BB);
 
     std::vector<ValueAsMetadata *> MDs;
     for (size_t I = 0; I != Expr->getNumLocationOperands(); ++I) {

--- a/test/DebugInfo/DebugDeclareUnused.cl
+++ b/test/DebugInfo/DebugDeclareUnused.cl
@@ -16,4 +16,4 @@ void foo() {
 
 // CHECK-SPIRV: ExtInst [[#]] [[#InfoNone:]] [[#]] DebugInfoNone
 // CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] DebugDeclare [[#]] [[#InfoNone]] [[#]]
-// CHECK-LLVM:  #dbg_declare(ptr poison, ![[#]], !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), ![[#]])
+// CHECK-LLVM:  #dbg_declare(ptr null, ![[#]], !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), ![[#]])

--- a/test/DebugInfo/mem2reged_local_var.ll
+++ b/test/DebugInfo/mem2reged_local_var.ll
@@ -25,7 +25,7 @@
 ; CHECK-SPIRV: ExtInst [[#]] [[#LocalVar:]] [[#]] DebugLocalVariable
 ; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] DebugDeclare [[#LocalVar]] [[#None]] [[#]]
 
-; CHECK-LLVM: #dbg_declare(ptr poison, ![[#LocalVar:]], !DIExpression(DW_OP_constu, 4, DW_OP_swap, DW_OP_xderef), ![[#Loc:]])
+; CHECK-LLVM: #dbg_declare(ptr null, ![[#LocalVar:]], !DIExpression(DW_OP_constu, 4, DW_OP_swap, DW_OP_xderef), ![[#Loc:]])
 ; CHECK-LLVM-DAG: ![[#LocalVar]] = !DILocalVariable(name: "bar"
 ; CHECK-LLVM-DAG: ![[#Loc]] = !DILocation(line: 23
 


### PR DESCRIPTION
It's a follow up to 367ede2 with the following additions:
1. don't create unnecessary temporary alloca, instead create nullptr
const - this helps tooling later on as it won't deal with poison;
2. partially revert a change in reverse translation resetting debug
location for debug declarations - we should always try to get
location information from DebugScope, and fall back to LocalVar only if
DebugScope doesn't provide such information.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>