### PR TITLE
[NFC] Change ExtensionNamesMap type to DenseMap<StringRef, ExtensionID>

### DIFF
--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -578,7 +578,7 @@ static int parseSPVExtOption(
     cl::list<std::string> &SPVExtList,
     SPIRV::TranslatorOpts::ExtensionsStatusMap &ExtensionsStatus) {
   // Map name -> id for known extensions
-  std::map<std::string, ExtensionID> ExtensionNamesMap;
+  DenseMap<StringRef, ExtensionID> ExtensionNamesMap;
 #define _STRINGIFY(X) #X
 #define STRINGIFY(X) _STRINGIFY(X)
 #define EXT(X) ExtensionNamesMap[STRINGIFY(X)] = ExtensionID::X;
@@ -602,7 +602,7 @@ static int parseSPVExtOption(
     return 0; // Nothing to do
 
   for (unsigned i = 0; i < SPVExtList.size(); ++i) {
-    const std::string &ExtString = SPVExtList[i];
+    StringRef ExtString = SPVExtList[i];
     if (ExtString.empty() ||
         ('+' != ExtString.front() && '-' != ExtString.front())) {
       errs() << "Invalid value of --spirv-ext, expected format is:\n"
@@ -610,7 +610,7 @@ static int parseSPVExtOption(
       return -1;
     }
 
-    auto ExtName = ExtString.substr(1);
+    StringRef ExtName = ExtString.drop_front();
 
     if (ExtName.empty()) {
       errs() << "Invalid value of --spirv-ext, expected format is:\n"


### PR DESCRIPTION
The new type is faster and avoids per-key mem allocation.