### PR TITLE
Update prefalign in DebugInfo test

### DIFF
--- a/test/DebugInfo/X86/header.ll
+++ b/test/DebugInfo/X86/header.ll
@@ -19,7 +19,7 @@ target triple = "spir64-unknown-unknown"
 ; CHECK: .file	"<stdin>"
 ; CHECK-NEXT: .text
 ; CHECK-NEXT: .globl	f
-; CHECK-NEXT: .p2align	4
+; CHECK-NEXT: {{.p2align 4|.prefalign       4, .Lfunc_end0, nop}}
 ; CHECK-NEXT: .type	f,@function
 ; CHECK-NEXT: f:                                      # @f
 


### PR DESCRIPTION
Update for llvm-project commit llvm/llvm-project@193d7a6ace9f ("[MC,CodeGen] Update .prefalign for symbol-based preferred alignment (#184032)", 2026-04-11).

Temporarily match both the old and new patterns, to ensure the test
also passes with outdated LLVM apt binaries on our CI.