### PR TITLE
[CI] Build SPIRV-Tools from main instead of lunarg packages

### DIFF
--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -15,7 +15,7 @@ on:
       - 'docs/**' # documentation
       - '**.md'   # README
       - '**/check-code-style.yml' # check-code-style workflow
-      - '**/check-out-of-tree-build.yml' # check-out-of-tree-build workflow
+      - '**/check-in-tree-build.yml' # check-in-tree-build workflow
       - '**/check-out-of-tree-build.yml' # check-out-of-tree-build workflow
       - '**/backport-to-branch.yml' # backport-to-branch workflow
       - '**/patch-release.yaml' # patch-release workflow
@@ -51,6 +51,7 @@ on:
 
 env:
   LLVM_VERSION: 23
+  SPIRV_TOOLS_INSTALL: ${{ github.workspace }}/spirv-tools-install
 
 jobs:
   build_and_test_linux:
@@ -68,16 +69,22 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
-          curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
           echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble main" | sudo tee -a /etc/apt/sources.list
-          echo "deb https://packages.lunarg.com/vulkan noble main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
-            clang-${{ env.LLVM_VERSION }} \
-            spirv-tools
+            clang-${{ env.LLVM_VERSION }}
           # Linux systems in GitHub Actions already have older versions of clang
           # pre-installed. Make sure to override these with the relevant version.
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
+      - name: Restore SPIRV-Tools cache
+        # The prebuild-spirv-tools workflow owns populating this cache.
+        # The primary key never matches (no one saves it); restore-keys
+        # pulls the most recent prebuild entry.
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ env.SPIRV_TOOLS_INSTALL }}
+          key: spirv-tools-main-latest
+          restore-keys: spirv-tools-main-
       - name: Checkout LLVM sources
         uses: actions/checkout@v5
         with:
@@ -115,6 +122,7 @@ jobs:
             -DSPIRV_SKIP_CLANG_BUILD=ON \
             -DSPIRV_SKIP_DEBUG_INFO_TESTS=ON \
             -DLLVM_LIT_ARGS="-sv --no-progress-bar" \
+            -DCMAKE_PREFIX_PATH=${{ env.SPIRV_TOOLS_INSTALL }} \
             -G "Unix Makefiles"
       - name: Build
         run: |

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -47,6 +47,7 @@ on:
 
 env:
   LLVM_VERSION: 23
+  SPIRV_TOOLS_INSTALL: ${{ github.workspace }}/spirv-tools-install
 
 jobs:
   build_and_test:
@@ -60,9 +61,7 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
-          curl -L "https://packages.lunarg.com/lunarg-signing-key-pub.asc" | sudo apt-key add -
           echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble main" | sudo tee -a /etc/apt/sources.list
-          echo "deb https://packages.lunarg.com/vulkan noble main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \
@@ -72,11 +71,19 @@ jobs:
             libomp-${{ env.LLVM_VERSION }}-dev \
             llvm-${{ env.LLVM_VERSION }}-tools \
             mlir-${{ env.LLVM_VERSION }}-tools \
-            libpolly-${{ env.LLVM_VERSION }}-dev \
-            spirv-tools
+            libpolly-${{ env.LLVM_VERSION }}-dev
           # Linux systems in GitHub Actions already have older versions of clang
           # pre-installed. Make sure to override these with the relevant version.
           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${{ env.LLVM_VERSION }} 1000
+      - name: Restore SPIRV-Tools cache
+        # The prebuild-spirv-tools workflow owns populating this cache.
+        # The primary key never matches (no one saves it); restore-keys
+        # pulls the most recent prebuild entry.
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ env.SPIRV_TOOLS_INSTALL }}
+          key: spirv-tools-main-latest
+          restore-keys: spirv-tools-main-
       - name:  Checkout the translator sources
         uses: actions/checkout@v5
         with:
@@ -100,6 +107,7 @@ jobs:
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_EXTERNAL_LIT="/usr/lib/llvm-${{ env.LLVM_VERSION }}/bin/lit" \
             -DLLVM_EXTERNAL_SPIRV_HEADERS_SOURCE_DIR=${{ github.workspace }}/SPIRV-Headers \
+            -DCMAKE_PREFIX_PATH=${{ env.SPIRV_TOOLS_INSTALL }} \
             -G "Unix Makefiles"
       - name: Build
         run: |

--- a/.github/workflows/prebuild-spirv-tools.yml
+++ b/.github/workflows/prebuild-spirv-tools.yml
@@ -1,0 +1,50 @@
+# This workflow builds SPIRV-Tools from main once per day and caches the
+# install tree. The build- and test-workflows only restore from this cache
+# (via restore-keys prefix match), so this workflow owns the freshness of
+# the tools.
+#
+# workflow_dispatch is provided for manual refresh when a SPIRV-Tools fix
+# needs to be picked up before the next scheduled run, or to bootstrap the
+# cache on first deployment.
+name: Prebuild SPIRV-Tools
+
+on:
+  schedule:
+    - cron: 0 23 * * *
+  workflow_dispatch:
+
+env:
+  SPIRV_TOOLS_INSTALL: ${{ github.workspace }}/spirv-tools-install
+
+jobs:
+  prebuild:
+    name: Build and cache SPIRV-Tools main
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Get current date for SPIRV-Tools cache key
+        id: date
+        run: echo "date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
+      - name: Check for existing cache entry
+        id: spirv-tools-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ env.SPIRV_TOOLS_INSTALL }}
+          key: spirv-tools-main-${{ steps.date.outputs.date }}
+          lookup-only: true
+      - name: Build and install SPIRV-Tools
+        if: steps.spirv-tools-cache.outputs.cache-hit != 'true'
+        run: |
+          git clone --depth=1 https://github.com/KhronosGroup/SPIRV-Tools SPIRV-Tools
+          python3 SPIRV-Tools/utils/git-sync-deps
+          cmake -S SPIRV-Tools -B SPIRV-Tools/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${{ env.SPIRV_TOOLS_INSTALL }} \
+            -DSPIRV_SKIP_TESTS=ON \
+            -G "Unix Makefiles"
+          make -C SPIRV-Tools/build install -j$(nproc)
+      - name: Save SPIRV-Tools cache
+        if: steps.spirv-tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ env.SPIRV_TOOLS_INSTALL }}
+          key: spirv-tools-main-${{ steps.date.outputs.date }}


### PR DESCRIPTION
Resolves #3736 - replace the lunarg apt package for spirv-tools with a source build of SPIRV-Tools main.
The lunarg releases are infrequent and block CI validation of new extensions before they land in a published package.

A dedicated `prebuild-spirv-tools` workflow owns building and caching the tools.
It runs once a day at 23:00 UTC and saves the install tree under key `spirv-tools-main-YYYY-MM-DD`.
A manual `workflow_dispatch` trigger is provided for urgent refreshes and for bootstrapping the cache on first deployment.

The in-tree and out-of-tree build workflows only restore the cache via a restore-keys prefix match on `spirv-tools-main-`, which always pulls the most recent prebuild entry.
The Actions log for each build job records the exact key restored, so reviewers can see which tools build was used.

AI-assisted: Claude Sonnet 4.6 (commercial SaaS)