### PR TITLE
Update memset test checks after community change

### DIFF
--- a/test/llvm-intrinsics/memset-opaque.ll
+++ b/test/llvm-intrinsics/memset-opaque.ll
@@ -51,8 +51,8 @@
 ; CHECK-SPIRV: FunctionParameter [[#]] [[#Volatile:]]
 
 ; CHECK-SPIRV: Label [[#Entry:]]
-; CHECK-SPIRV: IEqual [[#]] [[#IsZeroLen:]] [[#Zero:]] [[#Len]]
-; CHECK-SPIRV: BranchConditional [[#IsZeroLen]] [[#End:]] [[#WhileBody:]]
+; CHECK-SPIRV: INotEqual [[#]] [[#IsNotZeroLen:]] [[#Len]] [[#Zero:]]
+; CHECK-SPIRV: BranchConditional [[#IsNotZeroLen]] [[#WhileBody:]] [[#End:]]
 
 ; CHECK-SPIRV: Label [[#WhileBody]]
 ; CHECK-SPIRV: Phi [[#]] [[#Offset:]] [[#Zero]] [[#Entry]] [[#OffsetInc:]] [[#WhileBody]]


### PR DESCRIPTION
We rely on `expandMemSetAsLoop()` from
`llvm/Transforms/Utils/LowerMemIntrinsics` in our LLVM Regularization pass.

After llvm/llvm-project@d24a675 and some prior transformations, the lowering of the memset starts with `icmp ne` instead of `icmp eq`.