### PR TITLE
Ensure DISubprogram always has a type

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -847,6 +847,19 @@ DINode *SPIRVToLLVMDbgTran::transTypeFunction(const SPIRVExtInst *DebugInst) {
   return getDIBuilder(DebugInst).createSubroutineType(ArgTypes, Flags);
 }
 
+DISubroutineType *
+SPIRVToLLVMDbgTran::transSubroutineType(const SPIRVExtInst *DebugInst,
+                                        SPIRVId TypeId) {
+  auto *TypeInst = BM->get<SPIRVExtInst>(TypeId);
+  if (auto *Ty = transDebugInst<DISubroutineType>(TypeInst))
+    return Ty;
+
+  // Avoid a null DISubroutineType in case the SPIR-V type was DebugInfoNone.
+  SmallVector<llvm::Metadata *, 1> Elements{nullptr};
+  DITypeArray ArgTypes = getDIBuilder(DebugInst).getOrCreateTypeArray(Elements);
+  return getDIBuilder(DebugInst).createSubroutineType(ArgTypes);
+}
+
 DINode *
 SPIRVToLLVMDbgTran::transTypePtrToMember(const SPIRVExtInst *DebugInst) {
   using namespace SPIRVDebug::Operand::TypePtrToMember;
@@ -904,8 +917,7 @@ DINode *SPIRVToLLVMDbgTran::transFunction(const SPIRVExtInst *DebugInst,
     assert(Ops.size() >= MinOperandCount && "Invalid number of operands");
 
   StringRef Name = getString(Ops[NameIdx]);
-  DISubroutineType *Ty =
-      transDebugInst<DISubroutineType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DISubroutineType *Ty = transSubroutineType(DebugInst, Ops[TypeIdx]);
   DIFile *File = getFile(Ops[SourceIdx]);
   SPIRVWord LineNo =
       getConstantValueOrLiteral(Ops, LineIdx, DebugInst->getExtSetKind());
@@ -1037,8 +1049,7 @@ DINode *SPIRVToLLVMDbgTran::transFunctionDecl(const SPIRVExtInst *DebugInst) {
   DIFile *File = getFile(Ops[SourceIdx]);
   SPIRVWord LineNo =
       getConstantValueOrLiteral(Ops, LineIdx, DebugInst->getExtSetKind());
-  DISubroutineType *Ty =
-      transDebugInst<DISubroutineType>(BM->get<SPIRVExtInst>(Ops[TypeIdx]));
+  DISubroutineType *Ty = transSubroutineType(DebugInst, Ops[TypeIdx]);
 
   SPIRVWord SPIRVDebugFlags =
       getConstantValueOrLiteral(Ops, FlagsIdx, DebugInst->getExtSetKind());

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -150,6 +150,8 @@ private:
   MDNode *transTypeTemplate(const SPIRVExtInst *DebugInst);
 
   DINode *transTypeFunction(const SPIRVExtInst *DebugInst);
+  DISubroutineType *transSubroutineType(const SPIRVExtInst *DebugInst,
+                                        SPIRVId TypeId);
 
   DINode *transTypePtrToMember(const SPIRVExtInst *DebugInst);
 

--- a/test/DebugInfo/NonSemantic/Shader200/SourceLanguageLLVMToSPIRV.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/SourceLanguageLLVMToSPIRV.ll
@@ -45,5 +45,7 @@ entry:
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 2, i32 0}
-!7 = distinct !DISubprogram(name: "func", scope: !8, file: !8, line: 1, scopeLine: 2, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!7 = distinct !DISubprogram(name: "func", scope: !8, file: !8, line: 1, scopeLine: 2, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, type: !9, unit: !0, retainedNodes: !2)
 !8 = !DIFile(filename: "test.cl", directory: "/tmp", checksumkind: CSK_MD5, checksum: "18aa9ce738eaafc7b7b7181c19092815")
+!9 = !DISubroutineType(types: !10)
+!10 = !{null}

--- a/test/DebugInfo/SourceLanguageLLVMToSPIRV.ll
+++ b/test/DebugInfo/SourceLanguageLLVMToSPIRV.ll
@@ -36,8 +36,10 @@ entry:
 !4 = !{i32 2, !"Debug Info Version", i32 3}
 !5 = !{i32 1, !"wchar_size", i32 4}
 !6 = !{i32 2, i32 0}
-!7 = distinct !DISubprogram(name: "func", scope: !8, file: !8, line: 1, scopeLine: 2, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !2)
+!7 = distinct !DISubprogram(name: "func", scope: !8, file: !8, line: 1, scopeLine: 2, flags: DIFlagPrototyped | DIFlagAllCallsDescribed, spFlags: DISPFlagDefinition | DISPFlagOptimized, type: !9, unit: !0, retainedNodes: !2)
 !8 = !DIFile(filename: "test.cl", directory: "/tmp", checksumkind: CSK_MD5, checksum: "18aa9ce738eaafc7b7b7181c19092815")
+!9 = !DISubroutineType(types: !10)
+!10 = !{null}
 
 ; CHECK-OPENCLC: DebugCompilationUnit {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} 3
 ; CHECK-CPP4OPENCL: DebugCompilationUnit {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} 6

--- a/test/DebugInfo/gv-before-cu.ll
+++ b/test/DebugInfo/gv-before-cu.ll
@@ -40,7 +40,9 @@ entry:
 !9 = !DISubrange(count: 3, lowerBound: 0)
 !10 = !{i32 7, !"Dwarf Version", i32 4}
 !11 = !{i32 2, !"Debug Info Version", i32 3}
-!12 = distinct !DISubprogram(name: "bar", linkageName: "_Z3barBase", scope: null, file: !3, line: 1, type: null, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2)
-!13 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooBase", scope: null, file: !3, line: 3, type: null, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2)
+!12 = distinct !DISubprogram(name: "bar", linkageName: "_Z3barBase", scope: null, file: !3, line: 1, type: !16, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2)
+!13 = distinct !DISubprogram(name: "foo", linkageName: "_Z3fooBase", scope: null, file: !3, line: 3, type: !16, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2)
 !14 = distinct !DILexicalBlock(scope: !13, file: !3, line: 3, column: 1)
 !15 = !DILocation(line: 3, column: 1, scope: !14)
+!16 = !DISubroutineType(types: !17)
+!17 = !{null}


### PR DESCRIPTION
The IR Verifier started rejecting some IR after llvm-project commit 81518d06acaa ("[DebugInfo] Verify DISubprogram has a type (#194556)", 2026-05-04).

Update some .ll tests in the same way the llvm-project commit did.

Make sure that a `DISubprogram` always has a non-null type by handling the case where the SPIR-V has a `DebugInfoNone` for the `DebugTypeFunction`.