### PR TITLE
Fix potential constructor ambiguity in BuiltinCallMutator::ValueTypePair

### DIFF
--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -139,7 +139,6 @@ public:
              "Must specify a pointer element type if value is a pointer.");
     }
     ValueTypePair(std::pair<llvm::Value *, llvm::Type *> P) : pair(P) {}
-    ValueTypePair(llvm::Value *&V, llvm::Type *&T) : pair(V, T) {}
     ValueTypePair() = delete;
     using pair::pair;
   };

--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -138,9 +138,9 @@ public:
       assert(!V->getType()->isPointerTy() &&
              "Must specify a pointer element type if value is a pointer.");
     }
-    ValueTypePair(std::pair<llvm::Value *, llvm::Type *> P) : pair(P) {}
-    ValueTypePair(llvm::Value *&V, llvm::Type *&T) : pair(V, T) {}
+
     ValueTypePair() = delete;
+  
     using pair::pair;
   };
 

--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -139,7 +139,7 @@ public:
              "Must specify a pointer element type if value is a pointer.");
     }
     ValueTypePair(std::pair<llvm::Value *, llvm::Type *> P) : pair(P) {}
-    ValueTypePair(llvm::Value *V, llvm::Type *T) : pair(V, T) {}
+    ValueTypePair(llvm::Value *&V, llvm::Type *&T) : pair(V, T) {}
     ValueTypePair() = delete;
     using pair::pair;
   };

--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -138,9 +138,9 @@ public:
       assert(!V->getType()->isPointerTy() &&
              "Must specify a pointer element type if value is a pointer.");
     }
-
+    ValueTypePair(std::pair<llvm::Value *, llvm::Type *> P) : pair(P) {}
+    ValueTypePair(llvm::Value *&V, llvm::Type *&T) : pair(V, T) {}
     ValueTypePair() = delete;
-  
     using pair::pair;
   };
 


### PR DESCRIPTION
BuiltinCallMutator::ValueTypePair defines its own constructor with arguments (llvm::Value *V, llvm::Type *T)
BuiltinCallMutator::ValueTypePair also uses std::pair constructor with arguments (llvm::Value *&V, llvm::Type *&T)

This causes an ambiguity that confuses GCC when compiling for C++20.
Issue repro on goldbolt: https://godbolt.org/z/MTnvx6E6T

There are multiple possible fixes. I think the one with the least impact is to change BuiltinCallMutator::ValueTypePair constructor signature to conform with std::pair constructor signature.
Fixed version: https://godbolt.org/z/49WzvjK63

Other possibility is to remove the constructors that are redundant. But maybe they are very important.