### PR TITLE
Use IRParser instead of BitcodeReader

### DIFF
--- a/test/addrspacecast_null.ll
+++ b/test/addrspacecast_null.ll
@@ -1,5 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %s -o %t.spv
 ; RUN: spirv-dis %t.spv | FileCheck %s
 
 ; Test that addrspacecast of null pointer generates appropriate OpConstantNull

--- a/test/align-duplicate.ll
+++ b/test/align-duplicate.ll
@@ -1,5 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %s -o %t.spv
 ; RUN: spirv-val %t.spv
 
 ; Test that duplicate align information does not result in SPIR-V validation

--- a/test/array-alloca.ll
+++ b/test/array-alloca.ll
@@ -1,18 +1,17 @@
-; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %s -o %t.spv
 
 ; Validation test.
 ; RUN: spirv-val %t.spv
 
 ; SPIR-V codegen test.
-; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %s -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; Roundtrip test.
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
-; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_KHR_untyped_pointers
+; RUN: llvm-spirv %s -o %t.spv --spirv-ext=+SPV_KHR_untyped_pointers
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv %t.bc -spirv-text --spirv-ext=+SPV_KHR_untyped_pointers -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %s -spirv-text --spirv-ext=+SPV_KHR_untyped_pointers -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -4,6 +4,7 @@ set(LLVM_LINK_COMPONENTS
   BitReader
   BitWriter
   Core
+  IRReader
   Passes
   Support
   TargetParser


### PR DESCRIPTION
The IRParser offers a higher level API, that allows us to also read bitcode assembly, and not only compiled bitcode.

This allows us to skip the `llvm-as %s -o %t.bc` step in several tests.
I've only updated 3 tests to show the difference; but we have more than 500 occurrences of `llvm-as %s -o` in the tests:

> $ grep -r "llvm-as %s -o" | cut -d':' -f1 | sort -u | wc -l
> 506

As a bonus, the function `llvm::getLazyIRFileModule` (https://llvm.org/doxygen/namespacellvm.html#aac226baa3ffd0f255a8d2b6d978b81b2) also calls `MemoryBuffer::getFileOrSTDIN`.