### PR TITLE
Fix `C4838: conversion from 'spv::Op' to 'SPIRV::SPIRVWord' requires a narrowing conversion`

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1124,7 +1124,8 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
       FPEncodingWrap DstEnc = GetEncodingAndUpdateType(SPVDstTy);
       if (IsFP4OrFP8Encoding(SrcEnc) || IsFP4OrFP8Encoding(DstEnc) ||
           SPVSrcTy->isTypeInt(4) || SPVDstTy->isTypeInt(4)) {
-        FPConversionDesc FPDesc = {SrcEnc, DstEnc, BC->getOpCode()};
+        FPConversionDesc FPDesc = {
+            SrcEnc, DstEnc, static_cast<SPIRV::SPIRVWord>(BC->getOpCode())};
         auto Conv = SPIRV::FPConvertToEncodingMap::rmap(FPDesc);
         std::vector<Value *> Ops = {Src};
         std::vector<Type *> OpsTys = {Src->getType()};


### PR DESCRIPTION
```
  FAILED: _deps/spirv-llvm-translator-build/lib/SPIRV/CMakeFiles/LLVMSPIRVLib.dir/SPIRVReader.cpp.obj
  C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe  /nologo /TP -DGTEST_HAS_RTTI=0 -DUNICODE -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_NONSTDC_NO_WARNINGS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS -D_GLIBCXX_ASSERTIONS -D_HAS_EXCEPTIONS=0 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS -D_UNICODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\_deps\spirv-llvm-translator-build\lib\SPIRV -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party\intel\lib\Target\SPIRV\SPIRVToLLVMTranslator\lib\SPIRV -IC:\gh19554838910\include -IC:\gh19554838910\. -IC:\Users\vagrant\.triton\llvm\llvm-f6ded0be-windows-x64\include -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\include -IC:\gh19554838910\third_party -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party -IC:\gh19554838910\python\src -IC:\gh19554838910\third_party\intel\include -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party\intel\include -IC:\gh19554838910\third_party\intel\lib -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party\intel\lib\Target\SPIRV\SPIRVToLLVMTranslator\include -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\_deps\spirv-llvm-translator-build\SPIRV-Headers\include -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party\intel\lib\Target\SPIRV\SPIRVToLLVMTranslator\lib\SPIRV\libSPIRV -IC:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party\intel\lib\Target\SPIRV\SPIRVToLLVMTranslator\lib\SPIRV\Mangler /DWIN32 /D_WINDOWS   -D__STDC_FORMAT_MACROS /wd4244 /wd4624 /wd4715 /wd4530 /WX /Zc:inline /Zc:preprocessor /Zc:__cplusplus /Oi /bigobj /permissive- /W4 -wd4141 -wd4146 -wd4244 -wd4267 -wd4291 -wd4351 -wd4456 -wd4457 -wd4458 -wd4459 -wd4503 -wd4624 -wd4722 -wd4100 -wd4127 -wd4512 -wd4505 -wd4610 -wd4510 -wd4702 -wd4245 -wd4706 -wd4310 -wd4701 -wd4703 -wd4389 -wd4611 -wd4805 -wd4204 -wd4577 -wd4091 -wd4592 -wd4319 -wd4709 -wd5105 -wd4324 -wd4251 -wd4275 -w14062 -we4238 /Gw /Zi /RTC1 /bigobj /Zc:preprocessor /permissive- -std:c++17 -MD  /EHs-c- /GR- -UNDEBUG /showIncludes /Fo_deps\spirv-llvm-translator-build\lib\SPIRV\CMakeFiles\LLVMSPIRVLib.dir\SPIRVReader.cpp.obj /Fd_deps\spirv-llvm-translator-build\lib\SPIRV\CMakeFiles\LLVMSPIRVLib.dir\LLVMSPIRVLib.pdb /FS -c C:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party\intel\lib\Target\SPIRV\SPIRVToLLVMTranslator\lib\SPIRV\SPIRVReader.cpp
  C:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party\intel\lib\Target\SPIRV\SPIRVToLLVMTranslator\lib\SPIRV\SPIRVReader.cpp(1118): error C2220: the following warning is treated as an error
  C:\gh19554838910\build\cmake.win-amd64-cpython-3.10\third_party\intel\lib\Target\SPIRV\SPIRVToLLVMTranslator\lib\SPIRV\SPIRVReader.cpp(1118): warning C4838: conversion from 'spv::Op' to 'SPIRV::SPIRVWord' requires a narrowing conversion
  ```