### PR TITLE
[NFC] Use tool substitution for spirv-val in lit config

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -85,7 +85,7 @@ if config.spirv_tools_have_spirv_val:
     llvm_config.add_tool_substitutions(['spirv-val'], [config.spirv_tools_bin_dir])
     using_spirv_tools = True
 else:
-    llvm_config.add_tool_substitutions(['spirv-val'])
+    llvm_config.add_tool_substitutions([ToolSubst('spirv-val', ':')])
 
 if not config.llvm_spirv_build_external and config.llvm_build_shared_libs:
     config.available_features.add('pass-plugin')

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -85,7 +85,7 @@ if config.spirv_tools_have_spirv_val:
     llvm_config.add_tool_substitutions(['spirv-val'], [config.spirv_tools_bin_dir])
     using_spirv_tools = True
 else:
-    config.substitutions.append(('spirv-val', ':'))
+    llvm_config.add_tool_substitutions(['spirv-val'])
 
 if not config.llvm_spirv_build_external and config.llvm_build_shared_libs:
     config.available_features.add('pass-plugin')


### PR DESCRIPTION
Bare-string substitutions match as substrings and the replacement path contains the tool name, causing corrupted RUN lines

Port of the original patch in LLVM SPIR-V backend: https://github.com/llvm/llvm-project/pull/192462