### PR TITLE
[LLVM->SPV-IR] Add const to pointer arg of prefetch, change num_elements arg type to unsigned

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2617,6 +2617,9 @@ public:
     case OpenCLLIB::Nan:
       addUnsignedArg(0);
       break;
+    case OpenCLLIB::Prefetch:
+      addUnsignedArg(1);
+      break;
     case OpenCLLIB::Shuffle:
       addUnsignedArg(1);
       break;

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2618,6 +2618,7 @@ public:
       addUnsignedArg(0);
       break;
     case OpenCLLIB::Prefetch:
+      setArgAttr(0, SPIR::ATTR_CONST);
       addUnsignedArg(1);
       break;
     case OpenCLLIB::Shuffle:

--- a/test/extensions/INTEL/SPV_INTEL_cache_controls/decorate-prefetch-w-cache-controls.ll
+++ b/test/extensions/INTEL/SPV_INTEL_cache_controls/decorate-prefetch-w-cache-controls.ll
@@ -42,11 +42,11 @@ $_ZTSZ4mainEUlvE_ = comdat any
 ; translation
 
 ; CHECK-LLVM: %[[CALL1:.*]] = call spir_func ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}} !spirv.Decorations ![[MD1:.*]]
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetch{{.*}}(ptr addrspace(1) %[[CALL1]], i64 1)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1cm(ptr addrspace(1) %[[CALL1]], i64 1)
 ; CHECK-LLVM: %[[CALL2:.*]] = call spir_func ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}} !spirv.Decorations ![[MD2:.*]]
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetch{{.*}}(ptr addrspace(1) %[[CALL2]], i64 1)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1cm(ptr addrspace(1) %[[CALL2]], i64 1)
 ; CHECK-LLVM: %[[CALL3:.*]] = call spir_func ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}} !spirv.Decorations ![[MD3:.*]]
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetch{{.*}}(ptr addrspace(1) %[[CALL3]], i64 2)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1cm(ptr addrspace(1) %[[CALL3]], i64 2)
 
 
 ; Function Attrs: convergent norecurse nounwind

--- a/test/extensions/INTEL/SPV_INTEL_cache_controls/decorate-prefetch-w-cache-controls.ll
+++ b/test/extensions/INTEL/SPV_INTEL_cache_controls/decorate-prefetch-w-cache-controls.ll
@@ -42,11 +42,11 @@ $_ZTSZ4mainEUlvE_ = comdat any
 ; translation
 
 ; CHECK-LLVM: %[[CALL1:.*]] = call spir_func ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}} !spirv.Decorations ![[MD1:.*]]
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1cm(ptr addrspace(1) %[[CALL1]], i64 1)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1Kcm(ptr addrspace(1) %[[CALL1]], i64 1)
 ; CHECK-LLVM: %[[CALL2:.*]] = call spir_func ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}} !spirv.Decorations ![[MD2:.*]]
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1cm(ptr addrspace(1) %[[CALL2]], i64 1)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1Kcm(ptr addrspace(1) %[[CALL2]], i64 1)
 ; CHECK-LLVM: %[[CALL3:.*]] = call spir_func ptr addrspace(1) @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}} !spirv.Decorations ![[MD3:.*]]
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1cm(ptr addrspace(1) %[[CALL3]], i64 2)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS1Kcm(ptr addrspace(1) %[[CALL3]], i64 2)
 
 
 ; Function Attrs: convergent norecurse nounwind


### PR DESCRIPTION
Per SPIR-V OpenCL.ExtendedInstructionSet spec, the num_elements arg must be size_t. So this PR changes its type to unsigned in SPV-IR.
Adding const to pointer arg aligns with OpenCL spec and allows const pointer input.