### PR TITLE
[SPIRV->LLVM] Fix missing spir_func CC on builtin FP4/i4 conversion calls

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1138,10 +1138,7 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         if (MangledName.empty())
           MangledName = mangleBuiltin(BuiltinName, OpsTys, &Info);
 
-        FunctionType *FTy = FunctionType::get(Dst, OpsTys, false);
-        FunctionCallee Func = M->getOrInsertFunction(MangledName, FTy);
-        if (auto *F = dyn_cast<Function>(Func.getCallee()))
-          F->setCallingConv(CallingConv::SPIR_FUNC);
+        Function *Func = getOrCreateFunction(M, Dst, OpsTys, MangledName);
         auto *CI = CallInst::Create(Func, Ops, "", BB);
         CI->setCallingConv(CallingConv::SPIR_FUNC);
         return CI;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1140,7 +1140,11 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
 
         FunctionType *FTy = FunctionType::get(Dst, OpsTys, false);
         FunctionCallee Func = M->getOrInsertFunction(MangledName, FTy);
-        return CallInst::Create(Func, Ops, "", BB);
+        if (auto *F = dyn_cast<Function>(Func.getCallee()))
+          F->setCallingConv(CallingConv::SPIR_FUNC);
+        auto *CI = CallInst::Create(Func, Ops, "", BB);
+        CI->setCallingConv(CallingConv::SPIR_FUNC);
+        return CI;
       }
     }
     // These conversions can be done without __builtin_spirv prefixed functions

--- a/test/extensions/EXT/SPV_EXT_float8/conversions_matrix.ll
+++ b/test/extensions/EXT/SPV_EXT_float8/conversions_matrix.ll
@@ -28,7 +28,7 @@
 ; CHECK-SPIRV: Bitcast [[#Int8MatrixTy]] [[#]] [[#Conv]]
 
 ; CHECK-LLVM: %[[#M:]] = call spir_func target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) @_Z26__spirv_CompositeConstructDh(half 0.000000e+00)
-; CHECK-LLVM: call target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) %[[#M]])
+; CHECK-LLVM: call spir_func target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) %[[#M]])
 
 ; ModuleID = 'test.bc'
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024-G1"
@@ -38,14 +38,14 @@ target triple = "spir-unknown-unknown"
 define spir_func void @int4_hf8() #0 {
 entry:
   %0 = call spir_func target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) @_Z26__spirv_CompositeConstructDh(half 0.0) #0
-  %1 = call target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) %0)
+  %1 = call spir_func target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) %0)
   ret void
 }
 
 ; Function Attrs: nounwind
 declare spir_func target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) @_Z26__spirv_CompositeConstructDh(half) #0
 
-declare target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2))
+declare spir_func target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2))
 
 attributes #0 = { nounwind }
 

--- a/test/extensions/EXT/SPV_EXT_float8/conversions_scalar_vector.ll
+++ b/test/extensions/EXT/SPV_EXT_float8/conversions_scalar_vector.ll
@@ -62,12 +62,12 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e4m3_hf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8 1)
 ; CHECK-LLVM: ret half %[[#Call]]
 
 define spir_func half @e4m3_hf16_scalar() {
 entry:
-  %0 = call half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8 1)
+  %0 = call spir_func half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8 1)
   ret half %0
 }
 
@@ -79,12 +79,12 @@ declare dso_local spir_func half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8)
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e4m3_hf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTDv8_c(<8 x i8> splat (i8 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTDv8_c(<8 x i8> splat (i8 1))
 ; CHECK-LLVM: ret <8 x half> %[[#Call]]
 
 define spir_func <8 x half> @e4m3_hf16_vector() {
 entry:
-  %0 = call <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
+  %0 = call spir_func <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
   ret <8 x half> %0
 }
 
@@ -96,12 +96,12 @@ declare dso_local spir_func <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXT
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e5m2_hf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8 1)
 ; CHECK-LLVM: ret half %[[#Call]]
 
 define spir_func half @e5m2_hf16_scalar() {
 entry:
-  %0 = call half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8 1)
+  %0 = call spir_func half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8 1)
   ret half %0
 }
 
@@ -113,12 +113,12 @@ declare dso_local spir_func half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8)
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e5m2_hf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTDv8_c(<8 x i8> splat (i8 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTDv8_c(<8 x i8> splat (i8 1))
 ; CHECK-LLVM: ret <8 x half> %[[#Call]]
 
 define spir_func <8 x half> @e5m2_hf16_vector() {
 entry:
-  %0 = call <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
+  %0 = call spir_func <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
   ret <8 x half> %0
 }
 
@@ -130,12 +130,12 @@ declare dso_local spir_func <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXT
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e4m3_bf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8 1)
 ; CHECK-LLVM: ret bfloat %[[#Call]]
 
 define spir_func bfloat @e4m3_bf16_scalar() {
 entry:
-  %0 = call bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8 1)
+  %0 = call spir_func bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8 1)
   ret bfloat %0
 }
 
@@ -147,12 +147,12 @@ declare dso_local spir_func bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e4m3_bf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTDv8_c(<8 x i8> splat (i8 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTDv8_c(<8 x i8> splat (i8 1))
 ; CHECK-LLVM: ret <8 x bfloat> %[[#Call]]
 
 define spir_func <8 x bfloat> @e4m3_bf16_vector() {
 entry:
-  %0 = call <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
+  %0 = call spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
   ret <8 x bfloat> %0
 }
 
@@ -164,12 +164,12 @@ declare dso_local spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16E
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e5m2_bf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8 1)
 ; CHECK-LLVM: ret bfloat %[[#Call]]
 
 define spir_func bfloat @e5m2_bf16_scalar() {
 entry:
-  %0 = call bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8 1)
+  %0 = call spir_func bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8 1)
   ret bfloat %0
 }
 
@@ -181,12 +181,12 @@ declare dso_local spir_func bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e5m2_bf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTDv8_c(<8 x i8> splat (i8 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTDv8_c(<8 x i8> splat (i8 1))
 ; CHECK-LLVM: ret <8 x bfloat> %[[#Call]]
 
 define spir_func <8 x bfloat> @e5m2_bf16_vector() {
 entry:
-  %0 = call <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
+  %0 = call spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
   ret <8 x bfloat> %0
 }
 
@@ -198,12 +198,12 @@ declare dso_local spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16E
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: hf16_e4m3_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half 1.000000e+00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_e4m3_scalar() {
 entry:
-  %0 = call i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half 0xH3C00)
+  %0 = call spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half 0xH3C00)
   ret i8 %0
 }
 
@@ -215,12 +215,12 @@ declare dso_local spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half)
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: hf16_e4m3_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv8_Dh(<8 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv8_Dh(<8 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @hf16_e4m3_vector() {
 entry:
-  %0 = call <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv8_Dh(<8 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>)
+  %0 = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv8_Dh(<8 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>)
   ret <8 x i8> %0
 }
 
@@ -232,12 +232,12 @@ declare dso_local spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: hf16_e5m2_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half 1.000000e+00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_e5m2_scalar() {
 entry:
-  %0 = call i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half 0xH3C00)
+  %0 = call spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half 0xH3C00)
   ret i8 %0
 }
 
@@ -249,12 +249,12 @@ declare dso_local spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half)
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: hf16_e5m2_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv8_Dh(<8 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv8_Dh(<8 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @hf16_e5m2_vector() {
 entry:
-  %0 = call <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv8_Dh(<8 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>)
+  %0 = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv8_Dh(<8 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>)
   ret <8 x i8> %0
 }
 
@@ -266,12 +266,12 @@ declare dso_local spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: bf16_e4m3_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bfloat 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bfloat 1.000000e+00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_e4m3_scalar() {
 entry:
-  %0 = call i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bfloat 0xR3F80)
+  %0 = call spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bfloat 0xR3F80)
   ret i8 %0
 }
 
@@ -283,12 +283,12 @@ declare dso_local spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bf
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: bf16_e4m3_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv8_DF16b(<8 x bfloat> splat (bfloat 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv8_DF16b(<8 x bfloat> splat (bfloat 1.000000e+00))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @bf16_e4m3_vector() {
 entry:
-  %0 = call <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv8_DF16b(<8 x bfloat> <bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80>)
+  %0 = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv8_DF16b(<8 x bfloat> <bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80>)
   ret <8 x i8> %0
 }
 
@@ -300,12 +300,12 @@ declare dso_local spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: bf16_e5m2_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bfloat 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bfloat 1.000000e+00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_e5m2_scalar() {
 entry:
-  %0 = call i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bfloat 0xR3F80)
+  %0 = call spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bfloat 0xR3F80)
   ret i8 %0
 }
 
@@ -317,12 +317,12 @@ declare dso_local spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bf
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: bf16_e5m2_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDv8_DF16b(<8 x bfloat> splat (bfloat 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDv8_DF16b(<8 x bfloat> splat (bfloat 1.000000e+00))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @bf16_e5m2_vector() {
 entry:
-  %0 = call <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDv8_DF16b(<8 x bfloat> <bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80>)
+  %0 = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDv8_DF16b(<8 x bfloat> <bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80>)
   ret <8 x i8> %0
 }
 

--- a/test/extensions/INTEL/SPV_INTEL_float4/conversions_packed.ll
+++ b/test/extensions/INTEL/SPV_INTEL_float4/conversions_packed.ll
@@ -89,7 +89,7 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_32
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i32 1 to <8 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @fp4e2m1_hf8_32() {
@@ -106,13 +106,13 @@ declare dso_local spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_32
-; CHECK-LLVM: %[[#Call:]] = call <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <8 x i4> %[[#Call]] to i32
 ; CHECK-LLVM: ret i32 %[[#Cast]]
 
 define spir_func i32 @hf16_fp4e2m1_32() {
 entry:
-  %0 = call i32 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i32 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i32 %0
 }
 
@@ -128,7 +128,7 @@ declare dso_local spir_func i32 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_D
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_8
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i8 1 to <2 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <2 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv2_i(<2 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <2 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv2_i(<2 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <2 x i8> %[[#Call]]
 
 define spir_func <2 x i8> @fp4e2m1_hf8_8() {
@@ -145,13 +145,13 @@ declare dso_local spir_func <2 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_8
-; CHECK-LLVM: %[[#Call:]] = call <2 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh(<2 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <2 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh(<2 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <2 x i4> %[[#Call]] to i8
 ; CHECK-LLVM: ret i8 %[[#Cast]]
 
 define spir_func i8 @hf16_fp4e2m1_8() {
 entry:
-  %0 = call i8 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh(<2 x half> <half 1.0, half 1.0>)
+  %0 = call spir_func i8 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh(<2 x half> <half 1.0, half 1.0>)
   ret i8 %0
 }
 
@@ -167,7 +167,7 @@ declare dso_local spir_func i8 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_16
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i16 1 to <4 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <4 x i8> %[[#Call]]
 
 define spir_func <4 x i8> @fp4e2m1_hf8_16() {
@@ -188,7 +188,7 @@ declare dso_local spir_func <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_64
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i64 1 to <16 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <16 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv16_i(<16 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <16 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv16_i(<16 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <16 x i8> %[[#Call]]
 
 define spir_func <16 x i8> @fp4e2m1_hf8_64() {
@@ -209,7 +209,7 @@ declare dso_local spir_func <16 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTE
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_vec2xi8
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <2 x i8> splat (i8 1) to <4 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <4 x i8> %[[#Call]]
 
 define spir_func <4 x i8> @fp4e2m1_hf8_vec2xi8() {
@@ -228,13 +228,13 @@ declare dso_local spir_func <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_16
-; CHECK-LLVM: %[[#Call:]] = call <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <4 x i4> %[[#Call]] to i16
 ; CHECK-LLVM: ret i16 %[[#Cast]]
 
 define spir_func i16 @hf16_fp4e2m1_16() {
 entry:
-  %0 = call i16 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i16 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i16 %0
 }
 
@@ -248,13 +248,13 @@ declare dso_local spir_func i16 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_D
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_64
-; CHECK-LLVM: %[[#Call:]] = call <16 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_Dh(<16 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <16 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_Dh(<16 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <16 x i4> %[[#Call]] to i64
 ; CHECK-LLVM: ret i64 %[[#Cast]]
 
 define spir_func i64 @hf16_fp4e2m1_64() {
 entry:
-  %0 = call i64 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_Dh(<16 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i64 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_Dh(<16 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i64 %0
 }
 
@@ -268,13 +268,13 @@ declare dso_local spir_func i64 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_vec2xi8
-; CHECK-LLVM: %[[#Call:]] = call <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <4 x i4> %[[#Call]] to <2 x i8>
 ; CHECK-LLVM: ret <2 x i8> %[[#Cast]]
 
 define spir_func <2 x i8> @hf16_fp4e2m1_vec2xi8() {
 entry:
-  %0 = call <2 x i8> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELKDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func <2 x i8> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELKDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
   ret <2 x i8> %0
 }
 

--- a/test/extensions/INTEL/SPV_INTEL_float4/conversions_scalar_vector.ll
+++ b/test/extensions/INTEL/SPV_INTEL_float4/conversions_scalar_vector.ll
@@ -70,12 +70,12 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @fp4e2m1_hf8_scalar() {
 entry:
-  %0 = call i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4 1)
+  %0 = call spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4 1)
   ret i8 %0
 }
 
@@ -88,12 +88,12 @@ declare dso_local spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4)
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> splat (i4 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> splat (i4 1))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @fp4e2m1_hf8_vector() {
 entry:
-  %0 = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
+  %0 = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
   ret <8 x i8> %0
 }
 
@@ -106,12 +106,12 @@ declare dso_local spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_bf8_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @fp4e2m1_bf8_scalar() {
 entry:
-  %0 = call i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4 1)
+  %0 = call spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4 1)
   ret i8 %0
 }
 
@@ -124,12 +124,12 @@ declare dso_local spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4)
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_bf8_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELDv8_i(<8 x i4> splat (i4 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELDv8_i(<8 x i4> splat (i4 1))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @fp4e2m1_bf8_vector() {
 entry:
-  %0 = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
+  %0 = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
   ret <8 x i8> %0
 }
 
@@ -141,12 +141,12 @@ declare dso_local spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTEL
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4 1)
 ; CHECK-LLVM: ret half %[[#Call]]
 
 define spir_func half @fp4e2m1_hf16_scalar() {
 entry:
-  %0 = call half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4 1)
+  %0 = call spir_func half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4 1)
   ret half %0
 }
 
@@ -158,12 +158,12 @@ declare dso_local spir_func half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv8_i(<8 x i4> splat (i4 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv8_i(<8 x i4> splat (i4 1))
 ; CHECK-LLVM: ret <8 x half> %[[#Call]]
 
 define spir_func <8 x half> @fp4e2m1_hf16_vector() {
 entry:
-  %0 = call <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
+  %0 = call spir_func <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
   ret <8 x half> %0
 }
 
@@ -175,12 +175,12 @@ declare dso_local spir_func <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INT
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_bf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(i4 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(i4 1)
 ; CHECK-LLVM: ret bfloat %[[#Call]]
 
 define spir_func bfloat @fp4e2m1_bf16_scalar() {
 entry:
-  %0 = call bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(i4 1)
+  %0 = call spir_func bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(i4 1)
   ret bfloat %0
 }
 
@@ -192,12 +192,12 @@ declare dso_local spir_func bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_bf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELDv8_i(<8 x i4> splat (i4 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELDv8_i(<8 x i4> splat (i4 1))
 ; CHECK-LLVM: ret <8 x bfloat> %[[#Call]]
 
 define spir_func <8 x bfloat> @fp4e2m1_bf16_vector() {
 entry:
-  %0 = call <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
+  %0 = call spir_func <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
   ret <8 x bfloat> %0
 }
 
@@ -211,12 +211,12 @@ declare dso_local spir_func <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16I
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_scalar
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(half 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(half 1.000000e+00)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @hf16_fp4e2m1_scalar() {
 entry:
-  %0 = call i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(half 1.0)
+  %0 = call spir_func i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(half 1.0)
   ret i4 %0
 }
 
@@ -228,12 +228,12 @@ declare dso_local spir_func i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(hal
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: ret <8 x i4> %[[#Call]]
 
 define spir_func <8 x i4> @hf16_fp4e2m1_vector() {
 entry:
-  %0 = call <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
   ret <8 x i4> %0
 }
 
@@ -245,12 +245,12 @@ declare dso_local spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_fp4e2m1_scalar
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(bfloat 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(bfloat 1.000000e+00)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @bf16_fp4e2m1_scalar() {
 entry:
-  %0 = call i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(bfloat 1.0)
+  %0 = call spir_func i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(bfloat 1.0)
   ret i4 %0
 }
 
@@ -262,12 +262,12 @@ declare dso_local spir_func i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_fp4e2m1_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i4> @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDv8_DF16b(<8 x bfloat> splat (bfloat 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDv8_DF16b(<8 x bfloat> splat (bfloat 1.000000e+00))
 ; CHECK-LLVM: ret <8 x i4> %[[#Call]]
 
 define spir_func <8 x i4> @bf16_fp4e2m1_vector() {
 entry:
-  %0 = call <8 x i4> @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDv8_DF16b(<8 x bfloat> <bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0>)
+  %0 = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDv8_DF16b(<8 x bfloat> <bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0>)
   ret <8 x i4> %0
 }
 

--- a/test/extensions/INTEL/SPV_INTEL_float4/upscale_o0.ll
+++ b/test/extensions/INTEL/SPV_INTEL_float4/upscale_o0.ll
@@ -56,9 +56,9 @@
 ; CHECK-SPIRV: FConvert [[#VecHalfTy]] [[#Conv2:]] [[#Cast2]]
 ; CHECK-SPIRV: Store [[#]] [[#Conv2]] 2 4
 
-; CHECK-LLVM: %[[#Conv1:]] = call <2 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv2_i(<2 x i4> %[[#]])
+; CHECK-LLVM: %[[#Conv1:]] = call spir_func <2 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv2_i(<2 x i4> %[[#]])
 ; CHECK-LLVM: store <2 x half> %[[#Conv1]], ptr %[[#]]
-; CHECK-LLVM: %[[#Conv2:]] = call <2 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv2_i(<2 x i4> %[[#]])
+; CHECK-LLVM: %[[#Conv2:]] = call spir_func <2 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv2_i(<2 x i4> %[[#]])
 ; CHECK-LLVM: store <2 x half> %[[#Conv2]], ptr %[[#]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/extensions/INTEL/SPV_INTEL_float4/upscale_o2.ll
+++ b/test/extensions/INTEL/SPV_INTEL_float4/upscale_o2.ll
@@ -53,8 +53,8 @@
 ; CHECK-SPIRV: FConvert [[#VecHalfTy]] [[#Conv2:]] [[#Cast2]]
 ; CHECK-SPIRV: FAdd [[#VecHalfTy]] [[#]] [[#Conv1]] [[#Conv2]]
 
-; CHECK-LLVM: %[[#in1:]] = call <2 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv2_i(<2 x i4> %[[#]])
-; CHECK-LLVM: %[[#in2:]] = call <2 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv2_i(<2 x i4> %[[#]])
+; CHECK-LLVM: %[[#in1:]] = call spir_func <2 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv2_i(<2 x i4> %[[#]])
+; CHECK-LLVM: %[[#in2:]] = call spir_func <2 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv2_i(<2 x i4> %[[#]])
 ; CHECK-LLVM: fadd <2 x half> %[[#in1]], %[[#in2]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/extensions/INTEL/SPV_INTEL_fp_conversions/spv_intel_fp_conversions.ll
+++ b/test/extensions/INTEL/SPV_INTEL_fp_conversions/spv_intel_fp_conversions.ll
@@ -66,12 +66,12 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_hf8_clamp
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 1.000000e+00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_hf8_clamp() {
 entry:
-  %0 = call i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 1.0)
+  %0 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 1.0)
   ret i8 %0
 }
 
@@ -83,12 +83,12 @@ declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELD
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half 1.000000e+00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_clamp() {
 entry:
-  %0 = call i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half 1.0)
+  %0 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half 1.0)
   ret i8 %0
 }
 
@@ -100,12 +100,12 @@ declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELD
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_hf8_clamp
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat 1.000000e+00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_hf8_clamp() {
 entry:
-  %0 = call i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat 1.0)
+  %0 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat 1.0)
   ret i8 %0
 }
 
@@ -117,12 +117,12 @@ declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELD
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_bf8_clamp
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat 1.000000e+00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat 1.000000e+00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_bf8_clamp() {
 entry:
-  %0 = call i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat 1.0)
+  %0 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat 1.0)
   ret i8 %0
 }
 
@@ -134,12 +134,12 @@ declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELD
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhi(half 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhi(half 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_stochastic() {
 entry:
-  %0 = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhi(half 1.0, i32 1)
+  %0 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhi(half 1.0, i32 1)
   ret i8 %0
 }
 
@@ -151,12 +151,12 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_hf8_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INTELDhi(half 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INTELDhi(half 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_hf8_stochastic() {
 entry:
-  %0 = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INTELDhi(half 1.0, i32 1)
+  %0 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INTELDhi(half 1.0, i32 1)
   ret i8 %0
 }
 
@@ -168,12 +168,12 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_bf8_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_bf8_stochastic() {
 entry:
-  %0 = call i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.0, i32 1)
   ret i8 %0
 }
 
@@ -185,12 +185,12 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_hf8_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INTELDF16bi(bfloat 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INTELDF16bi(bfloat 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_hf8_stochastic() {
 entry:
-  %0 = call i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INTELDF16bi(bfloat 1.0, i32 1)
   ret i8 %0
 }
 
@@ -202,12 +202,12 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @hf16_fp4e2m1_stochastic() {
 entry:
-  %0 = call i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 1.0, i32 1)
+  %0 = call spir_func i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 1.0, i32 1)
   ret i4 %0
 }
 
@@ -219,12 +219,12 @@ declare dso_local spir_func i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_fp4e2m1_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @bf16_fp4e2m1_stochastic() {
 entry:
-  %0 = call i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 1.0, i32 1)
   ret i4 %0
 }
 
@@ -235,12 +235,12 @@ declare dso_local spir_func i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INT
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhi(half 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhi(half 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @hf16_int4_stochastic() {
 entry:
-  %0 = call i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhs(half 1.0, i32 1)
+  %0 = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhs(half 1.0, i32 1)
   ret i4 %0
 }
 
@@ -251,12 +251,12 @@ declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToIn
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: bf16_int4_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @bf16_int4_stochastic() {
 entry:
-  %0 = call i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat 1.0, i32 1)
   ret i4 %0
 }
 
@@ -268,12 +268,12 @@ declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToIn
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_clamp_stochastic() {
 entry:
-  %0 = call i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 1.0, i32 1)
+  %0 = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 1.0, i32 1)
   ret i8 %0
 }
 
@@ -285,12 +285,12 @@ declare dso_local spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_bf8_clamp_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.000000e+00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.000000e+00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_bf8_clamp_stochastic() {
 entry:
-  %0 = call i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.0, i32 1)
   ret i8 %0
 }
 
@@ -304,13 +304,13 @@ declare dso_local spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5
 
 ; CHECK-LLVM-LABEL: hf16_bf8_stochastic_last_seed
 ; CHECK-LLVM: %[[#Ptr:]] = alloca i32
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhiPi(half 1.000000e+00, i32 1, ptr %[[#Ptr]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhiPi(half 1.000000e+00, i32 1, ptr %[[#Ptr]])
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_stochastic_last_seed() {
 entry:
   %0 = alloca i32
-  %1 = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhiPi(half 1.0, i32 1, ptr %0)
+  %1 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhiPi(half 1.0, i32 1, ptr %0)
   ret i8 %1
 }
 
@@ -323,13 +323,13 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INT
 
 ; CHECK-LLVM-LABEL: hf16_int4_stochastic_last_seed
 ; CHECK-LLVM: %[[#Ptr:]] = alloca i32
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhiPi(half 1.000000e+00, i32 1, ptr %[[#Ptr]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhiPi(half 1.000000e+00, i32 1, ptr %[[#Ptr]])
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @hf16_int4_stochastic_last_seed() {
 entry:
   %0 = alloca i32
-  %1 = call i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhiPi(half 1.0, i32 1, ptr %0)
+  %1 = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhiPi(half 1.0, i32 1, ptr %0)
   ret i4 %1
 }
 
@@ -343,13 +343,13 @@ declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToIn
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp_stochastic_last_seed
 ; CHECK-LLVM: %[[#Ptr:]] = alloca i32
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhiPi(half 1.000000e+00, i32 1, ptr %[[#Ptr]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhiPi(half 1.000000e+00, i32 1, ptr %[[#Ptr]])
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_clamp_stochastic_last_seed() {
 entry:
   %0 = alloca i32
-  %1 = call i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhiPi(half 1.0, i32 1, ptr %0)
+  %1 = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhiPi(half 1.0, i32 1, ptr %0)
   ret i8 %1
 }
 

--- a/test/extensions/INTEL/SPV_INTEL_int4/conversions_packed.ll
+++ b/test/extensions/INTEL/SPV_INTEL_int4/conversions_packed.ll
@@ -92,7 +92,7 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK-LLVM-LABEL: int4_e4m3_32
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i32 1 to <8 x i4>
-; CHECK-LLVM: %[[#Conv:]] = call <8 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv8_i(<8 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Conv:]] = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv8_i(<8 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <8 x i8> %[[#Conv]]
 
 ; Function Attrs: nounwind readnone
@@ -110,7 +110,7 @@ declare dso_local spir_func <8 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_32
-; CHECK-LLVM: %[[#Conv:]] = call <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv8_Dh(<8 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Conv:]] = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv8_Dh(<8 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: [[#Cast:]] = bitcast <8 x i4> %[[#Conv]] to i32
 ; CHECK-LLVM: ret i32 %[[#Cast]]
 
@@ -133,7 +133,7 @@ declare dso_local spir_func i32 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELi(<8 
 
 ; CHECK-LLVM-LABEL: int4_e4m3_8
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i8 1 to <2 x i4>
-; CHECK-LLVM: %[[#Conv:]] = call <2 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv2_i(<2 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Conv:]] = call spir_func <2 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv2_i(<2 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <2 x i8> %[[#Conv]]
 
 ; Function Attrs: nounwind readnone
@@ -151,7 +151,7 @@ declare dso_local spir_func <2 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_8
-; CHECK-LLVM: %[[#Conv:]] = call <2 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv2_Dh(<2 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Conv:]] = call spir_func <2 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv2_Dh(<2 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: [[#Cast:]] = bitcast <2 x i4> %[[#Conv]] to i8
 ; CHECK-LLVM: ret i8 %[[#Cast]]
 
@@ -174,7 +174,7 @@ declare dso_local spir_func i8 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELc(<2 x
 
 ; CHECK-LLVM-LABEL: int4_e4m3_16
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i16 1 to <4 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <4 x i8> %[[#Call]]
 
 define spir_func <4 x i8> @int4_e4m3_16() {
@@ -195,7 +195,7 @@ declare dso_local spir_func <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTEL
 
 ; CHECK-LLVM-LABEL: int4_e4m3_64
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i64 1 to <16 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <16 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv16_i(<16 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <16 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv16_i(<16 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <16 x i8> %[[#Call]]
 
 define spir_func <16 x i8> @int4_e4m3_64() {
@@ -216,7 +216,7 @@ declare dso_local spir_func <16 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTE
 
 ; CHECK-LLVM-LABEL: int4_e4m3_vec2xi8
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <2 x i8> splat (i8 1) to <4 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <4 x i8> %[[#Call]]
 
 define spir_func <4 x i8> @int4_e4m3_vec2xi8() {
@@ -235,13 +235,13 @@ declare dso_local spir_func <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_16
-; CHECK-LLVM: %[[#Call:]] = call <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <4 x i4> %[[#Call]] to i16
 ; CHECK-LLVM: ret i16 %[[#Cast]]
 
 define spir_func i16 @hf16_int4_16() {
 entry:
-  %0 = call i16 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i16 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i16 %0
 }
 
@@ -255,13 +255,13 @@ declare dso_local spir_func i16 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_D
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_64
-; CHECK-LLVM: %[[#Call:]] = call <16 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_Dh(<16 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <16 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_Dh(<16 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <16 x i4> %[[#Call]] to i64
 ; CHECK-LLVM: ret i64 %[[#Cast]]
 
 define spir_func i64 @hf16_int4_64() {
 entry:
-  %0 = call i64 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_Dh(<16 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i64 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_Dh(<16 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i64 %0
 }
 
@@ -275,13 +275,13 @@ declare dso_local spir_func i64 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_vec2xi8
-; CHECK-LLVM: %[[#Call:]] = call <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> splat (half 1.000000e+00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> splat (half 1.000000e+00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <4 x i4> %[[#Call]] to <2 x i8>
 ; CHECK-LLVM: ret <2 x i8> %[[#Cast]]
 
 define spir_func <2 x i8> @hf16_int4_vec2xi8() {
 entry:
-  %0 = call <2 x i8> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELKDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func <2 x i8> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELKDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
   ret <2 x i8> %0
 }
 


### PR DESCRIPTION
When translating SPIRV FP4/FP8/i4 conversions (`OpFConvert` etc.) back to LLVM IR, the code path that creates `__builtin_spirv_*` calls via `getOrInsertFunction` used the default calling convention.

Fix by setting `CallingConv::SPIR_FUNC` on both the function declaration and the call instruction, consistent with all other builtin call sites in the translator.