### PR TITLE
Lower llvm.ldexp via OpenCL ldexp ext-inst

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3986,6 +3986,7 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::floor:
   case Intrinsic::fma:
   case Intrinsic::frexp:
+  case Intrinsic::ldexp:
   case Intrinsic::log:
   case Intrinsic::log10:
   case Intrinsic::log2:
@@ -4118,6 +4119,8 @@ static SPIRVWord getBuiltinIdForIntrinsic(Intrinsic::ID IID) {
     return OpenCLLIB::Fma;
   case Intrinsic::frexp:
     return OpenCLLIB::Frexp;
+  case Intrinsic::ldexp:
+    return OpenCLLIB::Ldexp;
   case Intrinsic::log:
     return OpenCLLIB::Log;
   case Intrinsic::log10:
@@ -4416,6 +4419,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
   // Binary FP intrinsics
   case Intrinsic::atan2:
   case Intrinsic::copysign:
+  case Intrinsic::ldexp:
   case Intrinsic::pow:
   case Intrinsic::powi:
   case Intrinsic::maximumnum:

--- a/test/llvm-intrinsics/ldexp.ll
+++ b/test/llvm-intrinsics/ldexp.ll
@@ -1,0 +1,40 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+; RUN: spirv-val %t.spv
+
+; CHECK: ExtInstImport [[ExtInstSetId:[0-9]+]] "OpenCL.std"
+; CHECK-DAG: TypeFloat [[Half:[0-9]+]] 16
+; CHECK-DAG: TypeFloat [[Float:[0-9]+]] 32
+; CHECK-DAG: TypeFloat [[Double:[0-9]+]] 64
+; CHECK-DAG: TypeInt [[Int32:[0-9]+]] 32 0
+; CHECK-DAG: TypeVector [[Float4:[0-9]+]] [[Float]] 4
+; CHECK-DAG: TypeVector [[Int32V4:[0-9]+]] [[Int32]] 4
+
+target datalayout = "e-p:64:64-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64"
+
+define spir_func void @test_ldexp(half %h, float %f, double %d, <4 x float> %vf,
+                                  i32 %k, <4 x i32> %vk) #0 {
+entry:
+  %0 = call half @llvm.ldexp.f16.i32(half %h, i32 %k)
+  %1 = call float @llvm.ldexp.f32.i32(float %f, i32 %k)
+  %2 = call double @llvm.ldexp.f64.i32(double %d, i32 %k)
+  %3 = call <4 x float> @llvm.ldexp.v4f32.v4i32(<4 x float> %vf, <4 x i32> %vk)
+; CHECK: ExtInst [[Half]] {{[0-9]+}} [[ExtInstSetId]] ldexp
+; CHECK: ExtInst [[Float]] {{[0-9]+}} [[ExtInstSetId]] ldexp
+; CHECK: ExtInst [[Double]] {{[0-9]+}} [[ExtInstSetId]] ldexp
+; CHECK: ExtInst [[Float4]] {{[0-9]+}} [[ExtInstSetId]] ldexp
+  ret void
+}
+
+declare half @llvm.ldexp.f16.i32(half, i32) #1
+declare float @llvm.ldexp.f32.i32(float, i32) #1
+declare double @llvm.ldexp.f64.i32(double, i32) #1
+declare <4 x float> @llvm.ldexp.v4f32.v4i32(<4 x float>, <4 x i32>) #1
+
+attributes #0 = { noinline nounwind optnone }
+attributes #1 = { nounwind readnone speculatable willreturn }
+
+!llvm.module.flags = !{!0}
+!0 = !{i32 1, !"wchar_size", i32 4}

--- a/test/llvm-intrinsics/ldexp.ll
+++ b/test/llvm-intrinsics/ldexp.ll
@@ -1,5 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %s -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
 ; RUN: spirv-val %t.spv
 


### PR DESCRIPTION
## Summary

clang emits `Intrinsic::ldexp` for `ldexp()`, `scalbn()`, `scalbln()`, and integer-exponent `exp2()` in device code, but `transIntrinsicInst()` had no case for it, so translation aborted at `SPIRVWriter.cpp` with:

```
InvalidFunctionCall: Unexpected llvm intrinsic:
 llvm.ldexp.f64.i32
```

This blocks compilation of any TU using math functions that lower to `ldexp`, including Kokkos tests for `ldexp`, `scalbn`, `scalbln`, `frexp`, and `exp2`.

## Change

Three small inserts in `lib/SPIRV/SPIRVWriter.cpp`:

1. Add `Intrinsic::ldexp` to `isKnownIntrinsic()` so its declaration isn't emitted as a SPIR-V function declaration.
2. Map `Intrinsic::ldexp` to `OpenCLLIB::Ldexp` (opcode 34) in `getBuiltinIdForIntrinsic()`.
3. Add `Intrinsic::ldexp` to the binary-FP intrinsics dispatch case -- the same path used by `Intrinsic::powi`, which has the same `(gentype, int)` signature.

`f16`, `f32`, `f64` scalar and vector forms are all handled because the type is derived from `II->getType()`.

New lit test `test/llvm-intrinsics/ldexp.ll` exercises all three scalar widths plus a `<4 x float>` vector form, validates with `spirv-val`. The existing `test/transcoding/ldexp.cl` only covered the OpenCL-mangled builtin path, which doesn't go through `Intrinsic::ldexp`.

Originally observed compiling Kokkos device code through chipStar.