### PR TITLE
[Backport to 21]: Fix C4838: conversion from 'spv::Op' to 'SPIRV::SPIRVWord' requires a narrowing conversion

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1141,7 +1141,8 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
       FPEncodingWrap DstEnc = GetEncodingAndUpdateType(SPVDstTy);
       if (IsFP4OrFP8Encoding(SrcEnc) || IsFP4OrFP8Encoding(DstEnc) ||
           SPVSrcTy->isTypeInt(4) || SPVDstTy->isTypeInt(4)) {
-        FPConversionDesc FPDesc = {SrcEnc, DstEnc, BC->getOpCode()};
+        FPConversionDesc FPDesc = {
+            SrcEnc, DstEnc, static_cast<SPIRV::SPIRVWord>(BC->getOpCode())};
         auto Conv = SPIRV::FPConvertToEncodingMap::rmap(FPDesc);
         std::vector<Value *> Ops = {Src};
         std::vector<Type *> OpsTys = {Src->getType()};


### PR DESCRIPTION
Backport of https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3462 to llvm_release_210 since the same warning appears with latest 21.1.8 release.