### PR TITLE
[Backport to 17] [LLVM->SPIRV] Fix FMA name check (#3499)

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5079,7 +5079,7 @@ SPIRVValue *LLVMToSPIRVBase::transDirectCallInst(CallInst *CI,
         BM->addExtension(
             ExtensionID::SPV_EXT_relaxed_printf_string_address_space);
       }
-    } else if (DemangledName.find("__spirv_ocl_fma") != StringRef::npos) {
+    } else if (DemangledName == "__spirv_ocl_fma") {
       if (BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_fma))
         return BM->addInstTemplate(OpFmaKHR,
                                    BM->getIds(transValue(getArguments(CI), BB)),

--- a/test/transcoding/fmax.ll
+++ b/test/transcoding/fmax.ll
@@ -1,0 +1,25 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_fma -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.rev.ll
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; Check enabling SPV_KHR_fma does not translate fmax to fma.
+
+; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] fmax [[#]] [[#]]
+
+; CHECK-LLVM: %{{.*}} = call spir_func float @_Z4fmaxff(float %{{.*}}, float %{{.*}})
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; Case to test fmax translation via OCL builtins.
+define spir_func float @test_fmax_ocl_scalar(float %a, float %b) {
+entry:
+  %result = call spir_func float @_Z16__spirv_ocl_fmaxff(float %a, float %b)
+  ret float %result
+}
+
+declare spir_func float @_Z16__spirv_ocl_fmaxff(float, float)


### PR DESCRIPTION
Previous check in 199d2e027d65 translated __spirv_ocl_fmax to FMA.

(cherry picked from commit 64b7a078f6a800231c8c2343c3937c72a121f4b5)