### PR TITLE
[DebugInfo] Use native for the system separator for source path string

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -453,11 +453,12 @@ SmallVector<unsigned, 3> decodeMDNode(MDNode *N);
 template <typename T> std::string getFullPath(const T *Scope) {
   if (!Scope)
     return std::string();
-  std::string Filename = Scope->getFilename().str();
-  if (sys::path::is_absolute(Filename))
-    return Filename;
+  StringRef Filename = Scope->getFilename();
+  auto Style = sys::path::Style::native;
+  if (sys::path::is_absolute(Filename, Style))
+    return Filename.str();
   SmallString<16> DirName = Scope->getDirectory();
-  sys::path::append(DirName, sys::path::Style::posix, Filename);
+  sys::path::append(DirName, Style, Filename.str());
   return DirName.str().str();
 }
 

--- a/test/DebugInfo/LocalAddressSpace.ll
+++ b/test/DebugInfo/LocalAddressSpace.ll
@@ -22,7 +22,7 @@
 ; CHECK: DW_TAG_variable
 ; CHECK-NEXT: DW_AT_name {{.*}} = "a")
 ; CHECK-NEXT: DW_AT_type {{.*}} "int")
-; CHECK-NEXT: DW_AT_decl_file {{.*}} ("/work/tmp{{[/\\]}}tmp.cl")
+; CHECK-NEXT: DW_AT_decl_file {{.*}} ("/work{{[/\\]}}tmp{{[/\\]}}tmp.cl")
 ; CHECK-NEXT: DW_AT_decl_line {{.*}} (2)
 ; CHECK-NEXT: DW_AT_location [DW_FORM_exprloc]      (DW_OP_addr 0x0)
 

--- a/test/DebugInfo/RelativeSrcPath.ll
+++ b/test/DebugInfo/RelativeSrcPath.ll
@@ -49,7 +49,7 @@ attributes #0 = { convergent noinline nounwind optnone "correctly-rounded-divide
 !6 = !{i32 1, i32 2}
 !7 = !{!"clang version 8.0.0 (cfe/trunk)"}
 !8 = distinct !DISubprogram(name: "foo", scope: !9, file: !9, line: 1, type: !10, isLocal: false, isDefinition: true, scopeLine: 1, flags: DIFlagPrototyped, isOptimized: false, unit: !0, retainedNodes: !2)
-; CHECK: String [[ID:[0-9]+]] "/tmp/RelativeSrcPath.cl"
+; CHECK: String [[ID:[0-9]+]] "/tmp{{[/\\]}}RelativeSrcPath.cl"
 ; CHECK: Line [[ID]]
 !9 = !DIFile(filename: "RelativeSrcPath.cl", directory: "/tmp")
 !10 = !DISubroutineType(types: !2)


### PR DESCRIPTION
Previously it used posix, causing strange behaviour like reported in https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3126

It's NFC change for the translator-based tool chains. Yet if SPIR-V consumer is not llvm-spirv - the fix should help.

Note, the patch is not attempting to guess separators depending on the user's IR input, so for the linux <-> windows cross compilation the result will be odd (like it was before).