### PR TITLE
Three tests are ported from llvm-project to translator

### DIFF
--- a/test/Opencl/get_global_offset.ll
+++ b/test/Opencl/get_global_offset.ll
@@ -1,0 +1,53 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -to-text %t.spv -o - | FileCheck %s
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-DAG: EntryPoint 6 [[#test_func:]] "test"
+; CHECK-DAG: Decorate [[#f2_decl:]] LinkageAttributes "BuiltInGlobalOffset" Import
+; CHECK-DAG: TypeInt [[#int32_ty:]] 32 0
+; CHECK-DAG: TypePointer [[#i32ptr_ty:]] 5 [[#int32_ty]]
+; CHECK-DAG: TypeVoid [[#void_ty:]]
+; CHECK-DAG: TypeFunction [[#func_ty:]] [[#void_ty]] [[#i32ptr_ty]]
+; CHECK-DAG: TypeInt [[#int64_ty:]] 64 0
+; CHECK-DAG: TypeVector [[#vec_ty:]] [[#int64_ty]] 3
+; CHECK-DAG: TypeFunction [[#func2_ty:]] [[#vec_ty]]
+; CECK-DAG: Function [[#vec_ty]] [[#f2_decl]] 0 [[#func2_ty]]
+; CHECK: FunctionEnd
+
+define spir_kernel void @test(i32 addrspace(1)* %outOffsets) {
+entry:
+  %0 = call spir_func <3 x i64> @BuiltInGlobalOffset() #1
+  %call = extractelement <3 x i64> %0, i32 0
+  %conv = trunc i64 %call to i32
+
+; CHECK: InBoundsPtrAccessChain [[#i32ptr_ty]] [[#i1:]] [[#outOffsets:]] 
+; CHECK: Store [[#i1]] [[#]] 2 4
+
+  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %outOffsets, i64 0
+  store i32 %conv, i32 addrspace(1)* %arrayidx, align 4
+  %1 = call spir_func <3 x i64> @BuiltInGlobalOffset() #1
+  %call1 = extractelement <3 x i64> %1, i32 1
+  %conv2 = trunc i64 %call1 to i32
+
+; CHECK: InBoundsPtrAccessChain [[#i32ptr_ty]] [[#i2:]] [[#outOffsets]] 
+; CHECK: Store [[#i2]] [[#]] 2 4
+
+  %arrayidx3 = getelementptr inbounds i32, i32 addrspace(1)* %outOffsets, i64 1
+  store i32 %conv2, i32 addrspace(1)* %arrayidx3, align 4
+  %2 = call spir_func <3 x i64> @BuiltInGlobalOffset() #1
+  %call4 = extractelement <3 x i64> %2, i32 2
+  %conv5 = trunc i64 %call4 to i32
+
+; CHECK: InBoundsPtrAccessChain [[#i32ptr_ty]] [[#i3:]] [[#outOffsets]] 
+; CHECK: Store [[#i3]] [[#]] 2 4
+
+  %arrayidx6 = getelementptr inbounds i32, i32 addrspace(1)* %outOffsets, i64 2
+  store i32 %conv5, i32 addrspace(1)* %arrayidx6, align 4
+  ret void
+}
+declare spir_func <3 x i64> @BuiltInGlobalOffset() #1
+attributes #1 = { nounwind readnone }

--- a/test/const-composite.ll
+++ b/test/const-composite.ll
@@ -1,0 +1,30 @@
+; This test is to ensure that OpConstantComposite reuses a constant when it's
+; already created and available in the same machine function. In this test case
+; it's `1` that is passed implicitly as a part of the `foo` function argument
+; and also takes part in a composite constant creation.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s 
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+
+; CHECK-DAG: TypeInt [[#type_int32:]] 32 0
+; CHECK-DAG: Constant [[#type_int32]] [[#const1:]] 1
+; CHECK-DAG: TypeArray [[#]] [[#]] [[#const1]]
+; CHECK-DAG: Constant [[#type_int32]] [[#const0:]] 0
+; CHECK-DAG: ConstantComposite [[#]] [[#]] [[#const0]] [[#const1]]
+
+%struct = type { [1 x i64] }
+define spir_kernel void @foo(ptr noundef byval(%struct) %arg) {
+entry:
+  call spir_func void @bar(<2 x i32> noundef <i32 0, i32 1>)
+  ret void
+}
+
+define spir_func void @bar(<2 x i32> noundef) {
+entry:
+  ret void
+}

--- a/test/const-nested-vecs.ll
+++ b/test/const-nested-vecs.ll
@@ -1,0 +1,124 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: FileCheck < %t %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir"
+
+; CHECK: Name [[#]] "var"
+; CHECK: Name [[#Gvar:]] "g_var"
+; CHECK: Name [[#Avar:]] "a_var"
+; CHECK: Name [[#Pvar:]] "p_var"
+; CHECK-DAG: TypeInt [[#CharTy:]] 8 0
+; CHECK-DAG: TypeInt [[#IntTy:]] 32 0
+; CHECK-DAG: TypeVector [[#V2CharTy:]] [[#CharTy]] 2
+; CHECK-DAG: ConstantNull [[#V2CharTy]] [[#V2ConstNull:]]
+; CHECK-DAG: Constant [[#CharTy]] [[#Const1:]] 1
+; CHECK-DAG: Constant [[#IntTy]] [[#Const2:]] 2
+; CHECK-DAG: TypeArray  [[#Arr2V2CharTy:]] [[#V2CharTy]] [[#Const2]]
+; CHECK-DAG: TypeInt [[#LongTy:]] 64 0
+; CHECK-DAG: TypePointer [[#PtrV2CharTy:]] 5 [[#V2CharTy]]
+; CHECK-DAG: ConstantComposite [[#V2CharTy]] [[#V2Char1:]] [[#Const1]] [[#Const1]]
+; CHECK-DAG: ConstantComposite [[#Arr2V2CharTy]] [[#Arr2V2Char:]] [[#V2Char1]] [[#V2Char1]]
+; CHECK-DAG: TypePointer [[#PtrCharTy:]] 5 [[#CharTy]]
+; CHECK-DAG: TypePointer [[#PtrArr2V2CharTy:]] 5 [[#Arr2V2CharTy]]
+; CHECK-DAG: Constant [[#LongTy]] [[#LongZero:]] 0
+; CHECK-DAG: Constant [[#LongTy]] [[#ConstLong2:]] 2
+; CHECK-DAG: SpecConstantOp [[#]] [[#PvarInit:]] [[#]] 17 [[#ConstLong2]]
+; CHECK-DAG: TypePointer [[#PtrPtrCharTy:]] 5 [[#PtrCharTy]]
+; CHECK-DAG: Variable [[#PtrArr2V2CharTy]] [[#Avar]] 5 [[#Arr2V2Char]]
+; CHECK-DAG: Variable [[#PtrPtrCharTy]] [[#Pvar]] 5 [[#PvarInit]]
+; CHECK-DAG: Variable [[#PtrV2CharTy]] [[#Gvar]] 5 [[#V2Char1]]
+; CHECK-DAG: Variable [[#PtrV2CharTy]] [[#]] 5 [[#V2ConstNull]]
+
+@var = addrspace(1) global <2 x i8> zeroinitializer, align 2
+@g_var = addrspace(1) global <2 x i8> <i8 1, i8 1>, align 2
+@a_var = addrspace(1) global [2 x <2 x i8>] [<2 x i8> <i8 1, i8 1>, <2 x i8> <i8 1, i8 1>], align 2
+@p_var = addrspace(1) global ptr addrspace(1) getelementptr (i8, ptr addrspace(1) @a_var, i64 2), align 8
+
+define spir_func <2 x i8> @from_buf(<2 x i8> %a) #0 {
+entry:
+  ret <2 x i8> %a
+}
+
+define spir_func <2 x i8> @to_buf(<2 x i8> %a) #0 {
+entry:
+  ret <2 x i8> %a
+}
+
+define spir_kernel void @writer(ptr addrspace(1) %src, i32 %idx) #0 !kernel_arg_addr_space !5 !kernel_arg_access_qual !6 !kernel_arg_type !7 !kernel_arg_type_qual !8 !kernel_arg_base_type !7 !spirv.ParameterDecorations !9 {
+entry:
+  %arrayidx = getelementptr inbounds <2 x i8>, ptr addrspace(1) %src, i64 0
+  %0 = load <2 x i8>, ptr addrspace(1) %arrayidx, align 2
+  %call = call spir_func <2 x i8> @from_buf(<2 x i8> %0) #0
+  store <2 x i8> %call, ptr addrspace(1) @var, align 2
+  %arrayidx1 = getelementptr inbounds <2 x i8>, ptr addrspace(1) %src, i64 1
+  %1 = load <2 x i8>, ptr addrspace(1) %arrayidx1, align 2
+  %call2 = call spir_func <2 x i8> @from_buf(<2 x i8> %1) #0
+  store <2 x i8> %call2, ptr addrspace(1) @g_var, align 2
+  %arrayidx3 = getelementptr inbounds <2 x i8>, ptr addrspace(1) %src, i64 2
+  %2 = load <2 x i8>, ptr addrspace(1) %arrayidx3, align 2
+  %call4 = call spir_func <2 x i8> @from_buf(<2 x i8> %2) #0
+  %3 = getelementptr inbounds [2 x <2 x i8>], ptr addrspace(1) @a_var, i64 0, i64 0
+  store <2 x i8> %call4, ptr addrspace(1) %3, align 2
+  %arrayidx5 = getelementptr inbounds <2 x i8>, ptr addrspace(1) %src, i64 3
+  %4 = load <2 x i8>, ptr addrspace(1) %arrayidx5, align 2
+  %call6 = call spir_func <2 x i8> @from_buf(<2 x i8> %4) #0
+  %5 = getelementptr inbounds [2 x <2 x i8>], ptr addrspace(1) @a_var, i64 0, i64 1
+  store <2 x i8> %call6, ptr addrspace(1) %5, align 2
+  %idx.ext = zext i32 %idx to i64
+  %add.ptr = getelementptr inbounds <2 x i8>, ptr addrspace(1) %3, i64 %idx.ext
+  store ptr addrspace(1) %add.ptr, ptr addrspace(1) @p_var, align 8
+  ret void
+}
+
+define spir_kernel void @reader(ptr addrspace(1) %dest, <2 x i8> %ptr_write_val) #0 !kernel_arg_addr_space !5 !kernel_arg_access_qual !6 !kernel_arg_type !10 !kernel_arg_type_qual !8 !kernel_arg_base_type !10 !spirv.ParameterDecorations !9 {
+entry:
+  %call = call spir_func <2 x i8> @from_buf(<2 x i8> %ptr_write_val) #0
+  %0 = load ptr addrspace(1), ptr addrspace(1) @p_var, align 8
+  store volatile <2 x i8> %call, ptr addrspace(1) %0, align 2
+  %1 = load <2 x i8>, ptr addrspace(1) @var, align 2
+  %call1 = call spir_func <2 x i8> @to_buf(<2 x i8> %1) #0
+  %arrayidx = getelementptr inbounds <2 x i8>, ptr addrspace(1) %dest, i64 0
+  store <2 x i8> %call1, ptr addrspace(1) %arrayidx, align 2
+  %2 = load <2 x i8>, ptr addrspace(1) @g_var, align 2
+  %call2 = call spir_func <2 x i8> @to_buf(<2 x i8> %2) #0
+  %arrayidx3 = getelementptr inbounds <2 x i8>, ptr addrspace(1) %dest, i64 1
+  store <2 x i8> %call2, ptr addrspace(1) %arrayidx3, align 2
+  %3 = getelementptr inbounds [2 x <2 x i8>], ptr addrspace(1) @a_var, i64 0, i64 0
+  %4 = load <2 x i8>, ptr addrspace(1) %3, align 2
+  %call4 = call spir_func <2 x i8> @to_buf(<2 x i8> %4) #0
+  %arrayidx5 = getelementptr inbounds <2 x i8>, ptr addrspace(1) %dest, i64 2
+  store <2 x i8> %call4, ptr addrspace(1) %arrayidx5, align 2
+  %5 = getelementptr inbounds [2 x <2 x i8>], ptr addrspace(1) @a_var, i64 0, i64 1
+  %6 = load <2 x i8>, ptr addrspace(1) %5, align 2
+  %call6 = call spir_func <2 x i8> @to_buf(<2 x i8> %6) #0
+  %arrayidx7 = getelementptr inbounds <2 x i8>, ptr addrspace(1) %dest, i64 3
+  store <2 x i8> %call6, ptr addrspace(1) %arrayidx7, align 2
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!spirv.MemoryModel = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!spirv.Source = !{!1}
+!opencl.spir.version = !{!2}
+!opencl.ocl.version = !{!2}
+!opencl.used.extensions = !{!3}
+!opencl.used.optional.core.features = !{!3}
+!spirv.Generator = !{!4}
+
+!0 = !{i32 2, i32 2}
+!1 = !{i32 3, i32 200000}
+!2 = !{i32 2, i32 0}
+!3 = !{}
+!4 = !{i16 6, i16 14}
+!5 = !{i32 1, i32 0}
+!6 = !{!"none", !"none"}
+!7 = !{!"char2*", !"int"}
+!8 = !{!"", !""}
+!9 = !{!3, !3}
+!10 = !{!"char2*", !"char2"}


### PR DESCRIPTION
Ported  tests to validate global offset handling, constant composite and nested vector constant generation.