### PR TITLE
Enable opaque pointers by default in SPIRV->LLVM translation

### DIFF
--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -157,7 +157,7 @@ static cl::opt<bool>
                   cl::desc("Emit textual assembly using SPIRV-Tools"));
 
 static cl::opt<bool>
-    EmitOpaquePointers("emit-opaque-pointers", cl::init(false),
+    EmitOpaquePointers("emit-opaque-pointers", cl::init(true),
                        cl::desc("Emit opaque instead of typed LLVM pointers "
                                 "for the translation from SPIR-V."),
                        cl::Hidden);


### PR DESCRIPTION
This makes sure usage of opaque pointers is consistent. LLVM 16 uses opaque pointers by default.