### PR TITLE
Drop undef/poison initializers for global variables in SPIR-V translation

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2073,12 +2073,20 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
 
   if (auto *GV = dyn_cast<GlobalVariable>(V)) {
     llvm::Type *Ty = Scavenger->getScavengedType(GV);
-    // Though variables with common linkage type are initialized by 0,
-    // they can be represented in SPIR-V as uninitialized variables with
-    // 'Export' linkage type, just as tentative definitions look in C
-    llvm::Constant *Init = GV->hasInitializer() && !GV->hasCommonLinkage()
-                               ? GV->getInitializer()
-                               : nullptr;
+    // Check whether the global has an initializer for SPIR-V.
+    // Variables with common linkage are represented as uninitialized with
+    // 'Export' linkage, just as tentative definitions look in C.
+    // Undef/poison initializers are dropped unless the variable is constant
+    // with an aggregate type
+    auto HasInit = [](const GlobalVariable *GV) {
+      if (!GV->hasInitializer() || GV->hasCommonLinkage())
+        return false;
+      if (isa<UndefValue>(GV->getInitializer()))
+        return GV->isConstant() &&
+               GV->getInitializer()->getType()->isAggregateType();
+      return true;
+    };
+    llvm::Constant *Init = HasInit(GV) ? GV->getInitializer() : nullptr;
     SPIRVValue *BVarInit = nullptr;
     StructType *ST = Init ? dyn_cast<StructType>(Init->getType()) : nullptr;
     if (ST && ST->hasName() && isSPIRVConstantName(ST->getName())) {

--- a/test/var_undef.ll
+++ b/test/var_undef.ll
@@ -7,17 +7,17 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix CHECK-LLVM
-; FIXME: FILECHECK_FAIL during llvm-spirv -r in llc compilation flow
+; RUN: %if spirv-backend %{ llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj %s -o %t.llc.spv %}
+; RUN: %if spirv-backend %{ llvm-spirv -r %t.llc.spv -o %t.llc.rev.bc %}
+; RUN: %if spirv-backend %{ llvm-dis %t.llc.rev.bc -o %t.llc.rev.ll %}
+; RUN: %if spirv-backend %{ FileCheck %s --input-file %t.llc.rev.ll --check-prefix CHECK-LLVM %}
 
 ; CHECK-SPIRV: Name [[FOO_VAR:[0-9]+]] "foo"
 ; CHECK-SPIRV: Name [[BAR_VAR:[0-9]+]] "bar"
-;; foo variable has optional initializer (OpUndef)
-; CHECK-SPIRV: 5 Variable [[#]] [[FOO_VAR]]
-;; bar variable does not have optional initializer
-;; word count must be 4
+; CHECK-SPIRV: 4 Variable [[#]] [[FOO_VAR]]
 ; CHECK-SPIRV: 4 Variable [[#]] [[BAR_VAR]]
 
-; CHECK-LLVM: @foo = internal addrspace(3) global %anon undef, align 8
+; CHECK-LLVM: @foo = internal addrspace(3) global %anon poison, align 8
 ; CHECK-LLVM: @bar = internal addrspace(3) global %range poison, align 8
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"


### PR DESCRIPTION
Align the translator with the LLVM SPIR-V backend behavior : undef/poison initializers are dropped unless the variable is constant with an aggregate type. This avoids emitting unnecessary OpUndef initializers in the generated SPIR-V.