### PR TITLE
[Draft] Reduce `MaximumVersion` to `SPIRV_1_4`

### DIFF
--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -66,7 +66,7 @@ enum class VersionNumber : uint32_t {
   SPIRV_1_5 = 0x00010500,
   SPIRV_1_6 = 0x00010600,
   MinimumVersion = SPIRV_1_0,
-  MaximumVersion = SPIRV_1_6
+  MaximumVersion = SPIRV_1_4
 };
 
 inline constexpr std::string_view formatVersionNumber(uint32_t Version) {


### PR DESCRIPTION
This draft PR addresses a current issue with Intel Triton. We kindly request that you refrain from closing it at this time. We will close the PR once https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3137 is addressed. 