### PR TITLE
Correctly set IsSigned for ConstantInt creation

### DIFF
--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -84,8 +84,8 @@ void SPIRVLowerBoolBase::handleExtInstructions(Instruction &I) {
     auto Opcode = I.getOpcode();
     auto *Ty = I.getType();
     auto *Zero = getScalarOrVectorConstantInt(Ty, 0, false);
-    auto *One = getScalarOrVectorConstantInt(
-        Ty, (Opcode == Instruction::SExt) ? ~0 : 1, false);
+    bool IsSigned = Opcode == Instruction::SExt;
+    auto *One = getScalarOrVectorConstantInt(Ty, IsSigned ? ~0 : 1, IsSigned);
     assert(Zero && One && "Couldn't create constant int");
     auto *Sel = SelectInst::Create(Op, One, Zero, "", I.getIterator());
     replace(&I, Sel);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -188,7 +188,7 @@ static void addBufferLocationMetadata(
       ValueVec.push_back(ForeachFnArg(Arg));
     } else {
       llvm::Metadata *DefaultNode = ConstantAsMetadata::get(
-          ConstantInt::get(Type::getInt32Ty(*Context), -1));
+          ConstantInt::get(Type::getInt32Ty(*Context), -1, true));
       ValueVec.push_back(DefaultNode);
     }
   });

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1573,7 +1573,7 @@ Value *getScalarOrArray(Value *V, unsigned Size, BasicBlock::iterator Pos) {
 
 Constant *getScalarOrVectorConstantInt(Type *T, uint64_t V, bool IsSigned) {
   if (auto *IT = dyn_cast<IntegerType>(T))
-    return ConstantInt::get(IT, V);
+    return ConstantInt::get(IT, V, IsSigned);
   if (auto *VT = dyn_cast<FixedVectorType>(T)) {
     std::vector<Constant *> EV(
         VT->getNumElements(),


### PR DESCRIPTION
Ensure `IsSigned` is correctly set when creating `ConstantInt`s. llvm-project commit `a83c89495ba6 ("Reapply [ConstantInt] Disable implicit truncation in ConstantInt::get() (#171456)", 2026-01-07)` revealed some places where we did not set the flag correctly.