### PR TITLE
[Draft] Remove `SPV_KHR_bfloat16` error

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -397,6 +397,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
     }
   }
 
+#if 0
   if (T->isBFloatTy()) {
     BM->getErrorLog().checkError(
         BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_bfloat16),
@@ -406,6 +407,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
         "requires this extension");
     return mapType(T, BM->addFloatType(16, FPEncodingBFloat16KHR));
   }
+#endif
 
   if (T->isFloatingPointTy())
     return mapType(T, BM->addFloatType(T->getPrimitiveSizeInBits()));


### PR DESCRIPTION
This draft PR addresses a current issue with Intel Triton. We kindly request that you refrain from closing it at this time. We will close the PR once the Intel Rolling driver, as detailed at https://dgpu-docs.intel.com/driver/installation-rolling.html, is updated to incorporate the SPIRV translator with the SPV_KHR_bfloat16 extension.