### PR TITLE
Fix invalid DebugInfoNone placement for DebugFunction

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1310,13 +1310,14 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgFunction(const DISubprogram *Func) {
     if (DISubprogram *FuncDecl = Func->getDeclaration())
       Ops.push_back(transDbgEntry(FuncDecl)->getId());
     else {
-      Ops.push_back(getDebugInfoNoneId());
       if (BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200) {
         // Translate targetFuncName mostly for Fortran trampoline function if it
         // is the case
         StringRef TargetFunc = Func->getTargetFuncName();
-        if (!TargetFunc.empty())
+        if (!TargetFunc.empty()) {
+          Ops.push_back(getDebugInfoNoneId());
           Ops.push_back(BM->getString(TargetFunc.str())->getId());
+        }
       }
     }
 

--- a/test/DebugInfo/DebugFunction.cl
+++ b/test/DebugInfo/DebugFunction.cl
@@ -5,6 +5,7 @@
 //   even if in LLVM IR it points to a DIFile instead of DICompileUnit.
 
 // RUN: %clang_cc1 %s -cl-std=clc++ -emit-llvm-bc -triple spir -debug-info-kind=line-tables-only -O0 -o - | llvm-spirv -o %t.spv
+// RUN: spirv-val %t.spv
 // RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 // RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
@@ -18,8 +19,8 @@ void kernel k() {
 // CHECK-SPIRV: String [[foo:[0-9]+]] "foo"
 // CHECK-SPIRV: String [[k:[0-9]+]] "k"
 // CHECK-SPIRV: [[CU:[0-9]+]] {{[0-9]+}} DebugCompilationUnit
-// CHECK-SPIRV: DebugFunction [[foo]] {{.*}} [[CU]] {{.*}} [[foo_id:[0-9]+]] {{[0-9]+}} {{$}}
-// CHECK-SPIRV: DebugFunction [[k]] {{.*}} [[CU]] {{.*}} [[k_id:[0-9]+]] {{[0-9]+}} {{$}}
+// CHECK-SPIRV: DebugFunction [[foo]] {{.*}} [[CU]] {{.*}} [[foo_id:[0-9]+]] {{$}}
+// CHECK-SPIRV: DebugFunction [[k]] {{.*}} [[CU]] {{.*}} [[k_id:[0-9]+]] {{$}}
 
 // CHECK-SPIRV: Function {{[0-9]+}} [[foo_id]]
 // CHECK-LLVM: define spir_func float @_Z3fooi(i32 %i) #{{[0-9]+}} !dbg !{{[0-9]+}} {


### PR DESCRIPTION
In case of missing declaration we shouldn't place DebugInfoNone for OpenCL and Shader.DebugInfo.100 instruction sets.

Solves issue from https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3275