### PR TITLE
Fix is_fpclass translation for inverted case

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5304,11 +5304,6 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       IsInverted = true;
       FPClass = InvertedCheck;
     }
-    auto GetInvertedTestIfNeeded = [&](SPIRVValue *TestInst) -> SPIRVValue * {
-      if (!IsInverted)
-        return TestInst;
-      return BM->addInstTemplate(OpLogicalNot, {TestInst->getId()}, BB, ResTy);
-    };
 
     // TODO: we can add some optimization for fcFinite check by replacing it
     // with fabs + cmp to 0x7FF0000000000000
@@ -5322,7 +5317,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       if (FPClass & fcSNan && FPClass & fcQNan) {
         auto *TestIsNan =
             BM->addInstTemplate(OpIsNan, {InputFloat->getId()}, BB, ResTy);
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsNan));
+        ResultVec.emplace_back(TestIsNan);
       } else {
         // isquiet(V) ==> abs(V) >= (unsigned(Inf) | quiet_bit)
         APInt QNaNBitMask =
@@ -5335,7 +5330,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
         auto *TestIsQNan = BM->addCmpInst(OpUGreaterThanEqual, ResTy,
                                           BitCastToInt, QNanBitConst, BB);
         if (FPClass & fcQNan) {
-          ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsQNan));
+          ResultVec.emplace_back(TestIsQNan);
         } else {
           // issignaling(V) ==> isnan(V) && !isquiet(V)
           auto *TestIsNan =
@@ -5344,7 +5339,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
                                               {TestIsQNan->getId()}, BB, ResTy);
           auto *TestIsSNan = BM->addInstTemplate(
               OpLogicalAnd, {TestIsNan->getId(), NotQNan->getId()}, BB, ResTy);
-          ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsSNan));
+          ResultVec.emplace_back(TestIsSNan);
         }
       }
     }
@@ -5353,22 +5348,22 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
           BM->addInstTemplate(OpIsInf, {InputFloat->getId()}, BB, ResTy);
       if (FPClass & fcNegInf && FPClass & fcPosInf)
         // Map on OpIsInf if we have both Inf test bits set
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsInf));
+        ResultVec.emplace_back(TestIsInf);
       else
         // Map on OpIsInf with following check for sign bit
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(
-            GetNegPosInstTest(TestIsInf, FPClass & fcNegInf)));
+        ResultVec.emplace_back(
+            GetNegPosInstTest(TestIsInf, FPClass & fcNegInf));
     }
     if (FPClass & fcNormal) {
       auto *TestIsNormal =
           BM->addInstTemplate(OpIsNormal, {InputFloat->getId()}, BB, ResTy);
       if (FPClass & fcNegNormal && FPClass & fcPosNormal)
         // Map on OpIsNormal if we have both Normal test bits set
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsNormal));
+        ResultVec.emplace_back(TestIsNormal);
       else
         // Map on OpIsNormal with following check for sign bit
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(
-            GetNegPosInstTest(TestIsNormal, FPClass & fcNegNormal)));
+        ResultVec.emplace_back(
+            GetNegPosInstTest(TestIsNormal, FPClass & fcNegNormal));
     }
     if (FPClass & fcSubnormal) {
       // issubnormal(V) ==> unsigned(abs(V) - 1) < (all mantissa bits set)
@@ -5383,10 +5378,10 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       auto *TestIsSubnormal =
           BM->addCmpInst(OpULessThan, ResTy, MinusOne, MantissaConst, BB);
       if (FPClass & fcPosSubnormal && FPClass & fcNegSubnormal)
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsSubnormal));
+        ResultVec.emplace_back(TestIsSubnormal);
       else
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(
-            GetNegPosInstTest(TestIsSubnormal, FPClass & fcNegSubnormal)));
+        ResultVec.emplace_back(
+            GetNegPosInstTest(TestIsSubnormal, FPClass & fcNegSubnormal));
     }
     if (FPClass & fcZero) {
       // Create zero integer constant and check for equality with bitcasted to
@@ -5418,19 +5413,17 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
             OpBitwiseAnd, OpSPIRVTy, BitCastToInt, MaskToClearSignBitConst, BB);
         auto *TestIsZero =
             BM->addCmpInst(OpIEqual, ResTy, BitwiseAndRes, ZeroConst, BB);
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsZero));
+        ResultVec.emplace_back(TestIsZero);
       } else if (FPClass & fcPosZero) {
         auto *TestIsPosZero =
             SetUpCMPToZero(BitCastToInt, true /*'positive' zero*/);
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsPosZero));
+        ResultVec.emplace_back(TestIsPosZero);
       } else {
         auto *TestIsNegZero =
             SetUpCMPToZero(BitCastToInt, false /*'negated' zero*/);
-        ResultVec.emplace_back(GetInvertedTestIfNeeded(TestIsNegZero));
+        ResultVec.emplace_back(TestIsNegZero);
       }
     }
-    if (ResultVec.size() == 1)
-      return ResultVec.back();
     SPIRVValue *Result = ResultVec.front();
     for (size_t I = 1; I != ResultVec.size(); ++I) {
       // Create a sequence of LogicalOr instructions from ResultVec to get
@@ -5438,6 +5431,10 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       std::vector<SPIRVId> LogicOps = {Result->getId(), ResultVec[I]->getId()};
       Result = BM->addInstTemplate(OpLogicalOr, LogicOps, BB, ResTy);
     }
+    // If the FPClass mask was inverted to keep the per-component lowering
+    // simple, negate the final OR-combined result.
+    if (IsInverted)
+      Result = BM->addInstTemplate(OpLogicalNot, {Result->getId()}, BB, ResTy);
     return Result;
   }
   default:

--- a/test/llvm-intrinsics/fpclass.ll
+++ b/test/llvm-intrinsics/fpclass.ll
@@ -65,6 +65,10 @@
 ; CHECK-SPIRV-DAG: Name [[#ComplexFunc1:]] "test_class_neginf_posnormal_negsubnormal_poszero_snan_f64"
 ; CHECK-SPIRV-DAG: Name [[#ComplexFunc2:]] "test_class_neginf_posnormal_negsubnormal_poszero_snan_v2f16"
 ; CHECK-SPIRV-DAG: Name [[#NotNanFunc:]] "test_class_inverted_is_not_nan_f32"
+; CHECK-SPIRV-DAG: Name [[#NotFiniteFunc:]] "test_class_inverted_not_finite_f32"
+; CHECK-SPIRV-DAG: Name [[#NotPosFiniteFunc:]] "test_class_inverted_not_pos_finite_f32"
+; CHECK-SPIRV-DAG: Name [[#NotNegFiniteFunc:]] "test_class_inverted_not_neg_finite_f32"
+; CHECK-SPIRV-DAG: Name [[#NotZeroFunc:]] "test_class_inverted_not_zero_f32"
 
 ; ModuleID = 'fpclass.bc'
 source_filename = "fpclass.ll"
@@ -438,6 +442,93 @@ define i1 @test_class_inverted_is_not_nan_f32(float %x) {
 ; CHECK-SPIRV-NEXT: LogicalNot [[#BoolTy]] [[#Not:]] [[#IsNan]]
 ; CHECK-SPIRV-NEXT: ReturnValue [[#Not]]
   %val = call i1 @llvm.is.fpclass.f32(float %x, i32 1020)
+  ret i1 %val
+}
+
+; inverted check for finite
+; 519 = ~fcFinite & fcAllFlags == fcNan | fcInf
+define i1 @test_class_inverted_not_finite_f32(float %x) {
+; CHECK-SPIRV: Function [[#]] [[#NotFiniteFunc]]
+; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
+; CHECK-SPIRV-EMPTY:
+; CHECK-SPIRV-NEXT: Label
+; CHECK-SPIRV-NEXT: IsNormal [[#BoolTy]] [[#IsNormal:]] [[#Val]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast1:]] [[#Val]]
+; CHECK-SPIRV-NEXT: ISub [[#Int32Ty]] [[#Sub:]] [[#BitCast1]] [[#const32One]]
+; CHECK-SPIRV-NEXT: ULessThan [[#BoolTy]] [[#Less:]] [[#Sub]] [[#MantissaConst]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast2:]] [[#Val]]
+; CHECK-SPIRV-NEXT: BitwiseAnd [[#Int32Ty]] [[#BitwiseAndRes:]] [[#BitCast2]] [[#MaskToClearSignBit]]
+; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#EqualZero:]] [[#BitwiseAndRes]] [[#ZeroConst]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or1:]] [[#IsNormal]] [[#Less]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or2:]] [[#Or1]] [[#EqualZero]]
+; CHECK-SPIRV-NEXT: LogicalNot [[#BoolTy]] [[#NotResult:]] [[#Or2]]
+; CHECK-SPIRV-NEXT: ReturnValue [[#NotResult]]
+  %val = call i1 @llvm.is.fpclass.f32(float %x, i32 519)
+  ret i1 %val
+}
+
+; inverted check for pos-finite
+; 575 = ~fcPosFinite & fcAllFlags
+define i1 @test_class_inverted_not_pos_finite_f32(float %x) {
+; CHECK-SPIRV: Function [[#]] [[#NotPosFiniteFunc]]
+; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
+; CHECK-SPIRV-EMPTY:
+; CHECK-SPIRV-NEXT: Label
+; CHECK-SPIRV-NEXT: IsNormal [[#BoolTy]] [[#IsNormal:]] [[#Val]]
+; CHECK-SPIRV-NEXT: SignBitSet [[#BoolTy]] [[#Sign:]] [[#Val]]
+; CHECK-SPIRV-NEXT: LogicalNot [[#BoolTy]] [[#NotSign:]] [[#Sign]]
+; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#AndNorm:]] [[#NotSign]] [[#IsNormal]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast1:]] [[#Val]]
+; CHECK-SPIRV-NEXT: ISub [[#Int32Ty]] [[#Sub:]] [[#BitCast1]] [[#const32One]]
+; CHECK-SPIRV-NEXT: ULessThan [[#BoolTy]] [[#Less:]] [[#Sub]] [[#MantissaConst]]
+; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#AndSub:]] [[#NotSign]] [[#Less]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast2:]] [[#Val]]
+; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#EqualPosZero:]] [[#BitCast2]] [[#ZeroConst]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or1:]] [[#AndNorm]] [[#AndSub]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or2:]] [[#Or1]] [[#EqualPosZero]]
+; CHECK-SPIRV-NEXT: LogicalNot [[#BoolTy]] [[#NotResult:]] [[#Or2]]
+; CHECK-SPIRV-NEXT: ReturnValue [[#NotResult]]
+  %val = call i1 @llvm.is.fpclass.f32(float %x, i32 575)
+  ret i1 %val
+}
+
+; inverted check for neg-finite
+; 967 = ~fcNegFinite & fcAllFlags
+define i1 @test_class_inverted_not_neg_finite_f32(float %x) {
+; CHECK-SPIRV: Function [[#]] [[#NotNegFiniteFunc]]
+; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
+; CHECK-SPIRV-EMPTY:
+; CHECK-SPIRV-NEXT: Label
+; CHECK-SPIRV-NEXT: IsNormal [[#BoolTy]] [[#IsNormal:]] [[#Val]]
+; CHECK-SPIRV-NEXT: SignBitSet [[#BoolTy]] [[#Sign:]] [[#Val]]
+; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#AndNorm:]] [[#Sign]] [[#IsNormal]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast1:]] [[#Val]]
+; CHECK-SPIRV-NEXT: ISub [[#Int32Ty]] [[#Sub:]] [[#BitCast1]] [[#const32One]]
+; CHECK-SPIRV-NEXT: ULessThan [[#BoolTy]] [[#Less:]] [[#Sub]] [[#MantissaConst]]
+; CHECK-SPIRV-NEXT: LogicalAnd [[#BoolTy]] [[#AndSub:]] [[#Sign]] [[#Less]]
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast2:]] [[#Val]]
+; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#EqualNegZero:]] [[#BitCast2]] [[#NegatedZeroConst]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or1:]] [[#AndNorm]] [[#AndSub]]
+; CHECK-SPIRV-NEXT: LogicalOr [[#BoolTy]] [[#Or2:]] [[#Or1]] [[#EqualNegZero]]
+; CHECK-SPIRV-NEXT: LogicalNot [[#BoolTy]] [[#NotResult:]] [[#Or2]]
+; CHECK-SPIRV-NEXT: ReturnValue [[#NotResult]]
+  %val = call i1 @llvm.is.fpclass.f32(float %x, i32 967)
+  ret i1 %val
+}
+
+; inverted check for zero
+; 927 = ~fcZero & fcAllFlags
+define i1 @test_class_inverted_not_zero_f32(float %x) {
+; CHECK-SPIRV: Function [[#]] [[#NotZeroFunc]]
+; CHECK-SPIRV-NEXT: FunctionParameter [[#]] [[#Val:]]
+; CHECK-SPIRV-EMPTY:
+; CHECK-SPIRV-NEXT: Label
+; CHECK-SPIRV-NEXT: Bitcast [[#Int32Ty]] [[#BitCast:]] [[#Val]]
+; CHECK-SPIRV-NEXT: BitwiseAnd [[#Int32Ty]] [[#BitwiseAndRes:]] [[#BitCast]] [[#MaskToClearSignBit]]
+; CHECK-SPIRV-NEXT: IEqual [[#BoolTy]] [[#EqualZero:]] [[#BitwiseAndRes]] [[#ZeroConst]]
+; CHECK-SPIRV-NEXT: LogicalNot [[#BoolTy]] [[#NotResult:]] [[#EqualZero]]
+; CHECK-SPIRV-NEXT: ReturnValue [[#NotResult]]
+  %val = call i1 @llvm.is.fpclass.f32(float %x, i32 927)
   ret i1 %val
 }
 


### PR DESCRIPTION
Fixes: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3696