### PR TITLE
Fix MergeBlock error: a merge block for another header

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2512,7 +2512,11 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       Function *Fun = Branch->getFunction();
       DominatorTree DomTree(*Fun);
       LoopInfo LI(DomTree);
-      for (const auto *LoopObj : LI.getLoopsInPreorder()) {
+      // Find the innermost loop that contains the current basic block.
+      BasicBlock *CurrentBB = Branch->getParent();
+      const Loop *ContainingLoop = LI.getLoopFor(CurrentBB);
+
+      if (ContainingLoop) {
         // Check whether SuccessorFalse or SuccessorTrue is the loop header BB.
         // For example consider following LLVM IR:
         // br i1 %compare, label %for.body, label %for.end
@@ -2521,12 +2525,12 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
         //   <- SuccessorTrue is 'for.end' aka successor(1)
         // meanwhile the true successor (by definition) should be a loop header
         // aka 'for.body'
-        if (LoopObj->getHeader() == Branch->getSuccessor(1))
+        if (ContainingLoop->getHeader() == Branch->getSuccessor(1))
           // SuccessorFalse is the loop header BB.
           BM->addLoopMergeInst(SuccessorTrue->getId(), // Merge Block
                                BB->getId(),            // Continue Target
                                LoopControl, Parameters, SuccessorFalse);
-        else
+        else if (ContainingLoop->getHeader() == Branch->getSuccessor(0))
           // SuccessorTrue is the loop header BB.
           BM->addLoopMergeInst(SuccessorFalse->getId(), // Merge Block
                                BB->getId(),             // Continue Target

--- a/test/OpLoopMerge_mergeBlock.ll
+++ b/test/OpLoopMerge_mergeBlock.ll
@@ -1,6 +1,10 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
+; RUN: llvm-spirv --to-text %t.spv -o - | FileCheck %s
+
+; CHECK: LoopMerge
+; CHECK-NEXT: BranchConditional
 
 target triple = "spir64"
 


### PR DESCRIPTION
Code was assigning the same merge block to multiple headers. Added a fails as follows before the fix:

```
[3/4] Running the LLVM-SPIRV regression tests
llvm-lit: /space/pvelesko/.local/lib/python3.10/site-packages/lit/llvm/config.py:502: note: using clang: /space/pvelesko/install/llvm/21.0-upstream/bin/clang
FAIL: LLVM_SPIRV :: OpLoopMerge_mergeBlock.ll (1 of 918)
******************** TEST 'LLVM_SPIRV :: OpLoopMerge_mergeBlock.ll' FAILED ********************
Exit Code: 1

Command Output (stderr):
--
RUN: at line 5: /space/pvelesko/SPIRV-LLVM-Translator/build/tools/llvm-spirv/llvm-spirv /space/pvelesko/SPIRV-LLVM-Translator/test/../mergeBlock.bc -o /space/pvelesko/SPIRV-LLVM-Translator/build/test/test_output/Output/OpLoopMerge_mergeBlock.ll.tmp.spv
+ /space/pvelesko/SPIRV-LLVM-Translator/build/tools/llvm-spirv/llvm-spirv /space/pvelesko/SPIRV-LLVM-Translator/test/../mergeBlock.bc -o /space/pvelesko/SPIRV-LLVM-Translator/build/test/test_output/Output/OpLoopMerge_mergeBlock.ll.tmp.spv
RUN: at line 6: /usr/local/bin/spirv-val /space/pvelesko/SPIRV-LLVM-Translator/build/test/test_output/Output/OpLoopMerge_mergeBlock.ll.tmp.spv
+ /usr/local/bin/spirv-val /space/pvelesko/SPIRV-LLVM-Translator/build/test/test_output/Output/OpLoopMerge_mergeBlock.ll.tmp.spv
error: line 111: Block '46[%_Z11round_robiniiiPViS0__exit_loopexit]' is already a merge block for another header
  %_Z15gpu_round_robiniiiPViS0_ = OpFunction %void None %32
```


https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3277 should be merged first as this test will trigger that error before hitting merge block error. 