### PR TITLE
SPIRVReader: Add spirv.nontemporal for Nontemporal image op

### DIFF
--- a/docs/SPIRVRepresentationInLLVM.rst
+++ b/docs/SPIRVRepresentationInLLVM.rst
@@ -483,6 +483,27 @@ extra operands ``i32 1`` and ``i32 2``.
 decorates the argument ``b`` of ``k`` with ``Restrict`` in SPIR-V while not
 adding any decoration to argument ``a``.
 
+Instruction metadata
+--------------------
+
+Some translated instructions use instruction metadata to preserve SPIR-V
+information that does not have a direct LLVM IR encoding.
+
+``spirv.nontemporal`` is attached to translated image builtin calls that use the
+SPIR-V ``Nontemporal`` image operand. Its operand follows LLVM's
+``!nontemporal`` metadata, but it applies to translated builtin calls rather
+than LLVM memory operations.
+
+``spirv.nontemporal`` example:
+
+.. code-block:: llvm
+
+  %v = call spir_func <4 x float> @_Z25__spirv_ImageRead_Rfloat4PU3AS133__spirv_Image__void_0_0_0_0_0_0_0i(
+      target("spirv.Image", void, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0) %img,
+      i32 %coord) !spirv.nontemporal !1
+  ...
+  !1 = !{i32 1}
+
 Loop controls and loop metadata
 -------------------------------
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3847,6 +3847,18 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
   } else {
     Call = CallInst::Create(Func, transValue(Ops, BB->getParent(), BB), "", BB);
   }
+  auto HasImageOperandNonTemporal = [](SPIRVInstruction *Inst) -> bool {
+    size_t Idx = getImageOperandsIndex(Inst->getOpCode());
+    if (Idx == ~0U)
+      return false;
+    auto Ops = Inst->getOperands();
+    if (Ops.size() <= Idx)
+      return false;
+    auto ImOp = static_cast<SPIRVConstant *>(Ops[Idx])->getZExtIntValue();
+    return ImOp & ImageOperandsMask::ImageOperandsNontemporalMask;
+  };
+  if (HasImageOperandNonTemporal(BI))
+    transNonTemporalMetadata(Call);
   setName(Call, BI);
   setAttrByCalledFunc(Call);
   SPIRVDBG(spvdbgs() << "[transInstToBuiltinCall] " << *BI << " -> ";
@@ -4765,7 +4777,10 @@ SPIRVToLLVM::transOCLImageTypeAccessQualifier(SPIRV::SPIRVTypeImage *ST) {
 bool SPIRVToLLVM::transNonTemporalMetadata(Instruction *I) {
   Constant *One = ConstantInt::get(Type::getInt32Ty(*Context), 1);
   MDNode *Node = MDNode::get(*Context, ConstantAsMetadata::get(One));
-  I->setMetadata(M->getMDKindID("nontemporal"), Node);
+  if (isa<LoadInst>(I) || isa<StoreInst>(I))
+    I->setMetadata(LLVMContext::MD_nontemporal, Node);
+  else
+    I->setMetadata("spirv.nontemporal", Node);
   return true;
 }
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -3847,17 +3847,9 @@ Instruction *SPIRVToLLVM::transBuiltinFromInst(const std::string &FuncName,
   } else {
     Call = CallInst::Create(Func, transValue(Ops, BB->getParent(), BB), "", BB);
   }
-  auto HasImageOperandNonTemporal = [](SPIRVInstruction *Inst) -> bool {
-    size_t Idx = getImageOperandsIndex(Inst->getOpCode());
-    if (Idx == ~0U)
-      return false;
-    auto Ops = Inst->getOperands();
-    if (Ops.size() <= Idx)
-      return false;
-    auto ImOp = static_cast<SPIRVConstant *>(Ops[Idx])->getZExtIntValue();
-    return ImOp & ImageOperandsMask::ImageOperandsNontemporalMask;
-  };
-  if (HasImageOperandNonTemporal(BI))
+  if (getImageOperandsIndex(OC) != ~0U &&
+      static_cast<SPIRVImageInstBase *>(BI)->hasImageOperand(
+          ImageOperandsMask::ImageOperandsNontemporalMask))
     transNonTemporalMetadata(Call);
   setName(Call, BI);
   setAttrByCalledFunc(Call);

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -185,6 +185,15 @@ void SPIRVImageInstBase::setOpWords(const std::vector<SPIRVWord> &OpsArg) {
   SPIRVInstTemplateBase::setOpWords(Ops);
 }
 
+bool SPIRVImageInstBase::hasImageOperand(ImageOperandsMask Mask) const {
+  size_t ImgOpsIndex = getImageOperandsIndex(OpCode);
+  if (ImgOpsIndex == ~0U)
+    return false;
+  if (getOpWords().size() <= ImgOpsIndex)
+    return false;
+  return getOpWord(ImgOpsIndex) & Mask;
+}
+
 bool isSpecConstantOpAllowedOp(Op OC) {
   static SPIRVWord Table[] = {
       OpSConvert,

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -3163,6 +3163,7 @@ public:
   SPIRVCapVec getRequiredCapability() const override {
     return getVec(CapabilityImageBasic);
   }
+  bool hasImageOperand(ImageOperandsMask Mask) const;
 
 protected:
   void setOpWords(const std::vector<SPIRVWord> &OpsArg) override;

--- a/test/image_operand_nontemporal.spvasm
+++ b/test/image_operand_nontemporal.spvasm
@@ -41,5 +41,6 @@
 ; CHECK-LLVM: define spir_kernel void @read_write_image_nontemporal
 ; CHECK-LLVM: call spir_func <4 x float> [[READ_IMAGEF:@[a-zA-Z0-9_]+]](
 ; CHECK-LLVM: call spir_func void [[WRITE_IMAGEF:@[a-zA-Z0-9_]+]](
-; CHECK-LLVM: call spir_func <4 x float> [[READ_IMAGEF]](
-; CHECK-LLVM: call spir_func void [[WRITE_IMAGEF]](
+; CHECK-LLVM: call spir_func <4 x float> [[READ_IMAGEF]]({{.*}}){{.*}} !spirv.nontemporal [[NONTEMPMD:![0-9]+]]
+; CHECK-LLVM: call spir_func void [[WRITE_IMAGEF]]({{.*}}){{.*}} !spirv.nontemporal [[NONTEMPMD]]
+; CHECK-LLVM: [[NONTEMPMD]] = !{i32 1}


### PR DESCRIPTION
Add `spirv.nontemporal` metadata for image operations that have a `Nontemporal` image operand, such that the nontemporal information is preserved in the LLVM IR.