### PR TITLE
Allow translation of global internal constants with private address space

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -421,6 +421,42 @@ void SPIRVRegularizeLLVMBase::cleanupConversionToNonStdIntegers(Module *M) {
   }
 }
 
+void SPIRVRegularizeLLVMBase::replacePrivateConstGlobalsWithAllocas(Module *M) {
+  SmallVector<GlobalVariable *> GlobalsToRemove;
+  for (auto &GV : M->globals()) {
+
+    if (!GV.isConstant() || !GV.hasInternalLinkage() ||
+        !(GV.getAddressSpace() == SPIRAS_Private) || !GV.hasInitializer() ||
+        GV.getName().starts_with("llvm.compiler.used") ||
+        GV.getName().starts_with("llvm.used"))
+      continue;
+
+    SmallVector<User *> Users(GV.users());
+    // TODO: Handle other llvm::User types, for example, constant expressions.
+    if (llvm::any_of(Users, [](User *U) { return !isa<Instruction>(U); }))
+      continue;
+
+    DenseMap<Function *, AllocaInst *> LocalCopies;
+    for (User *U : Users) {
+      Instruction *Inst = cast<Instruction>(U);
+      Function *F = Inst->getFunction();
+      AllocaInst *&AI = LocalCopies[F];
+      if (!AI) {
+        IRBuilder<> Builder(&*F->getEntryBlock().getFirstInsertionPt());
+        AI = Builder.CreateAlloca(GV.getValueType(), nullptr, GV.getName());
+        if (GV.getAlign())
+          AI->setAlignment(GV.getAlign().value());
+        Builder.CreateStore(GV.getInitializer(), AI);
+      }
+      Inst->replaceUsesOfWith(&GV, AI);
+    }
+    GlobalsToRemove.push_back(&GV);
+  }
+
+  for (GlobalVariable *GV : GlobalsToRemove)
+    GV->eraseFromParent();
+}
+
 bool SPIRVRegularizeLLVMBase::runRegularizeLLVM(Module &Module) {
   M = &Module;
   Ctx = &M->getContext();
@@ -582,6 +618,7 @@ bool SPIRVRegularizeLLVMBase::regularize() {
   addKernelEntryPoint(M);
   expandSYCLTypeUsing(M);
   cleanupConversionToNonStdIntegers(M);
+  replacePrivateConstGlobalsWithAllocas(M);
 
   for (auto I = M->begin(), E = M->end(); I != E;) {
     Function *F = &(*I++);

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -102,6 +102,11 @@ public:
   // non-standard integer types.
   void cleanupConversionToNonStdIntegers(llvm::Module *M);
 
+  // Move internal constants in the private address space to function-scope
+  // variables. Such globals would otherwise be translated with Function storage
+  // class which is invalid for global variables in SPIR-V.
+  void replacePrivateConstGlobalsWithAllocas(llvm::Module *M);
+
   // According to the specification, the operands of a shift instruction must be
   // a scalar/vector of integer. When LLVM-IR contains a shift instruction with
   // i1 operands, they are treated as a bool. We need to extend them to i32 to

--- a/test/InternalConstantPrivateGlobal.ll
+++ b/test/InternalConstantPrivateGlobal.ll
@@ -1,0 +1,64 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv -s %t.bc -o %t.out.bc
+; RUN: llvm-dis < %t.out.bc | FileCheck %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; check that all internal private globals are removed
+; CHECK-NOT: @g_var_1
+; CHECK-NOT: @g_var_2
+@g_var_1 = internal unnamed_addr constant [8 x i32] [i32 0, i32 1, i32 -2, i32 3, i32 4, i32 5, i32 6, i32 7]
+@g_var_2 = internal unnamed_addr constant [8 x i32] [i32 2, i32 1, i32 -2, i32 3, i32 4, i32 5, i32 6, i32 7]
+
+; check that external global is not changed
+; CHECK: @g_var_e
+@g_var_e = external unnamed_addr constant [8 x i32]
+
+; check that non constant global is not changed
+; CHECK: @g_var_nc = internal global i32 4
+@g_var_nc = internal global i32 4
+
+; CHECK-LABEL: define spir_func i32 @foo(
+define spir_func i32 @foo(i32 %i) {
+  ; CHECK: [[alloca:%.*]] = alloca [8 x i32], align 4
+  ; CHECK: store [8 x i32] [i32 0, i32 1, i32 -2, i32 3, i32 4, i32 5, i32 6, i32 7], ptr [[alloca]], align 4
+  ; CHECK: [[p:%.*]] = getelementptr [8 x i32], ptr [[alloca]], i32 0, i32 %i
+  %p_1 = getelementptr [8 x i32], ptr @g_var_1, i32 0, i32 %i
+  %v = load i32, ptr %p_1, align 4
+
+  ; CaHECK: %p2 = getelementptr [8 x i32], ptr [[alloca]], i32 0, i32 %i
+  %p2 = getelementptr [8 x i32], ptr @g_var_1, i32 0, i32 %i
+  %v2 = load i32, ptr %p2, align 4
+  %v3 = add i32 %v, %v2
+
+  ret i32 %v3
+}
+
+; CHECK-LABEL: define spir_func i32 @bar
+define spir_func i32 @bar() {
+  ; CHECK: [[alloca:%.*]] = alloca [8 x i32], align 4
+  ; CHECK: store [8 x i32] [i32 2, i32 1, i32 -2, i32 3, i32 4, i32 5, i32 6, i32 7], ptr [[alloca]], align 4
+  ; CHECK: [[p:%.*]] = getelementptr [8 x i32], ptr [[alloca]], i32 0, i32 3
+  %p_1 = getelementptr [8 x i32], ptr @g_var_2, i32 0, i32 3
+  %v = load i32, ptr %p_1, align 4
+  ret i32 %v
+}
+
+; CHECK-LABEL: define spir_func i32 @foobar
+define spir_func i32 @foobar() {
+  ; CHECK: [[alloca_2:%.*]] = alloca [8 x i32], align 4
+  ; CHECK: store [8 x i32] [i32 2, i32 1, i32 -2, i32 3, i32 4, i32 5, i32 6, i32 7], ptr [[alloca_2]], align 4
+  ; CHECK: [[alloca_1:%.*]] = alloca [8 x i32], align 4
+  ; CHECK: store [8 x i32] [i32 0, i32 1, i32 -2, i32 3, i32 4, i32 5, i32 6, i32 7], ptr [[alloca_1]], align 4
+  ; CHECK: [[p_1:%.*]] = getelementptr [8 x i32], ptr [[alloca_1]], i32 0, i32 3
+  %p_1 = getelementptr [8 x i32], ptr @g_var_1, i32 0, i32 3
+  %v_1 = load i32, ptr %p_1, align 4
+
+  ; CHECK: [[p_2:%.*]] = getelementptr [8 x i32], ptr [[alloca_2]], i32 0, i32 4
+  %p_2 = getelementptr [8 x i32], ptr @g_var_2, i32 0, i32 4
+  %v_2 = load i32, ptr %p_1, align 4
+  %sum = add i32 %v_1, %v_2
+
+  ret i32 %sum
+}


### PR DESCRIPTION
Global constants cannot be processed in SPIRV. This change enables the translation of global constants declared in the private address space into local variables within the functions where they are used

