### PR TITLE
[CMake] Make LLVMSPIRVLib include directories PUBLIC for in-tree builds

### DIFF
--- a/lib/SPIRV/CMakeLists.txt
+++ b/lib/SPIRV/CMakeLists.txt
@@ -69,9 +69,10 @@ add_llvm_library(LLVMSPIRVLib
   )
 
 target_include_directories(LLVMSPIRVLib
+  PUBLIC
+    $<BUILD_INTERFACE:${LLVM_SPIRV_INCLUDE_DIRS}>
   PRIVATE
     ${LLVM_INCLUDE_DIRS}
-    ${LLVM_SPIRV_INCLUDE_DIRS}
     # TODO: Consider using SPIRV-Headers' as a header-only INTERFACE
     # instead. Right now this runs into exporting issues with
     # the LLVM in-tree builds.

--- a/tools/llvm-spirv/CMakeLists.txt
+++ b/tools/llvm-spirv/CMakeLists.txt
@@ -34,7 +34,6 @@ endif()
 target_include_directories(llvm-spirv
   PRIVATE
     ${LLVM_INCLUDE_DIRS}
-    ${LLVM_SPIRV_INCLUDE_DIRS}
 )
 
 if(SPIRV_TOOLS_FOUND AND LLVM_SPIRV_ENABLE_LIBSPIRV_DIS)


### PR DESCRIPTION
LLVMSPIRVLib provides a public API through headers like LLVMSPIRVLib.h, LLVMSPIRVOpts.h, and LLVMSPIRVExtensions.inc. Any target that links to LLVMSPIRVLib and calls its functions must include these headers.

Currently, the include directory is marked PRIVATE, which prevents CMake from automatically propagating include paths to downstream targets. This forces consumers to manually add the include directories.

This commit makes the include directory PUBLIC with BUILD_INTERFACE, following standard CMake practice for libraries with public APIs. This allows targets linking to LLVMSPIRVLib to automatically get the correct include paths, which is necessary for in-tree consumers like opencl-clang.

Changes:
- lib/SPIRV/CMakeLists.txt: Move ${LLVM_SPIRV_INCLUDE_DIRS} from PRIVATE to PUBLIC with $<BUILD_INTERFACE:...> generator expression
- tools/llvm-spirv/CMakeLists.txt: Remove redundant explicit include since it's now automatically propagated via CMake target propagation