### PR TITLE
Adjust Lifetime intrinsics translation after llvm/llvm-project@c23b4fb

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1874,43 +1874,18 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   case OpLifetimeStart: {
     SPIRVLifetimeStart *LTStart = static_cast<SPIRVLifetimeStart *>(BV);
     IRBuilder<> Builder(BB);
-    SPIRVWord Size = LTStart->getSize();
-    ConstantInt *S = nullptr;
     auto *Var = transValue(LTStart->getObject(), F, BB);
-    Var = Var->stripPointerCasts();
-    if (Size)
-      S = Builder.getInt64(Size);
-    if (Size == 0) {
-      auto *Alloca = cast<AllocaInst>(Var);
-      if (Alloca->getAllocatedType()->isSized())
-        Size = M->getDataLayout().getTypeAllocSize(Alloca->getAllocatedType());
-      else
-        Size = static_cast<SPIRVWord>(-1);
-    }
-    CallInst *Start = Builder.CreateLifetimeStart(Var, S);
+    CallInst *Start = Builder.CreateLifetimeStart(Var);
     return mapValue(BV, Start);
   }
-
   case OpLifetimeStop: {
     SPIRVLifetimeStop *LTStop = static_cast<SPIRVLifetimeStop *>(BV);
     IRBuilder<> Builder(BB);
-    SPIRVWord Size = LTStop->getSize();
-    ConstantInt *S = nullptr;
     auto *Var = transValue(LTStop->getObject(), F, BB);
-    Var = Var->stripPointerCasts();
-    if (Size)
-      S = Builder.getInt64(Size);
-    if (Size == 0) {
-      auto *Alloca = cast<AllocaInst>(Var);
-      if (Alloca->getAllocatedType()->isSized())
-        Size = M->getDataLayout().getTypeAllocSize(Alloca->getAllocatedType());
-      else
-        Size = static_cast<SPIRVWord>(-1);
-    }
     for (const auto &I : Var->users())
       if (auto *II = getLifetimeStartIntrinsic(dyn_cast<Instruction>(I)))
-        return mapValue(BV, Builder.CreateLifetimeEnd(II->getOperand(1), S));
-    return mapValue(BV, Builder.CreateLifetimeEnd(Var, S));
+        return mapValue(BV, Builder.CreateLifetimeEnd(II->getOperand(0)));
+    return mapValue(BV, Builder.CreateLifetimeEnd(Var));
   }
 
   case OpStore: {

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4832,10 +4832,12 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     Op OC = (II->getIntrinsicID() == Intrinsic::lifetime_start)
                 ? OpLifetimeStart
                 : OpLifetimeStop;
-    int64_t Size = dyn_cast<ConstantInt>(II->getOperand(0))->getSExtValue();
-    if (Size == -1)
-      Size = 0;
-    Value *LLVMPtrOp = II->getOperand(1);
+    int64_t Size = 0;
+    Value *LLVMPtrOp = II->getOperand(0);
+    auto *Alloca = cast<AllocaInst>(LLVMPtrOp->stripPointerCasts());
+    if (Alloca->getAllocatedType()->isSized())
+      Size = M->getDataLayout().getTypeAllocSize(Alloca->getAllocatedType());
+
     unsigned PtrAS = cast<PointerType>(LLVMPtrOp->getType())->getAddressSpace();
     auto *PtrOp = transValue(LLVMPtrOp, BB);
     if (PtrAS == SPIRAS_Private)

--- a/test/llvm-intrinsics/lifetime.ll
+++ b/test/llvm-intrinsics/lifetime.ll
@@ -35,20 +35,20 @@
 
 ; CHECK-LLVM-LABEL: lifetime_simple
 ; CHECK-LLVM: %[[#Alloca:]] = alloca i32
-; CHECK-LLVM: call void @llvm.lifetime.start.p0(i64 -1, ptr %[[#Alloca]])
-; CHECK-LLVM: call void @llvm.lifetime.end.p0(i64 -1, ptr %[[#Alloca]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(ptr %[[#Alloca]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(ptr %[[#Alloca]])
 
 ; CHECK-LLVM-LABEL: lifetime_sized
 ; CHECK-LLVM: %[[#Alloca:]] = alloca i8
-; CHECK-LLVM: call void @llvm.lifetime.start.p0(i64 1, ptr %[[#Alloca]])
-; CHECK-LLVM: call void @llvm.lifetime.end.p0(i64 1, ptr %[[#Alloca]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(ptr %[[#Alloca]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(ptr %[[#Alloca]])
 
 ; CHECK-LLVM-LABEL: lifetime_generic
 ; CHECK-LLVM: %[[#Alloca:]] = alloca %class.anon
 ; CHECK-LLVM: %[[#Cast1:]] = addrspacecast ptr %[[#Alloca]] to ptr addrspace(4)
-; CHECK-LLVM: call void @llvm.lifetime.start.p0(i64 -1, ptr %[[#Alloca]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(ptr %[[#Alloca]])
 ; CHECK-LLVM: call spir_func void @boo(ptr addrspace(4) %[[#Cast1]])
-; CHECK-LLVM: call void @llvm.lifetime.end.p0(i64 -1, ptr %[[#Alloca]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(ptr %[[#Alloca]])
 
 ; ModuleID = 'main'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/llvm-intrinsics/memmove.ll
+++ b/test/llvm-intrinsics/memmove.ll
@@ -83,38 +83,38 @@
 ; CHECK-LLVM: %[[local:.*]] = alloca [128 x i8]
 ; CHECK-LLVM: %[[i8_in:.*]] = bitcast ptr addrspace(1) %in to ptr addrspace(1)
 ; CHECK-LLVM: %[[i8_out:.*]] = bitcast ptr addrspace(1) %out to ptr addrspace(1)
-; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[local]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(ptr %[[local]])
 ; CHECK-LLVM: call void @llvm.memcpy.p0.p1.i32(ptr align 64 %[[local]],
 ; CHECK-LLVM-SAME: ptr addrspace(1) align 64 %[[i8_in]], i32 128, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p1.p0.i32(ptr addrspace(1) align 64 %[[i8_out]],
 ; CHECK-LLVM-SAME: ptr align 64 %[[local]], i32 128, i1 false)
-; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[local]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(ptr %[[local]])
 
 ; CHECK-LLVM-LABEL: @test_partial_move
 ; CHECK-LLVM: %[[local:.*]] = alloca [68 x i8]
 ; CHECK-LLVM: %[[i8_in:.*]] = bitcast ptr addrspace(1) %in to ptr addrspace(1)
 ; CHECK-LLVM: %[[i8_out_generic:.*]] = bitcast ptr addrspace(4) %out to ptr addrspace(4)
 ; CHECK-LLVM: %[[i8_out:.*]] = addrspacecast ptr addrspace(4) %[[i8_out_generic]] to ptr addrspace(1)
-; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[local]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(ptr %[[local]])
 ; CHECK-LLVM: call void @llvm.memcpy.p0.p1.i32(ptr align 64 %[[local]],
 ; CHECK-LLVM-SAME: ptr addrspace(1) align 64 %[[i8_in]], i32 68, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p1.p0.i32(ptr addrspace(1) align 64 %[[i8_out]],
 ; CHECK-LLVM-SAME: ptr align 64 %[[local]], i32 68, i1 false)
-; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[local]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(ptr %[[local]])
 
 ; CHECK-LLVM-LABEL: @test_array
 ; CHECK-LLVM: %[[#ALLOCA:]] = alloca [72 x i8]
-; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[#ALLOCA]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(ptr %[[#ALLOCA]])
 ; CHECK-LLVM: call void @llvm.memcpy.p0.p1.i32(ptr %[[#ALLOCA]], ptr addrspace(1) %in, i32 72, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p1.p0.i32(ptr addrspace(1) %out, ptr %[[#ALLOCA]], i32 72, i1 false)
-; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[#ALLOCA]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(ptr %[[#ALLOCA]])
 
 ; CHECK-LLVM-LABEL: @test_phi
 ; CHECK-LLVM: %[[#ALLOCA:]] = alloca [32 x i8]
-; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[#ALLOCA]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(ptr %[[#ALLOCA]])
 ; CHECK-LLVM: call void @llvm.memcpy.p0.p4.i64(ptr align 8 %[[#ALLOCA]], ptr addrspace(4) align 8 %phi, i64 32, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p4.p0.i64(ptr addrspace(4) align 8 %[[#]], ptr align 8 %[[#ALLOCA]], i64 32, i1 false)
-; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[#ALLOCA]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(ptr %[[#ALLOCA]])
 
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"


### PR DESCRIPTION
`Size` argument was removed from the intrinsics as it can be implied from the alloca.