### PR TITLE
ESIMD W/A Feature Check Guard

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1203,8 +1203,13 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
   // extension for image-handle-to-index conversion, or redesigning ESIMD
   // accessor storage.
   case OpConvertPtrToU: {
-    if (Src->getType()->isTargetExtTy())
-      return transSPIRVBuiltinFromInst(BC, BB);
+    if (Src->getType()->isTargetExtTy()) {
+      if (BM->getExtension().count("SPV_INTEL_vector_compute"))
+        return transSPIRVBuiltinFromInst(BC, BB);
+      BM->getErrorLog().checkError(false, SPIRVEC_InvalidInstruction,
+                                   "OpConvertPtrToU on a target extension type "
+                                   "requires SPV_INTEL_vector_compute");
+    }
     [[fallthrough]];
   }
   default:

--- a/test/workarounds/ptrtoint-target-extension-types.spt
+++ b/test/workarounds/ptrtoint-target-extension-types.spt
@@ -17,6 +17,8 @@
 2 Capability Linkage
 2 Capability Kernel
 
+11 Extension "SPV_INTEL_vector_compute"
+
 5 ExtInstImport 1 "OpenCL.std"
 3 MemoryModel 2 2
 27 EntryPoint 6 35 "_ZTSN4sycl3_V16detail19__pf_kernel_wrapperIZZ4mainENKUlRNS0_7handlerEE_clES4_E4TestEE" 5 6


### PR DESCRIPTION
This is a follow-up to #3689

The original workaround (#3476) applied unconditionally, accepting invalid SPIR-V (`OpConvertPtrToU` applied to target extension types) in all contexts.

This PR gates that W/A on `SPV_INTEL_vector_compute` - to limit acceptance of spec-violating SPIR-V to the ESIMD use case that actually needs it.