### PR TITLE
Update DIModule test after LLVM change

### DIFF
--- a/test/DebugInfo/X86/dimodule-external-fortran.ll
+++ b/test/DebugInfo/X86/dimodule-external-fortran.ll
@@ -40,7 +40,7 @@
 ; CHECK:      DW_TAG_imported_module
 ; CHECK-NEXT:   DW_AT_decl_file
 ; CHECK-NEXT:   DW_AT_decl_line
-; CHECK-NEXT:   DW_AT_import  ([[DIE_ID]])
+; CHECK-NEXT:   DW_AT_import  ([[DIE_ID]] "external_module")
 
 ; When the debugger sees the module being imported is a declaration,
 ; it should go to the global scope to find the module's definition.


### PR DESCRIPTION
Update a test for llvm-project commit `5bc7b9d462f0 ("[llvm][dwarfdump] Print the name (if available) of entities referenced by DW_AT_import (#171859)", 2025-12-12)`.