### PR TITLE
fixes a new validation failure in a UniformId test

### DIFF
--- a/test/DecorateUniformId.spvasm
+++ b/test/DecorateUniformId.spvasm
@@ -15,9 +15,10 @@
                OpCapability UniformDecoration
                OpMemoryModel Physical64 OpenCL
                OpEntryPoint Kernel %2 "test"
-               OpDecorateId %uint_0 UniformId %uint_0
+               OpDecorateId %tgt_uint_0 UniformId %op_uint_0
        %uint = OpTypeInt 32 0
-     %uint_0 = OpConstant %uint 0
+  %op_uint_0 = OpConstant %uint 0
+ %tgt_uint_0 = OpConstant %uint 0
        %void = OpTypeVoid
           %1 = OpTypeFunction %void
           %2 = OpFunction %void None %1


### PR DESCRIPTION
A recent spirv-val change requires that OpDecorateId IDs are well-ordered, which means that the decoration operand ID cannot be the same as the decoration target ID.  See: https://github.com/KhronosGroup/SPIRV-Tools/pull/6227

This leads to the failure:

```
error: line 6: Parameter <ID> '2[%uint_0]' must appear earlier in the binary than the target
  OpDecorateId %uint_0 UniformId %uint_0
```

The fix is to use a different ID for the decoration operand and the decoration target.