### PR TITLE
Widen integers if arbitrary precision integers are not supported

### DIFF
--- a/test/extensions/INTEL/SPV_INTEL_arbitrary_precision_integers/widen-integers.ll
+++ b/test/extensions/INTEL/SPV_INTEL_arbitrary_precision_integers/widen-integers.ll
@@ -1,0 +1,43 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=-SPV_INTEL_arbitrary_precision_integers -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; RUN: llvm-spirv -spirv-text -r %t.spt -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-NOT: Capability ArbitraryPrecisionIntegersINTEL
+; CHECK-SPIRV-NOT: Extension "SPV_INTEL_arbitrary_precision_integers"
+
+; CHECK-SPIRV-DAG: TypeInt {{[0-9]+}} 16 0
+; CHECK-SPIRV-DAG: TypeInt {{[0-9]+}} 64 0
+; CHECK-SPIRV-DAG: TypeInt {{[0-9]+}} 32 0
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-LLVM: @a = addrspace(1) global i16 0, align 2
+@a = addrspace(1) global i13 0, align 2
+; CHECK-LLVM: @b = addrspace(1) global i64 0, align 8
+@b = addrspace(1) global i58 0, align 8
+; CHECK-LLVM: @c = addrspace(1) global i64 0, align 8
+@c = addrspace(1) global i48 0, align 8
+
+; Function Attrs: noinline nounwind optnone
+; CHECK-LLVM: void @_Z4funci(i32 %a)
+define spir_func void @_Z4funci(i30 %a) {
+entry:
+; CHECK-LLVM: %a.addr = alloca i32
+  %a.addr = alloca i30, align 4
+; CHECK-LLVM: store i32 %a, ptr %a.addr
+  store i30 %a, ptr %a.addr, align 4
+; CHECK-LLVM: store i32 1, ptr %a.addr
+  store i30 1, ptr %a.addr, align 4
+; underflowed to max(48bit) - 4294901761
+; CHECK-LLVM: store i64 281470681808895, ptr addrspace(1) @c
+  store i48 -4294901761, ptr addrspace(1) @c, align 8
+  ret void
+}


### PR DESCRIPTION
This is a conversion that's also happening in the LLVM SPIRV backend so it would make sense to add support for this.