### PR TITLE
Support casting of `OpConstantNull` to `SPIRVConstant`

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -180,6 +180,8 @@ protected:
 
   // Common method for getting values of size less or equal to 64 bits.
   template <typename T> T getValue() const {
+    if (OpCode == OpConstantNull)
+      return 0;
     constexpr auto ValueSize = static_cast<unsigned>(sizeof(T));
     assert((ValueSize <= 8) && "Incorrect result type of requested value");
     T TheValue{};

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -180,8 +180,11 @@ protected:
 
   // Common method for getting values of size less or equal to 64 bits.
   template <typename T> T getValue() const {
-    if (OpCode == OpConstantNull)
+    if (OpCode == OpConstantNull) {
+      assert(std::is_arithmetic_v<T> &&
+             "OpConstantNull has no defined value for this type");
       return 0;
+    }
     constexpr auto ValueSize = static_cast<unsigned>(sizeof(T));
     assert((ValueSize <= 8) && "Incorrect result type of requested value");
     T TheValue{};

--- a/test/extensions/KHR/SPV_KHR_cooperative_matrix/cooperative_matrix_constant_null.spvasm
+++ b/test/extensions/KHR/SPV_KHR_cooperative_matrix/cooperative_matrix_constant_null.spvasm
@@ -1,0 +1,25 @@
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o - %t.spv | llvm-dis | FileCheck %s
+
+OpCapability Addresses
+OpCapability Kernel
+OpCapability CooperativeMatrixKHR
+OpExtension "SPV_KHR_cooperative_matrix"
+OpMemoryModel Physical64 OpenCL
+OpEntryPoint Kernel %1 "test"
+%uint = OpTypeInt 32 0
+%uint_0 = OpConstantNull %uint
+%uint_12 = OpConstant %uint 12
+%uint_2 = OpConstant %uint 2
+%void = OpTypeVoid
+%fnTy = OpTypeFunction %void
+%matTy = OpTypeCooperativeMatrixKHR %uint %uint_0 %uint_12 %uint_12 %uint_0
+%1 = OpFunction %void None %fnTy
+%2 = OpLabel
+%3 = OpCompositeConstruct %matTy %uint_0
+OpReturn
+OpFunctionEnd
+
+; CHECK: call spir_func target("spirv.CooperativeMatrixKHR", i32, 0, 12, 12, 0) @_Z26__spirv_CompositeConstructi(i32 0)


### PR DESCRIPTION
Current design does not imply inheritance between `SPIRVConstantNull` and `SPIRVConstant` classes, however it is possible that we do the `static_cast` of `SPIRVValue` to `SPIRVConstant` for null constant. Return zero-value in that case.