### PR TITLE
Fix build after LLVM InlineAsm changes

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5550,7 +5550,7 @@ SPIRVValue *LLVMToSPIRVBase::transAsmINTEL(InlineAsm *IA) {
       BM->getOrAddAsmTargetINTEL(TripleStr.str()));
   auto *SIA = BM->addAsmINTEL(
       static_cast<SPIRVTypeFunction *>(transType(IA->getFunctionType())),
-      AsmTarget, IA->getAsmString(), IA->getConstraintString());
+      AsmTarget, IA->getAsmString().str(), IA->getConstraintString().str());
   if (IA->hasSideEffects())
     SIA->addDecorate(DecorationSideEffectsINTEL);
   return SIA;


### PR DESCRIPTION
Update after llvm commits
50e949f3cc47 ("[IR] Teach getAsmString to return StringRef (NFC) (#139406)", 2025-05-10) and
58014a506dd3 ("[IR] Teach getConstraintString to return StringRef (NFC) (#139401)", 2025-05-10).