### PR TITLE
Add llvm.stack[save/restore] intrinsics to isKnownIntrinsic

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3998,6 +3998,8 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::masked_scatter:
   case Intrinsic::modf:
   case Intrinsic::fake_use:
+  case Intrinsic::stacksave:
+  case Intrinsic::stackrestore:
     return true;
   default:
     // Unknown intrinsics' declarations should always be translated

--- a/test/extensions/INTEL/SPV_INTEL_variable_length_array/basic.ll
+++ b/test/extensions/INTEL/SPV_INTEL_variable_length_array/basic.ll
@@ -36,6 +36,9 @@
 ; CHECK-SPIRV: VariableLengthArrayINTEL [[#IntPtr]] [[#]] [[#A]]
 ; CHECK-SPIRV: RestoreMemoryINTEL [[#SavedMem]]
 
+; CHECK-SPIRV-NOT: Name [[#]] "llvm.stacksave."
+; CHECK-SPIRV-NOT: Name [[#]] "llvm.stackrestore."
+
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"
 


### PR DESCRIPTION
Otherwise their declarations would survive translation to SPIR-V.