### PR TITLE
[LLVM->SPV-IR] Set vload/vstore's offset arg type to unsigned

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2708,6 +2708,21 @@ public:
     case OpenCLLIB::Shuffle2:
       addUnsignedArg(2);
       break;
+    case OpenCLLIB::Vloadn:
+    case OpenCLLIB::Vload_half:
+    case OpenCLLIB::Vload_halfn:
+    case OpenCLLIB::Vloada_halfn:
+      addUnsignedArg(0);
+      break;
+    case OpenCLLIB::Vstoren:
+    case OpenCLLIB::Vstore_half:
+    case OpenCLLIB::Vstore_half_r:
+    case OpenCLLIB::Vstore_halfn:
+    case OpenCLLIB::Vstore_halfn_r:
+    case OpenCLLIB::Vstorea_halfn:
+    case OpenCLLIB::Vstorea_halfn_r:
+      addUnsignedArg(1);
+      break;
     default:;
       // No special handling is needed
     }

--- a/test/OpenCL.std/vload_half.spvasm
+++ b/test/OpenCL.std/vload_half.spvasm
@@ -6,22 +6,22 @@
 ;
 ; CHECK-LABEL: spir_kernel void @test
 ;
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS1Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS3Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPU3AS2Dh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatiPDh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS1Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS1Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS1Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS1Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS3Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS3Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS3Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS3Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS2Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS2Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS2Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS2Dh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPDh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPDh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPDh(
+; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPDh(
 ;
 ; CHECK-CL20: call spir_func float @_Z10vload_halfjPU3AS1KDh
 ; CHECK-CL20: call spir_func float @_Z10vload_halfjPU3AS1KDh

--- a/test/OpenCL.std/vload_halfn.spvasm
+++ b/test/OpenCL.std/vload_halfn.spvasm
@@ -6,26 +6,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @test
 ;
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2iPDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3iPDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4iPDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8iPDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16iPDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2jPDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3jPDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4jPDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8jPDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16jPDhi(
 ;
 ; CHECK-CL20: call spir_func <2 x float> @_Z11vload_half2jPU3AS1KDh(
 ; CHECK-CL20: call spir_func <3 x float> @_Z11vload_half3jPU3AS1KDh(

--- a/test/OpenCL.std/vloada_halfn.spvasm
+++ b/test/OpenCL.std/vloada_halfn.spvasm
@@ -6,26 +6,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @test
 ;
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2iPDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3iPDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4iPDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8iPDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16iPDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2jPDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3jPDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4jPDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8jPDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16jPDhi(
 ;
 ; CHECK-CL20: call spir_func <2 x float> @_Z12vloada_half2jPU3AS1KDh(
 ; CHECK-CL20: call spir_func <3 x float> @_Z12vloada_half3jPU3AS1KDh(

--- a/test/OpenCL.std/vloadn.spvasm
+++ b/test/OpenCL.std/vloadn.spvasm
@@ -6,26 +6,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testChar
 ;
-; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2iPU3AS1ci(
-; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3iPU3AS1ci(
-; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4iPU3AS1ci(
-; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8iPU3AS1ci(
-; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16iPU3AS1ci(
-; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2iPU3AS3ci(
-; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3iPU3AS3ci(
-; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4iPU3AS3ci(
-; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8iPU3AS3ci(
-; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16iPU3AS3ci(
-; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2iPU3AS2ci(
-; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3iPU3AS2ci(
-; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4iPU3AS2ci(
-; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8iPU3AS2ci(
-; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16iPU3AS2ci(
-; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2iPci(
-; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3iPci(
-; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4iPci(
-; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8iPci(
-; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16iPci(
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2jPU3AS1ci(
+; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3jPU3AS1ci(
+; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4jPU3AS1ci(
+; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8jPU3AS1ci(
+; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16jPU3AS1ci(
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2jPU3AS3ci(
+; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3jPU3AS3ci(
+; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4jPU3AS3ci(
+; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8jPU3AS3ci(
+; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16jPU3AS3ci(
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2jPU3AS2ci(
+; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3jPU3AS2ci(
+; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4jPU3AS2ci(
+; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8jPU3AS2ci(
+; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16jPU3AS2ci(
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2jPci(
+; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3jPci(
+; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4jPci(
+; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8jPci(
+; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16jPci(
 ;
 ; CHECK-CL20: call spir_func <2 x i8> @_Z6vload2jPU3AS1Kc(
 ; CHECK-CL20: call spir_func <3 x i8> @_Z6vload3jPU3AS1Kc(
@@ -50,26 +50,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testShort
 ;
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2iPU3AS1si(
-; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3iPU3AS1si(
-; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4iPU3AS1si(
-; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8iPU3AS1si(
-; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16iPU3AS1si(
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2iPU3AS3si(
-; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3iPU3AS3si(
-; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4iPU3AS3si(
-; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8iPU3AS3si(
-; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16iPU3AS3si(
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2iPU3AS2si(
-; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3iPU3AS2si(
-; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4iPU3AS2si(
-; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8iPU3AS2si(
-; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16iPU3AS2si(
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2iPsi(
-; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3iPsi(
-; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4iPsi(
-; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8iPsi(
-; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16iPsi(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2jPU3AS1si(
+; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3jPU3AS1si(
+; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4jPU3AS1si(
+; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8jPU3AS1si(
+; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16jPU3AS1si(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2jPU3AS3si(
+; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3jPU3AS3si(
+; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4jPU3AS3si(
+; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8jPU3AS3si(
+; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16jPU3AS3si(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2jPU3AS2si(
+; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3jPU3AS2si(
+; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4jPU3AS2si(
+; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8jPU3AS2si(
+; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16jPU3AS2si(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2jPsi(
+; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3jPsi(
+; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4jPsi(
+; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8jPsi(
+; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16jPsi(
 ;
 ; CHECK-CL20: call spir_func <2 x i16> @_Z6vload2jPU3AS1Ks(
 ; CHECK-CL20: call spir_func <3 x i16> @_Z6vload3jPU3AS1Ks(
@@ -94,26 +94,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testInt
 ;
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2iPU3AS1ii(
-; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3iPU3AS1ii(
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4iPU3AS1ii(
-; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8iPU3AS1ii(
-; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16iPU3AS1ii(
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2iPU3AS3ii(
-; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3iPU3AS3ii(
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4iPU3AS3ii(
-; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8iPU3AS3ii(
-; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16iPU3AS3ii(
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2iPU3AS2ii(
-; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3iPU3AS2ii(
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4iPU3AS2ii(
-; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8iPU3AS2ii(
-; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16iPU3AS2ii(
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2iPii(
-; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3iPii(
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4iPii(
-; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8iPii(
-; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16iPii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2jPU3AS1ii(
+; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3jPU3AS1ii(
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4jPU3AS1ii(
+; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8jPU3AS1ii(
+; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16jPU3AS1ii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2jPU3AS3ii(
+; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3jPU3AS3ii(
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4jPU3AS3ii(
+; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8jPU3AS3ii(
+; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16jPU3AS3ii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2jPU3AS2ii(
+; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3jPU3AS2ii(
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4jPU3AS2ii(
+; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8jPU3AS2ii(
+; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16jPU3AS2ii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2jPii(
+; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3jPii(
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4jPii(
+; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8jPii(
+; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16jPii(
 ;
 ; CHECK-CL20: call spir_func <2 x i32> @_Z6vload2jPU3AS1Ki(
 ; CHECK-CL20: call spir_func <3 x i32> @_Z6vload3jPU3AS1Ki(
@@ -138,26 +138,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testLong
 ;
-; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2iPU3AS1li(
-; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3iPU3AS1li(
-; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4iPU3AS1li(
-; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8iPU3AS1li(
-; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16iPU3AS1li(
-; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2iPU3AS3li(
-; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3iPU3AS3li(
-; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4iPU3AS3li(
-; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8iPU3AS3li(
-; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16iPU3AS3li(
-; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2iPU3AS2li(
-; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3iPU3AS2li(
-; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4iPU3AS2li(
-; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8iPU3AS2li(
-; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16iPU3AS2li(
-; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2iPli(
-; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3iPli(
-; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4iPli(
-; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8iPli(
-; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16iPli(
+; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2jPU3AS1li(
+; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3jPU3AS1li(
+; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4jPU3AS1li(
+; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8jPU3AS1li(
+; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16jPU3AS1li(
+; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2jPU3AS3li(
+; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3jPU3AS3li(
+; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4jPU3AS3li(
+; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8jPU3AS3li(
+; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16jPU3AS3li(
+; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2jPU3AS2li(
+; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3jPU3AS2li(
+; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4jPU3AS2li(
+; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8jPU3AS2li(
+; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16jPU3AS2li(
+; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2jPli(
+; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3jPli(
+; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4jPli(
+; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8jPli(
+; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16jPli(
 ;
 ; CHECK-CL20: call spir_func <2 x i64> @_Z6vload2jPU3AS1Kl(
 ; CHECK-CL20: call spir_func <3 x i64> @_Z6vload3jPU3AS1Kl(
@@ -182,26 +182,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testHalf
 ;
-; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16iPU3AS1Dhi(
-; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16iPU3AS3Dhi(
-; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16iPU3AS2Dhi(
-; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2iPDhi(
-; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3iPDhi(
-; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4iPDhi(
-; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8iPDhi(
-; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16iPDhi(
+; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16jPU3AS1Dhi(
+; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16jPU3AS3Dhi(
+; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16jPU3AS2Dhi(
+; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2jPDhi(
+; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3jPDhi(
+; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4jPDhi(
+; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8jPDhi(
+; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16jPDhi(
 ;
 ; CHECK-CL20: call spir_func <2 x half> @_Z6vload2jPU3AS1KDh(
 ; CHECK-CL20: call spir_func <3 x half> @_Z6vload3jPU3AS1KDh(
@@ -226,26 +226,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testFloat
 ;
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2iPU3AS1fi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3iPU3AS1fi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4iPU3AS1fi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8iPU3AS1fi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16iPU3AS1fi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2iPU3AS3fi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3iPU3AS3fi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4iPU3AS3fi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8iPU3AS3fi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16iPU3AS3fi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2iPU3AS2fi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3iPU3AS2fi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4iPU3AS2fi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8iPU3AS2fi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16iPU3AS2fi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2iPfi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3iPfi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4iPfi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8iPfi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16iPfi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2jPU3AS1fi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3jPU3AS1fi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4jPU3AS1fi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8jPU3AS1fi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16jPU3AS1fi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2jPU3AS3fi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3jPU3AS3fi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4jPU3AS3fi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8jPU3AS3fi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16jPU3AS3fi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2jPU3AS2fi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3jPU3AS2fi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4jPU3AS2fi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8jPU3AS2fi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16jPU3AS2fi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2jPfi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3jPfi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4jPfi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8jPfi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16jPfi(
 ;
 ; CHECK-CL20: call spir_func <2 x float> @_Z6vload2jPU3AS1Kf(
 ; CHECK-CL20: call spir_func <3 x float> @_Z6vload3jPU3AS1Kf(
@@ -270,26 +270,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testDouble
 ;
-; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2iPU3AS1di(
-; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3iPU3AS1di(
-; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4iPU3AS1di(
-; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8iPU3AS1di(
-; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16iPU3AS1di(
-; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2iPU3AS3di(
-; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3iPU3AS3di(
-; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4iPU3AS3di(
-; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8iPU3AS3di(
-; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16iPU3AS3di(
-; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2iPU3AS2di(
-; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3iPU3AS2di(
-; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4iPU3AS2di(
-; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8iPU3AS2di(
-; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16iPU3AS2di(
-; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2iPdi(
-; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3iPdi(
-; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4iPdi(
-; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8iPdi(
-; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16iPdi(
+; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2jPU3AS1di(
+; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3jPU3AS1di(
+; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4jPU3AS1di(
+; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8jPU3AS1di(
+; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16jPU3AS1di(
+; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2jPU3AS3di(
+; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3jPU3AS3di(
+; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4jPU3AS3di(
+; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8jPU3AS3di(
+; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16jPU3AS3di(
+; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2jPU3AS2di(
+; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3jPU3AS2di(
+; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4jPU3AS2di(
+; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8jPU3AS2di(
+; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16jPU3AS2di(
+; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2jPdi(
+; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3jPdi(
+; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4jPdi(
+; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8jPdi(
+; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16jPdi(
 ;
 ; CHECK-CL20: call spir_func <2 x double> @_Z6vload2jPU3AS1Kd(
 ; CHECK-CL20: call spir_func <3 x double> @_Z6vload3jPU3AS1Kd(

--- a/test/OpenCL.std/vstore_half.spvasm
+++ b/test/OpenCL.std/vstore_half.spvasm
@@ -10,19 +10,19 @@
 ; CHECK-SPV-BACK: TypeVoid [[VoidTy:[0-9]+]]
 
 ; CHECK-LABEL: spir_kernel void @test
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPU3AS1Dh(float {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPU3AS1Dh(float {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPU3AS1Dh(float {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPU3AS1Dh(float {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPU3AS3Dh(float {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPU3AS3Dh(float {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPU3AS3Dh(float {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPU3AS3Dh(float {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPDh(float {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPDh(float {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPDh(float {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffiPDh(float {{.*}}, i32 0, ptr {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPU3AS1Dh(float {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPU3AS1Dh(float {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPU3AS1Dh(float {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPU3AS1Dh(float {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPU3AS3Dh(float {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPU3AS3Dh(float {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPU3AS3Dh(float {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPU3AS3Dh(float {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPDh(float {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPDh(float {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPDh(float {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z23__spirv_ocl_vstore_halffjPDh(float {{.*}}, i32 0, ptr {{.*}})
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half
@@ -50,19 +50,19 @@
 ; CHECK-CL20: call spir_func void @_Z11vstore_halffjPDh(float {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTE
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 0)
-
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 0)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 0
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 0
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 0
@@ -90,19 +90,19 @@
 ; CHECK-CL20: call spir_func void @_Z15vstore_half_rtefjPDh(float {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTZ
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 1)
-
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 1)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 1
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 1
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 1
@@ -130,19 +130,19 @@
 ; CHECK-CL20: call spir_func void @_Z15vstore_half_rtzfjPDh(float {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTP
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 2)
-
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 2)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 2
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 2
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 2
@@ -170,19 +170,19 @@
 ; CHECK-CL20: call spir_func void @_Z15vstore_half_rtpfjPDh(float {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTN
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfiPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 3)
-
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS1Dhi(float {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPU3AS3Dhi(float {{.*}}, i32 0, ptr addrspace(3) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstore_half_rfjPDhi(float {{.*}}, i32 0, ptr {{.*}}, i32 3)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 3
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 3
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_half_r {{.*}} {{.*}} 3

--- a/test/OpenCL.std/vstore_halfn.spvasm
+++ b/test/OpenCL.std/vstore_halfn.spvasm
@@ -12,12 +12,12 @@
 ; CHECK-SPV-BACK: TypeVoid [[VoidTy:[0-9]+]]
 
 ; CHECK-LABEL: spir_kernel void @test
-; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv2_fiPU3AS1Dh(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv3_fiPU3AS1Dh(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv4_fiPU3AS1Dh(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv8_fiPU3AS1Dh(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv16_fiPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv2_fjPU3AS1Dh(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv3_fjPU3AS1Dh(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv4_fjPU3AS1Dh(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv8_fjPU3AS1Dh(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z24__spirv_ocl_vstore_halfnDv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn
@@ -31,12 +31,12 @@
 ; CHECK-CL20: call spir_func void @_Z13vstore_half16Dv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTE
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv2_fiPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv3_fiPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv4_fiPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv8_fiPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv16_fiPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv2_fjPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv3_fjPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv4_fjPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv8_fjPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv16_fjPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 0
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 0
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 0
@@ -50,12 +50,12 @@
 ; CHECK-CL20: call spir_func void @_Z17vstore_half16_rteDv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTZ
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv2_fiPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv3_fiPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv4_fiPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv8_fiPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv16_fiPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv2_fjPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv3_fjPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv4_fjPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv8_fjPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv16_fjPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 1
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 1
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 1
@@ -69,12 +69,12 @@
 ; CHECK-CL20: call spir_func void @_Z17vstore_half16_rtzDv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTP
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv2_fiPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv3_fiPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv4_fiPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv8_fiPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv16_fiPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv2_fjPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv3_fjPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv4_fjPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv8_fjPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv16_fjPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 2
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 2
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 2
@@ -88,12 +88,12 @@
 ; CHECK-CL20: call spir_func void @_Z17vstore_half16_rtpDv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTN
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv2_fiPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv3_fiPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv4_fiPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv8_fiPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv16_fiPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv2_fjPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv3_fjPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv4_fjPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv8_fjPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z26__spirv_ocl_vstore_halfn_rDv16_fjPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 3
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 3
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstore_halfn_r {{.*}} [[Zero]] {{.*}} 3

--- a/test/OpenCL.std/vstorea_halfn.spvasm
+++ b/test/OpenCL.std/vstorea_halfn.spvasm
@@ -12,12 +12,12 @@
 ; CHECK-SPV-BACK: TypeVoid [[VoidTy:[0-9]+]]
 
 ; CHECK-LABEL: spir_kernel void @test
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv2_fiPU3AS1Dh(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv3_fiPU3AS1Dh(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv4_fiPU3AS1Dh(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv8_fiPU3AS1Dh(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv16_fiPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv2_fjPU3AS1Dh(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv3_fjPU3AS1Dh(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv4_fjPU3AS1Dh(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv8_fjPU3AS1Dh(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z25__spirv_ocl_vstorea_halfnDv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn
@@ -31,12 +31,12 @@
 ; CHECK-CL20: call spir_func void @_Z14vstorea_half16Dv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTE
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv2_fiPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv3_fiPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv4_fiPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv8_fiPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv16_fiPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
-
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv2_fjPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv3_fjPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv4_fjPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv8_fjPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv16_fjPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 0)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 0
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 0
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 0
@@ -50,12 +50,12 @@
 ; CHECK-CL20: call spir_func void @_Z18vstorea_half16_rteDv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTZ
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv2_fiPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv3_fiPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv4_fiPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv8_fiPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv16_fiPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
-
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv2_fjPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv3_fjPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv4_fjPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv8_fjPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv16_fjPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 1)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 1
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 1
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 1
@@ -69,12 +69,12 @@
 ; CHECK-CL20: call spir_func void @_Z18vstorea_half16_rtzDv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTP
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv2_fiPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv3_fiPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv4_fiPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv8_fiPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv16_fiPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
-
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv2_fjPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv3_fjPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv4_fjPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv8_fjPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv16_fjPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 2)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 2
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 2
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 2
@@ -88,12 +88,12 @@
 ; CHECK-CL20: call spir_func void @_Z18vstorea_half16_rtpDv16_fjPU3AS1Dh(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testRTN
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv2_fiPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv3_fiPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv4_fiPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv8_fiPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv16_fiPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
-
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv2_fjPU3AS1Dhi(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv3_fjPU3AS1Dhi(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv4_fjPU3AS1Dhi(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv8_fjPU3AS1Dhi(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+; CHECK-SPV-IR: call spir_func void @_Z27__spirv_ocl_vstorea_halfn_rDv16_fjPU3AS1Dhi(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}}, i32 3)
+;
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 3
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 3
 ; CHECK-SPV-BACK: ExtInst [[VoidTy]] {{.*}} [[Set]] vstorea_halfn_r {{.*}} [[Zero]] {{.*}} 3

--- a/test/OpenCL.std/vstoren.spvasm
+++ b/test/OpenCL.std/vstoren.spvasm
@@ -10,22 +10,22 @@
 ; CHECK-SPV-BACK: TypeVoid [[VoidTy:[0-9]+]]
 
 ; CHECK-LABEL: spir_kernel void @testChar
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ciPU3AS1c(<2 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ciPU3AS1c(<3 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ciPU3AS1c(<4 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ciPU3AS1c(<8 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ciPU3AS1c(<16 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ciPU3AS3c(<2 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ciPU3AS3c(<3 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ciPU3AS3c(<4 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ciPU3AS3c(<8 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ciPU3AS3c(<16 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ciPc(<2 x i8> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ciPc(<3 x i8> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ciPc(<4 x i8> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ciPc(<8 x i8> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ciPc(<16 x i8> {{.*}}, i32 0, ptr {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_cjPU3AS1c(<2 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_cjPU3AS1c(<3 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_cjPU3AS1c(<4 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_cjPU3AS1c(<8 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_cjPU3AS1c(<16 x i8> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_cjPU3AS3c(<2 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_cjPU3AS3c(<3 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_cjPU3AS3c(<4 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_cjPU3AS3c(<8 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_cjPU3AS3c(<16 x i8> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_cjPc(<2 x i8> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_cjPc(<3 x i8> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_cjPc(<4 x i8> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_cjPc(<8 x i8> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_cjPc(<16 x i8> {{.*}}, i32 0, ptr {{.*}})
+;
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
@@ -59,22 +59,22 @@
 ; CHECK-CL20: call spir_func void @_Z8vstore16Dv16_cjPc(<16 x i8> {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testShort
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_siPU3AS1s(<2 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_siPU3AS1s(<3 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_siPU3AS1s(<4 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_siPU3AS1s(<8 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_siPU3AS1s(<16 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_siPU3AS3s(<2 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_siPU3AS3s(<3 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_siPU3AS3s(<4 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_siPU3AS3s(<8 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_siPU3AS3s(<16 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_siPs(<2 x i16> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_siPs(<3 x i16> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_siPs(<4 x i16> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_siPs(<8 x i16> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_siPs(<16 x i16> {{.*}}, i32 0, ptr {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_sjPU3AS1s(<2 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_sjPU3AS1s(<3 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_sjPU3AS1s(<4 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_sjPU3AS1s(<8 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_sjPU3AS1s(<16 x i16> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_sjPU3AS3s(<2 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_sjPU3AS3s(<3 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_sjPU3AS3s(<4 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_sjPU3AS3s(<8 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_sjPU3AS3s(<16 x i16> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_sjPs(<2 x i16> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_sjPs(<3 x i16> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_sjPs(<4 x i16> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_sjPs(<8 x i16> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_sjPs(<16 x i16> {{.*}}, i32 0, ptr {{.*}})
+;
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
@@ -108,22 +108,22 @@
 ; CHECK-CL20: call spir_func void @_Z8vstore16Dv16_sjPs(<16 x i16> {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testInt
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_iiPU3AS1i(<2 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_iiPU3AS1i(<3 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_iiPU3AS1i(<4 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_iiPU3AS1i(<8 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_iiPU3AS1i(<16 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_iiPU3AS3i(<2 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_iiPU3AS3i(<3 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_iiPU3AS3i(<4 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_iiPU3AS3i(<8 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_iiPU3AS3i(<16 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_iiPi(<2 x i32> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_iiPi(<3 x i32> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_iiPi(<4 x i32> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_iiPi(<8 x i32> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_iiPi(<16 x i32> {{.*}}, i32 0, ptr {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ijPU3AS1i(<2 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ijPU3AS1i(<3 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ijPU3AS1i(<4 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ijPU3AS1i(<8 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ijPU3AS1i(<16 x i32> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ijPU3AS3i(<2 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ijPU3AS3i(<3 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ijPU3AS3i(<4 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ijPU3AS3i(<8 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ijPU3AS3i(<16 x i32> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ijPi(<2 x i32> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ijPi(<3 x i32> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ijPi(<4 x i32> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ijPi(<8 x i32> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ijPi(<16 x i32> {{.*}}, i32 0, ptr {{.*}})
+;
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
@@ -157,22 +157,22 @@
 ; CHECK-CL20: call spir_func void @_Z8vstore16Dv16_ijPi(<16 x i32> {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testLong
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_liPU3AS1l(<2 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_liPU3AS1l(<3 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_liPU3AS1l(<4 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_liPU3AS1l(<8 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_liPU3AS1l(<16 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_liPU3AS3l(<2 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_liPU3AS3l(<3 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_liPU3AS3l(<4 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_liPU3AS3l(<8 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_liPU3AS3l(<16 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_liPl(<2 x i64> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_liPl(<3 x i64> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_liPl(<4 x i64> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_liPl(<8 x i64> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_liPl(<16 x i64> {{.*}}, i32 0, ptr {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ljPU3AS1l(<2 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ljPU3AS1l(<3 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ljPU3AS1l(<4 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ljPU3AS1l(<8 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ljPU3AS1l(<16 x i64> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ljPU3AS3l(<2 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ljPU3AS3l(<3 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ljPU3AS3l(<4 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ljPU3AS3l(<8 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ljPU3AS3l(<16 x i64> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_ljPl(<2 x i64> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_ljPl(<3 x i64> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_ljPl(<4 x i64> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_ljPl(<8 x i64> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_ljPl(<16 x i64> {{.*}}, i32 0, ptr {{.*}})
+;
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
@@ -206,22 +206,22 @@
 ; CHECK-CL20: call spir_func void @_Z8vstore16Dv16_ljPl(<16 x i64> {{.*}}, i32 0, ptr {{.*}})
  
 ; CHECK-LABEL: spir_kernel void @testHalf
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_DhiPU3AS1Dh(<2 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_DhiPU3AS1Dh(<3 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_DhiPU3AS1Dh(<4 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_DhiPU3AS1Dh(<8 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_DhiPU3AS1Dh(<16 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_DhiPU3AS3Dh(<2 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_DhiPU3AS3Dh(<3 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_DhiPU3AS3Dh(<4 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_DhiPU3AS3Dh(<8 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_DhiPU3AS3Dh(<16 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_DhiPDh(<2 x half> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_DhiPDh(<3 x half> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_DhiPDh(<4 x half> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_DhiPDh(<8 x half> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_DhiPDh(<16 x half> {{.*}}, i32 0, ptr {{.*}})
- 
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_DhjPU3AS1Dh(<2 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_DhjPU3AS1Dh(<3 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_DhjPU3AS1Dh(<4 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_DhjPU3AS1Dh(<8 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_DhjPU3AS1Dh(<16 x half> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_DhjPU3AS3Dh(<2 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_DhjPU3AS3Dh(<3 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_DhjPU3AS3Dh(<4 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_DhjPU3AS3Dh(<8 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_DhjPU3AS3Dh(<16 x half> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_DhjPDh(<2 x half> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_DhjPDh(<3 x half> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_DhjPDh(<4 x half> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_DhjPDh(<8 x half> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_DhjPDh(<16 x half> {{.*}}, i32 0, ptr {{.*}})
+;
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
@@ -255,22 +255,22 @@
 ; CHECK-CL20: call spir_func void @_Z8vstore16Dv16_DhjPDh(<16 x half> {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testFloat
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_fiPU3AS1f(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_fiPU3AS1f(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_fiPU3AS1f(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_fiPU3AS1f(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_fiPU3AS1f(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_fiPU3AS3f(<2 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_fiPU3AS3f(<3 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_fiPU3AS3f(<4 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_fiPU3AS3f(<8 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_fiPU3AS3f(<16 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_fiPf(<2 x float> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_fiPf(<3 x float> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_fiPf(<4 x float> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_fiPf(<8 x float> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_fiPf(<16 x float> {{.*}}, i32 0, ptr {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_fjPU3AS1f(<2 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_fjPU3AS1f(<3 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_fjPU3AS1f(<4 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_fjPU3AS1f(<8 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_fjPU3AS1f(<16 x float> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_fjPU3AS3f(<2 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_fjPU3AS3f(<3 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_fjPU3AS3f(<4 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_fjPU3AS3f(<8 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_fjPU3AS3f(<16 x float> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_fjPf(<2 x float> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_fjPf(<3 x float> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_fjPf(<4 x float> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_fjPf(<8 x float> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_fjPf(<16 x float> {{.*}}, i32 0, ptr {{.*}})
+;
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
@@ -304,22 +304,22 @@
 ; CHECK-CL20: call spir_func void @_Z8vstore16Dv16_fjPf(<16 x float> {{.*}}, i32 0, ptr {{.*}})
 
 ; CHECK-LABEL: spir_kernel void @testDouble
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_diPU3AS1d(<2 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_diPU3AS1d(<3 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_diPU3AS1d(<4 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_diPU3AS1d(<8 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_diPU3AS1d(<16 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_diPU3AS3d(<2 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_diPU3AS3d(<3 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_diPU3AS3d(<4 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_diPU3AS3d(<8 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_diPU3AS3d(<16 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_diPd(<2 x double> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_diPd(<3 x double> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_diPd(<4 x double> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_diPd(<8 x double> {{.*}}, i32 0, ptr {{.*}})
-; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_diPd(<16 x double> {{.*}}, i32 0, ptr {{.*}})
-
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_djPU3AS1d(<2 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_djPU3AS1d(<3 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_djPU3AS1d(<4 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_djPU3AS1d(<8 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_djPU3AS1d(<16 x double> {{.*}}, i32 0, ptr addrspace(1) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_djPU3AS3d(<2 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_djPU3AS3d(<3 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_djPU3AS3d(<4 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_djPU3AS3d(<8 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_djPU3AS3d(<16 x double> {{.*}}, i32 0, ptr addrspace(3) {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv2_djPd(<2 x double> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv3_djPd(<3 x double> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv4_djPd(<4 x double> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv8_djPd(<8 x double> {{.*}}, i32 0, ptr {{.*}})
+; CHECK-SPV-IR: call spir_func void @_Z19__spirv_ocl_vstorenDv16_djPd(<16 x double> {{.*}}, i32 0, ptr {{.*}})
+;
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren
 ; CHECK-SPV-BACK ExtInst [[VoidTy]] {{.*}} [[Set]] vstoren


### PR DESCRIPTION
Offset arg type is size_t in OpenCL ExtendedInstructionSet Spec.