### PR TITLE
Enabled RuntimeAlignedINTEL functionParameterAttribute.

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -995,13 +995,9 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
           !isa<MDNode>(RuntimeAligned->getOperand(ArgNo)))
         IsRuntimeAligned = getMDOperandAsInt(RuntimeAligned, ArgNo);
       if (IsRuntimeAligned == 1) {
-        // TODO: to replace non-conformant to the spec decoration generation
-        // with:
-        // BM->addExtension(ExtensionID::SPV_INTEL_runtime_aligned);
-        // BM->addCapability(CapabilityRuntimeAlignedAttributeINTEL);
-        // BA->addAttr(FunctionParameterAttributeRuntimeAlignedINTEL);
-        BA->addDecorate(internal::DecorationRuntimeAlignedINTEL,
-                        IsRuntimeAligned);
+        BM->addExtension(ExtensionID::SPV_INTEL_runtime_aligned);
+        BM->addCapability(CapabilityRuntimeAlignedAttributeINTEL);
+        BA->addAttr(FunctionParameterAttributeRuntimeAlignedINTEL);
       }
     }
   }


### PR DESCRIPTION
- Current implemention was non-conformant with spec. So removed it.Uncommented actual implementation.
- `error: 24: Invalid decoration operand: 5940`
This error would show up on trying to run _/test/extensions/INTEL/SPV_INTEL_runtime_aligned/RuntimeAligned.ll_ . So corrected it.