### PR TITLE
Update OCL nan builtin translation to work with bfloat type

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2660,7 +2660,7 @@ class OpenCLStdToSPIRVFriendlyIRMangleInfo : public BuiltinFuncMangleInfo {
 public:
   OpenCLStdToSPIRVFriendlyIRMangleInfo(OCLExtOpKind ExtOpId,
                                        ArrayRef<Type *> ArgTys, Type *RetTy)
-      : ExtOpId(ExtOpId), ArgTys(ArgTys) {
+      : ExtOpId(ExtOpId), ArgTys(ArgTys), RetTy(RetTy) {
 
     std::string Postfix = "";
     if (needRetTypePostfix())
@@ -2675,8 +2675,12 @@ public:
     case OpenCLLIB::Vload_halfn:
     case OpenCLLIB::Vloada_halfn:
     case OpenCLLIB::Vloadn:
-    case OpenCLLIB::Nan:
       return true;
+    case OpenCLLIB::Nan:
+      // Only add return type mangling for bfloat16 to disambiguate from half
+      // (both are represented as i16 in LLVM). Float and half use traditional
+      // naming for backward compatibility.
+      return RetTy->getScalarType()->isBFloatTy();
     default:
       return false;
     }
@@ -2742,6 +2746,7 @@ public:
 private:
   OCLExtOpKind ExtOpId;
   ArrayRef<Type *> ArgTys;
+  Type *RetTy;
 };
 } // namespace
 

--- a/test/transcoding/OpenCL/nan.ll
+++ b/test/transcoding/OpenCL/nan.ll
@@ -16,7 +16,7 @@ target triple = "spir64"
 
 ; CHECK-LLVM: call spir_func float @_Z3nanj(
 
-; CHECK-SPV-IR: call spir_func float @_Z22__spirv_ocl_nan_Rfloatj(
+; CHECK-SPV-IR: call spir_func float @_Z15__spirv_ocl_nanj(
 
 define dso_local spir_kernel void @test(ptr addrspace(1) align 4 %a, i32 %b) {
 entry:

--- a/test/transcoding/OpenCL/nan_bfloat.ll
+++ b/test/transcoding/OpenCL/nan_bfloat.ll
@@ -17,7 +17,7 @@ target triple = "spir64"
 ; CHECK-SPIRV: ExtInst [[#HALF]] [[#]] [[#]] nan
 
 ; CHECK-SPV-IR: call spir_func bfloat @_Z22__spirv_ocl_nan_RDF16bt(
-; CHECK-SPV-IR: call spir_func half @_Z21__spirv_ocl_nan_Rhalft(
+; CHECK-SPV-IR: call spir_func half @_Z15__spirv_ocl_nant(
 
 define dso_local spir_kernel void @test_bfloat(ptr addrspace(1) align 2 %a, i16 %b) {
 entry:


### PR DESCRIPTION
To avoid name clash between builtins with different return types, (`half` and `bfloat` specifically), introduce return type postfix for `nan` builtin in reverse translation to SPIR-V Friendly IR. 