### PR TITLE
Configurable address space numbering

### DIFF
--- a/include/LLVMSPIRVLib.h
+++ b/include/LLVMSPIRVLib.h
@@ -200,7 +200,8 @@ bool regularizeLlvmForSpirv(Module *M, std::string &ErrMsg,
 /// TypedPointerType instead, to faithfully represent the pointer element types
 /// for name mangling.
 void mangleOpenClBuiltin(const std::string &UnmangledName,
-                         ArrayRef<Type *> ArgTypes, std::string &MangledName);
+                         ArrayRef<Type *> ArgTypes, std::string &MangledName,
+                         const SPIRV::AddrSpaceMap *Map = nullptr);
 
 /// Create a pass for translating LLVM to SPIR-V.
 ModulePass *createLLVMToSPIRVLegacy(SPIRV::SPIRVModule *);

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -42,6 +42,7 @@
 #include <llvm/ADT/SmallVector.h>
 #include <llvm/ADT/StringRef.h>
 
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <map>
@@ -117,6 +118,22 @@ enum class DebugInfoEIS : uint32_t {
 };
 
 enum class BuiltinFormat : uint32_t { Function, Global };
+
+enum SPIRAddressSpace : uint32_t {
+  SPIRAS_Private,
+  SPIRAS_Global,
+  SPIRAS_Constant,
+  SPIRAS_Local,
+  SPIRAS_Generic,
+  SPIRAS_GlobalDevice,
+  SPIRAS_GlobalHost,
+  SPIRAS_Input,
+  SPIRAS_Output,
+  SPIRAS_CodeSectionINTEL,
+  SPIRAS_Count,
+};
+
+using AddrSpaceMap = std::array<uint32_t, SPIRAS_Count>;
 
 /// \brief Helper class to manage SPIR-V translation
 class TranslatorOpts {
@@ -245,6 +262,22 @@ public:
     EmitFunctionPtrAddrSpace = Value;
   }
 
+  void setAddrSpaceMap(AddrSpaceMap Map) noexcept { ASMap = std::move(Map); }
+
+  uint32_t mapAddrSpace(uint32_t SPIRAS) const noexcept {
+    if (ASMap && SPIRAS < SPIRAS_Count)
+      return (*ASMap)[SPIRAS];
+    return SPIRAS;
+  }
+
+  void setFunctionProgramAddrSpace(uint32_t AS) noexcept {
+    FunctionProgramAS = AS;
+  }
+
+  uint32_t getFunctionProgramAddrSpace() const noexcept {
+    return FunctionProgramAS;
+  }
+
   void setBuiltinFormat(BuiltinFormat Value) noexcept {
     SPIRVBuiltinFormat = Value;
   }
@@ -345,6 +378,12 @@ private:
   // Controls if CodeSectionINTEL can be emitted and consumed with a dedicated
   // address space
   bool EmitFunctionPtrAddrSpace = false;
+
+  // Optional per-target mapping from SPIRAddressSpace values to LLVM AS numbers
+  std::optional<AddrSpaceMap> ASMap;
+
+  // Address space for function definitions; independent of the data-pointer map
+  uint32_t FunctionProgramAS = SPIRAS_Private;
 
   bool PreserveAuxData = false;
 

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -264,6 +264,10 @@ public:
 
   void setAddrSpaceMap(AddrSpaceMap Map) noexcept { ASMap = std::move(Map); }
 
+  const AddrSpaceMap *getAddrSpaceMap() const noexcept {
+    return ASMap ? &*ASMap : nullptr;
+  }
+
   uint32_t mapAddrSpace(uint32_t SPIRAS) const noexcept {
     if (ASMap && SPIRAS < SPIRAS_Count)
       return (*ASMap)[SPIRAS];

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -265,7 +265,7 @@ public:
   void setAddrSpaceMap(AddrSpaceMap Map) noexcept { ASMap = std::move(Map); }
 
   const AddrSpaceMap *getAddrSpaceMap() const noexcept {
-    return ASMap ? &*ASMap : nullptr;
+    return ASMap ? &ASMap.value() : nullptr;
   }
 
   uint32_t mapAddrSpace(uint32_t SPIRAS) const noexcept {
@@ -279,7 +279,9 @@ public:
   }
 
   uint32_t getFunctionProgramAddrSpace() const noexcept {
-    return FunctionProgramAS;
+    if (FunctionProgramAS)
+      return *FunctionProgramAS;
+    return mapAddrSpace(SPIRAS_Private);
   }
 
   void setBuiltinFormat(BuiltinFormat Value) noexcept {
@@ -380,14 +382,19 @@ private:
   bool PreserveOCLKernelArgTypeMetadataThroughString = false;
 
   // Controls if CodeSectionINTEL can be emitted and consumed with a dedicated
-  // address space
+  // address space. This option overrides address space set in
+  // FunctionProgramAS for functions that have their address taken with
+  // SPIRAS_CodeSectionINTEL.
   bool EmitFunctionPtrAddrSpace = false;
 
-  // Optional per-target mapping from SPIRAddressSpace values to LLVM AS numbers
+  // Optional per-target mapping from SPIRAddressSpace values to LLVM AS
+  // numbers.
   std::optional<AddrSpaceMap> ASMap;
 
-  // Address space for function definitions; independent of the data-pointer map
-  uint32_t FunctionProgramAS = SPIRAS_Private;
+  // Address space for function definitions. When set, overrides the address
+  // space map. Otherwise getFunctionProgramAddrSpace() falls back to
+  // SPIRAS_Private, which may be resolved unsign ASMap if set.
+  std::optional<uint32_t> FunctionProgramAS;
 
   bool PreserveAuxData = false;
 

--- a/include/LLVMSPIRVOpts.h
+++ b/include/LLVMSPIRVOpts.h
@@ -262,7 +262,7 @@ public:
     EmitFunctionPtrAddrSpace = Value;
   }
 
-  void setAddrSpaceMap(AddrSpaceMap Map) noexcept { ASMap = std::move(Map); }
+  void setAddrSpaceMap(AddrSpaceMap Map) noexcept { ASMap = Map; }
 
   const AddrSpaceMap *getAddrSpaceMap() const noexcept {
     return ASMap ? &ASMap.value() : nullptr;
@@ -393,7 +393,7 @@ private:
 
   // Address space for function definitions. When set, overrides the address
   // space map. Otherwise getFunctionProgramAddrSpace() falls back to
-  // SPIRAS_Private, which may be resolved unsign ASMap if set.
+  // SPIRAS_Private, which may be resolved using ASMap if set.
   std::optional<uint32_t> FunctionProgramAS;
 
   bool PreserveAuxData = false;

--- a/lib/SPIRV/OCLUtil.cpp
+++ b/lib/SPIRV/OCLUtil.cpp
@@ -899,34 +899,40 @@ unsigned transVecTypeHint(MDNode *Node) {
   return encodeVecTypeHint(getMDOperandAsType(Node, 0));
 }
 
-SPIRAddressSpace getOCLOpaqueTypeAddrSpace(Op OpCode) {
+SPIRAddressSpace getOCLOpaqueTypeAddrSpace(Op OpCode,
+                                           const SPIRV::AddrSpaceMap *MapPtr) {
+  auto Map = [&](SPIRAddressSpace AS) -> SPIRAddressSpace {
+    return (MapPtr && AS < SPIRAS_Count)
+               ? static_cast<SPIRAddressSpace>((*MapPtr)[AS])
+               : AS;
+  };
   switch ((unsigned)OpCode) {
   case OpTypeQueue:
-    return SPIRV_QUEUE_T_ADDR_SPACE;
+    return Map(SPIRV_QUEUE_T_ADDR_SPACE);
   case OpTypeEvent:
-    return SPIRV_EVENT_T_ADDR_SPACE;
+    return Map(SPIRV_EVENT_T_ADDR_SPACE);
   case OpTypeDeviceEvent:
-    return SPIRV_CLK_EVENT_T_ADDR_SPACE;
+    return Map(SPIRV_CLK_EVENT_T_ADDR_SPACE);
   case OpTypeReserveId:
-    return SPIRV_RESERVE_ID_T_ADDR_SPACE;
+    return Map(SPIRV_RESERVE_ID_T_ADDR_SPACE);
   case OpTypePipe:
   case OpTypePipeStorage:
-    return SPIRV_PIPE_ADDR_SPACE;
+    return Map(SPIRV_PIPE_ADDR_SPACE);
   case OpTypeImage:
   case OpTypeSampledImage:
   case OpTypeVmeImageINTEL:
-    return SPIRV_IMAGE_ADDR_SPACE;
+    return Map(SPIRV_IMAGE_ADDR_SPACE);
   case OpConstantSampler:
   case OpTypeSampler:
-    return SPIRV_SAMPLER_T_ADDR_SPACE;
+    return Map(SPIRV_SAMPLER_T_ADDR_SPACE);
   case OpTypeCooperativeMatrixKHR:
   case internal::OpTypeTaskSequenceINTEL:
     return SPIRAS_Global;
   default:
     if (isSubgroupAvcINTELTypeOpCode(OpCode))
-      return SPIRV_AVC_INTEL_T_ADDR_SPACE;
+      return Map(SPIRV_AVC_INTEL_T_ADDR_SPACE);
     assert(false && "No address space is determined for some OCL type");
-    return SPIRV_OCL_SPECIAL_TYPES_DEFAULT_ADDR_SPACE;
+    return Map(SPIRV_OCL_SPECIAL_TYPES_DEFAULT_ADDR_SPACE);
   }
 }
 
@@ -953,19 +959,25 @@ static SPIR::TypeAttributeEnum mapAddrSpaceEnums(SPIRAddressSpace Addrspace) {
 }
 
 SPIR::TypeAttributeEnum
-getOCLOpaqueTypeAddrSpace(SPIR::TypePrimitiveEnum Prim) {
+getOCLOpaqueTypeAddrSpace(SPIR::TypePrimitiveEnum Prim,
+                          const SPIRV::AddrSpaceMap *MapPtr) {
+  auto Map = [&](SPIRAddressSpace AS) -> SPIRAddressSpace {
+    return (MapPtr && AS < SPIRAS_Count)
+               ? static_cast<SPIRAddressSpace>((*MapPtr)[AS])
+               : AS;
+  };
   switch (Prim) {
   case SPIR::PRIMITIVE_QUEUE_T:
-    return mapAddrSpaceEnums(SPIRV_QUEUE_T_ADDR_SPACE);
+    return mapAddrSpaceEnums(Map(SPIRV_QUEUE_T_ADDR_SPACE));
   case SPIR::PRIMITIVE_EVENT_T:
-    return mapAddrSpaceEnums(SPIRV_EVENT_T_ADDR_SPACE);
+    return mapAddrSpaceEnums(Map(SPIRV_EVENT_T_ADDR_SPACE));
   case SPIR::PRIMITIVE_CLK_EVENT_T:
-    return mapAddrSpaceEnums(SPIRV_CLK_EVENT_T_ADDR_SPACE);
+    return mapAddrSpaceEnums(Map(SPIRV_CLK_EVENT_T_ADDR_SPACE));
   case SPIR::PRIMITIVE_RESERVE_ID_T:
-    return mapAddrSpaceEnums(SPIRV_RESERVE_ID_T_ADDR_SPACE);
+    return mapAddrSpaceEnums(Map(SPIRV_RESERVE_ID_T_ADDR_SPACE));
   case SPIR::PRIMITIVE_PIPE_RO_T:
   case SPIR::PRIMITIVE_PIPE_WO_T:
-    return mapAddrSpaceEnums(SPIRV_PIPE_ADDR_SPACE);
+    return mapAddrSpaceEnums(Map(SPIRV_PIPE_ADDR_SPACE));
   case SPIR::PRIMITIVE_IMAGE1D_RO_T:
   case SPIR::PRIMITIVE_IMAGE1D_ARRAY_RO_T:
   case SPIR::PRIMITIVE_IMAGE1D_BUFFER_RO_T:
@@ -1002,7 +1014,7 @@ getOCLOpaqueTypeAddrSpace(SPIR::TypePrimitiveEnum Prim) {
   case SPIR::PRIMITIVE_IMAGE2D_MSAA_DEPTH_RW_T:
   case SPIR::PRIMITIVE_IMAGE2D_ARRAY_MSAA_DEPTH_RW_T:
   case SPIR::PRIMITIVE_IMAGE3D_RW_T:
-    return mapAddrSpaceEnums(SPIRV_IMAGE_ADDR_SPACE);
+    return mapAddrSpaceEnums(Map(SPIRV_IMAGE_ADDR_SPACE));
   default:
     llvm_unreachable("No address space is determined for a SPIR primitive");
   }
@@ -1607,7 +1619,8 @@ Value *SPIRV::transSPIRVMemorySemanticsIntoOCLMemFenceFlags(
 
 void llvm::mangleOpenClBuiltin(const std::string &UniqName,
                                ArrayRef<Type *> ArgTypes,
-                               std::string &MangledName) {
+                               std::string &MangledName,
+                               const SPIRV::AddrSpaceMap *Map) {
   OCLUtil::OCLBuiltinFuncMangleInfo BtnInfo;
-  MangledName = SPIRV::mangleBuiltin(UniqName, ArgTypes, &BtnInfo);
+  MangledName = SPIRV::mangleBuiltin(UniqName, ArgTypes, &BtnInfo, Map);
 }

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -39,6 +39,7 @@
 #ifndef SPIRV_OCLUTIL_H
 #define SPIRV_OCLUTIL_H
 
+#include "LLVMSPIRVOpts.h"
 #include "SPIRVInternal.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/IR/IRBuilder.h"
@@ -477,8 +478,10 @@ unsigned transVecTypeHint(MDNode *Node);
 /// Decode SPIR-V encoding of vector type hint execution mode.
 Type *decodeVecTypeHint(LLVMContext &C, unsigned Code);
 
-SPIRAddressSpace getOCLOpaqueTypeAddrSpace(Op OpCode);
-SPIR::TypeAttributeEnum getOCLOpaqueTypeAddrSpace(SPIR::TypePrimitiveEnum Prim);
+SPIRAddressSpace getOCLOpaqueTypeAddrSpace(
+    Op OpCode, const SPIRV::AddrSpaceMap *Map = nullptr);
+SPIR::TypeAttributeEnum getOCLOpaqueTypeAddrSpace(
+    SPIR::TypePrimitiveEnum Prim, const SPIRV::AddrSpaceMap *Map = nullptr);
 
 inline unsigned mapOCLMemSemanticToSPIRV(unsigned MemFenceFlag,
                                          OCLMemOrderKind Order) {

--- a/lib/SPIRV/OCLUtil.h
+++ b/lib/SPIRV/OCLUtil.h
@@ -478,10 +478,11 @@ unsigned transVecTypeHint(MDNode *Node);
 /// Decode SPIR-V encoding of vector type hint execution mode.
 Type *decodeVecTypeHint(LLVMContext &C, unsigned Code);
 
-SPIRAddressSpace getOCLOpaqueTypeAddrSpace(
-    Op OpCode, const SPIRV::AddrSpaceMap *Map = nullptr);
-SPIR::TypeAttributeEnum getOCLOpaqueTypeAddrSpace(
-    SPIR::TypePrimitiveEnum Prim, const SPIRV::AddrSpaceMap *Map = nullptr);
+SPIRAddressSpace
+getOCLOpaqueTypeAddrSpace(Op OpCode, const SPIRV::AddrSpaceMap *Map = nullptr);
+SPIR::TypeAttributeEnum
+getOCLOpaqueTypeAddrSpace(SPIR::TypePrimitiveEnum Prim,
+                          const SPIRV::AddrSpaceMap *Map = nullptr);
 
 inline unsigned mapOCLMemSemanticToSPIRV(unsigned MemFenceFlag,
                                          OCLMemOrderKind Order) {

--- a/lib/SPIRV/SPIRVBuiltinHelper.cpp
+++ b/lib/SPIRV/SPIRVBuiltinHelper.cpp
@@ -368,7 +368,7 @@ Type *BuiltinCallHelper::getSPIRVType(spv::Op TypeOpcode,
   if (!STy)
     STy = StructType::create(M->getContext(), FullName);
 
-  unsigned AddrSpace = getOCLOpaqueTypeAddrSpace(TypeOpcode);
+  unsigned AddrSpace = getOCLOpaqueTypeAddrSpace(TypeOpcode, AddrSpaceMapper);
   return UseRealType ? (Type *)PointerType::get(M->getContext(), AddrSpace)
                      : TypedPointerType::get(STy, AddrSpace);
 }

--- a/lib/SPIRV/SPIRVBuiltinHelper.h
+++ b/lib/SPIRV/SPIRVBuiltinHelper.h
@@ -250,6 +250,7 @@ public:
 class BuiltinCallHelper {
   ManglingRules Rules;
   std::function<std::string(llvm::StringRef)> NameMapFn;
+  const SPIRV::AddrSpaceMap *AddrSpaceMapper = nullptr;
 
 protected:
   llvm::Module *M = nullptr;
@@ -260,10 +261,14 @@ public:
   /// The Rules argument selects which name mangler to use for mangling.
   /// The NameMapFn function will map type names during demangling; it defaults
   /// to the identity function.
+  /// The AddrSpaceMapper, if non-null, is used to remap address spaces of
+  /// opaque OCL types (images, events, samplers, etc.) during mangling.
   explicit BuiltinCallHelper(
       ManglingRules Rules,
-      std::function<std::string(llvm::StringRef)> NameMapFn = nullptr)
-      : Rules(Rules), NameMapFn(std::move(NameMapFn)) {}
+      std::function<std::string(llvm::StringRef)> NameMapFn = nullptr,
+      const SPIRV::AddrSpaceMap *AddrSpaceMapper = nullptr)
+      : Rules(Rules), NameMapFn(std::move(NameMapFn)),
+        AddrSpaceMapper(AddrSpaceMapper) {}
 
   /// Initialize the module that will be operated on. This method must be called
   /// before future methods.

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -179,19 +179,6 @@ typedef SPIRVMap<Op, Op, IntBoolOpMapId> IntBoolOpMap;
   "-v128:128:128-v192:256:256-v256:256:256"                                    \
   "-v512:512:512-v1024:1024:1024"
 
-enum SPIRAddressSpace {
-  SPIRAS_Private,
-  SPIRAS_Global,
-  SPIRAS_Constant,
-  SPIRAS_Local,
-  SPIRAS_Generic,
-  SPIRAS_GlobalDevice,
-  SPIRAS_GlobalHost,
-  SPIRAS_Input,
-  SPIRAS_Output,
-  SPIRAS_CodeSectionINTEL,
-  SPIRAS_Count,
-};
 
 template <> inline void SPIRVMap<SPIRAddressSpace, std::string>::init() {
   add(SPIRAS_Private, "Private");

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -885,7 +885,8 @@ bool containsUnsignedAtomicType(StringRef Name);
 /// \return \param UniqName if \param BtnInfo is null pointer, otherwise
 ///    return IA64 mangled name.
 std::string mangleBuiltin(StringRef UniqName, ArrayRef<Type *> ArgTypes,
-                          BuiltinFuncMangleInfo *BtnInfo);
+                          BuiltinFuncMangleInfo *BtnInfo,
+                          const SPIRV::AddrSpaceMap *Map = nullptr);
 
 /// Extract the true pointer types, expressed as a TypedPointerType, of
 /// arguments from a mangled function name. If the corresponding type is not a
@@ -909,7 +910,8 @@ bool getRetParamSignedness(Function *F, ParamSignedness &RetSignedness,
 /// manner
 std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
                                            ArrayRef<Type *> ArgTys,
-                                           Type *RetTy = nullptr);
+                                           Type *RetTy = nullptr,
+                                           const SPIRV::AddrSpaceMap *Map = nullptr);
 
 /// Mangle a function in SPIR-V friendly IR manner
 /// \param UniqName full unmangled name of the SPIR-V built-in function that
@@ -922,7 +924,8 @@ std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
 /// \return IA64 mangled name.
 std::string getSPIRVFriendlyIRFunctionName(const std::string &UniqName,
                                            spv::Op OC, ArrayRef<Type *> ArgTys,
-                                           ArrayRef<SPIRVValue *> Ops);
+                                           ArrayRef<SPIRVValue *> Ops,
+                                           const SPIRV::AddrSpaceMap *Map = nullptr);
 
 /// Get i8* with the same address space.
 PointerType *getInt8PtrTy(PointerType *T);

--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -179,7 +179,6 @@ typedef SPIRVMap<Op, Op, IntBoolOpMapId> IntBoolOpMap;
   "-v128:128:128-v192:256:256-v256:256:256"                                    \
   "-v512:512:512-v1024:1024:1024"
 
-
 template <> inline void SPIRVMap<SPIRAddressSpace, std::string>::init() {
   add(SPIRAS_Private, "Private");
   add(SPIRAS_Global, "Global");
@@ -908,10 +907,10 @@ bool getRetParamSignedness(Function *F, ParamSignedness &RetSignedness,
 
 /// Mangle a function from OpenCL extended instruction set in SPIR-V friendly IR
 /// manner
-std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
-                                           ArrayRef<Type *> ArgTys,
-                                           Type *RetTy = nullptr,
-                                           const SPIRV::AddrSpaceMap *Map = nullptr);
+std::string
+getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId, ArrayRef<Type *> ArgTys,
+                               Type *RetTy = nullptr,
+                               const SPIRV::AddrSpaceMap *Map = nullptr);
 
 /// Mangle a function in SPIR-V friendly IR manner
 /// \param UniqName full unmangled name of the SPIR-V built-in function that
@@ -922,10 +921,9 @@ std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
 /// \param Types of arguments of SPIR-V built-in function
 /// \param Ops Operands of SPIRVInstruction
 /// \return IA64 mangled name.
-std::string getSPIRVFriendlyIRFunctionName(const std::string &UniqName,
-                                           spv::Op OC, ArrayRef<Type *> ArgTys,
-                                           ArrayRef<SPIRVValue *> Ops,
-                                           const SPIRV::AddrSpaceMap *Map = nullptr);
+std::string getSPIRVFriendlyIRFunctionName(
+    const std::string &UniqName, spv::Op OC, ArrayRef<Type *> ArgTys,
+    ArrayRef<SPIRVValue *> Ops, const SPIRV::AddrSpaceMap *Map = nullptr);
 
 /// Get i8* with the same address space.
 PointerType *getInt8PtrTy(PointerType *T);

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -369,16 +369,18 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     if (BM->shouldEmitFunctionPtrAddrSpace() &&
         T->getPointerElementType()->getOpCode() == OpTypeFunction)
       AS = SPIRAS_CodeSectionINTEL;
+    unsigned MappedAS = BM->mapAddrSpace(AS);
     Type *ElementTy = transType(T->getPointerElementType(), UseTPT);
     if (UseTPT)
-      return TypedPointerType::get(ElementTy, AS);
-    return mapType(T, PointerType::get(*Context, AS));
+      return TypedPointerType::get(ElementTy, MappedAS);
+    return mapType(T, PointerType::get(*Context, MappedAS));
   }
   case OpTypeUntypedPointerKHR: {
     unsigned AS = SPIRSPIRVAddrSpaceMap::rmap(T->getPointerStorageClass());
     if (AS == SPIRAS_CodeSectionINTEL && !BM->shouldEmitFunctionPtrAddrSpace())
       AS = SPIRAS_Private;
-    return mapType(T, PointerType::get(*Context, AS));
+    unsigned MappedAS = BM->mapAddrSpace(AS);
+    return mapType(T, PointerType::get(*Context, MappedAS));
   }
   case OpTypeVector:
     return mapType(T,
@@ -465,7 +467,7 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     Type *Ty = nullptr;
     if (UseTPT) {
       Type *StructTy = getOrCreateOpaqueStructType(M, transVCTypeName(PST));
-      Ty = TypedPointerType::get(StructTy, SPIRAS_Global);
+      Ty = TypedPointerType::get(StructTy, BM->mapAddrSpace(SPIRAS_Global));
     } else {
       std::vector<unsigned> Params;
       if (PST->hasAccessQualifier()) {
@@ -1406,7 +1408,7 @@ Value *SPIRVToLLVM::oclTransConstantPipeStorage(
   return new GlobalVariable(*M, CPSTy, false, GlobalValue::LinkOnceODRLinkage,
                             ConstantStruct::get(CPSTy, CPSElems),
                             BCPS->getName(), nullptr,
-                            GlobalValue::NotThreadLocal, SPIRAS_Global);
+                            GlobalValue::NotThreadLocal, BM->mapAddrSpace(SPIRAS_Global));
 }
 
 // Translate aliasing memory access masks for SPIRVLoad and SPIRVStore
@@ -1699,9 +1701,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     SPIRVFunction *F = BC->getFunction();
     BV->setName(F->getName());
     const unsigned AS = BM->shouldEmitFunctionPtrAddrSpace()
-                            ? SPIRAS_CodeSectionINTEL
-                            : SPIRAS_Private;
-    return mapValue(BV, transFunction(F, AS));
+                            ? BM->mapAddrSpace(SPIRAS_CodeSectionINTEL)
+                            : BM->getFunctionProgramAddrSpace();
+    Function *Func = transFunction(F, AS);
+    Type *ResTy = transType(BV->getType());
+    unsigned ResAS = isa<TypedPointerType>(ResTy)
+                         ? cast<TypedPointerType>(ResTy)->getAddressSpace()
+                         : cast<PointerType>(ResTy)->getAddressSpace();
+    return mapValue(BV, castFunctionToAddrSpace(Func, ResAS));
   }
 
   case OpUndef:
@@ -1747,7 +1754,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       // execution instance, so emit an alloca instead of a global.
       assert(BB && "OpVariable with Function storage class requires BB");
       IRBuilder<> Builder(BB);
-      AllocaInst *AI = Builder.CreateAlloca(Ty, nullptr, BV->getName());
+      AllocaInst *AI = Builder.CreateAlloca(Ty, BM->mapAddrSpace(SPIRAS_Private),
+                                            nullptr, BV->getName());
       if (Init) {
         auto *Src = transValue(Init, F, BB);
         const bool IsVolatile = BVar->hasDecorate(DecorationVolatile);
@@ -1876,7 +1884,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     llvm::Type *Ty = transType(BV->getType()->getPointerElementType());
     llvm::Value *ArrSize = transValue(VLA->getOperand(0), F, BB);
     return mapValue(BV,
-                    new AllocaInst(Ty, M->getDataLayout().getAllocaAddrSpace(),
+                    new AllocaInst(Ty, BM->mapAddrSpace(SPIRAS_Private),
                                    ArrSize, BV->getName(), BB));
   }
 
@@ -1884,13 +1892,18 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     IRBuilder<> Builder(BB);
     auto *Restore = static_cast<SPIRVRestoreMemoryINTEL *>(BV);
     llvm::Value *Ptr = transValue(Restore->getOperand(0), F, BB);
-    auto *StackRestore = Builder.CreateStackRestore(Ptr);
+    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
+    auto *Ty = PointerType::get(Builder.getContext(), PrivateAS);
+    auto *StackRestore =
+        Builder.CreateIntrinsic(Intrinsic::stackrestore, {Ty}, {Ptr});
     return mapValue(BV, StackRestore);
   }
 
   case OpSaveMemoryINTEL: {
     IRBuilder<> Builder(BB);
-    auto *StackSave = Builder.CreateStackSave();
+    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
+    auto *Ty = PointerType::get(Builder.getContext(), PrivateAS);
+    auto *StackSave = Builder.CreateIntrinsic(Intrinsic::stacksave, {Ty}, {});
     return mapValue(BV, StackSave);
   }
 
@@ -2337,7 +2350,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     SPIRVCopyObject *CO = static_cast<SPIRVCopyObject *>(BV);
     auto *Ty = transType(CO->getOperand()->getType());
     AllocaInst *AI =
-        new AllocaInst(Ty, M->getDataLayout().getAllocaAddrSpace(), "", BB);
+        new AllocaInst(Ty, BM->mapAddrSpace(SPIRAS_Private), "", BB);
     new StoreInst(transValue(CO->getOperand(), F, BB), AI, BB);
     LoadInst *LI = new LoadInst(Ty, AI, "", BB);
     return mapValue(BV, LI);
@@ -2354,7 +2367,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
     IRBuilder<> Builder(BB);
 
-    auto *SrcAI = Builder.CreateAlloca(SrcTy);
+    auto *SrcAI = Builder.CreateAlloca(SrcTy, BM->mapAddrSpace(SPIRAS_Private));
     Builder.CreateAlignedStore(transValue(CL->getOperand(), F, BB), SrcAI,
                                SrcAI->getAlign());
 
@@ -2501,7 +2514,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         return mapValue(BV, ConstantArray::get(AT, CV));
 
       AllocaInst *Alloca =
-          new AllocaInst(AT, M->getDataLayout().getAllocaAddrSpace(), "", BB);
+          new AllocaInst(AT, BM->mapAddrSpace(SPIRAS_Private), "", BB);
 
       // get pointer to the element of the array
       // store the result of argument
@@ -2521,7 +2534,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         return mapValue(BV, ConstantStruct::get(ST, CV));
 
       AllocaInst *Alloca =
-          new AllocaInst(ST, M->getDataLayout().getAllocaAddrSpace(), "", BB);
+          new AllocaInst(ST, BM->mapAddrSpace(SPIRAS_Private), "", BB);
 
       // get pointer to the element of structure
       // store the result of argument
@@ -2901,7 +2914,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     SPIRVFPGARegINTELInstBase *BC =
         static_cast<SPIRVFPGARegINTELInstBase *>(BV);
 
-    PointerType *Int8PtrTyPrivate = PointerType::get(*Context, SPIRAS_Private);
+    PointerType *Int8PtrTyPrivate = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
     IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
     Value *UndefInt8Ptr = PoisonValue::get(Int8PtrTyPrivate);
@@ -3138,10 +3151,13 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
   Args.reserve(8);
   if (RetTy->getIntegerBitWidth() > 64) {
     llvm::PointerType *RetPtrTy =
-        llvm::PointerType::get(*Context, SPIRAS_Generic);
+        llvm::PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     Value *Alloca =
-        new AllocaInst(RetTy, M->getDataLayout().getAllocaAddrSpace(), "", BB);
-    Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
+        new AllocaInst(RetTy, BM->mapAddrSpace(SPIRAS_Private), "", BB);
+    Value *RetValPtr =
+        (Alloca->getType() == RetPtrTy)
+            ? Alloca
+            : static_cast<Value *>(new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB));
     ArgTys.emplace_back(RetPtrTy);
     Args.emplace_back(RetValPtr);
   }
@@ -3263,11 +3279,14 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
 
   if (RetTy->getIntegerBitWidth() > 64) {
     llvm::PointerType *RetPtrTy =
-        llvm::PointerType::get(*Context, SPIRAS_Generic);
+        llvm::PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     ArgTys.push_back(RetPtrTy);
     Value *Alloca =
-        new AllocaInst(RetTy, M->getDataLayout().getAllocaAddrSpace(), "", BB);
-    Value *RetValPtr = new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
+        new AllocaInst(RetTy, BM->mapAddrSpace(SPIRAS_Private), "", BB);
+    Value *RetValPtr =
+        (Alloca->getType() == RetPtrTy)
+            ? Alloca
+            : static_cast<Value *>(new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB));
     Args.push_back(RetValPtr);
   }
 
@@ -3518,6 +3537,17 @@ void SPIRVToLLVM::parseFloatControls2ExecutionModeId(SPIRVFunction *BF,
   }
 }
 
+Constant *SPIRVToLLVM::castFunctionToAddrSpace(Function *Func,
+                                               unsigned ExpectedAS) {
+  // The pointer's address space may differ from the function's own address
+  // space when FunctionProgramAddrSpace is set to different value than
+  // SPIRAS_Private. Emit an addrspacecast constant expression to fix that.
+  if (Func->getAddressSpace() == ExpectedAS)
+    return Func;
+  return ConstantExpr::getAddrSpaceCast(
+      Func, PointerType::get(*Context, ExpectedAS));
+}
+
 Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
   auto Loc = FuncMap.find(BF);
   if (Loc != FuncMap.end())
@@ -3678,7 +3708,7 @@ SPIRVToLLVM::transOCLBuiltinPostproc(SPIRVInstruction *BI, CallInst *CI,
 
 Value *SPIRVToLLVM::transBlockInvoke(SPIRVValue *Invoke, BasicBlock *BB) {
   auto *TranslatedInvoke = transFunction(static_cast<SPIRVFunction *>(Invoke));
-  auto *Int8PtrTyGen = PointerType::get(*Context, SPIRAS_Generic);
+  auto *Int8PtrTyGen = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
   return CastInst::CreatePointerBitCastOrAddrSpaceCast(TranslatedInvoke,
                                                        Int8PtrTyGen, "", BB);
 }
@@ -3692,7 +3722,7 @@ Instruction *SPIRVToLLVM::transWGSizeQueryBI(SPIRVInstruction *BI,
 
   Function *F = M->getFunction(FName);
   if (!F) {
-    auto *Int8PtrTyGen = PointerType::get(*Context, SPIRAS_Generic);
+    auto *Int8PtrTyGen = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     FunctionType *FT = FunctionType::get(Type::getInt32Ty(*Context),
                                          {Int8PtrTyGen, Int8PtrTyGen}, false);
     F = Function::Create(FT, GlobalValue::ExternalLinkage, FName, M);
@@ -3717,7 +3747,7 @@ Instruction *SPIRVToLLVM::transSGSizeQueryBI(SPIRVInstruction *BI,
   auto Ops = BI->getOperands();
   Function *F = M->getFunction(FName);
   if (!F) {
-    auto *Int8PtrTyGen = PointerType::get(*Context, SPIRAS_Generic);
+    auto *Int8PtrTyGen = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     SmallVector<Type *, 3> Tys = {
         transType(Ops[0]->getType()), // ndrange
         Int8PtrTyGen,                 // block_invoke
@@ -3765,8 +3795,9 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
       auto *AI = static_cast<SPIRVAtomicInstBase *>(BI);
       ArgTys[PtrIdx] = TypedPointerType::get(
           transType(AI->getSemanticType()),
-          SPIRSPIRVAddrSpaceMap::rmap(BI->getValueType(Ops[PtrIdx]->getId())
-                                          ->getPointerStorageClass()));
+          BM->mapAddrSpace(
+              SPIRSPIRVAddrSpaceMap::rmap(BI->getValueType(Ops[PtrIdx]->getId())
+                                             ->getPointerStorageClass())));
     }
   }
 
@@ -3789,7 +3820,7 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
 
   for (auto &I : ArgTys) {
     if (isa<FunctionType>(I)) {
-      I = TypedPointerType::get(I, SPIRAS_Private);
+      I = TypedPointerType::get(I, BM->mapAddrSpace(SPIRAS_Private));
     }
   }
 
@@ -3882,7 +3913,7 @@ Type *SPIRVToLLVM::getTypedPtrFromUntypedOperand(SPIRVValue *Val, Type *RetTy) {
   }
 
   unsigned AddrSpace =
-      SPIRSPIRVAddrSpaceMap::rmap(Val->getType()->getPointerStorageClass());
+      BM->mapAddrSpace(SPIRSPIRVAddrSpaceMap::rmap(Val->getType()->getPointerStorageClass()));
   if (Ty)
     return TypedPointerType::get(Ty, AddrSpace);
 
@@ -4081,9 +4112,14 @@ bool SPIRVToLLVM::translate() {
     SPIRVFunction *F = BC->getFunction();
     FP->setName(F->getName());
     const unsigned AS = BM->shouldEmitFunctionPtrAddrSpace()
-                            ? SPIRAS_CodeSectionINTEL
-                            : SPIRAS_Private;
-    mapValue(FP, transFunction(F, AS));
+                            ? BM->mapAddrSpace(SPIRAS_CodeSectionINTEL)
+                            : BM->getFunctionProgramAddrSpace();
+    Function *Func = transFunction(F, AS);
+    Type *ResTy = transType(FP->getType());
+    unsigned ResAS = isa<TypedPointerType>(ResTy)
+                         ? cast<TypedPointerType>(ResTy)->getAddressSpace()
+                         : cast<PointerType>(ResTy)->getAddressSpace();
+    mapValue(FP, castFunctionToAddrSpace(Func, ResAS));
   }
 
   for (unsigned I = 0, E = BM->getNumFunctions(); I != E; ++I) {
@@ -4126,14 +4162,24 @@ bool SPIRVToLLVM::translate() {
 
 bool SPIRVToLLVM::transAddressingModel() {
   switch (BM->getAddressingModel()) {
-  case AddressingModelPhysical64:
+  case AddressingModelPhysical64: {
     M->setTargetTriple(Triple(SPIR_TARGETTRIPLE64));
-    M->setDataLayout(SPIR_DATALAYOUT64);
+    std::string DL = SPIR_DATALAYOUT64;
+    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
+    if (PrivateAS != SPIRAS_Private)
+      DL += "-A" + std::to_string(PrivateAS);
+    M->setDataLayout(DL);
     break;
-  case AddressingModelPhysical32:
+  }
+  case AddressingModelPhysical32: {
     M->setTargetTriple(Triple(SPIR_TARGETTRIPLE32));
-    M->setDataLayout(SPIR_DATALAYOUT32);
+    std::string DL = SPIR_DATALAYOUT32;
+    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
+    if (PrivateAS != SPIRAS_Private)
+      DL += "-A" + std::to_string(PrivateAS);
+    M->setDataLayout(DL);
     break;
+  }
   case AddressingModelLogical:
     // Do not set target triple and data layout
     break;
@@ -4321,8 +4367,8 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
 
     IRBuilder<> Builder(Inst->getParent());
 
-    Type *Int8PtrTyPrivate = PointerType::get(*Context, SPIRAS_Private);
-    Type *PtrTyConstant = PointerType::get(*Context, SPIRAS_Constant);
+    Type *Int8PtrTyPrivate = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
+    Type *PtrTyConstant = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Constant));
     IntegerType *Int32Ty = IntegerType::get(*Context, 32);
 
     Value *UndefInt8Ptr = PoisonValue::get(Int8PtrTyPrivate);
@@ -4457,7 +4503,7 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
           GV->getContext(), M->getDataLayout().getDefaultGlobalsAddressSpace());
       Constant *C = ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, ResType);
 
-      Type *Int8PtrTyPrivate = PointerType::get(*Context, SPIRAS_Private);
+      Type *Int8PtrTyPrivate = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
       IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
       llvm::Constant *Fields[5] = {
@@ -4518,7 +4564,7 @@ void SPIRVToLLVM::transUserSemantic(SPIRV::SPIRVFunction *Fun) {
     Constant *C =
         ConstantExpr::getPointerBitCastOrAddrSpaceCast(TransFun, ResType);
 
-    Type *Int8PtrTyPrivate = PointerType::get(*Context, SPIRAS_Private);
+    Type *Int8PtrTyPrivate = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
     IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
     llvm::Constant *Fields[5] = {
@@ -5058,7 +5104,7 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
         else if (ArgTy->isTypeOCLImage() || ArgTy->isTypePipe())
           AS = SPIRAS_Global;
         return ConstantAsMetadata::get(
-            ConstantInt::get(Type::getInt32Ty(*Context), AS));
+            ConstantInt::get(Type::getInt32Ty(*Context), BM->mapAddrSpace(AS)));
       });
   // Generate metadata for kernel_arg_access_qual
   addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_ACCESS_QUAL, BF, F,

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1131,14 +1131,16 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
                 SPIRSPIRVAddrSpaceMap::rmap(PtrTy->getPointerStorageClass());
             Type *ElementTy = transType(PtrTy->getPointerElementType());
             OpsTys.emplace_back(TypedPointerType::get(ElementTy, AS));
-            MangledName = mangleBuiltin(BuiltinName, OpsTys, &Info);
+            MangledName = mangleBuiltin(BuiltinName, OpsTys, &Info,
+                                        BM->getAddrSpaceMap());
             // But to create function itself we need untyped pointer type.
             OpsTys[2] = opaquifyType(OpsTys[2]);
           }
         }
 
         if (MangledName.empty())
-          MangledName = mangleBuiltin(BuiltinName, OpsTys, &Info);
+          MangledName = mangleBuiltin(BuiltinName, OpsTys, &Info,
+                                      BM->getAddrSpaceMap());
 
         FunctionType *FTy = FunctionType::get(Dst, OpsTys, false);
         FunctionCallee Func = M->getOrInsertFunction(MangledName, FTy);
@@ -2728,7 +2730,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     Type *RetTy = Type::getVoidTy(*Context);
 
     std::string MangledName =
-        getSPIRVFriendlyIRFunctionName(OpenCLLIB::Prefetch, ArgTypes, RetTy);
+        getSPIRVFriendlyIRFunctionName(OpenCLLIB::Prefetch, ArgTypes, RetTy,
+                                       BM->getAddrSpaceMap());
     opaquifyTypedPointers(ArgTypes);
 
     FunctionType *FT = FunctionType::get(RetTy, ArgTypes, false);
@@ -3825,9 +3828,10 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
   }
 
   if (BM->getDesiredBIsRepresentation() != BIsRepresentation::SPIRVFriendlyIR)
-    mangleOpenClBuiltin(FuncName, ArgTys, MangledName);
+    mangleOpenClBuiltin(FuncName, ArgTys, MangledName, BM->getAddrSpaceMap());
   else
-    MangledName = getSPIRVFriendlyIRFunctionName(FuncName, OC, ArgTys, Ops);
+    MangledName = getSPIRVFriendlyIRFunctionName(FuncName, OC, ArgTys, Ops,
+                                                 BM->getAddrSpaceMap());
 
   opaquifyTypedPointers(ArgTys);
 
@@ -3875,8 +3879,9 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
 }
 
 SPIRVToLLVM::SPIRVToLLVM(Module *LLVMModule, SPIRVModule *TheSPIRVModule)
-    : BuiltinCallHelper(ManglingRules::OpenCL), M(LLVMModule),
-      BM(TheSPIRVModule) {
+    : BuiltinCallHelper(ManglingRules::OpenCL, nullptr,
+                        TheSPIRVModule->getAddrSpaceMap()),
+      M(LLVMModule), BM(TheSPIRVModule) {
   assert(M && "Initialization without an LLVM module is not allowed");
   initialize(*M);
   Context = &M->getContext();
@@ -5479,7 +5484,8 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC,
   }
 
   std::string MangledName =
-      getSPIRVFriendlyIRFunctionName(ExtOp, ArgTypes, RetTy);
+      getSPIRVFriendlyIRFunctionName(ExtOp, ArgTypes, RetTy,
+                                     BM->getAddrSpaceMap());
   opaquifyTypedPointers(ArgTypes);
 
   SPIRVDBG(spvdbgs() << "[transOCLBuiltinFromExtInst] UnmangledName: "

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1139,8 +1139,8 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         }
 
         if (MangledName.empty())
-          MangledName = mangleBuiltin(BuiltinName, OpsTys, &Info,
-                                      BM->getAddrSpaceMap());
+          MangledName =
+              mangleBuiltin(BuiltinName, OpsTys, &Info, BM->getAddrSpaceMap());
 
         FunctionType *FTy = FunctionType::get(Dst, OpsTys, false);
         FunctionCallee Func = M->getOrInsertFunction(MangledName, FTy);
@@ -1407,10 +1407,10 @@ Value *SPIRVToLLVM::oclTransConstantPipeStorage(
                           ConstantInt::get(Int32Ty, BCPS->getPacketAlign()),
                           ConstantInt::get(Int32Ty, BCPS->getCapacity())};
 
-  return new GlobalVariable(*M, CPSTy, false, GlobalValue::LinkOnceODRLinkage,
-                            ConstantStruct::get(CPSTy, CPSElems),
-                            BCPS->getName(), nullptr,
-                            GlobalValue::NotThreadLocal, BM->mapAddrSpace(SPIRAS_Global));
+  return new GlobalVariable(
+      *M, CPSTy, false, GlobalValue::LinkOnceODRLinkage,
+      ConstantStruct::get(CPSTy, CPSElems), BCPS->getName(), nullptr,
+      GlobalValue::NotThreadLocal, BM->mapAddrSpace(SPIRAS_Global));
 }
 
 // Translate aliasing memory access masks for SPIRVLoad and SPIRVStore
@@ -1756,8 +1756,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       // execution instance, so emit an alloca instead of a global.
       assert(BB && "OpVariable with Function storage class requires BB");
       IRBuilder<> Builder(BB);
-      AllocaInst *AI = Builder.CreateAlloca(Ty, BM->mapAddrSpace(SPIRAS_Private),
-                                            nullptr, BV->getName());
+      AllocaInst *AI = Builder.CreateAlloca(
+          Ty, BM->mapAddrSpace(SPIRAS_Private), nullptr, BV->getName());
       if (Init) {
         auto *Src = transValue(Init, F, BB);
         const bool IsVolatile = BVar->hasDecorate(DecorationVolatile);
@@ -1885,9 +1885,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto *VLA = static_cast<SPIRVVariableLengthArrayINTEL *>(BV);
     llvm::Type *Ty = transType(BV->getType()->getPointerElementType());
     llvm::Value *ArrSize = transValue(VLA->getOperand(0), F, BB);
-    return mapValue(BV,
-                    new AllocaInst(Ty, BM->mapAddrSpace(SPIRAS_Private),
-                                   ArrSize, BV->getName(), BB));
+    return mapValue(BV, new AllocaInst(Ty, BM->mapAddrSpace(SPIRAS_Private),
+                                       ArrSize, BV->getName(), BB));
   }
 
   case OpRestoreMemoryINTEL: {
@@ -2729,9 +2728,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         transTypeVector(BC->getValueTypes(BC->getArguments()), true);
     Type *RetTy = Type::getVoidTy(*Context);
 
-    std::string MangledName =
-        getSPIRVFriendlyIRFunctionName(OpenCLLIB::Prefetch, ArgTypes, RetTy,
-                                       BM->getAddrSpaceMap());
+    std::string MangledName = getSPIRVFriendlyIRFunctionName(
+        OpenCLLIB::Prefetch, ArgTypes, RetTy, BM->getAddrSpaceMap());
     opaquifyTypedPointers(ArgTypes);
 
     FunctionType *FT = FunctionType::get(RetTy, ArgTypes, false);
@@ -2917,7 +2915,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     SPIRVFPGARegINTELInstBase *BC =
         static_cast<SPIRVFPGARegINTELInstBase *>(BV);
 
-    PointerType *Int8PtrTyPrivate = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
+    PointerType *Int8PtrTyPrivate =
+        PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
     IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
     Value *UndefInt8Ptr = PoisonValue::get(Int8PtrTyPrivate);
@@ -3157,10 +3156,10 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
         llvm::PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     Value *Alloca =
         new AllocaInst(RetTy, BM->mapAddrSpace(SPIRAS_Private), "", BB);
-    Value *RetValPtr =
-        (Alloca->getType() == RetPtrTy)
-            ? Alloca
-            : static_cast<Value *>(new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB));
+    Value *RetValPtr = (Alloca->getType() == RetPtrTy)
+                           ? Alloca
+                           : static_cast<Value *>(new AddrSpaceCastInst(
+                                 Alloca, RetPtrTy, "", BB));
     ArgTys.emplace_back(RetPtrTy);
     Args.emplace_back(RetValPtr);
   }
@@ -3286,10 +3285,10 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
     ArgTys.push_back(RetPtrTy);
     Value *Alloca =
         new AllocaInst(RetTy, BM->mapAddrSpace(SPIRAS_Private), "", BB);
-    Value *RetValPtr =
-        (Alloca->getType() == RetPtrTy)
-            ? Alloca
-            : static_cast<Value *>(new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB));
+    Value *RetValPtr = (Alloca->getType() == RetPtrTy)
+                           ? Alloca
+                           : static_cast<Value *>(new AddrSpaceCastInst(
+                                 Alloca, RetPtrTy, "", BB));
     Args.push_back(RetValPtr);
   }
 
@@ -3547,8 +3546,8 @@ Constant *SPIRVToLLVM::castFunctionToAddrSpace(Function *Func,
   // SPIRAS_Private. Emit an addrspacecast constant expression to fix that.
   if (Func->getAddressSpace() == ExpectedAS)
     return Func;
-  return ConstantExpr::getAddrSpaceCast(
-      Func, PointerType::get(*Context, ExpectedAS));
+  return ConstantExpr::getAddrSpaceCast(Func,
+                                        PointerType::get(*Context, ExpectedAS));
 }
 
 Function *SPIRVToLLVM::transFunction(SPIRVFunction *BF, unsigned AS) {
@@ -3711,7 +3710,8 @@ SPIRVToLLVM::transOCLBuiltinPostproc(SPIRVInstruction *BI, CallInst *CI,
 
 Value *SPIRVToLLVM::transBlockInvoke(SPIRVValue *Invoke, BasicBlock *BB) {
   auto *TranslatedInvoke = transFunction(static_cast<SPIRVFunction *>(Invoke));
-  auto *Int8PtrTyGen = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
+  auto *Int8PtrTyGen =
+      PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
   return CastInst::CreatePointerBitCastOrAddrSpaceCast(TranslatedInvoke,
                                                        Int8PtrTyGen, "", BB);
 }
@@ -3725,7 +3725,8 @@ Instruction *SPIRVToLLVM::transWGSizeQueryBI(SPIRVInstruction *BI,
 
   Function *F = M->getFunction(FName);
   if (!F) {
-    auto *Int8PtrTyGen = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
+    auto *Int8PtrTyGen =
+        PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     FunctionType *FT = FunctionType::get(Type::getInt32Ty(*Context),
                                          {Int8PtrTyGen, Int8PtrTyGen}, false);
     F = Function::Create(FT, GlobalValue::ExternalLinkage, FName, M);
@@ -3750,7 +3751,8 @@ Instruction *SPIRVToLLVM::transSGSizeQueryBI(SPIRVInstruction *BI,
   auto Ops = BI->getOperands();
   Function *F = M->getFunction(FName);
   if (!F) {
-    auto *Int8PtrTyGen = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
+    auto *Int8PtrTyGen =
+        PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     SmallVector<Type *, 3> Tys = {
         transType(Ops[0]->getType()), // ndrange
         Int8PtrTyGen,                 // block_invoke
@@ -3796,11 +3798,11 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
     // builtin mangling of atomic and matrix operations.
     if (isAtomicOpCodeUntypedPtrSupported(OC)) {
       auto *AI = static_cast<SPIRVAtomicInstBase *>(BI);
-      ArgTys[PtrIdx] = TypedPointerType::get(
-          transType(AI->getSemanticType()),
-          BM->mapAddrSpace(
-              SPIRSPIRVAddrSpaceMap::rmap(BI->getValueType(Ops[PtrIdx]->getId())
-                                             ->getPointerStorageClass())));
+      ArgTys[PtrIdx] =
+          TypedPointerType::get(transType(AI->getSemanticType()),
+                                BM->mapAddrSpace(SPIRSPIRVAddrSpaceMap::rmap(
+                                    BI->getValueType(Ops[PtrIdx]->getId())
+                                        ->getPointerStorageClass())));
     }
   }
 
@@ -3917,8 +3919,8 @@ Type *SPIRVToLLVM::getTypedPtrFromUntypedOperand(SPIRVValue *Val, Type *RetTy) {
       Ty = RetTy;
   }
 
-  unsigned AddrSpace =
-      BM->mapAddrSpace(SPIRSPIRVAddrSpaceMap::rmap(Val->getType()->getPointerStorageClass()));
+  unsigned AddrSpace = BM->mapAddrSpace(
+      SPIRSPIRVAddrSpaceMap::rmap(Val->getType()->getPointerStorageClass()));
   if (Ty)
     return TypedPointerType::get(Ty, AddrSpace);
 
@@ -4372,8 +4374,10 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
 
     IRBuilder<> Builder(Inst->getParent());
 
-    Type *Int8PtrTyPrivate = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
-    Type *PtrTyConstant = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Constant));
+    Type *Int8PtrTyPrivate =
+        PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
+    Type *PtrTyConstant =
+        PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Constant));
     IntegerType *Int32Ty = IntegerType::get(*Context, 32);
 
     Value *UndefInt8Ptr = PoisonValue::get(Int8PtrTyPrivate);
@@ -4508,7 +4512,8 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
           GV->getContext(), M->getDataLayout().getDefaultGlobalsAddressSpace());
       Constant *C = ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, ResType);
 
-      Type *Int8PtrTyPrivate = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
+      Type *Int8PtrTyPrivate =
+          PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
       IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
       llvm::Constant *Fields[5] = {
@@ -4569,7 +4574,8 @@ void SPIRVToLLVM::transUserSemantic(SPIRV::SPIRVFunction *Fun) {
     Constant *C =
         ConstantExpr::getPointerBitCastOrAddrSpaceCast(TransFun, ResType);
 
-    Type *Int8PtrTyPrivate = PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
+    Type *Int8PtrTyPrivate =
+        PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
     IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
     llvm::Constant *Fields[5] = {
@@ -5483,9 +5489,8 @@ Instruction *SPIRVToLLVM::transOCLBuiltinFromExtInst(SPIRVExtInst *BC,
     }
   }
 
-  std::string MangledName =
-      getSPIRVFriendlyIRFunctionName(ExtOp, ArgTypes, RetTy,
-                                     BM->getAddrSpaceMap());
+  std::string MangledName = getSPIRVFriendlyIRFunctionName(
+      ExtOp, ArgTypes, RetTy, BM->getAddrSpaceMap());
   opaquifyTypedPointers(ArgTypes);
 
   SPIRVDBG(spvdbgs() << "[transOCLBuiltinFromExtInst] UnmangledName: "

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1756,8 +1756,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       // execution instance, so emit an alloca instead of a global.
       assert(BB && "OpVariable with Function storage class requires BB");
       IRBuilder<> Builder(BB);
-      AllocaInst *AI = Builder.CreateAlloca(
-          Ty, BM->mapAddrSpace(SPIRAS_Private), nullptr, BV->getName());
+      AllocaInst *AI = Builder.CreateAlloca(Ty, nullptr, BV->getName());
       if (Init) {
         auto *Src = transValue(Init, F, BB);
         const bool IsVolatile = BVar->hasDecorate(DecorationVolatile);
@@ -1782,7 +1781,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
       BV->setName(prefixSPIRVName(SPIRVBuiltInNameMap::map(BVKind)));
     auto *LVar = new GlobalVariable(*M, Ty, IsConst, LinkageTy,
                                     /*Initializer=*/nullptr, BV->getName(), 0,
-                                    GlobalVariable::NotThreadLocal, AddrSpace);
+                                    GlobalVariable::NotThreadLocal,
+                                    BM->mapAddrSpace(AddrSpace));
     auto *Res = mapValue(BV, LVar);
     if (Init)
       Initializer = dyn_cast<Constant>(transValue(Init, F, BB, false));
@@ -1886,27 +1886,21 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     auto *VLA = static_cast<SPIRVVariableLengthArrayINTEL *>(BV);
     llvm::Type *Ty = transType(BV->getType()->getPointerElementType());
     llvm::Value *ArrSize = transValue(VLA->getOperand(0), F, BB);
-    return mapValue(BV, new AllocaInst(Ty, BM->mapAddrSpace(SPIRAS_Private),
-                                       ArrSize, BV->getName(), BB));
+    return mapValue(BV,
+                    new AllocaInst(Ty, M->getDataLayout().getAllocaAddrSpace(),
+                                   ArrSize, BV->getName(), BB));
   }
 
   case OpRestoreMemoryINTEL: {
     IRBuilder<> Builder(BB);
     auto *Restore = static_cast<SPIRVRestoreMemoryINTEL *>(BV);
     llvm::Value *Ptr = transValue(Restore->getOperand(0), F, BB);
-    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
-    auto *Ty = PointerType::get(Builder.getContext(), PrivateAS);
-    auto *StackRestore =
-        Builder.CreateIntrinsic(Intrinsic::stackrestore, {Ty}, {Ptr});
-    return mapValue(BV, StackRestore);
+    return mapValue(BV, Builder.CreateStackRestore(Ptr));
   }
 
   case OpSaveMemoryINTEL: {
     IRBuilder<> Builder(BB);
-    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
-    auto *Ty = PointerType::get(Builder.getContext(), PrivateAS);
-    auto *StackSave = Builder.CreateIntrinsic(Intrinsic::stacksave, {Ty}, {});
-    return mapValue(BV, StackSave);
+    return mapValue(BV, Builder.CreateStackSave());
   }
 
   case OpBranch: {
@@ -2352,7 +2346,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     SPIRVCopyObject *CO = static_cast<SPIRVCopyObject *>(BV);
     auto *Ty = transType(CO->getOperand()->getType());
     AllocaInst *AI =
-        new AllocaInst(Ty, BM->mapAddrSpace(SPIRAS_Private), "", BB);
+        new AllocaInst(Ty, M->getDataLayout().getAllocaAddrSpace(), "", BB);
     new StoreInst(transValue(CO->getOperand(), F, BB), AI, BB);
     LoadInst *LI = new LoadInst(Ty, AI, "", BB);
     return mapValue(BV, LI);
@@ -2369,7 +2363,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
 
     IRBuilder<> Builder(BB);
 
-    auto *SrcAI = Builder.CreateAlloca(SrcTy, BM->mapAddrSpace(SPIRAS_Private));
+    auto *SrcAI = Builder.CreateAlloca(SrcTy);
     Builder.CreateAlignedStore(transValue(CL->getOperand(), F, BB), SrcAI,
                                SrcAI->getAlign());
 
@@ -2516,7 +2510,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         return mapValue(BV, ConstantArray::get(AT, CV));
 
       AllocaInst *Alloca =
-          new AllocaInst(AT, BM->mapAddrSpace(SPIRAS_Private), "", BB);
+          new AllocaInst(AT, M->getDataLayout().getAllocaAddrSpace(), "", BB);
 
       // get pointer to the element of the array
       // store the result of argument
@@ -2536,7 +2530,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         return mapValue(BV, ConstantStruct::get(ST, CV));
 
       AllocaInst *Alloca =
-          new AllocaInst(ST, BM->mapAddrSpace(SPIRAS_Private), "", BB);
+          new AllocaInst(ST, M->getDataLayout().getAllocaAddrSpace(), "", BB);
 
       // get pointer to the element of structure
       // store the result of argument
@@ -3157,7 +3151,7 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
     llvm::PointerType *RetPtrTy =
         llvm::PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     Value *Alloca =
-        new AllocaInst(RetTy, BM->mapAddrSpace(SPIRAS_Private), "", BB);
+        new AllocaInst(RetTy, M->getDataLayout().getAllocaAddrSpace(), "", BB);
     Value *RetValPtr = (Alloca->getType() == RetPtrTy)
                            ? Alloca
                            : static_cast<Value *>(new AddrSpaceCastInst(
@@ -3286,7 +3280,7 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
         llvm::PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
     ArgTys.push_back(RetPtrTy);
     Value *Alloca =
-        new AllocaInst(RetTy, BM->mapAddrSpace(SPIRAS_Private), "", BB);
+        new AllocaInst(RetTy, M->getDataLayout().getAllocaAddrSpace(), "", BB);
     Value *RetValPtr = (Alloca->getType() == RetPtrTy)
                            ? Alloca
                            : static_cast<Value *>(new AddrSpaceCastInst(
@@ -4171,22 +4165,30 @@ bool SPIRVToLLVM::translate() {
 }
 
 bool SPIRVToLLVM::transAddressingModel() {
+  // No -G: LLVM auto-injects -G1 for spir triples, and emitting our own
+  // would shift getDefaultGlobalsAddressSpace() away from AS 0 (the LLVM
+  // convention for llvm.global.annotations / llvm.metadata fields).
+  auto AppendAddrSpaceModifiers = [this](std::string &DL) {
+    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
+    if (PrivateAS != SPIRAS_Private)
+      DL += "-A" + std::to_string(PrivateAS);
+    unsigned ProgramAS = BM->getFunctionProgramAddrSpace();
+    if (ProgramAS != 0)
+      DL += "-P" + std::to_string(ProgramAS);
+  };
+
   switch (BM->getAddressingModel()) {
   case AddressingModelPhysical64: {
     M->setTargetTriple(Triple(SPIR_TARGETTRIPLE64));
     std::string DL = SPIR_DATALAYOUT64;
-    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
-    if (PrivateAS != SPIRAS_Private)
-      DL += "-A" + std::to_string(PrivateAS);
+    AppendAddrSpaceModifiers(DL);
     M->setDataLayout(DL);
     break;
   }
   case AddressingModelPhysical32: {
     M->setTargetTriple(Triple(SPIR_TARGETTRIPLE32));
     std::string DL = SPIR_DATALAYOUT32;
-    unsigned PrivateAS = BM->mapAddrSpace(SPIRAS_Private);
-    if (PrivateAS != SPIRAS_Private)
-      DL += "-A" + std::to_string(PrivateAS);
+    AppendAddrSpaceModifiers(DL);
     M->setDataLayout(DL);
     break;
   }
@@ -4500,13 +4502,19 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
       return;
     }
 
+    Type *Int8PtrTyPrivate =
+        PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
     for (const auto &AnnotStr : AnnotStrVec) {
       Constant *StrConstant =
           ConstantDataArray::getString(*Context, StringRef(AnnotStr));
 
+      // The annotation string is placed in the same address space as the i8*
+      // fields below so that the bitcast is in-AS and valid.
       auto *GS = new GlobalVariable(
           *GV->getParent(), StrConstant->getType(),
-          /*IsConstant*/ true, GlobalValue::PrivateLinkage, StrConstant, "");
+          /*IsConstant*/ true, GlobalValue::PrivateLinkage, StrConstant, "",
+          /*InsertBefore=*/nullptr, GlobalVariable::NotThreadLocal,
+          Int8PtrTyPrivate->getPointerAddressSpace());
 
       GS->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
       GS->setSection("llvm.metadata");
@@ -4515,8 +4523,6 @@ void SPIRVToLLVM::transIntelFPGADecorations(SPIRVValue *BV, Value *V) {
           GV->getContext(), M->getDataLayout().getDefaultGlobalsAddressSpace());
       Constant *C = ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, ResType);
 
-      Type *Int8PtrTyPrivate =
-          PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
       IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
       llvm::Constant *Fields[5] = {
@@ -4560,14 +4566,20 @@ void SPIRVToLLVM::transMemAliasingINTELDecorations(SPIRVValue *BV, Value *V) {
 // ect.)
 void SPIRVToLLVM::transUserSemantic(SPIRV::SPIRVFunction *Fun) {
   auto *TransFun = transFunction(Fun, BM->getFunctionProgramAddrSpace());
+  Type *Int8PtrTyPrivate =
+      PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
   for (const auto &UsSem :
        Fun->getDecorationStringLiteral(DecorationUserSemantic)) {
     auto *V = cast<Value>(TransFun);
     Constant *StrConstant =
         ConstantDataArray::getString(*Context, StringRef(UsSem));
+    // The annotation string is placed in the same address space as the i8*
+    // fields below so that the bitcast is in-AS and valid.
     auto *GS = new GlobalVariable(
         *TransFun->getParent(), StrConstant->getType(),
-        /*IsConstant*/ true, GlobalValue::PrivateLinkage, StrConstant, "");
+        /*IsConstant*/ true, GlobalValue::PrivateLinkage, StrConstant, "",
+        /*InsertBefore=*/nullptr, GlobalVariable::NotThreadLocal,
+        Int8PtrTyPrivate->getPointerAddressSpace());
 
     GS->setUnnamedAddr(GlobalValue::UnnamedAddr::Global);
     GS->setSection("llvm.metadata");
@@ -4577,8 +4589,6 @@ void SPIRVToLLVM::transUserSemantic(SPIRV::SPIRVFunction *Fun) {
     Constant *C =
         ConstantExpr::getPointerBitCastOrAddrSpaceCast(TransFun, ResType);
 
-    Type *Int8PtrTyPrivate =
-        PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Private));
     IntegerType *Int32Ty = Type::getInt32Ty(*Context);
 
     llvm::Constant *Fields[5] = {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1895,12 +1895,14 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     IRBuilder<> Builder(BB);
     auto *Restore = static_cast<SPIRVRestoreMemoryINTEL *>(BV);
     llvm::Value *Ptr = transValue(Restore->getOperand(0), F, BB);
-    return mapValue(BV, Builder.CreateStackRestore(Ptr));
+    auto *StackRestore = Builder.CreateStackRestore(Ptr);
+    return mapValue(BV, StackRestore);
   }
 
   case OpSaveMemoryINTEL: {
     IRBuilder<> Builder(BB);
-    return mapValue(BV, Builder.CreateStackSave());
+    auto *StackSave = Builder.CreateStackSave();
+    return mapValue(BV, StackSave);
   }
 
   case OpBranch: {

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3156,8 +3156,7 @@ Value *SPIRVToLLVM::transFixedPointInst(SPIRVInstruction *BI, BasicBlock *BB) {
         new AllocaInst(RetTy, M->getDataLayout().getAllocaAddrSpace(), "", BB);
     Value *RetValPtr = (Alloca->getType() == RetPtrTy)
                            ? Alloca
-                           : static_cast<Value *>(new AddrSpaceCastInst(
-                                 Alloca, RetPtrTy, "", BB));
+                           : new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
     ArgTys.emplace_back(RetPtrTy);
     Args.emplace_back(RetValPtr);
   }
@@ -3285,8 +3284,7 @@ Value *SPIRVToLLVM::transArbFloatInst(SPIRVInstruction *BI, BasicBlock *BB,
         new AllocaInst(RetTy, M->getDataLayout().getAllocaAddrSpace(), "", BB);
     Value *RetValPtr = (Alloca->getType() == RetPtrTy)
                            ? Alloca
-                           : static_cast<Value *>(new AddrSpaceCastInst(
-                                 Alloca, RetPtrTy, "", BB));
+                           : new AddrSpaceCastInst(Alloca, RetPtrTy, "", BB);
     Args.push_back(RetValPtr);
   }
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1832,7 +1832,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   }
 
   case OpFunction:
-    return mapValue(BV, transFunction(static_cast<SPIRVFunction *>(BV)));
+    return mapValue(BV, transFunction(static_cast<SPIRVFunction *>(BV),
+                                      BM->getFunctionProgramAddrSpace()));
 
   case OpAsmINTEL:
     return mapValue(BV, transAsmINTEL(static_cast<SPIRVAsmINTEL *>(BV)));
@@ -2675,8 +2676,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   case OpFunctionCall: {
     SPIRVFunctionCall *BC = static_cast<SPIRVFunctionCall *>(BV);
     std::vector<Value *> Args = transValue(BC->getArgumentValues(), F, BB);
-    auto *Call = CallInst::Create(transFunction(BC->getFunction()), Args,
-                                  BC->getName(), BB);
+    auto *Call = CallInst::Create(
+        transFunction(BC->getFunction(), BM->getFunctionProgramAddrSpace()),
+        Args, BC->getName(), BB);
     setCallingConv(Call);
     setAttrByCalledFunc(Call);
     return mapValue(BV, Call);
@@ -3709,7 +3711,8 @@ SPIRVToLLVM::transOCLBuiltinPostproc(SPIRVInstruction *BI, CallInst *CI,
 }
 
 Value *SPIRVToLLVM::transBlockInvoke(SPIRVValue *Invoke, BasicBlock *BB) {
-  auto *TranslatedInvoke = transFunction(static_cast<SPIRVFunction *>(Invoke));
+  auto *TranslatedInvoke = transFunction(static_cast<SPIRVFunction *>(Invoke),
+                                         BM->getFunctionProgramAddrSpace());
   auto *Int8PtrTyGen =
       PointerType::get(*Context, BM->mapAddrSpace(SPIRAS_Generic));
   return CastInst::CreatePointerBitCastOrAddrSpaceCast(TranslatedInvoke,
@@ -4130,7 +4133,7 @@ bool SPIRVToLLVM::translate() {
   }
 
   for (unsigned I = 0, E = BM->getNumFunctions(); I != E; ++I) {
-    transFunction(BM->getFunction(I));
+    transFunction(BM->getFunction(I), BM->getFunctionProgramAddrSpace());
     transUserSemantic(BM->getFunction(I));
   }
 
@@ -4556,7 +4559,7 @@ void SPIRVToLLVM::transMemAliasingINTELDecorations(SPIRVValue *BV, Value *V) {
 // attach some information on function and propagate that through SPIR-V and
 // ect.)
 void SPIRVToLLVM::transUserSemantic(SPIRV::SPIRVFunction *Fun) {
-  auto *TransFun = transFunction(Fun);
+  auto *TransFun = transFunction(Fun, BM->getFunctionProgramAddrSpace());
   for (const auto &UsSem :
        Fun->getDecorationStringLiteral(DecorationUserSemantic)) {
     auto *V = cast<Value>(TransFun);

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -109,6 +109,7 @@ public:
                                   Function *F, BasicBlock *);
   Function *transFunction(SPIRVFunction *F, unsigned AS = SPIRAS_Private);
   void transFunctionAttrs(SPIRVFunction *BF, Function *F);
+  Constant *castFunctionToAddrSpace(Function *Func, unsigned ExpectedAS);
   Value *transBlockInvoke(SPIRVValue *Invoke, BasicBlock *BB);
   Instruction *transWGSizeQueryBI(SPIRVInstruction *BI, BasicBlock *BB);
   Instruction *transSGSizeQueryBI(SPIRVInstruction *BI, BasicBlock *BB);

--- a/lib/SPIRV/SPIRVReader.h
+++ b/lib/SPIRV/SPIRVReader.h
@@ -107,7 +107,7 @@ public:
   void transAuxDataInst(SPIRVExtInst *BC);
   std::vector<Value *> transValue(const std::vector<SPIRVValue *> &,
                                   Function *F, BasicBlock *);
-  Function *transFunction(SPIRVFunction *F, unsigned AS = SPIRAS_Private);
+  Function *transFunction(SPIRVFunction *F, unsigned AS);
   void transFunctionAttrs(SPIRVFunction *BF, Function *F);
   Constant *castFunctionToAddrSpace(Function *Func, unsigned ExpectedAS);
   Value *transBlockInvoke(SPIRVValue *Invoke, BasicBlock *BB);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1007,7 +1007,8 @@ void SPIRVToLLVMDbgTran::transFunctionBody(DISubprogram *DIS, SPIRVId FuncId) {
   SPIRVEntry *E = BM->getEntry(FuncId);
   if (E->getOpCode() == OpFunction) {
     SPIRVFunction *BF = static_cast<SPIRVFunction *>(E);
-    llvm::Function *F = SPIRVReader->transFunction(BF);
+    llvm::Function *F = SPIRVReader->transFunction(
+        BF, BM->getFunctionProgramAddrSpace());
     assert(F && "Translation of function failed!");
     if (!F->hasMetadata("dbg"))
       F->setMetadata("dbg", DIS);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1007,8 +1007,8 @@ void SPIRVToLLVMDbgTran::transFunctionBody(DISubprogram *DIS, SPIRVId FuncId) {
   SPIRVEntry *E = BM->getEntry(FuncId);
   if (E->getOpCode() == OpFunction) {
     SPIRVFunction *BF = static_cast<SPIRVFunction *>(E);
-    llvm::Function *F = SPIRVReader->transFunction(
-        BF, BM->getFunctionProgramAddrSpace());
+    llvm::Function *F =
+        SPIRVReader->transFunction(BF, BM->getFunctionProgramAddrSpace());
     assert(F && "Translation of function failed!");
     if (!F->hasMetadata("dbg"))
       F->setMetadata("dbg", DIS);

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1359,7 +1359,8 @@ static SPIR::TypePrimitiveEnum getOCLTypePrimitiveEnum(TargetExtType *Ty) {
 static SPIR::RefParamType transTypeDesc(Type *Ty,
                                         const BuiltinArgTypeMangleInfo &Info,
                                         bool IsOpenCL,
-                                        StringRef InstName = "") {
+                                        StringRef InstName = "",
+                                        const SPIRV::AddrSpaceMap *Map = nullptr) {
   bool Signed = Info.IsSigned;
   unsigned Attr = Info.Attr;
   bool VoidPtr = Info.IsVoidPtr;
@@ -1375,7 +1376,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
     BuiltinArgTypeMangleInfo DTInfo = Info;
     DTInfo.IsAtomic = false;
     return SPIR::RefParamType(
-        new SPIR::AtomicType(transTypeDesc(Ty, DTInfo, IsOpenCL)));
+        new SPIR::AtomicType(transTypeDesc(Ty, DTInfo, IsOpenCL, "", Map)));
   }
   if (auto *IntTy = dyn_cast<IntegerType>(Ty)) {
     switch (IntTy->getBitWidth()) {
@@ -1409,12 +1410,12 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
     return SPIR::RefParamType(new SPIR::PrimitiveType(SPIR::PRIMITIVE_BFLOAT));
   if (auto *VecTy = dyn_cast<FixedVectorType>(Ty)) {
     return SPIR::RefParamType(new SPIR::VectorType(
-        transTypeDesc(VecTy->getElementType(), Info, IsOpenCL),
+        transTypeDesc(VecTy->getElementType(), Info, IsOpenCL, "", Map),
         VecTy->getNumElements()));
   }
   if (Ty->isArrayTy()) {
     return transTypeDesc(TypedPointerType::get(Ty->getArrayElementType(), 0),
-                         Info, IsOpenCL);
+                         Info, IsOpenCL, "", Map);
   }
   if (Ty->isStructTy()) {
     auto Name = Ty->getStructName();
@@ -1456,7 +1457,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
       if (Name.consume_front(kSPIRVTypeName::PrefixAndDelim)) {
         OS << "__spirv_" << Name;
         AS = getOCLOpaqueTypeAddrSpace(
-            SPIRVOpaqueTypeOpCodeMap::map(Name.str()));
+            SPIRVOpaqueTypeOpCodeMap::map(Name.str()), Map);
       } else {
         OS << Name;
       }
@@ -1483,7 +1484,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
       if (InstName.consume_front(kSPIRVName::Prefix) &&
           InstName.starts_with("TaskSequence")) {
         EPT = new SPIR::PointerType(
-            transTypeDesc(FT->getReturnType(), Info, IsOpenCL));
+            transTypeDesc(FT->getReturnType(), Info, IsOpenCL, "", Map));
       } else {
         assert((isVoidFuncTy(FT)) && "Not supported");
         EPT = new SPIR::BlockType;
@@ -1522,7 +1523,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
               Prim == SPIR::PRIMITIVE_PIPE_WO_T) {
             SPIR::RefParamType OpaqueTyRef(new SPIR::PrimitiveType(Prim));
             auto *OpaquePtrTy = new SPIR::PointerType(OpaqueTyRef);
-            OpaquePtrTy->setAddressSpace(getOCLOpaqueTypeAddrSpace(Prim));
+            OpaquePtrTy->setAddressSpace(getOCLOpaqueTypeAddrSpace(Prim, Map));
             EPT = OpaquePtrTy;
           } else {
             EPT = new SPIR::PrimitiveType(Prim);
@@ -1537,7 +1538,7 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
 
     if (VoidPtr && ET->isIntegerTy(8))
       ET = Type::getVoidTy(ET->getContext());
-    auto *PT = new SPIR::PointerType(transTypeDesc(ET, Info, IsOpenCL));
+    auto *PT = new SPIR::PointerType(transTypeDesc(ET, Info, IsOpenCL, "", Map));
     PT->setAddressSpace(static_cast<SPIR::TypeAttributeEnum>(
         TPT->getAddressSpace() + (unsigned)SPIR::ATTR_ADDR_SPACE_FIRST));
     for (unsigned I = SPIR::ATTR_QUALIFIER_FIRST, E = SPIR::ATTR_QUALIFIER_LAST;
@@ -1791,7 +1792,8 @@ manglePipeOrAddressSpaceCastBuiltin(const SPIR::FunctionDescriptor &Fd,
 }
 
 std::string mangleBuiltin(StringRef UniqName, ArrayRef<Type *> ArgTypes,
-                          BuiltinFuncMangleInfo *BtnInfo) {
+                          BuiltinFuncMangleInfo *BtnInfo,
+                          const SPIRV::AddrSpaceMap *Map) {
   if (!BtnInfo)
     return std::string(UniqName);
   BtnInfo->init(UniqName);
@@ -1820,7 +1822,8 @@ std::string mangleBuiltin(StringRef UniqName, ArrayRef<Type *> ArgTypes,
         T = MangleInfo.PointerTy;
       }
       FD.Parameters.emplace_back(transTypeDesc(T, BtnInfo->getTypeMangleInfo(I),
-                                               BtnInfo->isOpenCL(), UniqName));
+                                               BtnInfo->isOpenCL(), UniqName,
+                                               Map));
     }
   }
   // Ellipsis must be the last argument of any function
@@ -2754,16 +2757,18 @@ private:
 namespace SPIRV {
 std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
                                            ArrayRef<Type *> ArgTys,
-                                           Type *RetTy) {
+                                           Type *RetTy,
+                                           const SPIRV::AddrSpaceMap *Map) {
   OpenCLStdToSPIRVFriendlyIRMangleInfo MangleInfo(ExtOpId, ArgTys, RetTy);
-  return mangleBuiltin(MangleInfo.getUnmangledName(), ArgTys, &MangleInfo);
+  return mangleBuiltin(MangleInfo.getUnmangledName(), ArgTys, &MangleInfo, Map);
 }
 
 std::string getSPIRVFriendlyIRFunctionName(const std::string &UniqName,
                                            spv::Op OC, ArrayRef<Type *> ArgTys,
-                                           ArrayRef<SPIRVValue *> Ops) {
+                                           ArrayRef<SPIRVValue *> Ops,
+                                           const SPIRV::AddrSpaceMap *Map) {
   SPIRVFriendlyIRMangleInfo MangleInfo(OC, ArgTys, Ops);
-  return mangleBuiltin(UniqName, ArgTys, &MangleInfo);
+  return mangleBuiltin(UniqName, ArgTys, &MangleInfo, Map);
 }
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1356,11 +1356,10 @@ static SPIR::TypePrimitiveEnum getOCLTypePrimitiveEnum(TargetExtType *Ty) {
 /// Translates LLVM type to descriptor for mangler.
 /// \param Signed indicates integer type should be translated as signed.
 /// \param VoidPtr indicates i8* should be translated as void*.
-static SPIR::RefParamType transTypeDesc(Type *Ty,
-                                        const BuiltinArgTypeMangleInfo &Info,
-                                        bool IsOpenCL,
-                                        StringRef InstName = "",
-                                        const SPIRV::AddrSpaceMap *Map = nullptr) {
+static SPIR::RefParamType
+transTypeDesc(Type *Ty, const BuiltinArgTypeMangleInfo &Info, bool IsOpenCL,
+              StringRef InstName = "",
+              const SPIRV::AddrSpaceMap *Map = nullptr) {
   bool Signed = Info.IsSigned;
   unsigned Attr = Info.Attr;
   bool VoidPtr = Info.IsVoidPtr;
@@ -1538,7 +1537,8 @@ static SPIR::RefParamType transTypeDesc(Type *Ty,
 
     if (VoidPtr && ET->isIntegerTy(8))
       ET = Type::getVoidTy(ET->getContext());
-    auto *PT = new SPIR::PointerType(transTypeDesc(ET, Info, IsOpenCL, "", Map));
+    auto *PT =
+        new SPIR::PointerType(transTypeDesc(ET, Info, IsOpenCL, "", Map));
     PT->setAddressSpace(static_cast<SPIR::TypeAttributeEnum>(
         TPT->getAddressSpace() + (unsigned)SPIR::ATTR_ADDR_SPACE_FIRST));
     for (unsigned I = SPIR::ATTR_QUALIFIER_FIRST, E = SPIR::ATTR_QUALIFIER_LAST;
@@ -2756,8 +2756,7 @@ private:
 
 namespace SPIRV {
 std::string getSPIRVFriendlyIRFunctionName(OCLExtOpKind ExtOpId,
-                                           ArrayRef<Type *> ArgTys,
-                                           Type *RetTy,
+                                           ArrayRef<Type *> ArgTys, Type *RetTy,
                                            const SPIRV::AddrSpaceMap *Map) {
   OpenCLStdToSPIRVFriendlyIRMangleInfo MangleInfo(ExtOpId, ArgTys, RetTy);
   return mangleBuiltin(MangleInfo.getUnmangledName(), ArgTys, &MangleInfo, Map);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4954,7 +4954,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       std::vector<SPIRVValue *> Elts(TNumElts, transValue(Val, BB));
       Init = BM->addCompositeConstant(CompositeTy, Elts);
     }
-    SPIRVType *VarTy = transPointerType(AT, SPIRV::SPIRAS_Private);
+    SPIRVType *VarTy = transPointerType(AT, SPIRAS_Private);
     SPIRVBasicBlock *EntryBB = BB->getParent()->getBasicBlock(0);
     SPIRVValue *Var = BM->addVariable(VarTy, nullptr, /*isConstant*/ false,
                                       spv::internal::LinkageTypeInternal, Init,
@@ -4964,7 +4964,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     if (!MemAccess.empty() && MemAccess[0] == MemoryAccessAlignedMask)
       Var->setAlignment(MemAccess[1]);
     SPIRVType *SourceTy =
-        transPointerType(Val->getType(), SPIRV::SPIRAS_Private);
+        transPointerType(Val->getType(), SPIRAS_Private);
     SPIRVValue *Source = BM->addUnaryInst(OpBitcast, SourceTy, Var, BB);
     SPIRVValue *Target = transValue(MSI->getRawDest(), BB);
     return BM->addCopyMemorySizedInst(Target, Source, CompositeTy->getLength(),

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4963,8 +4963,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
         MSI, BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_4));
     if (!MemAccess.empty() && MemAccess[0] == MemoryAccessAlignedMask)
       Var->setAlignment(MemAccess[1]);
-    SPIRVType *SourceTy =
-        transPointerType(Val->getType(), SPIRAS_Private);
+    SPIRVType *SourceTy = transPointerType(Val->getType(), SPIRAS_Private);
     SPIRVValue *Source = BM->addUnaryInst(OpBitcast, SourceTy, Var, BB);
     SPIRVValue *Target = transValue(MSI->getRawDest(), BB);
     return BM->addCopyMemorySizedInst(Target, Source, CompositeTy->getLength(),

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -601,6 +601,14 @@ public:
     return TranslationOpts.shouldEmitFunctionPtrAddrSpace();
   }
 
+  unsigned mapAddrSpace(unsigned SPIRAS) const noexcept {
+    return TranslationOpts.mapAddrSpace(SPIRAS);
+  }
+
+  unsigned getFunctionProgramAddrSpace() const noexcept {
+    return TranslationOpts.getFunctionProgramAddrSpace();
+  }
+
   bool preserveAuxData() const noexcept {
     return TranslationOpts.preserveAuxData();
   }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -605,6 +605,10 @@ public:
     return TranslationOpts.mapAddrSpace(SPIRAS);
   }
 
+  const SPIRV::AddrSpaceMap *getAddrSpaceMap() const noexcept {
+    return TranslationOpts.getAddrSpaceMap();
+  }
+
   unsigned getFunctionProgramAddrSpace() const noexcept {
     return TranslationOpts.getFunctionProgramAddrSpace();
   }

--- a/test/spirv-addrspace-map-builtin-mangle.ll
+++ b/test/spirv-addrspace-map-builtin-mangle.ll
@@ -1,0 +1,43 @@
+; Test --spirv-addrspace-map address space remapping in SPIR-V builtin
+; function names for opaque (image) types.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r --spirv-target-env=SPV-IR %t.spv -o - \
+; RUN:   | llvm-dis | FileCheck %s --check-prefix=CHECK-DEFAULT
+; RUN: llvm-spirv -r --spirv-target-env=SPV-IR --spirv-addrspace-map=1:3 %t.spv -o - \
+; RUN:   | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @write_kernel(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %img, <2 x i32> %coord, <4 x float> %val) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {
+; Without an address space map, image types use global (AS1): U3AS1 in the name.
+; CHECK-DEFAULT: __spirv_ImageWritePU3AS1
+; With mapping 1->3 (global->local), U3AS3 must appear instead.
+; CHECK-MAPPED: __spirv_ImageWritePU3AS3
+; CHECK-MAPPED-NOT: __spirv_ImageWritePU3AS1
+  call spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %img, <2 x i32> %coord, <4 x float> %val)
+  ret void
+}
+
+declare spir_func void @_Z12write_imagef14ocl_image2d_woDv2_iDv4_f(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1), <2 x i32>, <4 x float>)
+
+attributes #0 = { nounwind }
+
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!6}
+!opencl.ocl.version = !{!6}
+!opencl.used.extensions = !{!7}
+!opencl.used.optional.core.features = !{!8}
+!opencl.compiler.options = !{!7}
+
+!1 = !{i32 1, i32 0, i32 0}
+!2 = !{!"write_only", !"none", !"none"}
+!3 = !{!"image2d_t", !"int2", !"float4"}
+!4 = !{!"image2d_t", !"int2", !"float4"}
+!5 = !{!"", !"", !""}
+!6 = !{i32 2, i32 0}
+!7 = !{}
+!8 = !{!"cl_images"}

--- a/test/spirv-addrspace-map-datalayout.ll
+++ b/test/spirv-addrspace-map-datalayout.ll
@@ -1,0 +1,36 @@
+; Test that the datalayout emitted by the SPIR-V reader reflects ASMap and
+; --spirv-function-program-addrspace.
+
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o - | llvm-dis \
+; RUN:   | FileCheck %s --check-prefix=CHECK-DEFAULT
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4 -o - | llvm-dis \
+; RUN:   | FileCheck %s --check-prefix=CHECK-PRIVATE-MAPPED
+; RUN: llvm-spirv -r %t.spv --spirv-function-program-addrspace=4 -o - | llvm-dis \
+; RUN:   | FileCheck %s --check-prefix=CHECK-PROG-EXPLICIT
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:3 \
+; RUN:   --spirv-function-program-addrspace=4 -o - | llvm-dis \
+; RUN:   | FileCheck %s --check-prefix=CHECK-PROG-OVERRIDE
+
+; CHECK-DEFAULT: target datalayout = "e-p:64:64:64-
+; CHECK-DEFAULT-NOT: -A{{[0-9]}}
+; CHECK-DEFAULT-NOT: -P{{[0-9]}}
+
+; private(0)->4: -A4-P4
+; CHECK-PRIVATE-MAPPED: target datalayout = "{{.*}}-A4-P4
+
+; --spirv-function-program-addrspace=4 with no map: -P4, no -A.
+; CHECK-PROG-EXPLICIT: target datalayout = "{{.*}}-P4
+; CHECK-PROG-EXPLICIT-NOT: -A{{[0-9]}}
+
+; --spirv-addrspace-map=0:3 plus explicit function AS=4: -A3-P4
+; (explicit --spirv-function-program-addrspace overrides the map for -P).
+; CHECK-PROG-OVERRIDE: target datalayout = "{{.*}}-A3-P4
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_func void @test() {
+  ret void
+}

--- a/test/spirv-addrspace-map-untyped.ll
+++ b/test/spirv-addrspace-map-untyped.ll
@@ -1,0 +1,27 @@
+; Test that --spirv-addrspace-map applies correctly when untyped pointers
+; (SPV_KHR_untyped_pointers) are used.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_untyped_pointers -o %t.untyped.spv
+; RUN: llvm-spirv -r %t.untyped.spv --spirv-addrspace-map=0:4,1:1,2:2,3:3,4:0 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED
+; RUN: llvm-spirv -r %t.untyped.spv \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-IDENTITY
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+; With mapping 4->0, the generic AS4 pointer remaps to AS0 (printed as bare ptr).
+; CHECK-MAPPED: define{{.*}} @test_generic_atomic(
+; CHECK-MAPPED: call spir_func i32 @{{.*}}atomic{{.*}}(ptr{{( addrspace\(0\))?}}
+
+; Without mapping, generic stays at AS4.
+; CHECK-IDENTITY: define{{.*}} @test_generic_atomic(
+; CHECK-IDENTITY: call spir_func i32 @{{.*}}atomic{{.*}}(ptr addrspace(4)
+
+define spir_func i32 @test_generic_atomic(ptr addrspace(4) %p) {
+  %v = load atomic i32, ptr addrspace(4) %p seq_cst, align 4
+  ret i32 %v
+}
+
+attributes #0 = { nounwind }

--- a/test/spirv-addrspace-map-untyped.ll
+++ b/test/spirv-addrspace-map-untyped.ll
@@ -13,11 +13,11 @@ target triple = "spir64-unknown-unknown"
 
 ; With mapping 4->0, the generic AS4 pointer remaps to AS0 (printed as bare ptr).
 ; CHECK-MAPPED: define{{.*}} @test_generic_atomic(
-; CHECK-MAPPED: call spir_func i32 @{{.*}}atomic{{.*}}(ptr{{( addrspace\(0\))?}}
+; CHECK-MAPPED: call spir_func i32 @_Z10atomic_addPVii(ptr
 
 ; Without mapping, generic stays at AS4.
 ; CHECK-IDENTITY: define{{.*}} @test_generic_atomic(
-; CHECK-IDENTITY: call spir_func i32 @{{.*}}atomic{{.*}}(ptr addrspace(4)
+; CHECK-IDENTITY: call spir_func i32 @_Z10atomic_addPU3AS4Vii(ptr addrspace(4)
 
 define spir_func i32 @test_generic_atomic(ptr addrspace(4) %p) {
   %v = load atomic i32, ptr addrspace(4) %p seq_cst, align 4

--- a/test/spirv-addrspace-map-untyped.ll
+++ b/test/spirv-addrspace-map-untyped.ll
@@ -13,7 +13,7 @@ target triple = "spir64-unknown-unknown"
 
 ; With mapping 4->0, the generic AS4 pointer remaps to AS0 (printed as bare ptr).
 ; CHECK-MAPPED: define{{.*}} @test_generic_atomic(
-; CHECK-MAPPED: call spir_func i32 @_Z10atomic_addPVii(ptr
+; CHECK-MAPPED: call spir_func addrspace(4) i32 @_Z10atomic_addPVii(ptr
 
 ; Without mapping, generic stays at AS4.
 ; CHECK-IDENTITY: define{{.*}} @test_generic_atomic(

--- a/test/spirv-addrspace-map-vla.ll
+++ b/test/spirv-addrspace-map-vla.ll
@@ -15,17 +15,17 @@ target triple = "spir64-unknown-unknown"
 ; triggers generation of alloca and @llvm.stacksave/restore which need to be
 ; emitted with correct addess space.
 ; CHECK-MAPPED: define{{.*}} @test_stack_save_restore(
-; CHECK-MAPPED: call ptr addrspace(4) @llvm.stacksave.p4()
+; CHECK-MAPPED: call addrspace(4) ptr addrspace(4) @llvm.stacksave.p4()
 ; CHECK-MAPPED: alloca i32, i64 %n, align 4, addrspace(4)
-; CHECK-MAPPED: call void @llvm.stackrestore.p4(ptr addrspace(4)
+; CHECK-MAPPED: call addrspace(4) void @llvm.stackrestore.p4(ptr addrspace(4)
 ; CHECK-IDENTITY: define{{.*}} @test_stack_save_restore(
 ; CHECK-IDENTITY: call ptr @llvm.stacksave.p0()
 ; CHECK-IDENTITY: alloca i32, i64 %n, align 4{{$}}
 ; CHECK-IDENTITY: call void @llvm.stackrestore.p0(ptr
 ; CHECK-PARTIAL: define{{.*}} @test_stack_save_restore(
-; CHECK-PARTIAL: call ptr addrspace(4) @llvm.stacksave.p4()
+; CHECK-PARTIAL: call addrspace(4) ptr addrspace(4) @llvm.stacksave.p4()
 ; CHECK-PARTIAL: alloca i32, i64 %n, align 4, addrspace(4)
-; CHECK-PARTIAL: call void @llvm.stackrestore.p4(ptr addrspace(4)
+; CHECK-PARTIAL: call addrspace(4) void @llvm.stackrestore.p4(ptr addrspace(4)
 define spir_func void @test_stack_save_restore(i64 %n) {
   %saved = call ptr @llvm.stacksave.p0()
   %vla = alloca i32, i64 %n, align 4

--- a/test/spirv-addrspace-map-vla.ll
+++ b/test/spirv-addrspace-map-vla.ll
@@ -1,0 +1,40 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_variable_length_array -o %t.spv
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4,1:1,2:2,3:3,4:0 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED
+; RUN: llvm-spirv -r %t.spv \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-IDENTITY
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-PARTIAL
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+; Test --spirv-addrspace-map address space remapping for functions using
+; variable-length arrays (requires SPV_INTEL_variable_length_array), this
+; triggers generation of alloca and @llvm.stacksave/restore which need to be
+; emitted with correct addess space.
+; CHECK-MAPPED: define{{.*}} @test_stack_save_restore(
+; CHECK-MAPPED: call ptr addrspace(4) @llvm.stacksave.p4()
+; CHECK-MAPPED: alloca i32, i64 %n, align 4, addrspace(4)
+; CHECK-MAPPED: call void @llvm.stackrestore.p4(ptr addrspace(4)
+; CHECK-IDENTITY: define{{.*}} @test_stack_save_restore(
+; CHECK-IDENTITY: call ptr @llvm.stacksave.p0()
+; CHECK-IDENTITY: alloca i32, i64 %n, align 4{{$}}
+; CHECK-IDENTITY: call void @llvm.stackrestore.p0(ptr
+; CHECK-PARTIAL: define{{.*}} @test_stack_save_restore(
+; CHECK-PARTIAL: call ptr addrspace(4) @llvm.stacksave.p4()
+; CHECK-PARTIAL: alloca i32, i64 %n, align 4, addrspace(4)
+; CHECK-PARTIAL: call void @llvm.stackrestore.p4(ptr addrspace(4)
+define spir_func void @test_stack_save_restore(i64 %n) {
+  %saved = call ptr @llvm.stacksave.p0()
+  %vla = alloca i32, i64 %n, align 4
+  store i32 0, ptr %vla, align 4
+  call void @llvm.stackrestore.p0(ptr %saved)
+  ret void
+}
+
+declare ptr @llvm.stacksave.p0() #0
+declare void @llvm.stackrestore.p0(ptr) #0
+
+attributes #0 = { nounwind }

--- a/test/spirv-addrspace-map.ll
+++ b/test/spirv-addrspace-map.ll
@@ -1,0 +1,85 @@
+; Test --spirv-addrspace-map address space remapping on SPIR-V -> LLVM translation.
+
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_variable_length_array,+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_arbitrary_precision_fixed_point -o %t.spv
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4,1:1,2:2,3:3,4:0 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED
+; RUN: llvm-spirv -r %t.spv \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-IDENTITY
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-PARTIAL
+; RUN: not llvm-spirv -r %t.spv --spirv-addrspace-map=99:0 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-IDX
+; RUN: not llvm-spirv -r %t.spv --spirv-addrspace-map=bad 2>&1 \
+; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-FMT
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-MAPPED: define{{.*}} @test_stable_and_generic({{.*}}ptr addrspace(1){{.*}}ptr addrspace(3){{.*}}ptr{{( addrspace\(0\))?}}
+; CHECK-IDENTITY: define{{.*}} @test_stable_and_generic({{.*}}ptr addrspace(1){{.*}}ptr addrspace(3){{.*}}ptr addrspace(4)
+; CHECK-PARTIAL: define{{.*}} @test_stable_and_generic({{.*}}ptr addrspace(1){{.*}}ptr addrspace(3){{.*}}ptr addrspace(4)
+define spir_kernel void @test_stable_and_generic(ptr addrspace(1) %global_p,
+                                                 ptr addrspace(3) %local_p,
+                                                 ptr addrspace(4) %generic_p) {
+  ret void
+}
+
+; CHECK-MAPPED: define{{.*}} @test_constant({{.*}}ptr addrspace(2)
+; CHECK-IDENTITY: define{{.*}} @test_constant({{.*}}ptr addrspace(2)
+; CHECK-PARTIAL: define{{.*}} @test_constant({{.*}}ptr addrspace(2)
+define spir_kernel void @test_constant(ptr addrspace(2) %const_p) {
+  ret void
+}
+
+; CHECK-MAPPED: define{{.*}} @test_private(
+; CHECK-MAPPED: alloca i32,{{.*}} addrspace(4)
+; CHECK-IDENTITY: define{{.*}} @test_private(
+; CHECK-IDENTITY: alloca i32, align
+; CHECK-PARTIAL: define{{.*}} @test_private(
+; CHECK-PARTIAL: alloca i32,{{.*}} addrspace(4)
+define spir_func i32 @test_private() {
+  %x = alloca i32
+  %v = load i32, ptr %x
+  ret i32 %v
+}
+
+; CHECK-MAPPED: define{{.*}} @test_stack_save_restore(
+; CHECK-MAPPED: call ptr addrspace(4) @llvm.stacksave.p4()
+; CHECK-MAPPED: call void @llvm.stackrestore.p4(ptr addrspace(4)
+; CHECK-IDENTITY: define{{.*}} @test_stack_save_restore(
+; CHECK-IDENTITY: call ptr @llvm.stacksave.p0()
+; CHECK-IDENTITY: call void @llvm.stackrestore.p0(ptr
+; CHECK-PARTIAL: define{{.*}} @test_stack_save_restore(
+; CHECK-PARTIAL: call ptr addrspace(4) @llvm.stacksave.p4()
+; CHECK-PARTIAL: call void @llvm.stackrestore.p4(ptr addrspace(4)
+define spir_func void @test_stack_save_restore(i64 %n) {
+  %saved = call ptr @llvm.stacksave.p0()
+  %vla = alloca i32, i64 %n, align 4
+  store i32 0, ptr %vla, align 4
+  call void @llvm.stackrestore.p0(ptr %saved)
+  ret void
+}
+
+; CHECK-MAPPED: define{{.*}} @test_wide_fixed_point(
+; CHECK-MAPPED: call void @intel_arbitrary_fixed_sincos.i66.i34(ptr{{( addrspace\(0\))?}} sret(i66)
+; CHECK-IDENTITY: define{{.*}} @test_wide_fixed_point(
+; CHECK-IDENTITY: call void @intel_arbitrary_fixed_sincos.i66.i34(ptr addrspace(4) sret(i66)
+define spir_func void @test_wide_fixed_point() {
+  %a = alloca i34, align 8
+  %a.ascast = addrspacecast ptr %a to ptr addrspace(4)
+  %result = alloca i66, align 8
+  %result.ascast = addrspacecast ptr %result to ptr addrspace(4)
+  %val = load i34, ptr addrspace(4) %a.ascast, align 8
+  call spir_func void @_Z24__spirv_FixedSinCosINTELILi34ELi66EEU7_ExtIntIXmlLi2ET0_EEiU7_ExtIntIXT_EEibiiii(ptr addrspace(4) sret(i66) align 8 %result.ascast, i34 %val, i1 zeroext true, i32 3, i32 2, i32 0, i32 0)
+  ret void
+}
+
+declare ptr @llvm.stacksave.p0() #0
+declare void @llvm.stackrestore.p0(ptr) #0
+declare spir_func void @_Z24__spirv_FixedSinCosINTELILi34ELi66EEU7_ExtIntIXmlLi2ET0_EEiU7_ExtIntIXT_EEibiiii(ptr addrspace(4) sret(i66) align 8, i34, i1 zeroext, i32, i32, i32, i32) #0
+
+attributes #0 = { nounwind }
+
+; CHECK-ERR-IDX: not a valid SPIRAddressSpace index
+; CHECK-ERR-FMT: Invalid format for --spirv-addrspace-map

--- a/test/spirv-addrspace-map.ll
+++ b/test/spirv-addrspace-map.ll
@@ -1,7 +1,7 @@
 ; Test --spirv-addrspace-map address space remapping on SPIR-V -> LLVM translation.
 
 ; RUN: llvm-as < %s -o %t.bc
-; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_variable_length_array,+SPV_INTEL_arbitrary_precision_integers,+SPV_INTEL_arbitrary_precision_fixed_point -o %t.spv
+; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4,1:1,2:2,3:3,4:0 \
 ; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED
 ; RUN: llvm-spirv -r %t.spv \
@@ -12,6 +12,9 @@
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-IDX
 ; RUN: not llvm-spirv -r %t.spv --spirv-addrspace-map=bad 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-FMT
+
+; CHECK-ERR-IDX: not a valid SPIRAddressSpace index
+; CHECK-ERR-FMT: Invalid format for --spirv-addrspace-map
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
 target triple = "spir64-unknown-unknown"
@@ -44,42 +47,4 @@ define spir_func i32 @test_private() {
   ret i32 %v
 }
 
-; CHECK-MAPPED: define{{.*}} @test_stack_save_restore(
-; CHECK-MAPPED: call ptr addrspace(4) @llvm.stacksave.p4()
-; CHECK-MAPPED: call void @llvm.stackrestore.p4(ptr addrspace(4)
-; CHECK-IDENTITY: define{{.*}} @test_stack_save_restore(
-; CHECK-IDENTITY: call ptr @llvm.stacksave.p0()
-; CHECK-IDENTITY: call void @llvm.stackrestore.p0(ptr
-; CHECK-PARTIAL: define{{.*}} @test_stack_save_restore(
-; CHECK-PARTIAL: call ptr addrspace(4) @llvm.stacksave.p4()
-; CHECK-PARTIAL: call void @llvm.stackrestore.p4(ptr addrspace(4)
-define spir_func void @test_stack_save_restore(i64 %n) {
-  %saved = call ptr @llvm.stacksave.p0()
-  %vla = alloca i32, i64 %n, align 4
-  store i32 0, ptr %vla, align 4
-  call void @llvm.stackrestore.p0(ptr %saved)
-  ret void
-}
-
-; CHECK-MAPPED: define{{.*}} @test_wide_fixed_point(
-; CHECK-MAPPED: call void @intel_arbitrary_fixed_sincos.i66.i34(ptr{{( addrspace\(0\))?}} sret(i66)
-; CHECK-IDENTITY: define{{.*}} @test_wide_fixed_point(
-; CHECK-IDENTITY: call void @intel_arbitrary_fixed_sincos.i66.i34(ptr addrspace(4) sret(i66)
-define spir_func void @test_wide_fixed_point() {
-  %a = alloca i34, align 8
-  %a.ascast = addrspacecast ptr %a to ptr addrspace(4)
-  %result = alloca i66, align 8
-  %result.ascast = addrspacecast ptr %result to ptr addrspace(4)
-  %val = load i34, ptr addrspace(4) %a.ascast, align 8
-  call spir_func void @_Z24__spirv_FixedSinCosINTELILi34ELi66EEU7_ExtIntIXmlLi2ET0_EEiU7_ExtIntIXT_EEibiiii(ptr addrspace(4) sret(i66) align 8 %result.ascast, i34 %val, i1 zeroext true, i32 3, i32 2, i32 0, i32 0)
-  ret void
-}
-
-declare ptr @llvm.stacksave.p0() #0
-declare void @llvm.stackrestore.p0(ptr) #0
-declare spir_func void @_Z24__spirv_FixedSinCosINTELILi34ELi66EEU7_ExtIntIXmlLi2ET0_EEiU7_ExtIntIXT_EEibiiii(ptr addrspace(4) sret(i66) align 8, i34, i1 zeroext, i32, i32, i32, i32) #0
-
 attributes #0 = { nounwind }
-
-; CHECK-ERR-IDX: not a valid SPIRAddressSpace index
-; CHECK-ERR-FMT: Invalid format for --spirv-addrspace-map

--- a/test/spirv-addrspace-map.ll
+++ b/test/spirv-addrspace-map.ll
@@ -8,6 +8,8 @@
 ; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-IDENTITY
 ; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4 \
 ; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-PARTIAL
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=1:5 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-GLOBAL
 ; RUN: not llvm-spirv -r %t.spv --spirv-addrspace-map=99:0 2>&1 \
 ; RUN:   | FileCheck %s --check-prefix=CHECK-ERR-IDX
 ; RUN: not llvm-spirv -r %t.spv --spirv-addrspace-map=bad 2>&1 \
@@ -19,9 +21,18 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
 target triple = "spir64-unknown-unknown"
 
+; Global variable: lives in SPIRAS_Global (1) by default.
+; With 1->5 mapping it must move to addrspace(5); all other cases keep AS1.
+; CHECK-MAPPED: @gv = {{.*}}addrspace(1){{.*}}global i32
+; CHECK-IDENTITY: @gv = {{.*}}addrspace(1){{.*}}global i32
+; CHECK-PARTIAL: @gv = {{.*}}addrspace(1){{.*}}global i32
+; CHECK-GLOBAL: @gv = {{.*}}addrspace(5){{.*}}global i32
+@gv = addrspace(1) global i32 0, align 4
+
 ; CHECK-MAPPED: define{{.*}} @test_stable_and_generic({{.*}}ptr addrspace(1){{.*}}ptr addrspace(3){{.*}}ptr{{( addrspace\(0\))?}}
 ; CHECK-IDENTITY: define{{.*}} @test_stable_and_generic({{.*}}ptr addrspace(1){{.*}}ptr addrspace(3){{.*}}ptr addrspace(4)
 ; CHECK-PARTIAL: define{{.*}} @test_stable_and_generic({{.*}}ptr addrspace(1){{.*}}ptr addrspace(3){{.*}}ptr addrspace(4)
+; CHECK-GLOBAL: define{{.*}} @test_stable_and_generic({{.*}}ptr addrspace(5){{.*}}ptr addrspace(3){{.*}}ptr addrspace(4)
 define spir_kernel void @test_stable_and_generic(ptr addrspace(1) %global_p,
                                                  ptr addrspace(3) %local_p,
                                                  ptr addrspace(4) %generic_p) {

--- a/test/spirv-function-program-addrspace.ll
+++ b/test/spirv-function-program-addrspace.ll
@@ -1,0 +1,92 @@
+; Test that --spirv-function-program-addrspace controls the address space of
+; function definitions when translating from SPIR-V to LLVM IR.
+; Demonstrates interaction with --spirv-addrspace-map,
+; --spirv-emit-function-ptr-addr-space (CodeSectionINTEL), and the
+; addrspacecast required when the function AS differs from the pointer type AS.
+
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_function_pointers -o %t.spv
+; RUN: llvm-spirv -r %t.spv \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-DEFAULT
+; RUN: llvm-spirv -r %t.spv --spirv-function-program-addrspace=4 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-AS4
+; RUN: llvm-spirv -r %t.spv --spirv-emit-function-ptr-addr-space \
+; RUN:   --spirv-function-program-addrspace=4 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-CODESECTION-AS4
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4,1:1,2:2,3:3,4:0 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4,1:1,2:2,3:3,4:0 \
+; RUN:   --spirv-function-program-addrspace=3 \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED-EXPLICIT
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4,1:1,2:2,3:3,4:0 \
+; RUN:   --spirv-emit-function-ptr-addr-space \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED-CODESECTION
+; RUN: llvm-spirv -r %t.spv --spirv-addrspace-map=0:4,1:1,2:2,3:3,4:0,9:5 \
+; RUN:   --spirv-emit-function-ptr-addr-space \
+; RUN:   -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-MAPPED-CODESECTION-REMAPPED
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+; Without any options all functions land in the default AS (Private/AS0).
+; CHECK-DEFAULT: define spir_func i32 @id_indirect({{.*}}) #
+; CHECK-DEFAULT: define spir_func i32 @id_direct({{.*}}) #
+; CHECK-DEFAULT: store ptr @id_indirect, ptr
+
+; --spirv-function-program-addrspace=4 places all functions in AS4. @id_indirect's
+; address must be cast from AS4 to AS0 to match the alloca pointer type.
+; CHECK-AS4: define spir_func i32 @id_indirect({{.*}}) addrspace(4)
+; CHECK-AS4: define spir_func i32 @id_direct({{.*}}) addrspace(4)
+; CHECK-AS4: store ptr addrspacecast (ptr addrspace(4) @id_indirect to ptr), ptr
+
+; --spirv-emit-function-ptr-addr-space overrides --spirv-function-program-addrspace
+; for functions referenced via OpConstantFunctionPointerINTEL: @id_indirect lands
+; in CodeSectionINTEL (AS9), while @id_direct (address not taken) keeps AS4.
+; No addrspacecast is needed since the alloca matches @id_indirect's AS,
+; intended CodeSectionINTEL behavior.
+; CHECK-CODESECTION-AS4: define spir_func i32 @id_indirect({{.*}}) addrspace(9)
+; CHECK-CODESECTION-AS4: define spir_func i32 @id_direct({{.*}}) addrspace(4)
+; CHECK-CODESECTION-AS4: store ptr addrspace(9) @id_indirect, ptr
+
+; With --spirv-addrspace-map alone, functions land in the AS mapped from Private
+; (0->4), so no addrspacecast is needed as all pointers use the same mapping.
+; CHECK-MAPPED: define spir_func i32 @id_indirect({{.*}}) addrspace(4)
+; CHECK-MAPPED: define spir_func i32 @id_direct({{.*}}) addrspace(4)
+; CHECK-MAPPED: store ptr addrspace(4) @id_indirect, ptr addrspace(4)
+
+; --spirv-function-program-addrspace overrides the map: functions land in AS3
+; while the alloca pointer type still follows the map (Private->AS4), requiring
+; a cast.
+; CHECK-MAPPED-EXPLICIT: define spir_func i32 @id_indirect({{.*}}) addrspace(3)
+; CHECK-MAPPED-EXPLICIT: define spir_func i32 @id_direct({{.*}}) addrspace(3)
+; CHECK-MAPPED-EXPLICIT: store ptr addrspace(4) addrspacecast (ptr addrspace(3) @id_indirect to ptr addrspace(4)), ptr addrspace(4)
+
+; --spirv-emit-function-ptr-addr-space overrides the map for @id_indirect
+; (CodeSection/AS9) while @id_direct still follows the map (Private->AS4).
+; CHECK-MAPPED-CODESECTION: define spir_func i32 @id_indirect({{.*}}) addrspace(9)
+; CHECK-MAPPED-CODESECTION: define spir_func i32 @id_direct({{.*}}) addrspace(4)
+; CHECK-MAPPED-CODESECTION: store ptr addrspace(9) @id_indirect, ptr addrspace(4)
+
+; When the map also remaps CodeSectionINTEL (9->5), @id_indirect lands in AS5.
+; CHECK-MAPPED-CODESECTION-REMAPPED: define spir_func i32 @id_indirect({{.*}}) addrspace(5)
+; CHECK-MAPPED-CODESECTION-REMAPPED: define spir_func i32 @id_direct({{.*}}) addrspace(4)
+; CHECK-MAPPED-CODESECTION-REMAPPED: store ptr addrspace(5) @id_indirect, ptr addrspace(4)
+
+define spir_func i32 @id_indirect(i32 %x) #0 {
+  ret i32 %x
+}
+
+define spir_func i32 @id_direct(i32 %x) #0 {
+  ret i32 %x
+}
+
+define spir_kernel void @test(ptr addrspace(1) %data) {
+  %fp = alloca ptr
+  store ptr @id_indirect, ptr %fp
+  %fn = load ptr, ptr %fp
+  %v = call spir_func i32 %fn(i32 42)
+  store i32 %v, ptr addrspace(1) %data
+  ret void
+}
+
+attributes #0 = { nounwind }

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -169,6 +169,22 @@ static cl::opt<bool> SPIRVEmitFunctionPtrAddrSpace(
     "spirv-emit-function-ptr-addr-space", cl::init(false),
     cl::desc("Emit and consume CodeSectionINTEL for function pointers"));
 
+static cl::opt<std::string> SPIRVAddrSpaceMap(
+    "spirv-addrspace-map",
+    cl::desc("Remap SPIR-V address spaces when translating SPIR-V to LLVM IR.\n"
+             "Comma-separated list of from:to pairs, e.g. \"0:4,4:0\".\n"
+             "from is a SPIRAddressSpace index (0-9); to is the LLVM IR "
+             "address space number to emit.\n"
+             "Unmapped entries keep their original SPIRAS value."),
+    cl::value_desc("from1:to1,from2:to2,..."));
+
+static cl::opt<unsigned> SPIRVFunctionProgramAddrSpace(
+    "spirv-function-program-addrspace",
+    cl::desc("Address space to assign to function definitions when translating "
+             "SPIR-V to LLVM IR (used for OpConstantFunctionPointerINTEL). "
+             "Defaults to 0 (SPIRAS_Private)."),
+    cl::value_desc("address-space"));
+
 using SPIRV::ExtensionID;
 
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
@@ -758,6 +774,40 @@ bool parseSpecConstOpt(llvm::StringRef SpecConstStr,
   return false;
 }
 
+// Returns true on error.
+static bool parseAddrSpaceMapOpt(SPIRV::TranslatorOpts &Opts) {
+  SPIRV::AddrSpaceMap ASMap;
+  for (unsigned I = 0; I < SPIRV::SPIRAS_Count; ++I)
+    ASMap[I] = I;
+
+  SmallVector<StringRef, 16> Pairs;
+  StringRef(SPIRVAddrSpaceMap).split(Pairs, ',', -1, false);
+  for (StringRef Pair : Pairs) {
+    SmallVector<StringRef, 2> KV;
+    Pair.split(KV, ':', 1);
+    if (KV.size() != 2) {
+      errs() << "Error: Invalid format for --spirv-addrspace-map entry \""
+             << Pair << "\". Expected \"from:to\".\n";
+      return true;
+    }
+    unsigned From, To;
+    if (KV[0].getAsInteger(10, From) || From >= SPIRV::SPIRAS_Count) {
+      errs() << "Error: --spirv-addrspace-map: \"" << KV[0]
+             << "\" is not a valid SPIRAddressSpace index (0-"
+             << (SPIRV::SPIRAS_Count - 1) << ").\n";
+      return true;
+    }
+    if (KV[1].getAsInteger(10, To)) {
+      errs() << "Error: --spirv-addrspace-map: \"" << KV[1]
+             << "\" is not a valid unsigned address space number.\n";
+      return true;
+    }
+    ASMap[From] = To;
+  }
+  Opts.setAddrSpaceMap(ASMap);
+  return false;
+}
+
 static void parseAllowUnknownIntrinsicsOpt(SPIRV::TranslatorOpts &Opts) {
   SPIRV::TranslatorOpts::ArgList PrefixList;
   for (const auto &Prefix : SPIRVAllowUnknownIntrinsics) {
@@ -911,6 +961,24 @@ int main(int Ac, char **Av) {
 
   if (SPIRVEmitFunctionPtrAddrSpace.getNumOccurrences() != 0)
     Opts.setEmitFunctionPtrAddrSpace(true);
+
+  if (SPIRVAddrSpaceMap.getNumOccurrences() != 0) {
+    if (!IsReverse) {
+      errs() << "Note: --spirv-addrspace-map option ignored as it only "
+                "affects translation from SPIR-V to LLVM IR";
+    } else if (parseAddrSpaceMapOpt(Opts)) {
+      return -1;
+    }
+  }
+
+  if (SPIRVFunctionProgramAddrSpace.getNumOccurrences() != 0) {
+    if (!IsReverse) {
+      errs() << "Note: --spirv-function-program-addrspace option ignored as it "
+                "only affects translation from SPIR-V to LLVM IR";
+    } else {
+      Opts.setFunctionProgramAddrSpace(SPIRVFunctionProgramAddrSpace);
+    }
+  }
 
   Opts.setFnVarSpecEnable(FnVarSpecEnable);
 

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -776,9 +776,9 @@ bool parseSpecConstOpt(llvm::StringRef SpecConstStr,
 
 // Returns true on error.
 static bool parseAddrSpaceMapOpt(SPIRV::TranslatorOpts &Opts) {
-  SPIRV::AddrSpaceMap ASMap;
+  SPIRV::AddrSpaceMap ParsedMap;
   for (unsigned I = 0; I < SPIRV::SPIRAS_Count; ++I)
-    ASMap[I] = I;
+    ParsedMap[I] = I;
 
   SmallVector<StringRef, 16> Pairs;
   StringRef(SPIRVAddrSpaceMap).split(Pairs, ',', -1, false);
@@ -802,9 +802,9 @@ static bool parseAddrSpaceMapOpt(SPIRV::TranslatorOpts &Opts) {
              << "\" is not a valid unsigned address space number.\n";
       return true;
     }
-    ASMap[From] = To;
+    ParsedMap[From] = To;
   }
-  Opts.setAddrSpaceMap(ASMap);
+  Opts.setAddrSpaceMap(ParsedMap);
   return false;
 }
 

--- a/tools/llvm-spirv/llvm-spirv.cpp
+++ b/tools/llvm-spirv/llvm-spirv.cpp
@@ -182,7 +182,8 @@ static cl::opt<unsigned> SPIRVFunctionProgramAddrSpace(
     "spirv-function-program-addrspace",
     cl::desc("Address space to assign to function definitions when translating "
              "SPIR-V to LLVM IR (used for OpConstantFunctionPointerINTEL). "
-             "Defaults to 0 (SPIRAS_Private)."),
+             "Defaults to 0 (SPIRAS_Private). Please note that this flag is not"
+             "supported by SPIR-V generator (writer). "),
     cl::value_desc("address-space"));
 
 using SPIRV::ExtensionID;


### PR DESCRIPTION
This change adds a new configuration knob that allows the user of SPIR-V reader to provide custom address space numbering to the translator. The user can provide an array with values for each logical SPIR-V address space (private, local, global, generic, constant etc.) that will be used by the translator when generating LLVM IR. The behavior of the reader remains unchanged if user does not explicitly change the setting.

This change was motivated by a need to support compilation target that uses different convention for address space numbering than SPIR-V. Generally the GPU targets in LLVM (AMDGPU, NVPTX) seem to use 0 (LLVM's default address space) as rough equivalent of generic address space. Without this option an additional address space renumbering pass is needed, while such pass is possible, it is somewhat fragile (need to visit all places in module where ptr type can be used, they change as LLVM changes) and consumes compilation time (this can't be done in single pass due to potential type/value dependencies). Configuring this in SPIR-V translator seems to be a simpler and cleaner solution.

The change replaces all hard-coded address space values in SPIR-V reader with a call that resolves the logical SPIR-V address space to value provided by the user. If the mapping was not configured the original values are used. Additionally analogous change was made to builtin name mangling.