### PR TITLE
[NFC] Fix getSourceLanguage build after llvm commit 6cba572

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -587,8 +587,8 @@ SPIRVEntry *LLVMToSPIRVDbgTran::transDbgCompileUnit(const DICompileUnit *CU) {
   if (isNonSemanticDebugInfo())
     generateBuildIdentifierAndStoragePath(CU);
 
-  auto DwarfLang =
-      static_cast<llvm::dwarf::SourceLanguage>(CU->getSourceLanguage());
+  auto DwarfLang = static_cast<llvm::dwarf::SourceLanguage>(
+      CU->getSourceLanguage().getUnversionedName());
   Ops[LanguageIdx] =
       BM->getDebugInfoEIS() == SPIRVEIS_NonSemantic_Shader_DebugInfo_200
           ? convertDWARFSourceLangToSPIRVNonSemanticDbgInfo(DwarfLang)


### PR DESCRIPTION
getSourceLanguage API is changed to return DISourceLanguageName in https://github.com/llvm/llvm-project/commit/6cba572d9efe