### PR TITLE
[Backport to 19] Rounding modes on int to int conversions are valid OpenCL C builtin functions

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -797,9 +797,6 @@ void OCLToSPIRVBase::visitCallConvert(CallInst *CI, StringRef MangledName,
       OC = OpFConvert;
   }
 
-  if (!Rounding.empty() && (isa<IntegerType>(SrcTy) && IsTargetInt))
-    return;
-
   assert(CI->getCalledFunction() && "Unexpected indirect call");
   mutateCallInst(
       CI, getSPIRVFuncName(OC, "_R" + DestTy + VecSize + Sat + Rounding));

--- a/test/transcoding/OpenCL/convert_functions.ll
+++ b/test/transcoding/OpenCL/convert_functions.ll
@@ -53,11 +53,15 @@ entry:
   %x.addr = alloca i32, align 4
   store i32 %x, ptr %x.addr, align 4
   %0 = load i32, ptr %x.addr, align 4
+; We don't get the convert_char_rtei back, but that's fine because they are
+; functionally equivalent anyway. The rounding information is lost when
+; translating to SPIR-V.
+; CHECK-LLVM: call spir_func i8 @_Z12convert_chari(i32 %[[#]])
+  call spir_func signext i8 @_Z16convert_char_rtei(i32 noundef %0) #1
 ; CHECK-LLVM: %[[Call:[a-z]+]] = sitofp i32 %[[#]] to float
 ; CHECK-LLVM: call spir_func void @_Z18convert_float_func(float %[[Call]])
 ; CHECK-LLVM: call spir_func void @_Z20convert_uint_satfunc(i32 %[[#]])
 ; CHECK-LLVM: call spir_func void @_Z21convert_float_rtzfunc(float %[[Call]])
-  call spir_func signext i8 @_Z16convert_char_rtei(i32 noundef %0) #1
   %call = call spir_func float @_Z13convert_floati(i32 noundef %0) #1
   call spir_func void @_Z18convert_float_func(float noundef %call) #0
   call spir_func void @_Z20convert_uint_satfunc(i32 noundef %0) #0

--- a/test/transcoding/OpenCL/convert_functions.ll
+++ b/test/transcoding/OpenCL/convert_functions.ll
@@ -14,9 +14,11 @@
 ; CHECK-SPIRV: Name [[#Func1:]] "_Z20convert_uint_satfunc"
 ; CHECK-SPIRV: Name [[#Func2:]] "_Z21convert_float_rtzfunc"
 ; CHECK-SPIRV-DAG: TypeVoid [[#VoidTy:]]
+; CHECK-SPIRV-DAG: TypeInt [[#CharTy:]] 8
 ; CHECK-SPIRV-DAG: TypeFloat [[#FloatTy:]] 32
 
 ; CHECK-SPIRV: Function [[#VoidTy]] [[#Func]]
+; CHECK-SPIRV: SConvert [[#CharTy]] [[#ConvertId:]] [[#]]
 ; CHECK-SPIRV: ConvertSToF [[#FloatTy]] [[#ConvertId:]] [[#]]
 ; CHECK-SPIRV: FunctionCall [[#VoidTy]] [[#]] [[#Func]] [[#ConvertId]]
 ; CHECK-SPIRV: FunctionCall [[#VoidTy]] [[#]] [[#Func1]] [[#]]
@@ -55,12 +57,16 @@ entry:
 ; CHECK-LLVM: call spir_func void @_Z18convert_float_func(float %[[Call]])
 ; CHECK-LLVM: call spir_func void @_Z20convert_uint_satfunc(i32 %[[#]])
 ; CHECK-LLVM: call spir_func void @_Z21convert_float_rtzfunc(float %[[Call]])
+  call spir_func signext i8 @_Z16convert_char_rtei(i32 noundef %0) #1
   %call = call spir_func float @_Z13convert_floati(i32 noundef %0) #1
   call spir_func void @_Z18convert_float_func(float noundef %call) #0
   call spir_func void @_Z20convert_uint_satfunc(i32 noundef %0) #0
   call spir_func void @_Z21convert_float_rtzfunc(float noundef %call) #0
   ret void
 }
+
+; Function Attrs: convergent nounwind willreturn memory(none)
+declare spir_func signext i8 @_Z16convert_char_rtei(i32 noundef) #1
 
 ; Function Attrs: convergent nounwind willreturn memory(none)
 declare spir_func float @_Z13convert_floati(i32 noundef) #1


### PR DESCRIPTION
commit aa529b41c808ba3c1ed57ef1991d1327986dba81
Author: Karol Herbst <kherbst@redhat.com>
Date:   Fri Apr 25 12:29:10 2025 +0200

    Add reverse translation test for integer convert with explicit rounding (#3128)

    As discussed in
    https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3120#pullrequestreview-2784086336

commit 80d20c4bcc9edb3894184309fd3b9e1fee1086ce
Author: Karol Herbst <kherbst@redhat.com>
Date:   Tue Apr 22 15:19:13 2025 +0200

    Rounding modes on int to int conversions are valid OpenCL C builtin functions (#3120)

    The OpenCL CTS also tests for this, so those can't be ignored.

    Fixes: 04144823 ("Rewrite OpenCL explicit conversion builtins handling
    (#2464)")