### PR TITLE
Fix error propagation in parseSPIRV

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -2599,7 +2599,7 @@ std::istream &SPIRVModuleImpl::parseSPIRV(std::istream &I) {
   SPIRVWord Header[5] = {0};
   I.read(reinterpret_cast<char *>(&Header), sizeof(Header));
 
-  SPIRVErrorLog ErrorLog = MI.getErrorLog();
+  SPIRVErrorLog &ErrorLog = MI.getErrorLog();
   if (!ErrorLog.checkError(!I.eof(), SPIRVEC_InvalidModule,
                            "input file is empty") ||
       !ErrorLog.checkError(!I.fail(), SPIRVEC_InvalidModule,


### PR DESCRIPTION
d54f77c5 ("[NFC] Split of SPT and SPIR-V in header parsing (#2316)", 2024-03-11) made a copy of the error log, with the presumably unintended consequence that errors are no longer propagated back to the SPIRVModule itself.