### PR TITLE
Make DebugLinePriority test valid SPIR-V

### DIFF
--- a/test/DebugInfo/NonSemantic/Shader200/DebugLinePriority.spt
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugLinePriority.spt
@@ -62,10 +62,10 @@
 7 ExtInst 7 17 2 DebugBuildIdentifier 16 12 
 6 ExtInst 7 19 2 DebugStoragePath 18 
 10 ExtInst 7 24 2 DebugCompilationUnit 20 21 15 22 23 
-8 ExtInst 7 27 2 DebugTypeBasic 25 26 21 
+9 ExtInst 7 27 2 DebugTypeBasic 25 26 21 5
 5 ExtInst 7 28 2 DebugInfoNone 
-7 ExtInst 7 29 2 DebugTypeFunction 5 28 
-15 ExtInst 7 34 2 DebugFunction 30 29 15 32 5 24 31 33 32 28 
+7 ExtInst 7 29 2 DebugTypeFunction 5 7
+14 ExtInst 7 34 2 DebugFunction 30 29 15 32 5 24 31 33 32
 6 ExtInst 7 36 2 DebugSource 18 
 11 ExtInst 7 40 2 DebugLexicalBlock 36 5 5 24 37 39 
 11 ExtInst 7 43 2 DebugLexicalBlock 36 5 5 40 41 42 
@@ -78,7 +78,7 @@
 6 ExtInst 7 49 2 DebugScope 34
 4 Line 14 357 113
 6 Load 3 11 6 2 4
-10 ExtInst 7 51 2 DebugLine 14 47 47 50 33
+10 ExtInst 7 51 2 DebugLine 15 47 47 50 33
 5 IAdd 3 13 11 12
 5 ExtInst 7 511 2 DebugNoLine
 5 ISub 3 137 11 12


### PR DESCRIPTION
A recent version of SPIRV-Tools found several issues with the test, such as `DebugTypeFunction` having the wrong return type operand and `DebugTypeBasic` missing the flags operand.