### PR TITLE
[Backport to 20] [CI] Move away from hardcoded -j2 (#3483)

### DIFF
--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -101,11 +101,11 @@ jobs:
       - name: Build
         run: |
           cd build
-          make llvm-spirv -j2
+          make llvm-spirv -j$(nproc)
       - name: Build tests & test
         run: |
           cd build
-          make check-llvm-spirv -j2
+          make check-llvm-spirv -j$(nproc)
 
   build_windows:
     name: Windows
@@ -200,7 +200,7 @@ jobs:
       - name: Build
         run: |
           cd build
-          make llvm-spirv -j2
+          make llvm-spirv -j$(sysctl -n hw.logicalcpu)
           # FIXME: Testing is disabled at the moment as it requires clang to be present
           # - name: Build tests & test
           #   run: |

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -87,8 +87,8 @@ jobs:
       - name: Build
         run: |
           cd build
-          make llvm-spirv -j2
+          make llvm-spirv -j$(nproc)
       - name: Build tests & test
         run: |
           cd build
-          make check-llvm-spirv -j2
+          make check-llvm-spirv -j$(nproc)


### PR DESCRIPTION
Instead of the hardcoded `-j2`, use the number of available processing units.

Fixes https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3481

(cherry picked from commit f20a37d81ce3b0cb04b246f45bed5576ed7423b3)