### PR TITLE
[Backport to 14] Make OCLUtil.h compatible with C++20 standard (#3149)

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -94,11 +94,19 @@ enum OCLScopeKind {
 // To avoid any inconsistence here, constants are explicitly initialized with
 // the corresponding constants from 'std::memory_order' enum.
 enum OCLMemOrderKind {
+#if __cplusplus >= 202002L
+  OCLMO_relaxed = std::memory_order_relaxed,
+  OCLMO_acquire = std::memory_order_acquire,
+  OCLMO_release = std::memory_order_release,
+  OCLMO_acq_rel = std::memory_order_acq_rel,
+  OCLMO_seq_cst = std::memory_order_seq_cst
+#else
   OCLMO_relaxed = std::memory_order::memory_order_relaxed,
   OCLMO_acquire = std::memory_order::memory_order_acquire,
   OCLMO_release = std::memory_order::memory_order_release,
   OCLMO_acq_rel = std::memory_order::memory_order_acq_rel,
   OCLMO_seq_cst = std::memory_order::memory_order_seq_cst
+#endif
 };
 
 enum IntelFPGAMemoryAccessesVal {


### PR DESCRIPTION
The std::memory_order enum gets changed in C++20:
https://en.cppreference.com/w/cpp/atomic/memory_order
This change makes OCLUtil.h includable by projects that use C++20.

(cherry picked from commit 61303255b75bb2322b53948140c0318db0eb95c4)