### PR TITLE
Translate llvm.trap and llvm.ubsantrap to OpAbortKHR

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5136,17 +5136,34 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
         "-spirv-allow-unknown-intrinsics option.");
     break;
   }
+  case Intrinsic::trap:
+  case Intrinsic::ubsantrap: {
+    // When the SPV_KHR_abort extension is disabled, ignore/drop the llvm.trap
+    // and llvm.ubsantrap intrinsics to not break the translator.
+    if (!BM->isAllowedToUseExtension(ExtensionID::SPV_KHR_abort))
+      return nullptr;
+
+    // For llvm.trap use the constant 32-bit "all ones" value, because there is
+    // no message present in the intrinsic.
+    uint64_t MsgVal = ~0u;
+    if (IID == Intrinsic::ubsantrap) {
+      // For llvm.ubsan intrinsic propagate the operand value.
+      auto *Arg = cast<ConstantInt>(II->getArgOperand(0));
+      MsgVal = Arg->getZExtValue();
+    }
+
+    auto *I32Ty = transType(Type::getInt32Ty(II->getContext()));
+    auto *Msg = BM->addConstant(I32Ty, MsgVal);
+    return BM->addAbortKHRInst(Msg, BB);
+  }
   // We can just ignore/drop some intrinsics, like optimizations hint.
   case Intrinsic::experimental_noalias_scope_decl:
   case Intrinsic::invariant_start:
   case Intrinsic::invariant_end:
   case Intrinsic::dbg_label:
-  // TODO: lower llvm.trap / llvm.ubsantrap / llvm.debugtrap to OpAbortKHR
-  // (with a null/undefined Message) when the SPV_KHR_abort extension is
-  // enabled. For now we silently drop these intrinsics so that the translator
-  // doesn't crash on input that contains them.
-  case Intrinsic::trap:
-  case Intrinsic::ubsantrap:
+  // llvm.debugtrap is silently dropped: it has no direct SPIR-V counterpart
+  // and cannot be lowered into the OpAbortKHR, because it doesn't terminate
+  // the execution.
   case Intrinsic::debugtrap:
   // Just ignore llvm.fake.use intrinsic, as it has no translation in SPIRV.
   case Intrinsic::fake_use:

--- a/test/extensions/KHR/SPV_KHR_abort/debugtrap-not-translated.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/debugtrap-not-translated.ll
@@ -1,0 +1,27 @@
+; Negative test: llvm.debugtrap should NOT produce OpAbortKHR.
+; Only llvm.trap and llvm.ubsantrap are translated to OpAbortKHR. The
+; debugtrap variant is currently dropped (return nullptr). This test ensures
+; it doesn't accidentally trigger the abort path.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_abort -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV --implicit-check-not AbortKHR
+
+; ---- debugtrap: no AbortKHR, unreachable still present ----
+; CHECK-SPIRV: Function
+; CHECK-SPIRV: Label
+; CHECK-SPIRV: Unreachable
+; CHECK-SPIRV: FunctionEnd
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_func void @uses_debugtrap() {
+entry:
+  call void @llvm.debugtrap()
+  unreachable
+}
+
+declare void @llvm.debugtrap() #0
+
+attributes #0 = { cold noreturn nounwind }

--- a/test/extensions/KHR/SPV_KHR_abort/trap-basic.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/trap-basic.ll
@@ -1,0 +1,62 @@
+; Basic test: llvm.trap translates to OpAbortKHR (with a 32-bit integer
+; constant zero Message operand) when SPV_KHR_abort is enabled, and the
+; reverse translation produces the SPIR-V friendly call to __spirv_AbortKHR
+; followed by an `unreachable` terminator.
+
+; --- Positive: extension enabled ---
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_abort -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Round-trip: SPIR-V binary -> LLVM IR (default OCL target environment)
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; Round-trip with explicit SPV-IR target environment
+; RUN: llvm-spirv -r %t.spv -o %t.rev.spv-ir.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.spv-ir.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; FIXME: enable the following run when the translator CI is updated to a new
+; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
+; extension.
+; RUN: not spirv-val %t.spv
+
+; --- Negative: extension not enabled ---
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.noext.spt
+; RUN: FileCheck < %t.noext.spt %s --check-prefix=CHECK-NO-EXT
+
+; Verify SPIR-V without extension is still valid
+; RUN: llvm-spirv %t.bc -o %t.noext.spv
+; RUN: spirv-val %t.noext.spv
+
+; ---- SPIR-V text: extension, capability, and instruction present ----
+; CHECK-SPIRV-DAG: Extension "SPV_KHR_abort"
+; CHECK-SPIRV-DAG: Capability AbortKHR
+; CHECK-SPIRV: TypeInt [[#I32Ty:]] 32
+; CHECK-SPIRV: Constant [[#I32Ty]] [[#MsgId:]] 4294967295
+; CHECK-SPIRV: Function
+; CHECK-SPIRV: Label
+; CHECK-SPIRV: AbortKHR [[#I32Ty]] [[#MsgId]]
+; CHECK-SPIRV: FunctionEnd
+
+; ---- Round-trip recovers a SPIR-V friendly call + unreachable ----
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 -1){{.*}}#[[#ATTR:]]
+; CHECK-LLVM-NEXT: unreachable
+; CHECK-LLVM: attributes #[[#ATTR]] = {{{.*}}noreturn{{.*}}}
+
+; ---- Without extension: no AbortKHR emitted ----
+; CHECK-NO-EXT-NOT: AbortKHR
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_func void @trap_simple() {
+entry:
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @llvm.trap() #0
+
+attributes #0 = { cold noreturn nounwind }

--- a/test/extensions/KHR/SPV_KHR_abort/trap-conditional.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/trap-conditional.ll
@@ -1,0 +1,69 @@
+; Conditional trap: models the assert() pattern where only some paths trap.
+; Verifies that:
+;   1. The trap BB gets OpAbortKHR (not OpUnreachable)
+;   2. The non-trap BB is unaffected (still has OpReturn)
+;   3. No double terminators in the trap block
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_abort -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Round-trip
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; FIXME: enable the following run when the translator CI is updated to a new
+; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
+; extension.
+; RUN: not spirv-val %t.spv
+
+; Without extension: trap dropped, unreachable remains
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.noext.spt
+; RUN: FileCheck < %t.noext.spt %s --check-prefix=CHECK-NO-EXT
+
+; ---- SPIR-V with extension ----
+; CHECK-SPIRV-DAG: Extension "SPV_KHR_abort"
+; CHECK-SPIRV-DAG: Capability AbortKHR
+; CHECK-SPIRV: Function
+;
+; Entry block: branch conditional
+; CHECK-SPIRV: BranchConditional
+;
+; OK block: normal return
+; CHECK-SPIRV: Return
+;
+; Trap block: abort only, no Unreachable after it
+; CHECK-SPIRV: AbortKHR
+; CHECK-SPIRV-EMPTY:
+; CHECK-SPIRV-NEXT: FunctionEnd
+
+; ---- Round-trip LLVM IR: SPIR-V friendly call + unreachable ----
+; CHECK-LLVM: define spir_func void @assert_like
+; CHECK-LLVM: br i1
+; CHECK-LLVM: ret void
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 -1)
+; CHECK-LLVM-NEXT: unreachable
+
+; ---- Without extension: no AbortKHR ----
+; CHECK-NO-EXT-NOT: AbortKHR
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_func void @assert_like(i32 %gid, i32 %N) {
+entry:
+  %cmp = icmp slt i32 %gid, %N
+  br i1 %cmp, label %ok, label %trap
+
+ok:
+  ret void
+
+trap:
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @llvm.trap() #0
+
+attributes #0 = { cold noreturn nounwind }

--- a/test/extensions/KHR/SPV_KHR_abort/trap-ext-disabled.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/trap-ext-disabled.ll
@@ -1,0 +1,35 @@
+; Negative test: explicitly disabling SPV_KHR_abort with --spirv-ext=-SPV_KHR_abort
+; ensures llvm.trap falls back to being dropped (no OpAbortKHR emitted).
+;
+; Also tests the case where all extensions are enabled EXCEPT SPV_KHR_abort.
+
+; Enable all then disable abort specifically
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+all,-SPV_KHR_abort -spirv-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-DISABLED
+
+; Explicit disable
+; RUN: llvm-spirv %t.bc --spirv-ext=-SPV_KHR_abort -spirv-text -o %t.spt2
+; RUN: FileCheck < %t.spt2 %s --check-prefix=CHECK-DISABLED
+
+; Verify both produce valid SPIR-V
+; RUN: llvm-spirv %t.bc --spirv-ext=+all,-SPV_KHR_abort -o %t.spv
+; RUN: spirv-val %t.spv
+
+; ---- Extension disabled: no abort capability, extension, or instruction ----
+; CHECK-DISABLED-NOT: Capability AbortKHR
+; CHECK-DISABLED-NOT: Extension "SPV_KHR_abort"
+; CHECK-DISABLED-NOT: AbortKHR
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_func void @trap_with_ext_disabled() {
+entry:
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @llvm.trap() #0
+
+attributes #0 = { cold noreturn nounwind }

--- a/test/extensions/KHR/SPV_KHR_abort/trap-in-kernel.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/trap-in-kernel.ll
@@ -1,0 +1,90 @@
+; Kernel function with assert-like trap pattern.
+; Models the real-world HIP assert() use case:
+;   kernel calls __assert_fail which calls llvm.trap.
+;
+; Verifies that OpAbortKHR works correctly inside callee functions
+; invoked from kernel entry points.
+;
+; Note: The kernel's assert.fail block has FunctionCall + Unreachable
+; (the unreachable is after the call, not after a trap — this is correct
+; because the trap is inside the callee, not the caller).
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_abort -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; FIXME: enable the following run when the translator CI is updated to a new
+; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
+; extension.
+; RUN: not spirv-val %t.spv
+
+; Round-trip
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; ---- SPIR-V ----
+; CHECK-SPIRV-DAG: Capability AbortKHR
+; CHECK-SPIRV-DAG: Extension "SPV_KHR_abort"
+; CHECK-SPIRV-DAG: EntryPoint 6 [[#KernelId:]] "test_kernel"
+
+; __assert_fail_internal: contains the trap → OpAbortKHR
+; CHECK-SPIRV: Function
+; CHECK-SPIRV: AbortKHR
+; CHECK-SPIRV: FunctionEnd
+
+; test_kernel: calls __assert_fail_internal, then unreachable (in caller)
+; CHECK-SPIRV: Function {{.*}} [[#KernelId]]
+; CHECK-SPIRV: BranchConditional
+; CHECK-SPIRV: Return
+; CHECK-SPIRV: FunctionCall
+; CHECK-SPIRV: Unreachable
+; CHECK-SPIRV: FunctionEnd
+
+; ---- Round-trip ----
+; CHECK-LLVM: define spir_func void @__assert_fail_internal
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 -1)
+; CHECK-LLVM-NEXT: unreachable
+;
+; CHECK-LLVM: define spir_kernel void @test_kernel
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; Models __assert_fail from device libraries
+define spir_func void @__assert_fail_internal() #0 {
+entry:
+  call void @llvm.trap()
+  unreachable
+}
+
+; Kernel entry point with conditional assert
+define spir_kernel void @test_kernel(ptr addrspace(1) %in, i32 %N) #1
+  !kernel_arg_addr_space !1 !kernel_arg_access_qual !2
+  !kernel_arg_type !3 !kernel_arg_base_type !3 !kernel_arg_type_qual !4 {
+entry:
+  %gid = call spir_func i64 @_Z13get_global_idj(i32 0)
+  %gid32 = trunc i64 %gid to i32
+  %cmp = icmp slt i32 %gid32, %N
+  br i1 %cmp, label %ok, label %assert.fail
+
+ok:
+  ret void
+
+assert.fail:
+  call spir_func void @__assert_fail_internal()
+  unreachable
+}
+
+declare spir_func i64 @_Z13get_global_idj(i32) #2
+declare void @llvm.trap() #3
+
+attributes #0 = { noinline noreturn nounwind }
+attributes #1 = { nounwind }
+attributes #2 = { nounwind }
+attributes #3 = { cold noreturn nounwind }
+
+!1 = !{i32 1, i32 0}
+!2 = !{!"none", !"none"}
+!3 = !{!"int*", !"int"}
+!4 = !{!"", !""}

--- a/test/extensions/KHR/SPV_KHR_abort/trap-multiple-blocks.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/trap-multiple-blocks.ll
@@ -1,0 +1,92 @@
+; Multiple basic blocks: some trap, some don't.
+; Verifies that:
+;   1. Non-trap blocks are completely unaffected (normal terminators preserved)
+;   2. Multiple trap blocks in the same function each get their own OpAbortKHR
+;   3. No cross-contamination between blocks
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_abort -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; FIXME: enable the following run when the translator CI is updated to a new
+; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
+; extension.
+; RUN: not spirv-val %t.spv
+
+; Round-trip
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; ---- SPIR-V checks ----
+; CHECK-SPIRV-DAG: Capability AbortKHR
+; CHECK-SPIRV-DAG: Extension "SPV_KHR_abort"
+
+; CHECK-SPIRV: Name [[#LabelEntry:]] "entry"
+; CHECK-SPIRV: Name [[#LabelWork:]] "work"
+; CHECK-SPIRV: Name [[#LabelRet:]] "ret"
+; CHECK-SPIRV: Name [[#LabelErr1:]] "err1"
+; CHECK-SPIRV: Name [[#LabelErr2:]] "err2"
+
+; Function with multiple paths
+; CHECK-SPIRV: Function
+;
+; Entry: conditional branch to %work / %err1
+; CHECK-SPIRV: Label [[#LabelEntry]]
+; CHECK-SPIRV: BranchConditional [[#]] [[#LabelWork]] [[#LabelErr1]]
+;
+; Work block: second conditional branch to %ret / %err2
+; CHECK-SPIRV: Label [[#LabelWork]]
+; CHECK-SPIRV: BranchConditional [[#]] [[#LabelRet]] [[#LabelErr2]]
+;
+; Return block: normal return
+; CHECK-SPIRV: Label [[#LabelRet]]
+; CHECK-SPIRV: ReturnValue
+;
+; First trap block
+; CHECK-SPIRV: Label [[#LabelErr1]]
+; CHECK-SPIRV: AbortKHR
+;
+; Second trap block
+; CHECK-SPIRV: Label [[#LabelErr2]]
+; CHECK-SPIRV: AbortKHR
+; CHECK-SPIRV: FunctionEnd
+
+; ---- Round-trip ----
+; CHECK-LLVM: define spir_func i32 @multi_trap
+; CHECK-LLVM: br i1
+; CHECK-LLVM: br i1
+; CHECK-LLVM: ret i32
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 -1)
+; CHECK-LLVM-NEXT: unreachable
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 -1)
+; CHECK-LLVM-NEXT: unreachable
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_func i32 @multi_trap(i32 %x) {
+entry:
+  %cmp1 = icmp sgt i32 %x, 0
+  br i1 %cmp1, label %work, label %err1
+
+work:
+  %result = mul i32 %x, 42
+  %cmp2 = icmp slt i32 %result, 1000
+  br i1 %cmp2, label %ret, label %err2
+
+ret:
+  ret i32 %result
+
+err1:
+  call void @llvm.trap()
+  unreachable
+
+err2:
+  call void @llvm.trap()
+  unreachable
+}
+
+declare void @llvm.trap() #0
+
+attributes #0 = { cold noreturn nounwind }

--- a/test/extensions/KHR/SPV_KHR_abort/trap-post-terminator-suppression.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/trap-post-terminator-suppression.ll
@@ -1,0 +1,89 @@
+; Edge case: instructions after llvm.trap in the same basic block.
+;
+; In real code (e.g. device libraries' __assert_fail), the pattern is:
+;   call void @llvm.trap()
+;   ; ... possibly lifetime.end intrinsics ...
+;   ret void            ; or unreachable
+;
+; OpAbortKHR is a block terminator, so ALL subsequent instructions in the
+; same BB must be suppressed to produce valid SPIR-V. This test verifies
+; that no instructions appear after OpAbortKHR in any function.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_abort -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; FIXME: enable the following run when the translator CI is updated to a new
+; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
+; extension.
+; RUN: not spirv-val %t.spv
+
+; Round-trip
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; ---- trap followed by unreachable (common pattern) ----
+; CHECK-SPIRV: Function
+; CHECK-SPIRV: AbortKHR
+; CHECK-SPIRV-EMPTY:
+; CHECK-SPIRV-NEXT: FunctionEnd
+
+; ---- trap followed by ret void (device library pattern) ----
+; CHECK-SPIRV: Function
+; CHECK-SPIRV: AbortKHR
+; CHECK-SPIRV-EMPTY:
+; CHECK-SPIRV-NEXT: FunctionEnd
+
+; ---- trap followed by lifetime.end + ret void (full device library pattern) ----
+; CHECK-SPIRV: Function
+; CHECK-SPIRV: AbortKHR
+; CHECK-SPIRV-EMPTY:
+; CHECK-SPIRV-NEXT: FunctionEnd
+
+; ---- Round-trip: all variants recover the SPIR-V friendly call + unreachable ----
+; CHECK-LLVM: define spir_func void @trap_then_unreachable
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 -1)
+; CHECK-LLVM-NEXT: unreachable
+;
+; CHECK-LLVM: define spir_func void @trap_then_ret
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 -1)
+; CHECK-LLVM-NEXT: unreachable
+;
+; CHECK-LLVM: define spir_func void @trap_then_lifetime_ret
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 -1)
+; CHECK-LLVM-NEXT: unreachable
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; Pattern 1: trap + unreachable (standard LLVM pattern after noreturn call)
+define spir_func void @trap_then_unreachable() {
+entry:
+  call void @llvm.trap()
+  unreachable
+}
+
+; Pattern 2: trap + ret void (seen in device library __assert_fail)
+define spir_func void @trap_then_ret() {
+entry:
+  call void @llvm.trap()
+  ret void
+}
+
+; Pattern 3: trap + lifetime.end + ret void (full device library pattern)
+define spir_func void @trap_then_lifetime_ret() {
+entry:
+  %buf = alloca i8, align 1
+  call void @llvm.lifetime.start.p0(i64 1, ptr %buf)
+  call void @llvm.trap()
+  call void @llvm.lifetime.end.p0(i64 1, ptr %buf)
+  ret void
+}
+
+declare void @llvm.trap() #0
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr captures(none)) #1
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr captures(none)) #1
+
+attributes #0 = { cold noreturn nounwind }
+attributes #1 = { argmemonly nounwind willreturn }

--- a/test/extensions/KHR/SPV_KHR_abort/ubsantrap-basic.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/ubsantrap-basic.ll
@@ -1,0 +1,60 @@
+; Test: llvm.ubsantrap translates to OpAbortKHR with the i8 failure-kind
+; argument zero-extended to a 32-bit integer Message operand. The reverse
+; translation produces the SPIR-V friendly call to __spirv_AbortKHR followed
+; by an `unreachable` terminator.
+
+; --- Positive: extension enabled ---
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_abort -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+
+; Round-trip: SPIR-V binary -> LLVM IR
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; Round-trip with explicit SPV-IR target environment
+; RUN: llvm-spirv -r %t.spv -o %t.rev.spv-ir.bc --spirv-target-env=SPV-IR
+; RUN: llvm-dis < %t.rev.spv-ir.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; FIXME: enable the following run when the translator CI is updated to a new
+; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
+; extension.
+; RUN: not spirv-val %t.spv
+
+; --- Negative: extension not enabled ---
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.noext.spt
+; RUN: FileCheck < %t.noext.spt %s --check-prefix=CHECK-NO-EXT
+
+; ---- SPIR-V text: extension, capability, and instruction present ----
+; CHECK-SPIRV-DAG: Extension "SPV_KHR_abort"
+; CHECK-SPIRV-DAG: Capability AbortKHR
+; CHECK-SPIRV: TypeInt [[#I32Ty:]] 32
+; The i8 failure-kind operand (7) is forwarded as a 32-bit zero-extended
+; constant Message operand to OpAbortKHR.
+; CHECK-SPIRV: Constant [[#I32Ty]] [[#MsgId:]] 7
+; CHECK-SPIRV: Function
+; CHECK-SPIRV: Label
+; CHECK-SPIRV: AbortKHR [[#I32Ty]] [[#MsgId]]
+; CHECK-SPIRV: FunctionEnd
+
+; ---- Round-trip recovers a SPIR-V friendly call + unreachable ----
+; CHECK-LLVM: call spir_func void @{{.*__spirv_AbortKHR.*}}(i32 7){{.*}}#[[#ATTR:]]
+; CHECK-LLVM-NEXT: unreachable
+; CHECK-LLVM: attributes #[[#ATTR]] = {{{.*}}noreturn{{.*}}}
+
+; ---- Without extension: no AbortKHR emitted ----
+; CHECK-NO-EXT-NOT: AbortKHR
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_func void @ubsantrap_simple() {
+entry:
+  call void @llvm.ubsantrap(i8 7)
+  unreachable
+}
+
+declare void @llvm.ubsantrap(i8) #0
+
+attributes #0 = { cold noreturn nounwind }


### PR DESCRIPTION
When the SPV_KHR_abort is enabled, the `llvm.trap` and `llvm.ubsantrap`
intrinsics are translated to `OpAbortKHR` instructions. The `llvm.trap`
intrinsic is translated with a reserved all-ones message value, while
the `llvm.ubsantrap` intrinsic propagates its i8 failure kind argument
zero-extended to 32 bits as the message value.

The reverse translation doesn't introduce the `llvm.trap` or
`llvm.ubsantrap` intrinsics back into the LLVM IR, as there is no way to
distinguish them from other uses of `OpAbortKHR`. So, the reader
preserves them as calls to the `__spirv_AbortKHR` functions.

The `llvm.debugtrap` intrinsic is still ignored, because it's not
an abort semantically.

Assisted-by: Claude Opus 4.7 <noreply@anthropic.com>