### PR TITLE
Explicitly cast OCLMemOrderKind members from std::memory_order in C++20 case

### DIFF
--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -99,11 +99,11 @@ enum OCLScopeKind {
 // the corresponding constants from 'std::memory_order' enum.
 enum OCLMemOrderKind {
 #if __cplusplus >= 202002L
-  OCLMO_relaxed = std::memory_order_relaxed,
-  OCLMO_acquire = std::memory_order_acquire,
-  OCLMO_release = std::memory_order_release,
-  OCLMO_acq_rel = std::memory_order_acq_rel,
-  OCLMO_seq_cst = std::memory_order_seq_cst
+  OCLMO_relaxed = static_cast<int>(std::memory_order::relaxed),
+  OCLMO_acquire = static_cast<int>(std::memory_order::acquire),
+  OCLMO_release = static_cast<int>(std::memory_order::release),
+  OCLMO_acq_rel = static_cast<int>(std::memory_order::acq_rel),
+  OCLMO_seq_cst = static_cast<int>(std::memory_order::seq_cst)
 #else
   OCLMO_relaxed = std::memory_order::memory_order_relaxed,
   OCLMO_acquire = std::memory_order::memory_order_acquire,


### PR DESCRIPTION
Clang does not like the current way of directly assigning members of one enum to another and requires explicit static_cast on the way.

Compilation failed:
https://godbolt.org/z/3PYqsETdc

Compilation successful:
https://godbolt.org/z/bjeYK376s