### PR TITLE
Add support for debug macro information (DW_MACINFO_define/undef)

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.h
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.h
@@ -165,6 +165,11 @@ private:
   // A module in programming language. Example - Fortran module, clang module.
   SPIRVEntry *transDbgModule(const DIModule *IE);
 
+  // Macros
+  SPIRVEntry *transDbgMacroDefine(const DIMacro *Macro, SPIRVString *FileName);
+  SPIRVEntry *transDbgMacroUndef(const DIMacro *Macro, SPIRVString *FileName);
+  void transDbgMacros();
+
   // Flags
   SPIRVWord mapDebugFlags(DINode::DIFlags DFlags);
   SPIRVWord transDebugFlags(const DINode *DN);
@@ -174,6 +179,7 @@ private:
   LLVMToSPIRVBase *SPIRVWriter;
   std::unordered_map<const MDNode *, SPIRVEntry *> MDMap;
   std::unordered_map<std::string, SPIRVExtInst *> FileMap;
+  std::unordered_map<std::string, SPIRVExtInst *> MacroDefMap;
   DebugInfoFinder DIF;
   SPIRVType *VoidT = nullptr;
   SPIRVType *Int32T = nullptr;

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -178,6 +178,13 @@ private:
 
   DINode *transModule(const SPIRVExtInst *DebugInst);
 
+  DIMacro *transMacroDef(const SPIRVExtInst *DebugInst);
+
+  DIMacro *transMacroUndef(const SPIRVExtInst *DebugInst);
+
+  DIMacroFile *getOrCreateMacroFile(DIFile *File,
+                                    const SPIRVExtInst *DebugInst);
+
   MDNode *transExpression(const SPIRVExtInst *DebugInst);
 
   SPIRVModule *BM;
@@ -188,6 +195,7 @@ private:
   std::unordered_map<std::string, DIFile *> FileMap;
   std::unordered_map<SPIRVId, DISubprogram *> FuncMap;
   std::unordered_map<const SPIRVExtInst *, MDNode *> DebugInstCache;
+  std::unordered_map<DIFile *, DIMacroFile *> MacroFileMap;
 
   struct SplitFileName {
     SplitFileName(const std::string &FileName);

--- a/lib/SPIRV/libSPIRV/SPIRV.debug.h
+++ b/lib/SPIRV/libSPIRV/SPIRV.debug.h
@@ -971,6 +971,25 @@ enum {
 } // namespace NonSemantic
 } // namespace ImportedEntity
 
+namespace MacroDef {
+enum {
+  SourceIdx      = 0,
+  LineIdx        = 1,
+  NameIdx        = 2,
+  ValueIdx       = 3,
+  MinOperandCount = 3
+};
+}
+
+namespace MacroUndef {
+enum {
+  SourceIdx      = 0,
+  LineIdx        = 1,
+  MacroIdx       = 2,
+  OperandCount   = 3
+};
+}
+
 namespace ModuleINTEL {
 enum {
   NameIdx         = 0,

--- a/lib/SPIRV/libSPIRV/SPIRVExtInst.h
+++ b/lib/SPIRV/libSPIRV/SPIRVExtInst.h
@@ -257,6 +257,8 @@ template <> inline void SPIRVMap<SPIRVDebugExtOpKind, std::string>::init() {
   add(SPIRVDebug::NoScope, "DebugNoScope");
   add(SPIRVDebug::InlinedAt, "DebugInlinedAt");
   add(SPIRVDebug::ImportedEntity, "DebugImportedEntity");
+  add(SPIRVDebug::MacroDef, "DebugMacroDef");
+  add(SPIRVDebug::MacroUndef, "DebugMacroUndef");
   add(SPIRVDebug::ModuleINTEL, "DebugModuleINTEL");
   add(SPIRVDebug::Module, "DebugModule");
   add(SPIRVDebug::Expression, "DebugExpression");

--- a/test/DebugInfo/DebugMacroDef.ll
+++ b/test/DebugInfo/DebugMacroDef.ll
@@ -1,0 +1,90 @@
+; Test round-trip translation of debug macro information:
+; LLVM IR -> SPIR-V -> LLVM IR
+
+; Also test that the macro's line is properly encoded as a literal or register.
+
+; RUN: llvm-spirv --spirv-debug-info-version=ocl-100 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-OCL
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LL
+
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_non_semantic_info --spirv-debug-info-version=nonsemantic-shader-100 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-NON-SEMANTIC-100
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LL
+
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_non_semantic_info --spirv-debug-info-version=nonsemantic-shader-200 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-NON-SEMANTIC-200
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc 
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LL
+
+; CHECK-LL-DAG: ![[#r1:]] = !DIFile(filename: "def.c", directory: ".")
+; CHECK-LL-DAG: ![[#r2:]] = !DIMacroFile(file: ![[#r1]], nodes: ![[#r3:]])
+; CHECK-LL-DAG: ![[#r3]] = !{![[#r4:]], ![[#r5:]]}
+; CHECK-LL-DAG: ![[#r4]] = !DIMacro(type: DW_MACINFO_define, line: 1, name: "SIZE", value: "5")
+; CHECK-LL-DAG: ![[#r5]] = !DIMacro(type: DW_MACINFO_undef, line: 1, name: "SIZE")
+
+; CHECK-SPIRV-OCL: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] 1 %[[#]] %[[#]]
+
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[type:.*]] = OpTypeInt 32 0
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[uint_1_reg:.*]] = OpConstant %[[type]] 1
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] %[[uint_1_reg]] %[[#]] %[[#]]
+
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[type:.*]] = OpTypeInt 32 0
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[uint_1_reg:.*]] = OpConstant %[[type]] 1
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[#]] = OpExtInst %void %[[#]] 32 %[[#]] %[[uint_1_reg]] %[[#]] %[[#]]
+
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_func i32 @main() #0 {
+entry:
+  ret i32 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !12}
+!llvm.dbg.cu = !{!4}
+!spirv.MemoryModel = !{!13}
+!opencl.enable.FP_CONTRACT = !{}
+!spirv.Source = !{!14}
+!opencl.spir.version = !{!15}
+!opencl.used.extensions = !{!16}
+!opencl.used.optional.core.features = !{!16}
+!spirv.Generator = !{!17}
+
+!0 = !{i32 7, !"Dwarf Version", i32 0}
+!1 = !{i32 2, !"Source Lang Literal", !2}
+!2 = !{!3}
+!3 = !{!4, i32 12}
+!4 = distinct !DICompileUnit(language: DW_LANG_OpenCL, file: !5, isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, macros: !6)
+!5 = !DIFile(filename: "def.c", directory: "/tmp")
+!6 = !{!7}
+!7 = !DIMacroFile(file: !8, nodes: !9)
+!8 = !DIFile(filename: "def.c", directory: ".")
+!9 = !{!10, !11}
+!10 = !DIMacro(type: DW_MACINFO_define, line: 1, name: "SIZE", value: "5")
+!11 = !DIMacro(type: DW_MACINFO_undef, line: 1, name: "SIZE")
+!12 = !{i32 2, !"Debug Info Version", i32 3}
+!13 = !{i32 2, i32 2}
+!14 = !{i32 4, i32 100000}
+!15 = !{i32 1, i32 2}
+!16 = !{}
+!17 = !{i16 7, i16 0}
+

--- a/test/DebugInfo/DebugMacroDefNoValue.ll
+++ b/test/DebugInfo/DebugMacroDefNoValue.ll
@@ -1,0 +1,110 @@
+; This test exercises the case where the DICompileUnit has as !DIMacro with and without a value.
+; It is not possible to distinguish the case between the macro with an empty value and without one.
+
+; Test round-trip translation of debug macro information:
+; LLVM IR -> SPIR-V -> LLVM IR
+
+; RUN: llvm-spirv --spirv-debug-info-version=ocl-100 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-OCL
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_non_semantic_info --spirv-debug-info-version=nonsemantic-shader-100 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-NON-SEMANTIC-100
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_non_semantic_info --spirv-debug-info-version=nonsemantic-shader-200 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-NON-SEMANTIC-200
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; CHECK-NOT: !DIMacroFile
+; CHECK-DAG: !DIMacro(type: DW_MACINFO_define, line: 1, name: "BAR")
+; CHECK-DAG: !DIMacro(type: DW_MACINFO_define, line: 2, name: "BAZ")
+; CHECK-DAG: !DIMacro(type: DW_MACINFO_define, line: 3, name: "FOO", value: "1")
+
+; CHECK-SPIRV-OCL-DAG: %[[bar_name:.*]] = OpString "BAR"
+; CHECK-SPIRV-OCL-DAG: %[[baz_name:.*]] = OpString "BAZ"
+; CHECK-SPIRV-OCL-DAG: %[[foo_name:.*]] = OpString "FOO"
+; CHECK-SPIRV-OCL-DAG: %[[foo_value:.*]] = OpString "1"
+; CHECK-SPIRV-OCL-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] 1 %[[bar_name]]
+; CHECK-SPIRV-OCL-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] 2 %[[baz_name]]
+; CHECK-SPIRV-OCL-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] 3 %[[foo_name]] %[[foo_value]]
+
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[type:.*]] = OpTypeInt 32 0
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[uint_1_reg:.*]] = OpConstant %[[type]] 1
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[uint_2_reg:.*]] = OpConstant %[[type]] 2
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[uint_3_reg:.*]] = OpConstant %[[type]] 3
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[bar_name:.*]] = OpString "BAR"
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[baz_name:.*]] = OpString "BAZ"
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[foo_name:.*]] = OpString "FOO"
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[foo_value:.*]] = OpString "1"
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] %[[uint_1_reg]] %[[bar_name]]
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] %[[uint_2_reg]] %[[baz_name]]
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] %[[uint_3_reg]] %[[foo_name]] %[[foo_value]]
+
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[type:.*]] = OpTypeInt 32 0
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[uint_1_reg:.*]] = OpConstant %[[type]] 1
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[uint_2_reg:.*]] = OpConstant %[[type]] 2
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[uint_3_reg:.*]] = OpConstant %[[type]] 3
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[bar_name:.*]] = OpString "BAR"
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[baz_name:.*]] = OpString "BAZ"
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[foo_name:.*]] = OpString "FOO"
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[foo_value:.*]] = OpString "1"
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[#]] = OpExtInst %void %[[#]] 32 %[[#]] %[[uint_1_reg]] %[[bar_name]]
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[#]] = OpExtInst %void %[[#]] 32 %[[#]] %[[uint_2_reg]] %[[baz_name]]
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[#]] = OpExtInst %void %[[#]] 32 %[[#]] %[[uint_3_reg]] %[[foo_name]] %[[foo_value]]
+
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_func i32 @main() #0 {
+entry:
+  ret i32 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !12}
+!llvm.dbg.cu = !{!4}
+!spirv.MemoryModel = !{!13}
+!opencl.enable.FP_CONTRACT = !{}
+!spirv.Source = !{!14}
+!opencl.spir.version = !{!15}
+!opencl.used.extensions = !{!16}
+!opencl.used.optional.core.features = !{!16}
+!spirv.Generator = !{!17}
+
+!0 = !{i32 7, !"Dwarf Version", i32 0}
+!1 = !{i32 2, !"Source Lang Literal", !2}
+!2 = !{!3}
+!3 = !{!4, i32 12}
+!4 = distinct !DICompileUnit(language: DW_LANG_OpenCL, file: !5, isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, macros: !6)
+!5 = !DIFile(filename: "def.c", directory: "/tmp")
+!6 = !{!10, !11, !18}
+!10 = !DIMacro(type: DW_MACINFO_define, line: 1, name: "BAR")
+!18 = !DIMacro(type: DW_MACINFO_define, line: 2, name: "BAZ", value: "")
+!11 = !DIMacro(type: DW_MACINFO_define, line: 3, name: "FOO", value: "1")
+!12 = !{i32 2, !"Debug Info Version", i32 3}
+!13 = !{i32 2, i32 2}
+!14 = !{i32 4, i32 100000}
+!15 = !{i32 1, i32 2}
+!16 = !{}
+!17 = !{i16 7, i16 0}
+

--- a/test/DebugInfo/DebugMacroDefRoot.ll
+++ b/test/DebugInfo/DebugMacroDefRoot.ll
@@ -1,0 +1,89 @@
+; This test exercises the case where the DICompileUnit has as !DIMacro without a DIMacroFile
+
+; Test round-trip translation of debug macro information:
+; LLVM IR -> SPIR-V -> LLVM IR
+
+; RUN: llvm-spirv --spirv-debug-info-version=ocl-100 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-OCL
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_non_semantic_info --spirv-debug-info-version=nonsemantic-shader-100 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-NON-SEMANTIC-100
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_non_semantic_info --spirv-debug-info-version=nonsemantic-shader-200 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-NON-SEMANTIC-200
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; CHECK-NOT: !DIMacroFile
+; CHECK-DAG: !DIMacro(type: DW_MACINFO_define, line: 1, name: "SIZE", value: "5")
+
+; CHECK-SPIRV-OCL-DAG: %[[size_name:.*]] = OpString "SIZE"
+; CHECK-SPIRV-OCL-DAG: %[[size_value:.*]] = OpString "5"
+; CHECK-SPIRV-OCL-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] 1 %[[size_name]] %[[size_value]]
+
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[type:.*]] = OpTypeInt 32 0
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[uint_1_reg:.*]] = OpConstant %[[type]] 1
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[size_name:.*]] = OpString "SIZE"
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[size_value:.*]] = OpString "5"
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroDef %[[#]] %[[uint_1_reg]] %[[size_name]] %[[size_value]]
+
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[type:.*]] = OpTypeInt 32 0
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[uint_1_reg:.*]] = OpConstant %[[type]] 1
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[size_name:.*]] = OpString "SIZE"
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[size_value:.*]] = OpString "5"
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[#]] = OpExtInst %void %[[#]] 32 %[[#]] %[[uint_1_reg]] %[[size_name]] %[[size_value]]
+
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_func i32 @main() #0 {
+entry:
+  ret i32 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !12}
+!llvm.dbg.cu = !{!4}
+!spirv.MemoryModel = !{!13}
+!opencl.enable.FP_CONTRACT = !{}
+!spirv.Source = !{!14}
+!opencl.spir.version = !{!15}
+!opencl.used.extensions = !{!16}
+!opencl.used.optional.core.features = !{!16}
+!spirv.Generator = !{!17}
+
+!0 = !{i32 7, !"Dwarf Version", i32 0}
+!1 = !{i32 2, !"Source Lang Literal", !2}
+!2 = !{!3}
+!3 = !{!4, i32 12}
+!4 = distinct !DICompileUnit(language: DW_LANG_OpenCL, file: !5, isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, macros: !6)
+!5 = !DIFile(filename: "def.c", directory: "/tmp")
+!6 = !{!10}
+!10 = !DIMacro(type: DW_MACINFO_define, line: 1, name: "SIZE", value: "5")
+!12 = !{i32 2, !"Debug Info Version", i32 3}
+!13 = !{i32 2, i32 2}
+!14 = !{i32 4, i32 100000}
+!15 = !{i32 1, i32 2}
+!16 = !{}
+!17 = !{i16 7, i16 0}
+

--- a/test/DebugInfo/DebugMacroUndefinedUndef.ll
+++ b/test/DebugInfo/DebugMacroUndefinedUndef.ll
@@ -1,0 +1,94 @@
+; This test exercises the cases where there is a DW_MACINFO_undef without a matching DW_MACINFO_def
+
+; Test round-trip translation of debug macro information:
+; LLVM IR -> SPIR-V -> LLVM IR
+
+; RUN: llvm-spirv --spirv-debug-info-version=ocl-100 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-OCL
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_non_semantic_info --spirv-debug-info-version=nonsemantic-shader-100 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-NON-SEMANTIC-100
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; RUN: llvm-spirv --spirv-ext=+SPV_KHR_non_semantic_info --spirv-debug-info-version=nonsemantic-shader-200 %s -o %t.spv
+; RUN: spirv-val %t.spv
+
+; RUN: spirv-dis %t.spv -o %t.spvasm
+; RUN: FileCheck %s --input-file %t.spvasm --check-prefix CHECK-SPIRV-NON-SEMANTIC-200
+
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck %s --input-file %t.rev.ll
+
+; CHECK-NOT: !DIMacro(type: DW_MACINFO_undef, line: 1, {{.*}})
+
+; CHECK-SPIRV-OCL-NOT: DebugMacroDef
+; CHECK-SPIRV-OCL-DAG: %[[source_file:.*]] = OpString "./def.c"
+; CHECK-SPIRV-OCL-DAG: %[[debug_none:.*]] = OpExtInst %void %[[#]] DebugInfoNone
+; CHECK-SPIRV-OCL-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroUndef %[[source_file]] 1 %[[debug_none]]
+
+; CHECK-SPIRV-NON-SEMANTIC-100-NOT: DebugMacroDef
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[type:.*]] = OpTypeInt 32 0
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[uint_1_reg:.*]] = OpConstant %[[type]] 1
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[source_file:.*]] = OpString "./def.c"
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[debug_none:.*]] = OpExtInst %void %[[#]] DebugInfoNone
+; CHECK-SPIRV-NON-SEMANTIC-100-DAG: %[[#]] = OpExtInst %void %[[#]] DebugMacroUndef %[[source_file]] %[[uint_1_reg]] %[[debug_none]]
+
+; CHECK-SPIRV-NON-SEMANTIC-200-NOT: DebugMacroDef
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[type:.*]] = OpTypeInt 32 0
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[uint_1_reg:.*]] = OpConstant %[[type]] 1
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[source_file:.*]] = OpString "./def.c"
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[debug_none:.*]] = OpExtInst %void %[[#]] 0
+; CHECK-SPIRV-NON-SEMANTIC-200-DAG: %[[#]] = OpExtInst %void %[[#]] 33 %[[source_file]] %[[uint_1_reg]] %[[debug_none]]
+
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: nounwind
+define spir_func i32 @main() #0 {
+entry:
+  ret i32 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !12}
+!llvm.dbg.cu = !{!4}
+!spirv.MemoryModel = !{!13}
+!opencl.enable.FP_CONTRACT = !{}
+!spirv.Source = !{!14}
+!opencl.spir.version = !{!15}
+!opencl.used.extensions = !{!16}
+!opencl.used.optional.core.features = !{!16}
+!spirv.Generator = !{!17}
+
+!0 = !{i32 7, !"Dwarf Version", i32 0}
+!1 = !{i32 2, !"Source Lang Literal", !2}
+!2 = !{!3}
+!3 = !{!4, i32 12}
+!4 = distinct !DICompileUnit(language: DW_LANG_OpenCL, file: !5, isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, macros: !6)
+!5 = !DIFile(filename: "def.c", directory: "/tmp")
+!6 = !{!7}
+!7 = !DIMacroFile(file: !8, nodes: !9)
+!8 = !DIFile(filename: "def.c", directory: ".")
+!9 = !{!11}
+!11 = !DIMacro(type: DW_MACINFO_undef, line: 1, name: "SIZE")
+!12 = !{i32 2, !"Debug Info Version", i32 3}
+!13 = !{i32 2, i32 2}
+!14 = !{i32 4, i32 100000}
+!15 = !{i32 1, i32 2}
+!16 = !{}
+!17 = !{i16 7, i16 0}
+


### PR DESCRIPTION
Implement bidirectional translation of LLVM [DIMacro](https://llvm.org/doxygen/classllvm_1_1DIMacro.html) to SPIR-V [DebugMacroDef ](https://registry.khronos.org/SPIR-V/specs/unified1/DebugInfo.html#DebugMacroDef)and [DebugMacroUndef](https://registry.khronos.org/SPIR-V/specs/unified1/DebugInfo.html#DebugMacroUndef) instructions.

LLVM to SPIR-V:
- Add transDbgMacros() to process all macro definitions and undefs
- Add transDbgMacroDefine() to translate DW_MACINFO_define to DebugMacroDef
- Add transDbgMacroUndef() to translate DW_MACINFO_undef to DebugMacroUndef
- DW_MACINFO_define are processed first, so they are available for DW_MACINFO_undef cases.

SPIR-V to LLVM:
- Add transMacroDef() to translate DebugMacroDef back to DIMacro
- Add transMacroUndef() to translate DebugMacroUndef back to DIMacro
- Add getOrCreateMacroFile() to manage DIMacroFile creation
- Handle edge case where LLVM IR allows undefining macros that were never defined (DebugMacroUndef with DebugInfoNone reference)

