### PR TITLE
[LLVM 17] ESIMD W/A Feature Check Guard

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1234,8 +1234,13 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
   // extension for image-handle-to-index conversion, or redesigning ESIMD
   // accessor storage.
   case OpConvertPtrToU: {
-    if (Src->getType()->isTargetExtTy())
-      return transSPIRVBuiltinFromInst(BC, BB);
+    if (Src->getType()->isTargetExtTy()) {
+      if (BM->getExtension().count("SPV_INTEL_vector_compute"))
+        return transSPIRVBuiltinFromInst(BC, BB);
+      BM->getErrorLog().checkError(false, SPIRVEC_InvalidInstruction,
+                                   "OpConvertPtrToU on a target extension type "
+                                   "requires SPV_INTEL_vector_compute");
+    }
     [[fallthrough]];
   }
   default:

--- a/test/workarounds/ptrtoint-target-extension-types.spt
+++ b/test/workarounds/ptrtoint-target-extension-types.spt
@@ -1,4 +1,4 @@
-; RUN: llvm-spirv -spirv-ext=+SPV_INTEL_vector_compute -spirv-text -r -spirv-target-env=SPV-IR %s -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_vector_compute -spirv-text -r -spirv-target-env=SPV-IR %s -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; The purpose of this test is to validate whether this workaround works fine:
 

--- a/test/workarounds/ptrtoint-target-extension-types.spt
+++ b/test/workarounds/ptrtoint-target-extension-types.spt
@@ -1,4 +1,4 @@
-; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_vector_compute -spirv-text -r -spirv-target-env=SPV-IR %s -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -spirv-text -r -spirv-target-env=SPV-IR %s -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; The purpose of this test is to validate whether this workaround works fine:
 
@@ -16,6 +16,8 @@
 2 Capability Addresses
 2 Capability Linkage
 2 Capability Kernel
+
+11 Extension "SPV_INTEL_vector_compute"
 
 5 ExtInstImport 1 "OpenCL.std"
 3 MemoryModel 2 2

--- a/test/workarounds/ptrtoint-target-extension-types.spt
+++ b/test/workarounds/ptrtoint-target-extension-types.spt
@@ -1,4 +1,4 @@
-; RUN: llvm-spirv -spirv-text -r -spirv-target-env=SPV-IR %s -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -spirv-ext=+SPV_INTEL_vector_compute -spirv-text -r -spirv-target-env=SPV-IR %s -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; The purpose of this test is to validate whether this workaround works fine:
 


### PR DESCRIPTION
The original workaround (#3476) applied unconditionally, accepting invalid SPIR-V (`OpConvertPtrToU` applied to target extension types) in all contexts.

This PR gates that W/A (merged to 17 release in #3683) on `SPV_INTEL_vector_compute` - to limit acceptance of spec-violating SPIR-V to the ESIMD use case that actually needs it.
