### PR TITLE
Update after IsNewDbgInfoFormat removal

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2672,13 +2672,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     case SPIRVEIS_OpenCL_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_200:
-      if (!M->IsNewDbgInfoFormat) {
-        return mapValue(
-            BV, cast<Instruction *>(DbgTran->transDebugIntrinsic(ExtInst, BB)));
-      } else {
-        DbgTran->transDebugIntrinsic(ExtInst, BB);
-        return mapValue(BV, nullptr);
-      }
+      DbgTran->transDebugIntrinsic(ExtInst, BB);
+      return mapValue(BV, nullptr);
     default:
       llvm_unreachable("Unknown extended instruction set!");
     }

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1604,13 +1604,8 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
     }
     if (!MDs.empty()) {
       DIArgList *AL = DIArgList::get(M->getContext(), MDs);
-      if (M->IsNewDbgInfoFormat) {
-        cast<DbgVariableRecord>(cast<DbgRecord *>(DbgValIntr))
-            ->setRawLocation(AL);
-      } else {
-        cast<DbgVariableIntrinsic>(cast<Instruction *>(DbgValIntr))
-            ->setRawLocation(AL);
-      }
+      cast<DbgVariableRecord>(cast<DbgRecord *>(DbgValIntr))
+          ->setRawLocation(AL);
     }
     return DbgValIntr;
   }


### PR DESCRIPTION
Remove occurrences of IsNewDbgInfoFormat after llvm-project commit 97ac6483aaea ("[DebugInfo][RemoveDIs] Delete debug-info-format flag (#143746)", 2025-06-12).

Now only the new DebugInfo format exists, so remove the code paths that handled the old format.  There might be more code we can remove, but keep this change minimal to just fix the build.