### PR TITLE
Restore entry point wrapper reverse translation

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3449,6 +3449,27 @@ Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
     return Loc->second;
 
   auto IsKernel = isKernel(BF);
+
+  // Backward compatibility: need to correctly translate entry point wrapper
+  // produced by an older writer.
+  if (IsKernel) {
+    // search for a previous function with the same name
+    // upgrade it to a kernel and drop this if it's found
+    for (auto &I : FuncMap) {
+      const auto &BFName = I.getFirst()->getName();
+      if (BF->getName() == BFName) {
+        auto *F = I.getSecond();
+        F->setCallingConv(CallingConv::SPIR_KERNEL);
+        F->setLinkage(GlobalValue::ExternalLinkage);
+        F->setDSOLocal(false);
+        F = cast<Function>(mapValue(BF, F));
+        mapFunction(BF, F);
+        transFunctionAttrs(BF, F);
+        return F;
+      }
+    }
+  }
+
   auto Linkage = IsKernel ? GlobalValue::ExternalLinkage : transLinkageType(BF);
   FunctionType *FT = cast<FunctionType>(transType(BF->getFunctionType()));
   std::string FuncName = BF->getName();

--- a/test/back-comp-entry-point.spt
+++ b/test/back-comp-entry-point.spt
@@ -1,0 +1,37 @@
+; Test verifies backward compatibility:
+; correct translation of entry point wrapper produced by an
+; older writer.
+
+; RUN: llvm-spirv -spirv-text -r %s -o %t.bc
+; RUN: llvm-dis < %t.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: define spir_kernel void @Test()
+
+119734787 65536 393230 9 0 
+2 Capability Addresses 
+2 Capability Linkage 
+2 Capability Kernel 
+5 ExtInstImport 1 "OpenCL.std" 
+3 MemoryModel 2 2 
+5 EntryPoint 6 6 "Test" 
+3 Source 3 300000 
+4 Name 4 "Test" 
+6 Decorate 4 LinkageAttributes "Test" Export 
+2 TypeVoid 2 
+3 TypeFunction 3 2 
+
+
+5 Function 2 4 0 3 
+
+2 Label 5 
+1 Return 
+
+1 FunctionEnd 
+
+5 Function 2 6 0 3 
+
+2 Label 7 
+4 FunctionCall 2 8 4 
+1 Return 
+
+1 FunctionEnd 


### PR DESCRIPTION
After https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3418, reader can not handle SPIR-V modules with entry point wrappers generated by older versions of the writer. This commit restores the ability to translate such modules back to LLVM IR.