### PR TITLE
Refactor WordCount Validation to Separate Static Function

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -2378,21 +2378,18 @@ void SPIRVModuleImpl::addUnknownStructField(SPIRVTypeStruct *Struct, unsigned I,
   UnknownStructFieldMap[Struct].push_back(std::make_pair(I, ID));
 }
 
-namespace {
-SPIRVEntry *parseAndCreateSPIRVEntry(SPIRVWord &WordCount, Op &OpCode,
-                                     SPIRVEntry *Scope, SPIRVModuleImpl &M,
-                                     std::istream &IS) {
-  if (WordCount == 0 || OpCode == OpNop) {
-    return nullptr;
-  }
+static void validateWordCount(SPIRVModuleImpl &M, std::istream &IS,
+                              SPIRVWord WordCount) {
   if (!SPIRVUseTextFormat) {
     std::streampos CurrentPos = IS.tellg();
     IS.seekg(0, std::ios::end);
     std::streamoff RemainingBytes = IS.tellg() - CurrentPos;
     IS.clear();
     IS.seekg(CurrentPos);
+
     std::streamoff ExpectedBytes =
         static_cast<std::streamoff>((WordCount - 1) * sizeof(SPIRVWord));
+
     if (RemainingBytes < ExpectedBytes) {
       M.getErrorLog().checkError(
           false, SPIRVEC_InvalidWordCount,
@@ -2401,6 +2398,15 @@ SPIRVEntry *parseAndCreateSPIRVEntry(SPIRVWord &WordCount, Op &OpCode,
               std::to_string(RemainingBytes) + " bytes");
       M.setInvalid();
     }
+  }
+}
+
+namespace {
+SPIRVEntry *parseAndCreateSPIRVEntry(SPIRVWord &WordCount, Op &OpCode,
+                                     SPIRVEntry *Scope, SPIRVModuleImpl &M,
+                                     std::istream &IS) {
+  if (WordCount == 0 || OpCode == OpNop) {
+    return nullptr;
   }
   SPIRVEntry *Entry = SPIRVEntry::create(OpCode);
   assert(Entry);

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -2401,13 +2401,14 @@ static void validateWordCount(SPIRVModuleImpl &M, std::istream &IS,
   }
 }
 
-namespace {
-SPIRVEntry *parseAndCreateSPIRVEntry(SPIRVWord &WordCount, Op &OpCode,
-                                     SPIRVEntry *Scope, SPIRVModuleImpl &M,
-                                     std::istream &IS) {
+static SPIRVEntry *parseAndCreateSPIRVEntry(SPIRVWord &WordCount, Op &OpCode,
+                                            SPIRVEntry *Scope,
+                                            SPIRVModuleImpl &M,
+                                            std::istream &IS) {
   if (WordCount == 0 || OpCode == OpNop) {
     return nullptr;
   }
+  validateWordCount(M, IS, WordCount);
   SPIRVEntry *Entry = SPIRVEntry::create(OpCode);
   assert(Entry);
   Entry->setModule(&M);
@@ -2464,7 +2465,6 @@ SPIRVEntry *parseAndCreateSPIRVEntry(SPIRVWord &WordCount, Op &OpCode,
   assert(!IS.bad() && !IS.fail() && "SPIRV stream fails");
   return Entry;
 }
-} // namespace
 
 std::istream &SPIRVModuleImpl::parseSPT(std::istream &I) {
   SPIRVModuleImpl &MI = *this;


### PR DESCRIPTION
This PR refactors the `parseAndCreateSPIRVEntry` function by extracting the word count check into a separate static function named `validateWordCount`, in `SPIRVModule.cpp`. 