### PR TITLE
[Backport to 14] Fix crash on coopmat conversion without decoration

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2852,7 +2852,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     if (isCvtOpCode(OC) && OC != OpGenericCastToPtrExplicit) {
       auto BI = static_cast<SPIRVInstruction *>(BV);
       Value *Inst = nullptr;
-      if (BI->hasFPRoundingMode() || BI->isSaturatedConversion())
+      if (BI->hasFPRoundingMode() || BI->isSaturatedConversion() ||
+          BI->getType()->isTypeCooperativeMatrixKHR())
         Inst = transSPIRVBuiltinFromInst(BI, BB);
       else
         Inst = transConvertInst(BV, F, BB);

--- a/test/transcoding/SPV_KHR_cooperative_matrix/conversion_instructions.ll
+++ b/test/transcoding/SPV_KHR_cooperative_matrix/conversion_instructions.ll
@@ -43,6 +43,19 @@ entry:
 }
 
 ; CHECK-SPIRV: CompositeConstruct [[#MatrixTypeFloat]] [[#MatrixIn:]] [[#]] {{$}}
+; CHECK-SPIRV: ConvertFToU [[#MatrixTypeInt32]] [[#]] [[#MatrixIn]]
+
+; CHECK-LLVM: %[[#Matrix:]] = call spir_func %spirv.CooperativeMatrixKHR._float_3_12_12_3 addrspace(1)* @_Z26__spirv_CompositeConstructf(float 0.000000e+00)
+; CHECK-LLVM: call spir_func %spirv.CooperativeMatrixKHR._int_3_12_12_3 addrspace(1)* @_Z72__spirv_ConvertFToU_RPU3AS143__spirv_CooperativeMatrixKHR__int_3_12_12_3PU3AS145__spirv_CooperativeMatrixKHR__float_3_12_12_3(%spirv.CooperativeMatrixKHR._float_3_12_12_3 addrspace(1)* %0)
+
+define void @convert_f_to_u_no_fproundingmode() {
+entry:
+  %0 = tail call spir_func noundef %spirv.CooperativeMatrixKHR._float_3_12_12_3 addrspace(1)* @_Z26__spirv_CompositeConstructFloat(float 0.000000e+00)
+  %call = call spir_func %spirv.CooperativeMatrixKHR._int_3_12_12_3 addrspace(1)* @_Z73__spirv_ConvertFToU_RPU3AS144__spirv_CooperativeMatrixKHR__uint_3_12_12_2PU3AS145__spirv_CooperativeMatrixKHR__float_3_12_12_2(%spirv.CooperativeMatrixKHR._float_3_12_12_3 addrspace(1)* %0)
+  ret void
+}
+
+; CHECK-SPIRV: CompositeConstruct [[#MatrixTypeFloat]] [[#MatrixIn:]] [[#]] {{$}}
 ; CHECK-SPIRV: ConvertFToS [[#MatrixTypeInt32]] [[#]] [[#MatrixIn]]
 
 ; CHECK-LLVM: %[[#Matrix:]] = call spir_func %spirv.CooperativeMatrixKHR._float_3_12_12_3 addrspace(1)*  @_Z26__spirv_CompositeConstructf(float 0.000000e+00)
@@ -131,6 +144,8 @@ declare spir_func noundef %spirv.CooperativeMatrixKHR._short_3_12_12_3 addrspace
 declare spir_func noundef %spirv.CooperativeMatrixKHR._char_3_12_12_3 addrspace(1)*  @_Z26__spirv_CompositeConstructInt8(i8 noundef)
 
 declare spir_func noundef %spirv.CooperativeMatrixKHR._int_3_12_12_3 addrspace(1)*  @_Z76__spirv_ConvertFToU_RPU3AS143__spirv_CooperativeMatrixKHR__int_3_12_12_3_rtpPU3AS145__spirv_CooperativeMatrixKHR__float_3_12_12_3(%spirv.CooperativeMatrixKHR._float_3_12_12_3 addrspace(1)*  noundef)
+
+declare spir_func noundef %spirv.CooperativeMatrixKHR._int_3_12_12_3 addrspace(1)*  @_Z73__spirv_ConvertFToU_RPU3AS144__spirv_CooperativeMatrixKHR__uint_3_12_12_2PU3AS145__spirv_CooperativeMatrixKHR__float_3_12_12_2(%spirv.CooperativeMatrixKHR._float_3_12_12_3 addrspace(1)*  noundef)
 
 declare spir_func noundef %spirv.CooperativeMatrixKHR._int_3_12_12_3 addrspace(1)*  @_Z76__spirv_ConvertFToS_RPU3AS143__spirv_CooperativeMatrixKHR__int_3_12_12_3_rtpPU3AS145__spirv_CooperativeMatrixKHR__float_3_12_12_3(%spirv.CooperativeMatrixKHR._float_3_12_12_3 addrspace(1)*  noundef)
 


### PR DESCRIPTION
The SPIR-V reader would crash on the added test during reverse translation. Ensure any cooperative matrix type conversion is handled the same way as a cooperative matrix type conversion with an FPRoundingMode or SaturatedConversion decoration.

(cherry picked from commit 32738f9371037124b8697f78605652fe1afc4423)