### PR TITLE
Fix UB in UntypedPtrTyMap

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -637,7 +637,7 @@ private:
   SPIRVUnknownStructFieldMap UnknownStructFieldMap;
   SPIRVTypeBool *BoolTy;
   SPIRVTypeVoid *VoidTy;
-  SmallDenseMap<SPIRVStorageClassKind, SPIRVTypeUntypedPointerKHR *>
+  std::unordered_map<SPIRVStorageClassKind, SPIRVTypeUntypedPointerKHR *>
       UntypedPtrTyMap;
   SmallDenseMap<unsigned, SPIRVTypeInt *, 4> IntTypeMap;
   SmallDenseMap<std::pair<unsigned, unsigned>, SPIRVTypeFloat *, 4>


### PR DESCRIPTION
SmallDenseMap requires sentinel values out of the `SPIRVStorageClassKind` range.  This became a build error after llvm-project commit `38f82534bbe9 ("Reject out-of-bounds enum sentinels in DenseMap/DenseSet. (#150308)", 2025-07-24)`.

As the `SPIRVStorageClassKind` enum comes from an external header we cannot change it to an enum class or add an underlying type.  This is actually solved in the `spirv.hpp11` header, but migrating to that header requires more widespread changes; just switch to a `std::unordered_map` for now.