### PR TITLE
Add round-trip tests through SPIR-V backend for previously failing tests

### DIFF
--- a/test/transcoding/OpAllAny.ll
+++ b/test/transcoding/OpAllAny.ll
@@ -7,7 +7,10 @@
 ; RUN: llvm-dis < %t.rev.spv.bc | FileCheck %s --check-prefix=CHECK-SPV-IR
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; FIXME: LLVM_SPIRV_REVERSE_FAIL for llc compilation flow
+; RUN: %if spirv-backend %{ llc -O0 -mtriple=spirv32-unknown-unknown -filetype=obj %s -o %t.llc.spv %}
+; RUN: %if spirv-backend %{ llvm-spirv -r %t.llc.spv -o %t.llc.rev.bc %}
+; RUN: %if spirv-backend %{ llvm-dis %t.llc.rev.bc -o %t.llc.rev.ll %}
+; RUN: %if spirv-backend %{ FileCheck %s --check-prefix=CHECK-LLVM < %t.llc.rev.ll %}
 
 ; This test checks SYCL relational builtin any and all with vector input types.
 

--- a/test/transcoding/linked-program.ll
+++ b/test/transcoding/linked-program.ll
@@ -5,7 +5,11 @@
 ; RUN: spirv-link %t.spv -o %t.linked.spv
 ; RUN: llvm-spirv -r %t.linked.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
-; FIXME: FILECHECK_FAIL during llvm-spirv -r in llc compilation flow
+; RUN: %if spirv-backend %{ llc -O0 -mtriple=spirv32-unknown-unknown -filetype=obj %s -o %t.llc.spv %}
+; RUN: %if spirv-backend %{ spirv-link %t.llc.spv -o %t.llc.linked.spv %}
+; RUN: %if spirv-backend %{ llvm-spirv -r %t.llc.linked.spv -o %t.llc.rev.bc %}
+; RUN: %if spirv-backend %{ llvm-dis %t.llc.rev.bc -o %t.llc.rev.ll %}
+; RUN: %if spirv-backend %{ FileCheck %s < %t.llc.rev.ll %}
 ;
 ; This checks that SPIR-V programs with global variables are still consumable
 ; after spirv-link.

--- a/test/transcoding/ptrtoaddr.ll
+++ b/test/transcoding/ptrtoaddr.ll
@@ -1,14 +1,16 @@
 ; Check "support" of ptrtoaddr instruction translation to SPIR-V.
 ; ptrtoaddr -> OpConvertPtrToU -> ptrtoint
 
-; FIXME: add llc compilation flow when ptrtoaddr is supported in SPIR-V backend
-
 ; RUN: llvm-spirv %s -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv %s -o %t.spv
 ; RUN: spirv-val %t.spv
 
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: %if spirv-backend %{ llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj %s -o %t.llc.spv %}
+; RUN: %if spirv-backend %{ llvm-spirv -r %t.llc.spv -o %t.llc.rev.bc %}
+; RUN: %if spirv-backend %{ llvm-dis %t.llc.rev.bc -o %t.llc.rev.ll %}
+; RUN: %if spirv-backend %{ FileCheck %s --check-prefix=CHECK-LLVM < %t.llc.rev.ll %}
 
 ; CHECK-SPIRV: TypeInt [[#TypeInt:]] 64 0
 ; CHECK-SPIRV: ConvertPtrToU [[#TypeInt]] [[#]] [[#]]


### PR DESCRIPTION
Enable tests that pass on the latest LLVM revision
