### PR TITLE
Fix LLVM_SPIRV_BACKEND_TARGET_PRESENT detection when building inside the LLVM tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,13 +102,6 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
 
   message(STATUS "Found LLVM: ${LLVM_VERSION}")
 
-  is_llvm_target_library("SPIRV" spirv_present_result INCLUDED_TARGETS)
-  if(spirv_present_result)
-    message(STATUS "Found SPIR-V Backend")
-    set(SPIRV_BACKEND_FOUND TRUE)
-    add_compile_definitions(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
-  endif()
-
   option(CCACHE_ALLOWED "allow use of ccache" TRUE)
   find_program(CCACHE_EXE_FOUND ccache)
   if(CCACHE_EXE_FOUND AND CCACHE_ALLOWED)
@@ -116,6 +109,13 @@ if(LLVM_SPIRV_BUILD_EXTERNAL)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
   endif()
+endif()
+
+is_llvm_target_library("SPIRV" spirv_present_result INCLUDED_TARGETS)
+if(spirv_present_result)
+  message(STATUS "Found SPIR-V Backend")
+  set(SPIRV_BACKEND_FOUND TRUE)
+  add_compile_definitions(LLVM_SPIRV_BACKEND_TARGET_PRESENT)
 endif()
 
 set(LLVM_SPIRV_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include)


### PR DESCRIPTION
Fixes part 2 of #3217