### PR TITLE
[Backport to 16] Remove `Aligned 0` from tests (#3105)

### DIFF
--- a/test/OpLoopMergeNone.spt
+++ b/test/OpLoopMergeNone.spt
@@ -39,7 +39,7 @@
 2 Label 20
 4 Variable 18 26 7
 4 Variable 18 27 7
-6 Load 9 21 7 2 0
+4 Load 9 21 7
 5 CompositeExtract 8 22 21 0
 5 ShiftLeftLogical 8 23 22 11
 5 ShiftRightArithmetic 8 24 23 11

--- a/test/composite_construct_struct.spt
+++ b/test/composite_construct_struct.spt
@@ -37,7 +37,7 @@
 2 Label 21
 5 CompositeConstruct 11 22 16 17
 5 CompositeConstruct 12 23 20 22
-6 Load 5 24 3 2 0
+4 Load 5 24 3
 5 CompositeExtract 4 25 24 0
 5 ShiftLeftLogical 4 26 25 15
 5 ShiftRightArithmetic 4 27 26 15

--- a/test/composite_construct_vector.spt
+++ b/test/composite_construct_vector.spt
@@ -30,7 +30,7 @@
 3 FunctionParameter 10 2
 
 2 Label 17
-6 Load 5 18 3 2 0
+4 Load 5 18 3
 5 CompositeExtract 4 19 18 0
 5 ShiftLeftLogical 4 20 19 12
 5 ShiftRightArithmetic 4 21 20 12

--- a/test/copy_object.spt
+++ b/test/copy_object.spt
@@ -27,7 +27,7 @@
 3 FunctionParameter 9 2
 
 2 Label 13
-6 Load 5 14 3 2 0
+4 Load 5 14 3
 5 CompositeExtract 4 15 14 0
 5 ShiftLeftLogical 4 16 15 11
 5 ShiftRightArithmetic 4 17 16 11

--- a/test/right_shift.spt
+++ b/test/right_shift.spt
@@ -31,7 +31,7 @@
 3 FunctionParameter 10 2
 
 2 Label 17
-6 Load 5 18 3 2 0
+4 Load 5 18 3
 5 CompositeExtract 4 19 18 0
 5 ShiftRightArithmetic 4 20 19 12
 5 ShiftLeftLogical 4 21 20 25

--- a/test/selection_merge.spt
+++ b/test/selection_merge.spt
@@ -35,7 +35,7 @@
 
 2 Label 18
 4 Variable 16 27 7
-6 Load 8 19 6 2 0
+4 Load 8 19 6
 5 CompositeExtract 7 20 19 0
 5 ShiftLeftLogical 7 21 20 13
 5 ShiftRightArithmetic 7 22 21 13

--- a/test/vector_times_scalar.spt
+++ b/test/vector_times_scalar.spt
@@ -34,7 +34,7 @@
 3 FunctionParameter 13 4 
 
 2 Label 17 
-6 Load 8 18 6 2 0 
+4 Load 8 18 6
 5 CompositeExtract 7 19 18 0 
 5 ShiftLeftLogical 7 20 19 10 
 5 ShiftRightArithmetic 7 21 20 10 


### PR DESCRIPTION
After https://github.com/KhronosGroup/SPIRV-Tools/pull/6027 spirv-val is now rejecting `Aligned 0` Memory Operands. This caused various tests to fail validation with a recent SPIRV-Tools version.