### PR TITLE
Disable spirv-val for SPV_KHR_abort tests

### DIFF
--- a/test/extensions/KHR/SPV_KHR_abort/abort-conditional.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-conditional.ll
@@ -16,7 +16,7 @@
 ; FIXME: enable the following run when the translator CI is updated to a new
 ; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
 ; extension.
-; RUN: not spirv-val %t.spv
+; TODO: RUNx: spirv-val %t.spv
 
 ; ---- SPIR-V with extension ----
 ; CHECK-SPIRV-DAG: Extension "SPV_KHR_abort"

--- a/test/extensions/KHR/SPV_KHR_abort/abort-in-kernel.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-in-kernel.ll
@@ -16,7 +16,7 @@
 ; FIXME: enable the following run when the translator CI is updated to a new
 ; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
 ; extension.
-; RUN: not spirv-val %t.spv
+; TODO: RUNx: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort-multiple-blocks.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-multiple-blocks.ll
@@ -12,7 +12,7 @@
 ; FIXME: enable the following run when the translator CI is updated to a new
 ; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
 ; extension.
-; RUN: not spirv-val %t.spv
+; TODO: RUNx: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort-post-terminator-suppression.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-post-terminator-suppression.ll
@@ -19,7 +19,7 @@
 ; FIXME: enable the following run when the translator CI is updated to a new
 ; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
 ; extension.
-; RUN: not spirv-val %t.spv
+; TODO: RUNx: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort.ll
@@ -9,7 +9,7 @@
 ; FIXME: enable the following run when the translator CI is updated to a new
 ; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
 ; extension.
-; RUN: not spirv-val %t.spv
+; TODO: RUNx: spirv-val %t.spv
 
 ; RUN: not llvm-spirv %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; CHECK-ERROR: RequiresExtension: Feature requires the following SPIR-V extension:


### PR DESCRIPTION
The current approach with `not` causes the spirv-val step to fail on recent enough SPIRV-Tools versions.  Avoid running spirv-val at all until a new SPIRV-Tools release is more widely available.