### PR TITLE
Handle ConstantFP vector splats in transConstant

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1412,6 +1412,16 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
   }
 
   if (auto *ConstFP = dyn_cast<ConstantFP>(V)) {
+    if (V->getType()->isVectorTy()) {
+      SPIRVType *InnerTy = ExpectedType->getScalarType();
+      SPIRVValue *ScalarVal =
+          transConstantUse(ConstantFP::get(V->getType()->getScalarType(),
+                                           ConstFP->getValueAPF()),
+                           InnerTy);
+      unsigned NumElts = cast<FixedVectorType>(V->getType())->getNumElements();
+      std::vector<SPIRVValue *> BV(NumElts, ScalarVal);
+      return BM->addCompositeConstant(ExpectedType, BV);
+    }
     auto *BT = static_cast<SPIRVType *>(ExpectedType);
     return BM->addConstant(
         BT, ConstFP->getValueAPF().bitcastToAPInt().getZExtValue());


### PR DESCRIPTION
llvm/llvm-project@d19e954b83 made `-use-constant-fp-for-fixed-length-splat` default to true. 
This causes `ConstantFP` to represent fixed-length vector splats natively instead of using `ConstantDataVector`.

The translator only handled scalar `ConstantFP`, so vector-typed `ConstantFP` splats were silently mistranslated.
For example, this LLVM IR call argument:

  `call <8 x i8> @convert(<8 x half> <half 0xH3C00, half 0xH3C00, ...>)`

produced a scalar `OpConstant` with a vector type:

  `%53 = OpConstant %v8half 15360    ; invalid: scalar op, vector type`

instead of the correct `OpConstantComposite`:
```
  %53 = OpConstant %half 15360
  %60 = OpConstantComposite %v8half %53 %53 %53 %53 %53 %53 %53 %53
```


Build an `OpConstantComposite` from repeated scalar references instead.

Existing tests that cover this:
- extensions/EXT/SPV_EXT_float8/conversions_scalar_vector.ll
- extensions/INTEL/SPV_INTEL_float4/conversions_packed.ll
- extensions/INTEL/SPV_INTEL_float4/conversions_scalar_vector.ll
- extensions/INTEL/SPV_INTEL_int4/conversions_packed.ll

AI-assisted: Claude Sonnet 4.6 (commercial SaaS)