### PR TITLE
[LLVM 16] Add workaround to translate casts from target ext types to int

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1204,6 +1204,12 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
       CO = Instruction::IntToPtr;
     }
     break;
+  // TODO: remove this as it's invalid SPIR-V.
+  case OpConvertPtrToU: {
+    if (Src->getType()->isTargetExtTy())
+      return transSPIRVBuiltinFromInst(BC, BB);
+    [[fallthrough]];
+  }
   default:
     CO = static_cast<CastInst::CastOps>(OpCodeMap::rmap(BC->getOpCode()));
   }


### PR DESCRIPTION
This patch should be reverted in the future as it supports translation of invalid SPIR-V modules.