### PR TITLE
Prevent duplicate array type insertion into TypeMap.

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2696,8 +2696,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
 
 SPIRVType *LLVMToSPIRVBase::mapType(Type *T, SPIRVType *BT) {
   assert(!T->isPointerTy() && "Pointer types cannot be stored in the type map");
-  [[maybe_unused]] auto EmplaceStatus = TypeMap.try_emplace(T, BT);
-  assert(EmplaceStatus.second && "The type was already added to the map");
+  TypeMap.try_emplace(T, BT);
   SPIRVDBG(dbgs() << "[mapType] " << *T << " => "; spvdbgs() << *BT << '\n');
   return BT;
 }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -461,7 +461,7 @@ SPIRVType *LLVMToSPIRVBase::transType(Type *T) {
             ConstantInt::get(getSizetType(), ArraySize, false), nullptr)));
     mapType(T, TransType);
     if (ElTy->isPointerTy()) {
-      auto ArrTy =
+      Type *ArrTy =
           ArrayType::get(TypedPointerType::get(Type::getInt8Ty(*Ctx),
                                                ElTy->getPointerAddressSpace()),
                          ArraySize);

--- a/test/duplicate-types.ll
+++ b/test/duplicate-types.ll
@@ -1,10 +1,10 @@
-; Check that we don't end up with duplicated types in TypeMap.
+; Check that we don't end up with duplicated array types in TypeMap.
 ; No FileCheck needed, we only want to check the absence of errors.
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 
-; ModuleID = 'duplicate-types'
+; ModuleID = 'duplicate-array-types'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
 target triple = "spir64-unknown-unknown"
 

--- a/test/duplicate-types.ll
+++ b/test/duplicate-types.ll
@@ -1,0 +1,19 @@
+; Check that we don't end up with duplicated types in TypeMap.
+; No FileCheck needed, we only want to check the absence of errors.
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+; ModuleID = 'duplicate-types'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+%duplicate = type { [2 x ptr addrspace(4)] }
+
+; Function Attrs: mustprogress norecurse nounwind
+define spir_kernel void @foo() {
+entry:
+  alloca [2 x ptr addrspace(4)], align 8
+  alloca %duplicate, align 8
+  ret void
+}


### PR DESCRIPTION
Check if an array type exists in TypeMap before inserting it to prevent duplications.