### PR TITLE
.clang-tidy: disable conflicting misc-use-anonymous-namespaces

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: |
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
   readability-identifier-naming
 WarningsAsErrors: |
   llvm-*,
@@ -19,6 +20,7 @@ WarningsAsErrors: |
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
   readability-identifier-naming
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase


### PR DESCRIPTION
The LLVM coding standard [1] generally prefers static function declarations, so turn off the `misc-use-anonymous-namespaces` option that suggests using anonymous namespaces.

[1] https://llvm.org/docs/CodingStandards.html#restrict-visibility