### PR TITLE
[Backport to 18] Always emit coopmat conversions as SPIR-V friendly IR calls

### DIFF
--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -650,6 +650,13 @@ void SPIRVToOCLBase::visitCallGenericCastToPtrExplicitBuiltIn(CallInst *CI,
 
 void SPIRVToOCLBase::visitCallSPIRVCvtBuiltin(CallInst *CI, Op OC,
                                               StringRef DemangledName) {
+  if (auto *TET =
+          dyn_cast<TargetExtType>(CI->getFunctionType()->getReturnType())) {
+    // Preserve any cooperative matrix type conversions as SPIR-V calls.
+    if (TET->getName() == "spirv.CooperativeMatrixKHR") {
+      return;
+    }
+  }
   std::string CastBuiltInName;
   if (isCvtFromUnsignedOpCode(OC))
     CastBuiltInName = "u";

--- a/test/extensions/KHR/SPV_KHR_cooperative_matrix/conversion_instructions.ll
+++ b/test/extensions/KHR/SPV_KHR_cooperative_matrix/conversion_instructions.ll
@@ -9,6 +9,11 @@
 ; RUN: llvm-dis %t.rev.bc 
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
+; Ensure cooperative matrix conversions are mapped to SPIR-V friendly IR calls.
+; RUN: llvm-spirv -r --spirv-target-env=CL2.0 %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
 ; CHECK-SPIRV: TypeInt [[#TypeInt32:]] 32 0
 ; CHECK-SPIRV: TypeInt [[#TypeInt16:]] 16 0
 ; CHECK-SPIRV: TypeInt [[#TypeInt8:]] 8 0


### PR DESCRIPTION
Map all cooperative matrix type conversions to SPIR-V friendly IR calls, regardless of the environment specified.

In particular, do not attempt to map such conversions to the OpenCL `convert` builtin. The SPIR-V TargetExtType is already encoded in the function suffix, so the previous translation was an odd hybrid between OpenCL and SPIR-V friendly IR.

(cherry picked from commit 9d56f01d558999875e946af31db7d3dde53952a8)