### PR TITLE
[NFCI] Remove getLifetimeStartIntrinsic function from SPIRVReader

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -249,23 +249,6 @@ translateSEVMetadata(SPIRVValue *BV, llvm::LLVMContext &Context) {
   return RetAttr;
 }
 
-IntrinsicInst *SPIRVToLLVM::getLifetimeStartIntrinsic(Instruction *I) {
-  auto *II = dyn_cast<IntrinsicInst>(I);
-  if (II && II->getIntrinsicID() == Intrinsic::lifetime_start)
-    return II;
-  // Bitcast might be inserted during translation of OpLifetimeStart
-  auto *BC = dyn_cast<BitCastInst>(I);
-  if (BC) {
-    for (const auto &U : BC->users()) {
-      II = dyn_cast<IntrinsicInst>(U);
-      if (II && II->getIntrinsicID() == Intrinsic::lifetime_start)
-        return II;
-      ;
-    }
-  }
-  return nullptr;
-}
-
 SPIRVErrorLog &SPIRVToLLVM::getErrorLog() { return BM->getErrorLog(); }
 
 void SPIRVToLLVM::setCallingConv(CallInst *Call) {


### PR DESCRIPTION
With new lifetime.start/end rules, which are:
    "The argument is either a pointer to an alloca instruction or a poison
    value."
it became obsolete on main branch. Note, no test is possible to add
on the main branch.

Moreover, it seem to be redundant overall, as IR like this was legal:
      %0 = alloca ...
      %1 = bitcast %0
      call void @llvm.lifetime.start(..., %1)
      %2 = bitcast %0
      call void @llvm.lifetime.end(..., %2)

Further implecations, and why this patch will be backported on older
branches. Right now there is a possibility to have a round-trip
translation failed, when it goes from main to pre-opaque pointers
branches as a bitcast from alloca to i8* will be inserted before
lifetime.start call. Later, due to the current logic, this bitcast will
be reused for lifetime.end call. But, lifetime.end won't always post-dominate
lifetime.start (in this case the object will be considered dead at
function return block), hence the bitcast won't dominate the
lifetime.stop call, invalidating the generated module.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>