### PR TITLE
Update for DITypeRefArray removal

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -899,7 +899,7 @@ LLVMToSPIRVDbgTran::transDbgSubroutineType(const DISubroutineType *FT) {
   SPIRVWordVec Ops(MinOperandCount);
   Ops[FlagsIdx] = transDebugFlags(FT);
 
-  DITypeRefArray Types = FT->getTypeArray();
+  DITypeArray Types = FT->getTypeArray();
   const size_t NumElements = Types.size();
   if (NumElements) {
     Ops.resize(1 + NumElements);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -843,8 +843,7 @@ DINode *SPIRVToLLVMDbgTran::transTypeFunction(const SPIRVExtInst *DebugInst) {
 
     Elements.push_back(Param);
   }
-  DITypeRefArray ArgTypes =
-      getDIBuilder(DebugInst).getOrCreateTypeArray(Elements);
+  DITypeArray ArgTypes = getDIBuilder(DebugInst).getOrCreateTypeArray(Elements);
   return getDIBuilder(DebugInst).createSubroutineType(ArgTypes, Flags);
 }
 


### PR DESCRIPTION
Update for llvm-project commit `8f90efdee83e ("[llvm][DebugInfo][NFC] Remove DITypeRefArray in favour of DITypeArray (#177066)", 2026-01-21)`.