### PR TITLE
[DebugInfo] Fix NonSemantic DebugLine Source operand

### DIFF
--- a/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -252,7 +252,8 @@ void LLVMToSPIRVDbgTran::transLocationInfo() {
               BM->getDebugInfoEIS() ==
                   SPIRVEIS_NonSemantic_Shader_DebugInfo_200)
             BM->addDebugLine(V, getVoidTy(),
-                             File ? File->getId() : getDebugInfoNoneId(),
+                             File ? getSource(DL.get())->getId()
+                                  : getDebugInfoNoneId(),
                              LineNo, LineNo, Col, Col + 1);
           else
             BM->addLine(V, File ? File->getId() : getDebugInfoNoneId(), LineNo,

--- a/test/DebugInfo/DebugInfoTypeBasic.ll
+++ b/test/DebugInfo/DebugInfoTypeBasic.ll
@@ -15,6 +15,7 @@
 
 ; RUN: llvm-spirv %t.bc -spirv-text --spirv-debug-info-version=nonsemantic-shader-100 -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-NONSEM
 ; RUN: llvm-spirv %t.bc --spirv-debug-info-version=nonsemantic-shader-100 -o %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM

--- a/test/DebugInfo/NonSemantic/DebugLine.ll
+++ b/test/DebugInfo/NonSemantic/DebugLine.ll
@@ -1,0 +1,33 @@
+; RUN: llvm-spirv %s --spirv-debug-info-version=nonsemantic-shader-100 -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
+
+; RUN: llvm-spirv %s --spirv-debug-info-version=nonsemantic-shader-200 -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix CHECK-SPIRV
+
+; Test that DebugLine's Source operand references a DebugSource instruction, not a
+; raw OpString (translated by default from DIFile).
+
+; CHECK-SPIRV: ExtInst [[#VoidTy:]] [[#Source:]] [[#]] DebugSource
+; CHECK-SPIRV: ExtInst [[#VoidTy]] [[#]] [[#]] DebugLine [[#Source]]
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define void @foo() !dbg !4 {
+entry:
+  ret void, !dbg !7
+}
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!2}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !3, nameTableKind: None)
+!1 = !DIFile(filename: "foo.cpp", directory: "/app")
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = !{}
+!4 = distinct !DISubprogram(name: "foo", scope: !1, file: !1, line: 1, type: !5, scopeLine: 1, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !3)
+!5 = !DISubroutineType(types: !6)
+!6 = !{null}
+!7 = !DILocation(line: 2, column: 1, scope: !4)

--- a/test/DebugInfo/NonSemantic/Shader200/InlineNamespace.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/InlineNamespace.ll
@@ -1,6 +1,7 @@
 ; RUN: llvm-spirv -spirv-text %s -o %t.spt --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -to-binary %t.spt -o %t.spv
+; RUN: spirv-val %t.spv
 
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll


### PR DESCRIPTION
NonSemantic.Shader.DebugInfo.100/.200 require the Source operand of DebugLine to reference a DebugSource instruction, not a raw OpString ID (DIFile in LLVM IR).
Use getSource() to emit a proper DebugSource reference.

Enable spirv-val on the NonSemantic paths of DebugInfoTypeBasic.ll and InlineNamespace.ll now that all three spec-compliance fixes are in place.

AI-assisted: Claude Sonnet 4.6 (commercial SaaS)