### PR TITLE
Follow return type name convention for extended instructions for SPIR-V friendly IR

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1906,7 +1906,7 @@ bool isSPIRVOCLExtInst(const CallInst *CI, OCLExtOpKind *ExtOp) {
     return false;
 
   auto ExtOpName = S.substr(Loc + 1);
-  auto PostFixPos = ExtOpName.find("_R");
+  auto PostFixPos = ExtOpName.find("__R");
   ExtOpName = ExtOpName.substr(0, PostFixPos);
 
   OCLExtOpKind EOC;
@@ -2659,7 +2659,8 @@ public:
 
     std::string Postfix = "";
     if (needRetTypePostfix())
-      Postfix = kSPIRVPostfix::Divider + getPostfixForReturnType(RetTy, true);
+      Postfix =
+          kSPIRVPostfix::ExtDivider + getPostfixForReturnType(RetTy, true);
 
     UnmangledName = getSPIRVExtFuncName(SPIRVEIS_OpenCL, ExtOpId, Postfix);
   }

--- a/test/OpenCL.std/vload_half.spvasm
+++ b/test/OpenCL.std/vload_half.spvasm
@@ -6,22 +6,22 @@
 ;
 ; CHECK-LABEL: spir_kernel void @test
 ;
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS1KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS1KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS1KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS1KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS3KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS3KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS3KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS3KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS2KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS2KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS2KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPU3AS2KDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPKDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPKDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPKDh(
-; CHECK-SPV-IR: call spir_func float @_Z29__spirv_ocl_vload_half_RfloatjPKDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS1KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS1KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS1KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS1KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS3KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS3KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS3KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS3KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS2KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS2KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS2KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPU3AS2KDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPKDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPKDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPKDh(
+; CHECK-SPV-IR: call spir_func float @_Z30__spirv_ocl_vload_half__RfloatjPKDh(
 ;
 ; CHECK-CL20: call spir_func float @_Z10vload_halfjPU3AS1KDh
 ; CHECK-CL20: call spir_func float @_Z10vload_halfjPU3AS1KDh

--- a/test/OpenCL.std/vload_halfn.spvasm
+++ b/test/OpenCL.std/vload_halfn.spvasm
@@ -6,26 +6,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @test
 ;
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat2jPKDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat3jPKDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat4jPKDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z31__spirv_ocl_vload_halfn_Rfloat8jPKDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z32__spirv_ocl_vload_halfn_Rfloat16jPKDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat2jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat3jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat4jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat8jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vload_halfn__Rfloat16jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat2jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat3jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat4jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat8jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vload_halfn__Rfloat16jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat2jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat3jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat4jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat8jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vload_halfn__Rfloat16jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat2jPKDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat3jPKDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat4jPKDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vload_halfn__Rfloat8jPKDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vload_halfn__Rfloat16jPKDhi(
 ;
 ; CHECK-CL20: call spir_func <2 x float> @_Z11vload_half2jPU3AS1KDh(
 ; CHECK-CL20: call spir_func <3 x float> @_Z11vload_half3jPU3AS1KDh(

--- a/test/OpenCL.std/vloada_halfn.spvasm
+++ b/test/OpenCL.std/vloada_halfn.spvasm
@@ -6,26 +6,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @test
 ;
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat2jPKDhi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat3jPKDhi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat4jPKDhi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z32__spirv_ocl_vloada_halfn_Rfloat8jPKDhi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z33__spirv_ocl_vloada_halfn_Rfloat16jPKDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat2jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat3jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat4jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat8jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z34__spirv_ocl_vloada_halfn__Rfloat16jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat2jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat3jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat4jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat8jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z34__spirv_ocl_vloada_halfn__Rfloat16jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat2jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat3jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat4jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat8jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z34__spirv_ocl_vloada_halfn__Rfloat16jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat2jPKDhi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat3jPKDhi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat4jPKDhi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z33__spirv_ocl_vloada_halfn__Rfloat8jPKDhi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z34__spirv_ocl_vloada_halfn__Rfloat16jPKDhi(
 ;
 ; CHECK-CL20: call spir_func <2 x float> @_Z12vloada_half2jPU3AS1KDh(
 ; CHECK-CL20: call spir_func <3 x float> @_Z12vloada_half3jPU3AS1KDh(

--- a/test/OpenCL.std/vloadn.spvasm
+++ b/test/OpenCL.std/vloadn.spvasm
@@ -6,26 +6,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testChar
 ;
-; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2jPU3AS1Kci(
-; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3jPU3AS1Kci(
-; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4jPU3AS1Kci(
-; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8jPU3AS1Kci(
-; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16jPU3AS1Kci(
-; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2jPU3AS3Kci(
-; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3jPU3AS3Kci(
-; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4jPU3AS3Kci(
-; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8jPU3AS3Kci(
-; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16jPU3AS3Kci(
-; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2jPU3AS2Kci(
-; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3jPU3AS2Kci(
-; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4jPU3AS2Kci(
-; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8jPU3AS2Kci(
-; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16jPU3AS2Kci(
-; CHECK-SPV-IR: call spir_func <2 x i8> @_Z25__spirv_ocl_vloadn_Rchar2jPKci(
-; CHECK-SPV-IR: call spir_func <3 x i8> @_Z25__spirv_ocl_vloadn_Rchar3jPKci(
-; CHECK-SPV-IR: call spir_func <4 x i8> @_Z25__spirv_ocl_vloadn_Rchar4jPKci(
-; CHECK-SPV-IR: call spir_func <8 x i8> @_Z25__spirv_ocl_vloadn_Rchar8jPKci(
-; CHECK-SPV-IR: call spir_func <16 x i8> @_Z26__spirv_ocl_vloadn_Rchar16jPKci(
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z26__spirv_ocl_vloadn__Rchar2jPU3AS1Kci(
+; CHECK-SPV-IR: call spir_func <3 x i8> @_Z26__spirv_ocl_vloadn__Rchar3jPU3AS1Kci(
+; CHECK-SPV-IR: call spir_func <4 x i8> @_Z26__spirv_ocl_vloadn__Rchar4jPU3AS1Kci(
+; CHECK-SPV-IR: call spir_func <8 x i8> @_Z26__spirv_ocl_vloadn__Rchar8jPU3AS1Kci(
+; CHECK-SPV-IR: call spir_func <16 x i8> @_Z27__spirv_ocl_vloadn__Rchar16jPU3AS1Kci(
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z26__spirv_ocl_vloadn__Rchar2jPU3AS3Kci(
+; CHECK-SPV-IR: call spir_func <3 x i8> @_Z26__spirv_ocl_vloadn__Rchar3jPU3AS3Kci(
+; CHECK-SPV-IR: call spir_func <4 x i8> @_Z26__spirv_ocl_vloadn__Rchar4jPU3AS3Kci(
+; CHECK-SPV-IR: call spir_func <8 x i8> @_Z26__spirv_ocl_vloadn__Rchar8jPU3AS3Kci(
+; CHECK-SPV-IR: call spir_func <16 x i8> @_Z27__spirv_ocl_vloadn__Rchar16jPU3AS3Kci(
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z26__spirv_ocl_vloadn__Rchar2jPU3AS2Kci(
+; CHECK-SPV-IR: call spir_func <3 x i8> @_Z26__spirv_ocl_vloadn__Rchar3jPU3AS2Kci(
+; CHECK-SPV-IR: call spir_func <4 x i8> @_Z26__spirv_ocl_vloadn__Rchar4jPU3AS2Kci(
+; CHECK-SPV-IR: call spir_func <8 x i8> @_Z26__spirv_ocl_vloadn__Rchar8jPU3AS2Kci(
+; CHECK-SPV-IR: call spir_func <16 x i8> @_Z27__spirv_ocl_vloadn__Rchar16jPU3AS2Kci(
+; CHECK-SPV-IR: call spir_func <2 x i8> @_Z26__spirv_ocl_vloadn__Rchar2jPKci(
+; CHECK-SPV-IR: call spir_func <3 x i8> @_Z26__spirv_ocl_vloadn__Rchar3jPKci(
+; CHECK-SPV-IR: call spir_func <4 x i8> @_Z26__spirv_ocl_vloadn__Rchar4jPKci(
+; CHECK-SPV-IR: call spir_func <8 x i8> @_Z26__spirv_ocl_vloadn__Rchar8jPKci(
+; CHECK-SPV-IR: call spir_func <16 x i8> @_Z27__spirv_ocl_vloadn__Rchar16jPKci(
 ;
 ; CHECK-CL20: call spir_func <2 x i8> @_Z6vload2jPU3AS1Kc(
 ; CHECK-CL20: call spir_func <3 x i8> @_Z6vload3jPU3AS1Kc(
@@ -50,26 +50,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testShort
 ;
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2jPU3AS1Ksi(
-; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3jPU3AS1Ksi(
-; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4jPU3AS1Ksi(
-; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8jPU3AS1Ksi(
-; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16jPU3AS1Ksi(
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2jPU3AS3Ksi(
-; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3jPU3AS3Ksi(
-; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4jPU3AS3Ksi(
-; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8jPU3AS3Ksi(
-; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16jPU3AS3Ksi(
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2jPU3AS2Ksi(
-; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3jPU3AS2Ksi(
-; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4jPU3AS2Ksi(
-; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8jPU3AS2Ksi(
-; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16jPU3AS2Ksi(
-; CHECK-SPV-IR: call spir_func <2 x i16> @_Z26__spirv_ocl_vloadn_Rshort2jPKsi(
-; CHECK-SPV-IR: call spir_func <3 x i16> @_Z26__spirv_ocl_vloadn_Rshort3jPKsi(
-; CHECK-SPV-IR: call spir_func <4 x i16> @_Z26__spirv_ocl_vloadn_Rshort4jPKsi(
-; CHECK-SPV-IR: call spir_func <8 x i16> @_Z26__spirv_ocl_vloadn_Rshort8jPKsi(
-; CHECK-SPV-IR: call spir_func <16 x i16> @_Z27__spirv_ocl_vloadn_Rshort16jPKsi(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z27__spirv_ocl_vloadn__Rshort2jPU3AS1Ksi(
+; CHECK-SPV-IR: call spir_func <3 x i16> @_Z27__spirv_ocl_vloadn__Rshort3jPU3AS1Ksi(
+; CHECK-SPV-IR: call spir_func <4 x i16> @_Z27__spirv_ocl_vloadn__Rshort4jPU3AS1Ksi(
+; CHECK-SPV-IR: call spir_func <8 x i16> @_Z27__spirv_ocl_vloadn__Rshort8jPU3AS1Ksi(
+; CHECK-SPV-IR: call spir_func <16 x i16> @_Z28__spirv_ocl_vloadn__Rshort16jPU3AS1Ksi(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z27__spirv_ocl_vloadn__Rshort2jPU3AS3Ksi(
+; CHECK-SPV-IR: call spir_func <3 x i16> @_Z27__spirv_ocl_vloadn__Rshort3jPU3AS3Ksi(
+; CHECK-SPV-IR: call spir_func <4 x i16> @_Z27__spirv_ocl_vloadn__Rshort4jPU3AS3Ksi(
+; CHECK-SPV-IR: call spir_func <8 x i16> @_Z27__spirv_ocl_vloadn__Rshort8jPU3AS3Ksi(
+; CHECK-SPV-IR: call spir_func <16 x i16> @_Z28__spirv_ocl_vloadn__Rshort16jPU3AS3Ksi(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z27__spirv_ocl_vloadn__Rshort2jPU3AS2Ksi(
+; CHECK-SPV-IR: call spir_func <3 x i16> @_Z27__spirv_ocl_vloadn__Rshort3jPU3AS2Ksi(
+; CHECK-SPV-IR: call spir_func <4 x i16> @_Z27__spirv_ocl_vloadn__Rshort4jPU3AS2Ksi(
+; CHECK-SPV-IR: call spir_func <8 x i16> @_Z27__spirv_ocl_vloadn__Rshort8jPU3AS2Ksi(
+; CHECK-SPV-IR: call spir_func <16 x i16> @_Z28__spirv_ocl_vloadn__Rshort16jPU3AS2Ksi(
+; CHECK-SPV-IR: call spir_func <2 x i16> @_Z27__spirv_ocl_vloadn__Rshort2jPKsi(
+; CHECK-SPV-IR: call spir_func <3 x i16> @_Z27__spirv_ocl_vloadn__Rshort3jPKsi(
+; CHECK-SPV-IR: call spir_func <4 x i16> @_Z27__spirv_ocl_vloadn__Rshort4jPKsi(
+; CHECK-SPV-IR: call spir_func <8 x i16> @_Z27__spirv_ocl_vloadn__Rshort8jPKsi(
+; CHECK-SPV-IR: call spir_func <16 x i16> @_Z28__spirv_ocl_vloadn__Rshort16jPKsi(
 ;
 ; CHECK-CL20: call spir_func <2 x i16> @_Z6vload2jPU3AS1Ks(
 ; CHECK-CL20: call spir_func <3 x i16> @_Z6vload3jPU3AS1Ks(
@@ -94,26 +94,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testInt
 ;
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2jPU3AS1Kii(
-; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3jPU3AS1Kii(
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4jPU3AS1Kii(
-; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8jPU3AS1Kii(
-; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16jPU3AS1Kii(
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2jPU3AS3Kii(
-; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3jPU3AS3Kii(
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4jPU3AS3Kii(
-; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8jPU3AS3Kii(
-; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16jPU3AS3Kii(
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2jPU3AS2Kii(
-; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3jPU3AS2Kii(
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4jPU3AS2Kii(
-; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8jPU3AS2Kii(
-; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16jPU3AS2Kii(
-; CHECK-SPV-IR: call spir_func <2 x i32> @_Z24__spirv_ocl_vloadn_Rint2jPKii(
-; CHECK-SPV-IR: call spir_func <3 x i32> @_Z24__spirv_ocl_vloadn_Rint3jPKii(
-; CHECK-SPV-IR: call spir_func <4 x i32> @_Z24__spirv_ocl_vloadn_Rint4jPKii(
-; CHECK-SPV-IR: call spir_func <8 x i32> @_Z24__spirv_ocl_vloadn_Rint8jPKii(
-; CHECK-SPV-IR: call spir_func <16 x i32> @_Z25__spirv_ocl_vloadn_Rint16jPKii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z25__spirv_ocl_vloadn__Rint2jPU3AS1Kii(
+; CHECK-SPV-IR: call spir_func <3 x i32> @_Z25__spirv_ocl_vloadn__Rint3jPU3AS1Kii(
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z25__spirv_ocl_vloadn__Rint4jPU3AS1Kii(
+; CHECK-SPV-IR: call spir_func <8 x i32> @_Z25__spirv_ocl_vloadn__Rint8jPU3AS1Kii(
+; CHECK-SPV-IR: call spir_func <16 x i32> @_Z26__spirv_ocl_vloadn__Rint16jPU3AS1Kii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z25__spirv_ocl_vloadn__Rint2jPU3AS3Kii(
+; CHECK-SPV-IR: call spir_func <3 x i32> @_Z25__spirv_ocl_vloadn__Rint3jPU3AS3Kii(
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z25__spirv_ocl_vloadn__Rint4jPU3AS3Kii(
+; CHECK-SPV-IR: call spir_func <8 x i32> @_Z25__spirv_ocl_vloadn__Rint8jPU3AS3Kii(
+; CHECK-SPV-IR: call spir_func <16 x i32> @_Z26__spirv_ocl_vloadn__Rint16jPU3AS3Kii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z25__spirv_ocl_vloadn__Rint2jPU3AS2Kii(
+; CHECK-SPV-IR: call spir_func <3 x i32> @_Z25__spirv_ocl_vloadn__Rint3jPU3AS2Kii(
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z25__spirv_ocl_vloadn__Rint4jPU3AS2Kii(
+; CHECK-SPV-IR: call spir_func <8 x i32> @_Z25__spirv_ocl_vloadn__Rint8jPU3AS2Kii(
+; CHECK-SPV-IR: call spir_func <16 x i32> @_Z26__spirv_ocl_vloadn__Rint16jPU3AS2Kii(
+; CHECK-SPV-IR: call spir_func <2 x i32> @_Z25__spirv_ocl_vloadn__Rint2jPKii(
+; CHECK-SPV-IR: call spir_func <3 x i32> @_Z25__spirv_ocl_vloadn__Rint3jPKii(
+; CHECK-SPV-IR: call spir_func <4 x i32> @_Z25__spirv_ocl_vloadn__Rint4jPKii(
+; CHECK-SPV-IR: call spir_func <8 x i32> @_Z25__spirv_ocl_vloadn__Rint8jPKii(
+; CHECK-SPV-IR: call spir_func <16 x i32> @_Z26__spirv_ocl_vloadn__Rint16jPKii(
 ;
 ; CHECK-CL20: call spir_func <2 x i32> @_Z6vload2jPU3AS1Ki(
 ; CHECK-CL20: call spir_func <3 x i32> @_Z6vload3jPU3AS1Ki(
@@ -138,26 +138,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testLong
 ;
-; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2jPU3AS1Kli(
-; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3jPU3AS1Kli(
-; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4jPU3AS1Kli(
-; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8jPU3AS1Kli(
-; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16jPU3AS1Kli(
-; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2jPU3AS3Kli(
-; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3jPU3AS3Kli(
-; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4jPU3AS3Kli(
-; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8jPU3AS3Kli(
-; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16jPU3AS3Kli(
-; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2jPU3AS2Kli(
-; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3jPU3AS2Kli(
-; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4jPU3AS2Kli(
-; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8jPU3AS2Kli(
-; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16jPU3AS2Kli(
-; CHECK-SPV-IR: call spir_func <2 x i64> @_Z25__spirv_ocl_vloadn_Rlong2jPKli(
-; CHECK-SPV-IR: call spir_func <3 x i64> @_Z25__spirv_ocl_vloadn_Rlong3jPKli(
-; CHECK-SPV-IR: call spir_func <4 x i64> @_Z25__spirv_ocl_vloadn_Rlong4jPKli(
-; CHECK-SPV-IR: call spir_func <8 x i64> @_Z25__spirv_ocl_vloadn_Rlong8jPKli(
-; CHECK-SPV-IR: call spir_func <16 x i64> @_Z26__spirv_ocl_vloadn_Rlong16jPKli(
+; CHECK-SPV-IR: call spir_func <2 x i64> @_Z26__spirv_ocl_vloadn__Rlong2jPU3AS1Kli(
+; CHECK-SPV-IR: call spir_func <3 x i64> @_Z26__spirv_ocl_vloadn__Rlong3jPU3AS1Kli(
+; CHECK-SPV-IR: call spir_func <4 x i64> @_Z26__spirv_ocl_vloadn__Rlong4jPU3AS1Kli(
+; CHECK-SPV-IR: call spir_func <8 x i64> @_Z26__spirv_ocl_vloadn__Rlong8jPU3AS1Kli(
+; CHECK-SPV-IR: call spir_func <16 x i64> @_Z27__spirv_ocl_vloadn__Rlong16jPU3AS1Kli(
+; CHECK-SPV-IR: call spir_func <2 x i64> @_Z26__spirv_ocl_vloadn__Rlong2jPU3AS3Kli(
+; CHECK-SPV-IR: call spir_func <3 x i64> @_Z26__spirv_ocl_vloadn__Rlong3jPU3AS3Kli(
+; CHECK-SPV-IR: call spir_func <4 x i64> @_Z26__spirv_ocl_vloadn__Rlong4jPU3AS3Kli(
+; CHECK-SPV-IR: call spir_func <8 x i64> @_Z26__spirv_ocl_vloadn__Rlong8jPU3AS3Kli(
+; CHECK-SPV-IR: call spir_func <16 x i64> @_Z27__spirv_ocl_vloadn__Rlong16jPU3AS3Kli(
+; CHECK-SPV-IR: call spir_func <2 x i64> @_Z26__spirv_ocl_vloadn__Rlong2jPU3AS2Kli(
+; CHECK-SPV-IR: call spir_func <3 x i64> @_Z26__spirv_ocl_vloadn__Rlong3jPU3AS2Kli(
+; CHECK-SPV-IR: call spir_func <4 x i64> @_Z26__spirv_ocl_vloadn__Rlong4jPU3AS2Kli(
+; CHECK-SPV-IR: call spir_func <8 x i64> @_Z26__spirv_ocl_vloadn__Rlong8jPU3AS2Kli(
+; CHECK-SPV-IR: call spir_func <16 x i64> @_Z27__spirv_ocl_vloadn__Rlong16jPU3AS2Kli(
+; CHECK-SPV-IR: call spir_func <2 x i64> @_Z26__spirv_ocl_vloadn__Rlong2jPKli(
+; CHECK-SPV-IR: call spir_func <3 x i64> @_Z26__spirv_ocl_vloadn__Rlong3jPKli(
+; CHECK-SPV-IR: call spir_func <4 x i64> @_Z26__spirv_ocl_vloadn__Rlong4jPKli(
+; CHECK-SPV-IR: call spir_func <8 x i64> @_Z26__spirv_ocl_vloadn__Rlong8jPKli(
+; CHECK-SPV-IR: call spir_func <16 x i64> @_Z27__spirv_ocl_vloadn__Rlong16jPKli(
 ;
 ; CHECK-CL20: call spir_func <2 x i64> @_Z6vload2jPU3AS1Kl(
 ; CHECK-CL20: call spir_func <3 x i64> @_Z6vload3jPU3AS1Kl(
@@ -182,26 +182,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testHalf
 ;
-; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16jPU3AS1KDhi(
-; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16jPU3AS3KDhi(
-; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16jPU3AS2KDhi(
-; CHECK-SPV-IR: call spir_func <2 x half> @_Z25__spirv_ocl_vloadn_Rhalf2jPKDhi(
-; CHECK-SPV-IR: call spir_func <3 x half> @_Z25__spirv_ocl_vloadn_Rhalf3jPKDhi(
-; CHECK-SPV-IR: call spir_func <4 x half> @_Z25__spirv_ocl_vloadn_Rhalf4jPKDhi(
-; CHECK-SPV-IR: call spir_func <8 x half> @_Z25__spirv_ocl_vloadn_Rhalf8jPKDhi(
-; CHECK-SPV-IR: call spir_func <16 x half> @_Z26__spirv_ocl_vloadn_Rhalf16jPKDhi(
+; CHECK-SPV-IR: call spir_func <2 x half> @_Z26__spirv_ocl_vloadn__Rhalf2jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <3 x half> @_Z26__spirv_ocl_vloadn__Rhalf3jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <4 x half> @_Z26__spirv_ocl_vloadn__Rhalf4jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <8 x half> @_Z26__spirv_ocl_vloadn__Rhalf8jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <16 x half> @_Z27__spirv_ocl_vloadn__Rhalf16jPU3AS1KDhi(
+; CHECK-SPV-IR: call spir_func <2 x half> @_Z26__spirv_ocl_vloadn__Rhalf2jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <3 x half> @_Z26__spirv_ocl_vloadn__Rhalf3jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <4 x half> @_Z26__spirv_ocl_vloadn__Rhalf4jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <8 x half> @_Z26__spirv_ocl_vloadn__Rhalf8jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <16 x half> @_Z27__spirv_ocl_vloadn__Rhalf16jPU3AS3KDhi(
+; CHECK-SPV-IR: call spir_func <2 x half> @_Z26__spirv_ocl_vloadn__Rhalf2jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <3 x half> @_Z26__spirv_ocl_vloadn__Rhalf3jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <4 x half> @_Z26__spirv_ocl_vloadn__Rhalf4jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <8 x half> @_Z26__spirv_ocl_vloadn__Rhalf8jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <16 x half> @_Z27__spirv_ocl_vloadn__Rhalf16jPU3AS2KDhi(
+; CHECK-SPV-IR: call spir_func <2 x half> @_Z26__spirv_ocl_vloadn__Rhalf2jPKDhi(
+; CHECK-SPV-IR: call spir_func <3 x half> @_Z26__spirv_ocl_vloadn__Rhalf3jPKDhi(
+; CHECK-SPV-IR: call spir_func <4 x half> @_Z26__spirv_ocl_vloadn__Rhalf4jPKDhi(
+; CHECK-SPV-IR: call spir_func <8 x half> @_Z26__spirv_ocl_vloadn__Rhalf8jPKDhi(
+; CHECK-SPV-IR: call spir_func <16 x half> @_Z27__spirv_ocl_vloadn__Rhalf16jPKDhi(
 ;
 ; CHECK-CL20: call spir_func <2 x half> @_Z6vload2jPU3AS1KDh(
 ; CHECK-CL20: call spir_func <3 x half> @_Z6vload3jPU3AS1KDh(
@@ -226,26 +226,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testFloat
 ;
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2jPU3AS1Kfi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3jPU3AS1Kfi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4jPU3AS1Kfi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8jPU3AS1Kfi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16jPU3AS1Kfi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2jPU3AS3Kfi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3jPU3AS3Kfi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4jPU3AS3Kfi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8jPU3AS3Kfi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16jPU3AS3Kfi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2jPU3AS2Kfi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3jPU3AS2Kfi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4jPU3AS2Kfi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8jPU3AS2Kfi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16jPU3AS2Kfi(
-; CHECK-SPV-IR: call spir_func <2 x float> @_Z26__spirv_ocl_vloadn_Rfloat2jPKfi(
-; CHECK-SPV-IR: call spir_func <3 x float> @_Z26__spirv_ocl_vloadn_Rfloat3jPKfi(
-; CHECK-SPV-IR: call spir_func <4 x float> @_Z26__spirv_ocl_vloadn_Rfloat4jPKfi(
-; CHECK-SPV-IR: call spir_func <8 x float> @_Z26__spirv_ocl_vloadn_Rfloat8jPKfi(
-; CHECK-SPV-IR: call spir_func <16 x float> @_Z27__spirv_ocl_vloadn_Rfloat16jPKfi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z27__spirv_ocl_vloadn__Rfloat2jPU3AS1Kfi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z27__spirv_ocl_vloadn__Rfloat3jPU3AS1Kfi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z27__spirv_ocl_vloadn__Rfloat4jPU3AS1Kfi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z27__spirv_ocl_vloadn__Rfloat8jPU3AS1Kfi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z28__spirv_ocl_vloadn__Rfloat16jPU3AS1Kfi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z27__spirv_ocl_vloadn__Rfloat2jPU3AS3Kfi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z27__spirv_ocl_vloadn__Rfloat3jPU3AS3Kfi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z27__spirv_ocl_vloadn__Rfloat4jPU3AS3Kfi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z27__spirv_ocl_vloadn__Rfloat8jPU3AS3Kfi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z28__spirv_ocl_vloadn__Rfloat16jPU3AS3Kfi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z27__spirv_ocl_vloadn__Rfloat2jPU3AS2Kfi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z27__spirv_ocl_vloadn__Rfloat3jPU3AS2Kfi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z27__spirv_ocl_vloadn__Rfloat4jPU3AS2Kfi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z27__spirv_ocl_vloadn__Rfloat8jPU3AS2Kfi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z28__spirv_ocl_vloadn__Rfloat16jPU3AS2Kfi(
+; CHECK-SPV-IR: call spir_func <2 x float> @_Z27__spirv_ocl_vloadn__Rfloat2jPKfi(
+; CHECK-SPV-IR: call spir_func <3 x float> @_Z27__spirv_ocl_vloadn__Rfloat3jPKfi(
+; CHECK-SPV-IR: call spir_func <4 x float> @_Z27__spirv_ocl_vloadn__Rfloat4jPKfi(
+; CHECK-SPV-IR: call spir_func <8 x float> @_Z27__spirv_ocl_vloadn__Rfloat8jPKfi(
+; CHECK-SPV-IR: call spir_func <16 x float> @_Z28__spirv_ocl_vloadn__Rfloat16jPKfi(
 ;
 ; CHECK-CL20: call spir_func <2 x float> @_Z6vload2jPU3AS1Kf(
 ; CHECK-CL20: call spir_func <3 x float> @_Z6vload3jPU3AS1Kf(
@@ -270,26 +270,26 @@
 ;
 ; CHECK-LABEL: spir_kernel void @testDouble
 ;
-; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2jPU3AS1Kdi(
-; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3jPU3AS1Kdi(
-; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4jPU3AS1Kdi(
-; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8jPU3AS1Kdi(
-; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16jPU3AS1Kdi(
-; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2jPU3AS3Kdi(
-; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3jPU3AS3Kdi(
-; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4jPU3AS3Kdi(
-; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8jPU3AS3Kdi(
-; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16jPU3AS3Kdi(
-; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2jPU3AS2Kdi(
-; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3jPU3AS2Kdi(
-; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4jPU3AS2Kdi(
-; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8jPU3AS2Kdi(
-; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16jPU3AS2Kdi(
-; CHECK-SPV-IR: call spir_func <2 x double> @_Z27__spirv_ocl_vloadn_Rdouble2jPKdi(
-; CHECK-SPV-IR: call spir_func <3 x double> @_Z27__spirv_ocl_vloadn_Rdouble3jPKdi(
-; CHECK-SPV-IR: call spir_func <4 x double> @_Z27__spirv_ocl_vloadn_Rdouble4jPKdi(
-; CHECK-SPV-IR: call spir_func <8 x double> @_Z27__spirv_ocl_vloadn_Rdouble8jPKdi(
-; CHECK-SPV-IR: call spir_func <16 x double> @_Z28__spirv_ocl_vloadn_Rdouble16jPKdi(
+; CHECK-SPV-IR: call spir_func <2 x double> @_Z28__spirv_ocl_vloadn__Rdouble2jPU3AS1Kdi(
+; CHECK-SPV-IR: call spir_func <3 x double> @_Z28__spirv_ocl_vloadn__Rdouble3jPU3AS1Kdi(
+; CHECK-SPV-IR: call spir_func <4 x double> @_Z28__spirv_ocl_vloadn__Rdouble4jPU3AS1Kdi(
+; CHECK-SPV-IR: call spir_func <8 x double> @_Z28__spirv_ocl_vloadn__Rdouble8jPU3AS1Kdi(
+; CHECK-SPV-IR: call spir_func <16 x double> @_Z29__spirv_ocl_vloadn__Rdouble16jPU3AS1Kdi(
+; CHECK-SPV-IR: call spir_func <2 x double> @_Z28__spirv_ocl_vloadn__Rdouble2jPU3AS3Kdi(
+; CHECK-SPV-IR: call spir_func <3 x double> @_Z28__spirv_ocl_vloadn__Rdouble3jPU3AS3Kdi(
+; CHECK-SPV-IR: call spir_func <4 x double> @_Z28__spirv_ocl_vloadn__Rdouble4jPU3AS3Kdi(
+; CHECK-SPV-IR: call spir_func <8 x double> @_Z28__spirv_ocl_vloadn__Rdouble8jPU3AS3Kdi(
+; CHECK-SPV-IR: call spir_func <16 x double> @_Z29__spirv_ocl_vloadn__Rdouble16jPU3AS3Kdi(
+; CHECK-SPV-IR: call spir_func <2 x double> @_Z28__spirv_ocl_vloadn__Rdouble2jPU3AS2Kdi(
+; CHECK-SPV-IR: call spir_func <3 x double> @_Z28__spirv_ocl_vloadn__Rdouble3jPU3AS2Kdi(
+; CHECK-SPV-IR: call spir_func <4 x double> @_Z28__spirv_ocl_vloadn__Rdouble4jPU3AS2Kdi(
+; CHECK-SPV-IR: call spir_func <8 x double> @_Z28__spirv_ocl_vloadn__Rdouble8jPU3AS2Kdi(
+; CHECK-SPV-IR: call spir_func <16 x double> @_Z29__spirv_ocl_vloadn__Rdouble16jPU3AS2Kdi(
+; CHECK-SPV-IR: call spir_func <2 x double> @_Z28__spirv_ocl_vloadn__Rdouble2jPKdi(
+; CHECK-SPV-IR: call spir_func <3 x double> @_Z28__spirv_ocl_vloadn__Rdouble3jPKdi(
+; CHECK-SPV-IR: call spir_func <4 x double> @_Z28__spirv_ocl_vloadn__Rdouble4jPKdi(
+; CHECK-SPV-IR: call spir_func <8 x double> @_Z28__spirv_ocl_vloadn__Rdouble8jPKdi(
+; CHECK-SPV-IR: call spir_func <16 x double> @_Z29__spirv_ocl_vloadn__Rdouble16jPKdi(
 ;
 ; CHECK-CL20: call spir_func <2 x double> @_Z6vload2jPU3AS1Kd(
 ; CHECK-CL20: call spir_func <3 x double> @_Z6vload3jPU3AS1Kd(


### PR DESCRIPTION
Align translation of SPIR-V extended instructions to the name convention described in SPIR-V friendly IR specification:

> "The first postfix starts with two underscores to facilitate identification since extended instruction name may contain underscore."