### PR TITLE
allow casting nullptr to any addrspace

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1652,6 +1652,9 @@ SPIRVValue *LLVMToSPIRVBase::transUnaryInst(UnaryInstruction *U,
       } else {
         BOC = OpCrossWorkgroupCastToPtrINTEL;
       }
+    } else if (isa<ConstantPointerNull>(Cast->getPointerOperand())) {
+      SPIRVType *TransTy = transScavengedType(U);
+      return BM->addNullConstant(bcast<SPIRVTypePointer>(TransTy));
     } else {
       getErrorLog().checkError(
           SrcAddrSpace == SPIRAS_Generic, SPIRVEC_InvalidModule, U,

--- a/test/addrspacecast_null.ll
+++ b/test/addrspacecast_null.ll
@@ -1,0 +1,19 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-dis %t.spv | FileCheck %s
+
+; Test that addrspacecast of null pointer generates appropriate OpConstantNull
+; instruction in SPIR-V.
+
+; CHECK: %_ptr_CrossWorkgroup_uchar = OpTypePointer CrossWorkgroup %uchar
+; CHECK: %[[NULL:[0-9]+]] = OpConstantNull %_ptr_CrossWorkgroup_uchar
+; CHECK: OpPtrEqual %bool %[[NULL]]
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @bar(ptr addrspace(1) %arg) {
+pass26:
+  %expr = icmp eq ptr addrspace(1) addrspacecast (ptr null to ptr addrspace(1)), %arg
+  ret void
+}


### PR DESCRIPTION
This allows translation of code like the following, which previously errored:

```llvm
target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
target triple = "spir64-unknown-unknown"

define spir_kernel void @bar(ptr addrspace(1) %arg) {
pass26:
  %expr = icmp eq ptr addrspace(1) addrspacecast (ptr null to ptr addrspace(1)), %arg
  ret void
}
```

It is important this works because the addrspacecast is needed for addrspaces where NULL doesn't correspond to a zero value. We previously ran into correctness errors on some platforms without this cast, ref ROCm/llvm-project#281
