### PR TITLE
Fix build when linking against SPIRVLib with SPIR-V backend support enabled

### DIFF
--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -40,10 +40,9 @@ set(SRC_LIST
   libSPIRV/SPIRVValue.cpp
   libSPIRV/SPIRVError.cpp
   libSPIRV/SPIRVFnVar.cpp
-)
-add_llvm_library(LLVMSPIRVLib
-  ${SRC_LIST}
-  LINK_COMPONENTS
+  )
+
+set(SPIRVLIB_LINK_COMPONENTS
     Analysis
     BitWriter
     CodeGen
@@ -55,6 +54,16 @@ add_llvm_library(LLVMSPIRVLib
     Support
     TargetParser
     TransformUtils
+    )
+
+if(SPIRV_BACKEND_FOUND)
+  list(APPEND SPIRVLIB_LINK_COMPONENTS "SPIRVCodeGen")
+endif()
+
+add_llvm_library(LLVMSPIRVLib
+  ${SRC_LIST}
+  LINK_COMPONENTS
+    ${SPIRVLIB_LINK_COMPONENTS}
   DEPENDS
     intrinsics_gen
   )

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -10,10 +10,6 @@ set(LLVM_LINK_COMPONENTS
   TransformUtils
 )
 
-if(SPIRV_BACKEND_FOUND)
-  list(APPEND LLVM_LINK_COMPONENTS "SPIRVCodeGen")
-endif()
-
 # llvm_setup_rpath messes with the rpath making llvm-spirv not
 # executable from the build directory in out-of-tree builds
 set(add_llvm_tool_options)


### PR DESCRIPTION
When building with SPIR-V backend support, naturally we need to link against the SPIR-V backend. Currently this is done as part of the tool (`llvm-spirv`)'s CMake dependencies, instead of `SPIRVLib` which is the actual CMake target that requires the SPIR-V backend (`SPIRVTranslateModule` call inside `SPIRVWriter.cpp`).

This causes a linker error if someone depends on `SPIRVLib` directly and doesn't depend on `llvm-spirv`.

Move the dependency from the tool to the lib. 