### PR TITLE
[CI] Move Windows builds away from hardcoded -j2

### DIFF
--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -168,7 +168,7 @@ jobs:
         shell: bash
         run: |
           cd build
-          cmake --build . --config ${{ matrix.build_type }} --target llvm-spirv -j2
+          cmake --build . --config ${{ matrix.build_type }} --target llvm-spirv -j $NUMBER_OF_PROCESSORS
           # FIXME: Testing is disabled at the moment as it requires clang to be present
           #       - name: Build tests & test
           #         shell: bash


### PR DESCRIPTION
Instead of the hardcoded `-j2`, use the build tool's default number.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3481