### PR TITLE
[Backport to 18] Missing addExtension in SPIRVWriter.cpp

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3003,10 +3003,12 @@ bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
           if (FMF.allowContract()) {
             M |= FPFastMathModeAllowContractFastINTELMask;
             BM->addCapability(CapabilityFPFastMathModeINTEL);
+            BM->addExtension(ExtensionID::SPV_INTEL_fp_fast_math_mode);
           }
           if (FMF.allowReassoc()) {
             M |= FPFastMathModeAllowReassocINTELMask;
             BM->addCapability(CapabilityFPFastMathModeINTEL);
+            BM->addExtension(ExtensionID::SPV_INTEL_fp_fast_math_mode);
           }
         }
       }

--- a/test/extensions/INTEL/SPV_INTEL_fp_fast_math_mode/fp_contract_reassoc_fast_mode.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fp_fast_math_mode/fp_contract_reassoc_fast_mode.ll
@@ -5,6 +5,7 @@
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
  
 ; CHECK-SPIRV-ON: 2 Capability FPFastMathModeINTEL
+; CHECK-SPIRV-ON: 8 Extension "SPV_INTEL_fp_fast_math_mode"
 ; CHECK-SPIRV-ON: 3 Name [[mu:[0-9]+]] "mul"
 ; CHECK-SPIRV-ON: 3 Name [[su:[0-9]+]] "sub"
 ; CHECK-SPIRV-ON-DAG: 4 Decorate [[mu]] FPFastMathMode 65536


### PR DESCRIPTION
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2028

was supposed to get cherry-picked