### PR TITLE
[Backport to 16] Translate OpIAddCarry and OpISubBorrow back to llvm intrinsics (#2877)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2810,13 +2810,35 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
   case OpSignBitSet:
     return mapValue(BV,
                     transRelational(static_cast<SPIRVInstruction *>(BV), BB));
-  case OpIAddCarry: {
-    auto *BC = static_cast<SPIRVBinary *>(BV);
-    return mapValue(BV, transBuiltinFromInst("__spirv_IAddCarry", BC, BB));
-  }
+  case OpIAddCarry:
   case OpISubBorrow: {
+    IRBuilder<> Builder(BB);
     auto *BC = static_cast<SPIRVBinary *>(BV);
-    return mapValue(BV, transBuiltinFromInst("__spirv_ISubBorrow", BC, BB));
+    const Intrinsic::ID ID = OC == OpIAddCarry ? Intrinsic::uadd_with_overflow
+                                               : Intrinsic::usub_with_overflow;
+    auto *Inst =
+        Builder.CreateBinaryIntrinsic(ID, transValue(BC->getOperand(0), F, BB),
+                                      transValue(BC->getOperand(1), F, BB));
+
+    // Extract components of the result.
+    auto *Result = Builder.CreateExtractValue(Inst, 0); // iN result
+    auto *Carry = Builder.CreateExtractValue(Inst, 1);  // i1 overflow
+
+    // Convert {iN, i1} into {iN, iN} for SPIR-V compatibility.
+    Value *CarryInt;
+    if (Carry->getType()->isVectorTy()) {
+      CarryInt = Builder.CreateZExt(
+          Carry, VectorType::get(
+                     cast<VectorType>(Result->getType())->getElementType(),
+                     cast<VectorType>(Carry->getType())->getElementCount()));
+    } else {
+      CarryInt = Builder.CreateZExt(Carry, Result->getType());
+    }
+    auto *ResultStruct = Builder.CreateInsertValue(
+        UndefValue::get(transType(BV->getType())), Result, 0);
+    ResultStruct = Builder.CreateInsertValue(ResultStruct, CarryInt, 1);
+
+    return mapValue(BV, ResultStruct);
   }
   case OpSMulExtended: {
     auto *BC = static_cast<SPIRVBinary *>(BV);

--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -360,6 +360,70 @@ bool SPIRVRegularizeLLVMBase::runRegularizeLLVM(Module &Module) {
   return true;
 }
 
+namespace {
+void regularizeWithOverflowInstrinsics(StringRef MangledName, CallInst *Call,
+                                       Module *M,
+                                       std::vector<Instruction *> &ToErase) {
+  IRBuilder<> Builder(Call);
+  Function *Builtin = Call->getModule()->getFunction(MangledName);
+  AllocaInst *A;
+  StructType *StructBuiltinTy;
+  if (Builtin) {
+    StructBuiltinTy = cast<StructType>(Builtin->getParamStructRetType(0));
+    {
+      const IRBuilderBase::InsertPointGuard Guard(Builder);
+      Builder.SetInsertPointPastAllocas(Call->getParent()->getParent());
+      A = Builder.CreateAlloca(StructBuiltinTy);
+    }
+    CallInst *C = Builder.CreateCall(
+        Builtin, {A, Call->getArgOperand(0), Call->getArgOperand(1)});
+    auto SretAttr = Attribute::get(
+        Builder.getContext(), Attribute::AttrKind::StructRet, StructBuiltinTy);
+    C->addParamAttr(0, SretAttr);
+  } else {
+    StructBuiltinTy = StructType::create(
+        Call->getContext(),
+        {Call->getArgOperand(0)->getType(), Call->getArgOperand(1)->getType()});
+    {
+      const IRBuilderBase::InsertPointGuard Guard(Builder);
+      Builder.SetInsertPointPastAllocas(Call->getParent()->getParent());
+      A = Builder.CreateAlloca(StructBuiltinTy);
+    }
+    FunctionType *FT =
+        FunctionType::get(Builder.getVoidTy(),
+                          {A->getType(), Call->getArgOperand(0)->getType(),
+                           Call->getArgOperand(1)->getType()},
+                          false);
+    Builtin =
+        Function::Create(FT, GlobalValue::ExternalLinkage, MangledName, M);
+    Builtin->setCallingConv(CallingConv::SPIR_FUNC);
+    Builtin->addFnAttr(Attribute::NoUnwind);
+    auto SretAttr = Attribute::get(
+        Builder.getContext(), Attribute::AttrKind::StructRet, StructBuiltinTy);
+    Builtin->addParamAttr(0, SretAttr);
+    CallInst *C = Builder.CreateCall(
+        Builtin, {A, Call->getArgOperand(0), Call->getArgOperand(1)});
+    C->addParamAttr(0, SretAttr);
+  }
+  Type *RetTy = Call->getArgOperand(0)->getType();
+  Constant *ConstZero = ConstantInt::get(RetTy, 0);
+  Value *L = Builder.CreateLoad(StructBuiltinTy, A);
+  Value *V0 = Builder.CreateExtractValue(L, {0});
+  Value *V1 = Builder.CreateExtractValue(L, {1});
+  Value *V2 = Builder.CreateICmpNE(V1, ConstZero);
+  Type *StructI32I1Ty =
+      StructType::create(Call->getContext(), {RetTy, V2->getType()});
+  Value *Undef = UndefValue::get(StructI32I1Ty);
+  Value *V3 = Builder.CreateInsertValue(Undef, V0, {0});
+  Value *V4 = Builder.CreateInsertValue(V3, V2, {1});
+  const SmallVector<User *> Users(Call->users());
+  for (User *U : Users) {
+    U->replaceUsesOfWith(Call, V4);
+  }
+  ToErase.push_back(Call);
+}
+} // namespace
+
 /// Remove entities not representable by SPIR-V
 bool SPIRVRegularizeLLVMBase::regularize() {
   eraseUselessFunctions(M);
@@ -390,6 +454,23 @@ bool SPIRVRegularizeLLVMBase::regularize() {
               lowerFunnelShift(II);
             else if (II->getIntrinsicID() == Intrinsic::umul_with_overflow)
               lowerUMulWithOverflow(II);
+            else if (II->getIntrinsicID() == Intrinsic::uadd_with_overflow) {
+              BuiltinFuncMangleInfo Info;
+              const std::string MangledName =
+                  mangleBuiltin("__spirv_IAddCarry",
+                                {Call->getArgOperand(0)->getType(),
+                                 Call->getArgOperand(1)->getType()},
+                                &Info);
+              regularizeWithOverflowInstrinsics(MangledName, Call, M, ToErase);
+            } else if (II->getIntrinsicID() == Intrinsic::usub_with_overflow) {
+              BuiltinFuncMangleInfo Info;
+              const std::string MangledName =
+                  mangleBuiltin("__spirv_ISubBorrow",
+                                {Call->getArgOperand(0)->getType(),
+                                 Call->getArgOperand(1)->getType()},
+                                &Info);
+              regularizeWithOverflowInstrinsics(MangledName, Call, M, ToErase);
+            }
           }
         }
 

--- a/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -708,7 +708,8 @@ void SPIRVTypeScavenger::deduceFunctionType(Function &F) {
         for (Argument *Arg : PointerArgs) {
           if (auto *Ty =
                   dyn_cast<TypedPointerType>(ParamTypes[Arg->getArgNo()]))
-            TypeArgument(Arg, Ty);
+            if (!Arg->hasAttribute(Attribute::StructRet))
+              TypeArgument(Arg, Ty);
         }
       }
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,11 @@ if(SPIRV_TOOLS_FOUND AND NOT SPIRV-Tools-tools_FOUND)
     set(SPIRV_TOOLS_SPIRV_AS_FOUND True)
   endif()
 
+  find_program(SPIRV_TOOLS_SPIRV_DIS NAMES spirv-dis PATHS ${SPIRV_TOOLS_PREFIX}/bin)
+  if(SPIRV_TOOLS_SPIRV_DIS)
+    set(SPIRV_TOOLS_SPIRV_DIS_FOUND True)
+  endif()
+
   find_program(SPIRV_TOOLS_SPIRV_LINK NAMES spirv-link PATHS ${SPIRV_TOOLS_PREFIX}/bin)
   if(SPIRV_TOOLS_SPIRV_LINK)
     set(SPIRV_TOOLS_SPIRV_LINK_FOUND True)
@@ -28,6 +33,10 @@ elseif(SPIRV-Tools-tools_FOUND)
 
   if(TARGET spirv-as)
     set(SPIRV_TOOLS_SPIRV_AS_FOUND True)
+  endif()
+
+  if(TARGET spirv-dis)
+    set(SPIRV_TOOLS_SPIRV_DIS_FOUND True)
   endif()
 
   if(TARGET spirv-link)
@@ -53,6 +62,11 @@ endif()
 if(NOT SPIRV_TOOLS_SPIRV_AS_FOUND)
   message(WARNING "spirv-as not found! SPIR-V assembly tests will not be run.")
   set(SPIRV_TOOLS_SPIRV_AS_FOUND False)
+endif()
+
+if(NOT SPIRV_TOOLS_SPIRV_DIS_FOUND)
+  message(WARNING "spirv-as not found! SPIR-V disassembly tests will not be run.")
+  set(SPIRV_TOOLS_SPIRV_DIS_FOUND False)
 endif()
 
 if(NOT SPIRV_TOOLS_SPIRV_LINK_FOUND)

--- a/test/builtin_returns_struct.spvasm
+++ b/test/builtin_returns_struct.spvasm
@@ -34,7 +34,7 @@
                OpBranch %20
          %20 = OpLabel
           %e = OpPhi %uint %a %19 %math %21
-         %16 = OpIAddCarry %_struct_7 %e %uint_1
+         %16 = OpUMulExtended %_struct_7 %e %uint_1
        %math = OpCompositeExtract %uint %16 0
          %17 = OpCompositeExtract %uint %16 1
          %ov = OpINotEqual %bool %17 %10
@@ -47,6 +47,6 @@
                OpFunctionEnd
 
 ; CHECK: %[[#Var:]] = alloca %structtype, align 8
-; CHECK: call spir_func void @_Z17__spirv_IAddCarryii(ptr sret(%structtype) %[[#Var:]]
+; CHECK: call spir_func void @_Z20__spirv_UMulExtendedii(ptr sret(%structtype) %[[#Var:]]
 ; CHECK: %[[#Load:]] = load %structtype, ptr %[[#Var]], align 4
 ; CHECK-2: extractvalue %structtype %[[#Load:]]

--- a/test/extensions/KHR/SPV_KHR_shader_clock/shader_clock.cl
+++ b/test/extensions/KHR/SPV_KHR_shader_clock/shader_clock.cl
@@ -1,3 +1,5 @@
+// This test will fail if Clang does not support the cl_khr_kernel_clock builtins (added in clang-19):
+// XFAIL: *
 // REQUIRES: spirv-dis
 // RUN: %clang_cc1 -triple spir-unknown-unknown -O1 -cl-std=CL2.0 -fdeclare-opencl-builtins -finclude-default-header -emit-llvm-bc %s -o %t.bc
 // RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_shader_clock -o %t.spv

--- a/test/iaddcarry_builtin.ll
+++ b/test/iaddcarry_builtin.ll
@@ -57,7 +57,13 @@ define spir_func void @test_builtin_iaddcarrycc(i8 %a, i8 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i8struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarrycc(ptr sret([[i8struct]]) %0, i8 %a, i8 %b)
+; CHECK-LLVM:   %1 = call { i8, i1 } @llvm.uadd.with.overflow.i8(i8 %a, i8 %b)
+; CHECK-LLVM:   %2 = extractvalue { i8, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i8, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i8
+; CHECK-LLVM:   %5 = insertvalue [[i8struct]] undef, i8 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[i8struct]] %5, i8 %4, 1
+; CHECK-LLVM:   store [[i8struct]] %6, ptr %0, align 1
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryss(i16 %a, i16 %b) {
   entry:
@@ -75,7 +81,13 @@ define spir_func void @test_builtin_iaddcarryss(i16 %a, i16 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i16struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryss(ptr sret([[i16struct]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   %1 = call { i16, i1 } @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
+; CHECK-LLVM:   %2 = extractvalue { i16, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i16, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i16
+; CHECK-LLVM:   %5 = insertvalue [[i16struct]] undef, i16 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[i16struct]] %5, i16 %4, 1
+; CHECK-LLVM:   store [[i16struct]] %6, ptr %0, align 2
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryii(i32 %a, i32 %b) {
   entry:
@@ -93,7 +105,13 @@ define spir_func void @test_builtin_iaddcarryii(i32 %a, i32 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i32struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryii(ptr sret([[i32struct]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   %1 = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
+; CHECK-LLVM:   %2 = extractvalue { i32, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i32, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i32
+; CHECK-LLVM:   %5 = insertvalue [[i32struct]] undef, i32 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[i32struct]] %5, i32 %4, 1
+; CHECK-LLVM:   store [[i32struct]] %6, ptr %0, align 4
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryll(i64 %a, i64 %b) {
   entry:
@@ -111,7 +129,13 @@ define spir_func void @test_builtin_iaddcarryll(i64 %a, i64 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i64struct]]
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryll(ptr sret([[i64struct]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   %1 = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
+; CHECK-LLVM:   %2 = extractvalue { i64, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i64, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i64
+; CHECK-LLVM:   %5 = insertvalue [[i64struct]] undef, i64 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[i64struct]] %5, i64 %4, 1
+; CHECK-LLVM:   store [[i64struct]] %6, ptr %0, align 8
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_iaddcarryDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
   entry:
@@ -129,7 +153,13 @@ define spir_func void @test_builtin_iaddcarryDv4_xS_(<4 x i32> %a, <4 x i32> %b)
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[vecstruct]]
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %1 = call { <4 x i32>, <4 x i1> } @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %2 = extractvalue { <4 x i32>, <4 x i1> } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { <4 x i32>, <4 x i1> } %1, 1
+; CHECK-LLVM:   %4 = zext <4 x i1> %3 to <4 x i32>
+; CHECK-LLVM:   %5 = insertvalue [[vecstruct]] undef, <4 x i32> %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[vecstruct]] %5, <4 x i32> %4, 1
+; CHECK-LLVM:   store [[vecstruct]] %6, ptr %0, align 16
 ; CHECK-LLVM:   ret void
 
 %struct.anon = type { i32, i32 }
@@ -151,7 +181,13 @@ define spir_func void @test_builtin_iaddcarry_anon(i32 %a, i32 %b) {
 
 ; CHECK-LLVM:  %0 = alloca [[struct_anon]], align 8
 ; CHECK-LLVM:  %1 = addrspacecast ptr %0 to ptr addrspace(4)
-; CHECK-LLVM:  call spir_func void @_Z17__spirv_IAddCarryii.1(ptr addrspace(4) sret([[struct_anon]]) %1, i32 %a, i32 %b)
+; CHECK-LLVM:  %2 = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
+; CHECK-LLVM:  %3 = extractvalue { i32, i1 } %2, 0
+; CHECK-LLVM:  %4 = extractvalue { i32, i1 } %2, 1
+; CHECK-LLVM:  %5 = zext i1 %4 to i32
+; CHECK-LLVM:  %6 = insertvalue [[struct_anon]] undef, i32 %3, 0
+; CHECK-LLVM:  %7 = insertvalue [[struct_anon]] %6, i32 %5, 1
+; CHECK-LLVM:  store [[struct_anon]] %7, ptr addrspace(4) %1, align 4
 ; CHECK-LLVM:  ret void
 
 declare void @_Z17__spirv_IAddCarryIiiE4anonIT_T0_ES1_S2_(ptr addrspace(4) sret(%struct.anon) align 4, i32, i32)

--- a/test/isubborrow_builtin.ll
+++ b/test/isubborrow_builtin.ll
@@ -58,7 +58,13 @@ define spir_func void @test_builtin_isubborrowcc(i8 %a, i8 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i8struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowcc(ptr sret([[i8struct]]) %0, i8 %a, i8 %b)
+; CHECK-LLVM:   %1 = call { i8, i1 } @llvm.usub.with.overflow.i8(i8 %a, i8 %b)
+; CHECK-LLVM:   %2 = extractvalue { i8, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i8, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i8
+; CHECK-LLVM:   %5 = insertvalue [[i8struct]] undef, i8 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[i8struct]] %5, i8 %4, 1
+; CHECK-LLVM:   store [[i8struct]] %6, ptr %0, align 1
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowss(i16 %a, i16 %b) {
   entry:
@@ -76,7 +82,13 @@ define spir_func void @test_builtin_isubborrowss(i16 %a, i16 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i16struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowss(ptr sret([[i16struct]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   %1 = call { i16, i1 } @llvm.usub.with.overflow.i16(i16 %a, i16 %b)
+; CHECK-LLVM:   %2 = extractvalue { i16, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i16, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i16
+; CHECK-LLVM:   %5 = insertvalue [[i16struct]] undef, i16 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[i16struct]] %5, i16 %4, 1
+; CHECK-LLVM:   store [[i16struct]] %6, ptr %0, align 2
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowii(i32 %a, i32 %b) {
   entry:
@@ -94,7 +106,13 @@ define spir_func void @test_builtin_isubborrowii(i32 %a, i32 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i32struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowii(ptr sret([[i32struct]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   %1 = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
+; CHECK-LLVM:   %2 = extractvalue { i32, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i32, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i32
+; CHECK-LLVM:   %5 = insertvalue [[i32struct]] undef, i32 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[i32struct]] %5, i32 %4, 1
+; CHECK-LLVM:   store [[i32struct]] %6, ptr %0, align 4
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowll(i64 %a, i64 %b) {
   entry:
@@ -112,7 +130,13 @@ define spir_func void @test_builtin_isubborrowll(i64 %a, i64 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i64struct]]
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowll(ptr sret([[i64struct]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   %1 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
+; CHECK-LLVM:   %2 = extractvalue { i64, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i64, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i64
+; CHECK-LLVM:   %5 = insertvalue [[i64struct]] undef, i64 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[i64struct]] %5, i64 %4, 1
+; CHECK-LLVM:   store [[i64struct]] %6, ptr %0, align 8
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_isubborrowDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
   entry:
@@ -130,7 +154,13 @@ define spir_func void @test_builtin_isubborrowDv4_xS_(<4 x i32> %a, <4 x i32> %b
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[vecstruct]]
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %1 = call { <4 x i32>, <4 x i1> } @llvm.usub.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %2 = extractvalue { <4 x i32>, <4 x i1> } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { <4 x i32>, <4 x i1> } %1, 1
+; CHECK-LLVM:   %4 = zext <4 x i1> %3 to <4 x i32>
+; CHECK-LLVM:   %5 = insertvalue [[vecstruct]] undef, <4 x i32> %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[vecstruct]] %5, <4 x i32> %4, 1
+; CHECK-LLVM:   store [[vecstruct]] %6, ptr %0, align 16
 ; CHECK-LLVM:   ret void
 
 
@@ -151,7 +181,13 @@ define spir_func void @test_builtin_isubborrow_anon(i32 %a, i32 %b) {
 
 ; CHECK-LLVM:  %0 = alloca [[struct_anon]], align 8
 ; CHECK-LLVM:  %1 = addrspacecast ptr %0 to ptr addrspace(4)
-; CHECK-LLVM:  call spir_func void @_Z18__spirv_ISubBorrowii.1(ptr addrspace(4) sret([[struct_anon]]) %1, i32 %a, i32 %b)
+; CHECK-LLVM:  %2 = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
+; CHECK-LLVM:  %3 = extractvalue { i32, i1 } %2, 0
+; CHECK-LLVM:  %4 = extractvalue { i32, i1 } %2, 1
+; CHECK-LLVM:  %5 = zext i1 %4 to i32
+; CHECK-LLVM:  %6 = insertvalue [[struct_anon]] undef, i32 %3, 0
+; CHECK-LLVM:  %7 = insertvalue [[struct_anon]] %6, i32 %5, 1
+; CHECK-LLVM:  store [[struct_anon]] %7, ptr addrspace(4) %1, align 4
 ; CHECK-LLVM:  ret void
 
 declare void @_Z18__spirv_ISubBorrowIiiE4anonIT_T0_ES1_S2_(ptr addrspace(4) sret(%struct.anon) align 4, i32, i32)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -65,6 +65,11 @@ if config.spirv_tools_have_spirv_as:
     config.available_features.add('spirv-as')
     using_spirv_tools = True
 
+if config.spirv_tools_have_spirv_dis:
+    llvm_config.add_tool_substitutions(['spirv-dis'], [config.spirv_tools_bin_dir])
+    config.available_features.add('spirv-dis')
+    using_spirv_tools = True
+
 if config.spirv_tools_have_spirv_link:
     llvm_config.add_tool_substitutions(['spirv-link'], [config.spirv_tools_bin_dir])
     config.available_features.add('spirv-link')

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -17,6 +17,7 @@ config.python_executable = "@PYTHON_EXECUTABLE@"
 config.test_run_dir = "@CMAKE_CURRENT_BINARY_DIR@"
 config.spirv_tools_found = "@SPIRV_TOOLS_FOUND@"
 config.spirv_tools_have_spirv_as = @SPIRV_TOOLS_SPIRV_AS_FOUND@
+config.spirv_tools_have_spirv_dis = @SPIRV_TOOLS_SPIRV_DIS_FOUND@
 config.spirv_tools_have_spirv_link = @SPIRV_TOOLS_SPIRV_LINK_FOUND@
 config.spirv_tools_have_spirv_val = @SPIRV_TOOLS_SPIRV_VAL_FOUND@
 config.spirv_tools_bin_dir = "@SPIRV_TOOLS_BINDIR@"

--- a/test/llvm-intrinsics/uadd.with.overflow.ll
+++ b/test/llvm-intrinsics/uadd.with.overflow.ll
@@ -1,51 +1,196 @@
+; REQUIRES: spirv-dis
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck --check-prefix CHECK-SPIRV %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; Current implementation doesn't comply with specification and should be fixed in future.
-; TODO: spirv-val %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis -o - %t.rev.bc | FileCheck --check-prefix CHECK-LLVM %s
 
 target triple = "spir64-unknown-unknown"
 
-; CHECK-SPIRV: TypeInt [[#I16TYPE:]] 16
-; CHECK-SPIRV: TypeInt [[#I32TYPE:]] 32
-; CHECK-SPIRV: TypeInt [[#I64TYPE:]] 64
-; CHECK-SPIRV: TypeBool [[#BTYPE:]]
-; CHECK-SPIRV: TypeStruct [[#S0TYPE:]] [[#I16TYPE]] [[#BTYPE]]
-; CHECK-SPIRV: TypeStruct [[#S1TYPE:]] [[#I32TYPE]] [[#BTYPE]]
-; CHECK-SPIRV: TypeStruct [[#S2TYPE:]] [[#I64TYPE]] [[#BTYPE]]
-; CHECK-SPIRV: TypeVector [[#V4XI32TYPE:]] [[#I32TYPE]] 4
-; CHECK-SPIRV: TypeVector [[#V4XBTYPE:]] [[#BTYPE]] 4
-; CHECK-SPIRV: TypeStruct [[#S3TYPE:]] [[#V4XI32TYPE]] [[#V4XBTYPE]]
-; CHECK-SPIRV: IAddCarry [[#S0TYPE]]
-; CHECK-SPIRV: IAddCarry [[#S1TYPE]]
-; CHECK-SPIRV: IAddCarry [[#S2TYPE]]
-; CHECK-SPIRV: IAddCarry [[#S3TYPE]]
+; CHECK-SPIRV-DAG:                   [[ushort:%[a-z0-9_.]+]] = OpTypeInt 16 0
+; CHECK-SPIRV-DAG:                     [[uint:%[a-z0-9_.]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG:                    [[ulong:%[a-z0-9_.]+]] = OpTypeInt 64 0
+; CHECK-SPIRV-DAG:                 [[ushort_0:%[a-z0-9_.]+]] = OpConstant [[ushort]] 0
+; CHECK-SPIRV-DAG:                   [[uint_0:%[a-z0-9_.]+]] = OpConstant [[uint]] 0
+; CHECK-SPIRV-DAG:                  [[ulong_0:%[a-z0-9_.]+]] = OpConstant [[ulong]] 0
+; CHECK-SPIRV-DAG:                     [[bool:%[a-z0-9_.]+]] = OpTypeBool
+; CHECK-SPIRV-DAG:                    [[var_4:%[a-z0-9_.]+]] = OpTypeFunction [[bool]] [[ushort]] [[ushort]]
+; CHECK-SPIRV-DAG:                [[_struct_9:%[a-z0-9_.]+]] = OpTypeStruct [[ushort]] [[ushort]]
+; CHECK-SPIRV-DAG:  [[_ptr_Function__struct_9:%[a-z0-9_.]+]] = OpTypePointer Function [[_struct_9]]
+; CHECK-SPIRV-DAG:               [[_struct_18:%[a-z0-9_.]+]] = OpTypeStruct [[ushort]] [[bool]]
+; CHECK-SPIRV-DAG:                   [[var_25:%[a-z0-9_.]+]] = OpTypeFunction [[bool]] [[uint]] [[uint]]
+; CHECK-SPIRV-DAG:               [[_struct_30:%[a-z0-9_.]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_30:%[a-z0-9_.]+]] = OpTypePointer Function [[_struct_30]]
+; CHECK-SPIRV-DAG:               [[_struct_39:%[a-z0-9_.]+]] = OpTypeStruct [[uint]] [[bool]]
+; CHECK-SPIRV-DAG:                   [[var_46:%[a-z0-9_.]+]] = OpTypeFunction [[bool]] [[ulong]] [[ulong]]
+; CHECK-SPIRV-DAG:               [[_struct_51:%[a-z0-9_.]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_51:%[a-z0-9_.]+]] = OpTypePointer Function [[_struct_51]]
+; CHECK-SPIRV-DAG:               [[_struct_60:%[a-z0-9_.]+]] = OpTypeStruct [[ulong]] [[bool]]
+; CHECK-SPIRV-DAG:                   [[v4bool:%[a-z0-9_.]+]] = OpTypeVector [[bool]] 4
+; CHECK-SPIRV-DAG:                   [[v4uint:%[a-z0-9_.]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV-DAG:                   [[var_68:%[a-z0-9_.]+]] = OpTypeFunction [[v4bool]] [[v4uint]] [[v4uint]]
+; CHECK-SPIRV-DAG:               [[_struct_73:%[a-z0-9_.]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_73:%[a-z0-9_.]+]] = OpTypePointer Function [[_struct_73]]
+; CHECK-SPIRV-DAG:               [[_struct_82:%[a-z0-9_.]+]] = OpTypeStruct [[v4uint]] [[v4bool]]
+; CHECK-SPIRV-DAG:                   [[var_19:%[a-z0-9_.]+]] = OpUndef [[_struct_18]]
+; CHECK-SPIRV-DAG:                   [[var_40:%[a-z0-9_.]+]] = OpUndef [[_struct_39]]
+; CHECK-SPIRV-DAG:                   [[var_61:%[a-z0-9_.]+]] = OpUndef [[_struct_60]]
+; CHECK-SPIRV-DAG:                   [[var_80:%[a-z0-9_.]+]] = OpConstantNull [[v4uint]]
+; CHECK-SPIRV-DAG:                   [[var_83:%[a-z0-9_.]+]] = OpUndef [[_struct_82]]
 
-define spir_func void @test_uadd_with_overflow_i16(i16 %a, i16 %b) {
+; CHECK-LLVM-DAG: [[structtype:%[a-z0-9._]+]] = type { i16, i16 }
+; CHECK-LLVM-DAG: [[structtype_0:%[a-z0-9._]+]] = type { i16, i1 }
+; CHECK-LLVM-DAG: [[structtype_1:%[a-z0-9._]+]] = type { i32, i32 }
+; CHECK-LLVM-DAG: [[structtype_2:%[a-z0-9._]+]] = type { i32, i1 }
+; CHECK-LLVM-DAG: [[structtype_3:%[a-z0-9._]+]] = type { i64, i64 }
+; CHECK-LLVM-DAG: [[structtype_4:%[a-z0-9._]+]] = type { i64, i1 }
+; CHECK-LLVM-DAG: [[structtype_5:%[a-z0-9._]+]] = type { <4 x i32>, <4 x i32> }
+; CHECK-LLVM-DAG: [[structtype_6:%[a-z0-9._]+]] = type { <4 x i32>, <4 x i1> }
+
+define spir_func i1 @test_uadd_with_overflow_i16(i16 %a, i16 %b) {
 entry:
   %res = call {i16, i1} @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
-  ret void
+  %0 = extractvalue {i16, i1} %res, 0
+  %1 = extractvalue {i16, i1} %res, 1
+  ret i1 %1
 }
 
-define spir_func void @test_uadd_with_overflow_i32(i32 %a, i32 %b) {
+; CHECK-SPIRV:               [[a:%[a-z0-9_.]+]] = OpFunctionParameter [[ushort]]
+; CHECK-SPIRV:               [[b:%[a-z0-9_.]+]] = OpFunctionParameter [[ushort]]
+; CHECK-SPIRV:           [[entry:%[a-z0-9_.]+]] = OpLabel
+; CHECK-SPIRV:          [[var_11:%[a-z0-9_.]+]] = OpVariable [[_ptr_Function__struct_9]] Function
+; CHECK-SPIRV:          [[var_12:%[a-z0-9_.]+]] = OpIAddCarry [[_struct_9]] [[a]] [[b]]
+; CHECK-SPIRV:                                    OpStore [[var_11]] [[var_12]]
+; CHECK-SPIRV:          [[var_13:%[a-z0-9_.]+]] = OpLoad [[_struct_9]] [[var_11]] Aligned 2
+; CHECK-SPIRV:          [[var_14:%[a-z0-9_.]+]] = OpCompositeExtract [[ushort]] [[var_13]] 0
+; CHECK-SPIRV:          [[var_15:%[a-z0-9_.]+]] = OpCompositeExtract [[ushort]] [[var_13]] 1
+; CHECK-SPIRV:          [[var_17:%[a-z0-9_.]+]] = OpINotEqual [[bool]] [[var_15]] [[ushort_0]]
+; CHECK-SPIRV:          [[var_20:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_18]] [[var_14]] [[var_19]] 0
+; CHECK-SPIRV:          [[var_21:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_18]] [[var_17]] [[var_20]] 1
+; CHECK-SPIRV:          [[var_22:%[a-z0-9_.]+]] = OpCompositeExtract [[ushort]] [[var_21]] 0
+; CHECK-SPIRV:          [[var_23:%[a-z0-9_.]+]] = OpCompositeExtract [[bool]] [[var_21]] 1
+; CHECK-SPIRV:                                    OpReturnValue [[var_23]]
+
+; CHECK-LLVM:   %0 = alloca [[structtype]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryss(ptr sret([[structtype]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   %1 = load [[structtype]], ptr %0, align 2
+; CHECK-LLVM:   %2 = extractvalue [[structtype]] %1, 0
+; CHECK-LLVM:   %3 = extractvalue [[structtype]] %1, 1
+; CHECK-LLVM:   %4 = icmp ne i16 %3, 0
+; CHECK-LLVM:   %5 = insertvalue [[structtype_0]] undef, i16 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_0]] %5, i1 %4, 1
+; CHECK-LLVM:   %7 = extractvalue [[structtype_0]] %6, 0
+; CHECK-LLVM:   %8 = extractvalue [[structtype_0]] %6, 1
+; CHECK-LLVM:   ret i1 %8
+define spir_func i1 @test_uadd_with_overflow_i32(i32 %a, i32 %b) {
 entry:
   %res = call {i32, i1} @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
-  ret void
+  %0 = extractvalue {i32, i1} %res, 0
+  %1 = extractvalue {i32, i1} %res, 1
+  ret i1 %1
 }
 
-define spir_func void @test_uadd_with_overflow_i64(i64 %a, i64 %b) {
+; CHECK-SPIRV:             [[a_0:%[a-z0-9_.]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:             [[b_0:%[a-z0-9_.]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:         [[entry_0:%[a-z0-9_.]+]] = OpLabel
+; CHECK-SPIRV:          [[var_32:%[a-z0-9_.]+]] = OpVariable [[_ptr_Function__struct_30]] Function
+; CHECK-SPIRV:          [[var_33:%[a-z0-9_.]+]] = OpIAddCarry [[_struct_30]] [[a_0]] [[b_0]]
+; CHECK-SPIRV:                                    OpStore [[var_32]] [[var_33]]
+; CHECK-SPIRV:          [[var_34:%[a-z0-9_.]+]] = OpLoad [[_struct_30]] [[var_32]] Aligned 4
+; CHECK-SPIRV:          [[var_35:%[a-z0-9_.]+]] = OpCompositeExtract [[uint]] [[var_34]] 0
+; CHECK-SPIRV:          [[var_36:%[a-z0-9_.]+]] = OpCompositeExtract [[uint]] [[var_34]] 1
+; CHECK-SPIRV:          [[var_38:%[a-z0-9_.]+]] = OpINotEqual [[bool]] [[var_36]] [[uint_0]]
+; CHECK-SPIRV:          [[var_41:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_39]] [[var_35]] [[var_40]] 0
+; CHECK-SPIRV:          [[var_42:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_39]] [[var_38]] [[var_41]] 1
+; CHECK-SPIRV:          [[var_43:%[a-z0-9_.]+]] = OpCompositeExtract [[uint]] [[var_42]] 0
+; CHECK-SPIRV:          [[var_44:%[a-z0-9_.]+]] = OpCompositeExtract [[bool]] [[var_42]] 1
+; CHECK-SPIRV:                                    OpReturnValue [[var_44]]
+
+
+; CHECK-LLVM:   %0 = alloca [[structtype_1]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryii(ptr sret([[structtype_1]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   %1 = load [[structtype_1]], ptr %0, align 4
+; CHECK-LLVM:   %2 = extractvalue [[structtype_1]] %1, 0
+; CHECK-LLVM:   %3 = extractvalue [[structtype_1]] %1, 1
+; CHECK-LLVM:   %4 = icmp ne i32 %3, 0
+; CHECK-LLVM:   %5 = insertvalue [[structtype_2]] undef, i32 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_2]] %5, i1 %4, 1
+; CHECK-LLVM:   %7 = extractvalue [[structtype_2]] %6, 0
+; CHECK-LLVM:   %8 = extractvalue [[structtype_2]] %6, 1
+; CHECK-LLVM:   ret i1 %8
+define spir_func i1 @test_uadd_with_overflow_i64(i64 %a, i64 %b) {
 entry:
   %res = call {i64, i1} @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
-  ret void
+  %0 = extractvalue {i64, i1} %res, 0
+  %1 = extractvalue {i64, i1} %res, 1
+  ret i1 %1
 }
 
-define spir_func void @test_uadd_with_overflow_v4i32(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-SPIRV:             [[a_1:%[a-z0-9_.]+]] = OpFunctionParameter [[ulong]]
+; CHECK-SPIRV:             [[b_1:%[a-z0-9_.]+]] = OpFunctionParameter [[ulong]]
+; CHECK-SPIRV:         [[entry_1:%[a-z0-9_.]+]] = OpLabel
+; CHECK-SPIRV:          [[var_53:%[a-z0-9_.]+]] = OpVariable [[_ptr_Function__struct_51]] Function
+; CHECK-SPIRV:          [[var_54:%[a-z0-9_.]+]] = OpIAddCarry [[_struct_51]] [[a_1]] [[b_1]]
+; CHECK-SPIRV:                                    OpStore [[var_53]] [[var_54]]
+; CHECK-SPIRV:          [[var_55:%[a-z0-9_.]+]] = OpLoad [[_struct_51]] [[var_53]] Aligned 4
+; CHECK-SPIRV:          [[var_56:%[a-z0-9_.]+]] = OpCompositeExtract [[ulong]] [[var_55]] 0
+; CHECK-SPIRV:          [[var_57:%[a-z0-9_.]+]] = OpCompositeExtract [[ulong]] [[var_55]] 1
+; CHECK-SPIRV:          [[var_59:%[a-z0-9_.]+]] = OpINotEqual [[bool]] [[var_57]] [[ulong_0]]
+; CHECK-SPIRV:          [[var_62:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_60]] [[var_56]] [[var_61]] 0
+; CHECK-SPIRV:          [[var_63:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_60]] [[var_59]] [[var_62]] 1
+; CHECK-SPIRV:          [[var_64:%[a-z0-9_.]+]] = OpCompositeExtract [[ulong]] [[var_63]] 0
+; CHECK-SPIRV:          [[var_65:%[a-z0-9_.]+]] = OpCompositeExtract [[bool]] [[var_63]] 1
+; CHECK-SPIRV:                                    OpReturnValue [[var_65]]
+
+; CHECK-LLVM:   %0 = alloca [[structtype_3]], align 8
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryll(ptr sret([[structtype_3]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   %1 = load [[structtype_3]], ptr %0, align 4
+; CHECK-LLVM:   %2 = extractvalue [[structtype_3]] %1, 0
+; CHECK-LLVM:   %3 = extractvalue [[structtype_3]] %1, 1
+; CHECK-LLVM:   %4 = icmp ne i64 %3, 0
+; CHECK-LLVM:   %5 = insertvalue [[structtype_4]] undef, i64 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_4]] %5, i1 %4, 1
+; CHECK-LLVM:   %7 = extractvalue [[structtype_4]] %6, 0
+; CHECK-LLVM:   %8 = extractvalue [[structtype_4]] %6, 1
+; CHECK-LLVM:   ret i1 %8
+define spir_func <4 x i1> @test_uadd_with_overflow_v4i32(<4 x i32> %a, <4 x i32> %b) {
 entry:
- %res = call {<4 x i32>, <4 x i1>} @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b) 
- ret void
+  %res = call {<4 x i32>, <4 x i1>} @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b) 
+  %0 = extractvalue {<4 x i32>, <4 x i1>} %res, 0
+  %1 = extractvalue {<4 x i32>, <4 x i1>} %res, 1
+  ret <4 x i1> %1
 }
 
+; CHECK-SPIRV:             [[a_2:%[a-z0-9_.]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:             [[b_2:%[a-z0-9_.]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:         [[entry_2:%[a-z0-9_.]+]] = OpLabel
+; CHECK-SPIRV:          [[var_75:%[a-z0-9_.]+]] = OpVariable [[_ptr_Function__struct_73]] Function
+; CHECK-SPIRV:          [[var_76:%[a-z0-9_.]+]] = OpIAddCarry [[_struct_73]] [[a_2]] [[b_2]]
+; CHECK-SPIRV:                                    OpStore [[var_75]] [[var_76]]
+; CHECK-SPIRV:          [[var_77:%[a-z0-9_.]+]] = OpLoad [[_struct_73]] [[var_75]] Aligned 16
+; CHECK-SPIRV:          [[var_78:%[a-z0-9_.]+]] = OpCompositeExtract [[v4uint]] [[var_77]] 0
+; CHECK-SPIRV:          [[var_79:%[a-z0-9_.]+]] = OpCompositeExtract [[v4uint]] [[var_77]] 1
+; CHECK-SPIRV:          [[var_81:%[a-z0-9_.]+]] = OpINotEqual [[v4bool]] [[var_79]] [[var_80]]
+; CHECK-SPIRV:          [[var_84:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_82]] [[var_78]] [[var_83]] 0
+; CHECK-SPIRV:          [[var_85:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_82]] [[var_81]] [[var_84]] 1
+; CHECK-SPIRV:          [[var_86:%[a-z0-9_.]+]] = OpCompositeExtract [[v4uint]] [[var_85]] 0
+; CHECK-SPIRV:          [[var_87:%[a-z0-9_.]+]] = OpCompositeExtract [[v4bool]] [[var_85]] 1
+; CHECK-SPIRV:                                    OpReturnValue [[var_87]]
+
+; CHECK-LLVM:   %0 = alloca [[structtype_5]], align 16
+; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret([[structtype_5]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %1 = load [[structtype_5]], ptr %0, align 16
+; CHECK-LLVM:   %2 = extractvalue [[structtype_5]] %1, 0
+; CHECK-LLVM:   %3 = extractvalue [[structtype_5]] %1, 1
+; CHECK-LLVM:   %4 = icmp ne <4 x i32> %3, zeroinitializer
+; CHECK-LLVM:   %5 = insertvalue [[structtype_6]] undef, <4 x i32> %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_6]] %5, <4 x i1> %4, 1
+; CHECK-LLVM:   %7 = extractvalue [[structtype_6]] %6, 0
+; CHECK-LLVM:   %8 = extractvalue [[structtype_6]] %6, 1
+; CHECK-LLVM:   ret <4 x i1> %8
 declare {i16, i1} @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
 declare {i32, i1} @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
 declare {i64, i1} @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
 declare {<4 x i32>, <4 x i1>} @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+declare void @_Z17__spirv_IAddCarryii(ptr sret({i32, i32}), i32, i32)

--- a/test/llvm-intrinsics/uadd.with.overflow.ll
+++ b/test/llvm-intrinsics/uadd.with.overflow.ll
@@ -73,16 +73,22 @@ entry:
 ; CHECK-SPIRV:                                    OpReturnValue [[var_23]]
 
 ; CHECK-LLVM:   %0 = alloca [[structtype]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryss(ptr sret([[structtype]]) %0, i16 %a, i16 %b)
-; CHECK-LLVM:   %1 = load [[structtype]], ptr %0, align 2
-; CHECK-LLVM:   %2 = extractvalue [[structtype]] %1, 0
-; CHECK-LLVM:   %3 = extractvalue [[structtype]] %1, 1
-; CHECK-LLVM:   %4 = icmp ne i16 %3, 0
-; CHECK-LLVM:   %5 = insertvalue [[structtype_0]] undef, i16 %2, 0
-; CHECK-LLVM:   %6 = insertvalue [[structtype_0]] %5, i1 %4, 1
-; CHECK-LLVM:   %7 = extractvalue [[structtype_0]] %6, 0
-; CHECK-LLVM:   %8 = extractvalue [[structtype_0]] %6, 1
-; CHECK-LLVM:   ret i1 %8
+; CHECK-LLVM:   %1 = call { i16, i1 } @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
+; CHECK-LLVM:   %2 = extractvalue { i16, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i16, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i16
+; CHECK-LLVM:   %5 = insertvalue [[structtype]] undef, i16 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype]] %5, i16 %4, 1
+; CHECK-LLVM:   store [[structtype]] %6, ptr %0, align 2
+; CHECK-LLVM:   %7 = load [[structtype]], ptr %0, align 2
+; CHECK-LLVM:   %8 = extractvalue [[structtype]] %7, 0
+; CHECK-LLVM:   %9 = extractvalue [[structtype]] %7, 1
+; CHECK-LLVM:   %10 = icmp ne i16 %9, 0
+; CHECK-LLVM:   %11 = insertvalue [[structtype_0]] undef, i16 %8, 0
+; CHECK-LLVM:   %12 = insertvalue [[structtype_0]] %11, i1 %10, 1
+; CHECK-LLVM:   %13 = extractvalue [[structtype_0]] %12, 0
+; CHECK-LLVM:   %14 = extractvalue [[structtype_0]] %12, 1
+; CHECK-LLVM:   ret i1 %14
 define spir_func i1 @test_uadd_with_overflow_i32(i32 %a, i32 %b) {
 entry:
   %res = call {i32, i1} @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
@@ -109,16 +115,22 @@ entry:
 
 
 ; CHECK-LLVM:   %0 = alloca [[structtype_1]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryii(ptr sret([[structtype_1]]) %0, i32 %a, i32 %b)
-; CHECK-LLVM:   %1 = load [[structtype_1]], ptr %0, align 4
-; CHECK-LLVM:   %2 = extractvalue [[structtype_1]] %1, 0
-; CHECK-LLVM:   %3 = extractvalue [[structtype_1]] %1, 1
-; CHECK-LLVM:   %4 = icmp ne i32 %3, 0
-; CHECK-LLVM:   %5 = insertvalue [[structtype_2]] undef, i32 %2, 0
-; CHECK-LLVM:   %6 = insertvalue [[structtype_2]] %5, i1 %4, 1
-; CHECK-LLVM:   %7 = extractvalue [[structtype_2]] %6, 0
-; CHECK-LLVM:   %8 = extractvalue [[structtype_2]] %6, 1
-; CHECK-LLVM:   ret i1 %8
+; CHECK-LLVM:   %1 = call { i32, i1 } @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
+; CHECK-LLVM:   %2 = extractvalue { i32, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i32, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i32
+; CHECK-LLVM:   %5 = insertvalue [[structtype_1]] undef, i32 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_1]] %5, i32 %4, 1
+; CHECK-LLVM:   store [[structtype_1]] %6, ptr %0, align 4
+; CHECK-LLVM:   %7 = load [[structtype_1]], ptr %0, align 4
+; CHECK-LLVM:   %8 = extractvalue [[structtype_1]] %7, 0
+; CHECK-LLVM:   %9 = extractvalue [[structtype_1]] %7, 1
+; CHECK-LLVM:   %10 = icmp ne i32 %9, 0
+; CHECK-LLVM:   %11 = insertvalue [[structtype_2]] undef, i32 %8, 0
+; CHECK-LLVM:   %12 = insertvalue [[structtype_2]] %11, i1 %10, 1
+; CHECK-LLVM:   %13 = extractvalue [[structtype_2]] %12, 0
+; CHECK-LLVM:   %14 = extractvalue [[structtype_2]] %12, 1
+; CHECK-LLVM:   ret i1 %14
 define spir_func i1 @test_uadd_with_overflow_i64(i64 %a, i64 %b) {
 entry:
   %res = call {i64, i1} @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
@@ -144,16 +156,22 @@ entry:
 ; CHECK-SPIRV:                                    OpReturnValue [[var_65]]
 
 ; CHECK-LLVM:   %0 = alloca [[structtype_3]], align 8
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryll(ptr sret([[structtype_3]]) %0, i64 %a, i64 %b)
-; CHECK-LLVM:   %1 = load [[structtype_3]], ptr %0, align 4
-; CHECK-LLVM:   %2 = extractvalue [[structtype_3]] %1, 0
-; CHECK-LLVM:   %3 = extractvalue [[structtype_3]] %1, 1
-; CHECK-LLVM:   %4 = icmp ne i64 %3, 0
-; CHECK-LLVM:   %5 = insertvalue [[structtype_4]] undef, i64 %2, 0
-; CHECK-LLVM:   %6 = insertvalue [[structtype_4]] %5, i1 %4, 1
-; CHECK-LLVM:   %7 = extractvalue [[structtype_4]] %6, 0
-; CHECK-LLVM:   %8 = extractvalue [[structtype_4]] %6, 1
-; CHECK-LLVM:   ret i1 %8
+; CHECK-LLVM:   %1 = call { i64, i1 } @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)
+; CHECK-LLVM:   %2 = extractvalue { i64, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i64, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i64
+; CHECK-LLVM:   %5 = insertvalue [[structtype_3]] undef, i64 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_3]] %5, i64 %4, 1
+; CHECK-LLVM:   store [[structtype_3]] %6, ptr %0, align 8
+; CHECK-LLVM:   %7 = load [[structtype_3]], ptr %0, align 4
+; CHECK-LLVM:   %8 = extractvalue [[structtype_3]] %7, 0
+; CHECK-LLVM:   %9 = extractvalue [[structtype_3]] %7, 1
+; CHECK-LLVM:   %10 = icmp ne i64 %9, 0
+; CHECK-LLVM:   %11 = insertvalue [[structtype_4]] undef, i64 %8, 0
+; CHECK-LLVM:   %12 = insertvalue [[structtype_4]] %11, i1 %10, 1
+; CHECK-LLVM:   %13 = extractvalue [[structtype_4]] %12, 0
+; CHECK-LLVM:   %14 = extractvalue [[structtype_4]] %12, 1
+; CHECK-LLVM:   ret i1 %14
 define spir_func <4 x i1> @test_uadd_with_overflow_v4i32(<4 x i32> %a, <4 x i32> %b) {
 entry:
   %res = call {<4 x i32>, <4 x i1>} @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b) 
@@ -179,16 +197,22 @@ entry:
 ; CHECK-SPIRV:                                    OpReturnValue [[var_87]]
 
 ; CHECK-LLVM:   %0 = alloca [[structtype_5]], align 16
-; CHECK-LLVM:   call spir_func void @_Z17__spirv_IAddCarryDv4_iS_(ptr sret([[structtype_5]]) %0, <4 x i32> %a, <4 x i32> %b)
-; CHECK-LLVM:   %1 = load [[structtype_5]], ptr %0, align 16
-; CHECK-LLVM:   %2 = extractvalue [[structtype_5]] %1, 0
-; CHECK-LLVM:   %3 = extractvalue [[structtype_5]] %1, 1
-; CHECK-LLVM:   %4 = icmp ne <4 x i32> %3, zeroinitializer
-; CHECK-LLVM:   %5 = insertvalue [[structtype_6]] undef, <4 x i32> %2, 0
-; CHECK-LLVM:   %6 = insertvalue [[structtype_6]] %5, <4 x i1> %4, 1
-; CHECK-LLVM:   %7 = extractvalue [[structtype_6]] %6, 0
-; CHECK-LLVM:   %8 = extractvalue [[structtype_6]] %6, 1
-; CHECK-LLVM:   ret <4 x i1> %8
+; CHECK-LLVM:   %1 = call { <4 x i32>, <4 x i1> } @llvm.uadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %2 = extractvalue { <4 x i32>, <4 x i1> } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { <4 x i32>, <4 x i1> } %1, 1
+; CHECK-LLVM:   %4 = zext <4 x i1> %3 to <4 x i32>
+; CHECK-LLVM:   %5 = insertvalue [[structtype_5]] undef, <4 x i32> %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_5]] %5, <4 x i32> %4, 1
+; CHECK-LLVM:   store [[structtype_5]] %6, ptr %0, align 16
+; CHECK-LLVM:   %7 = load [[structtype_5]], ptr %0, align 16
+; CHECK-LLVM:   %8 = extractvalue [[structtype_5]] %7, 0
+; CHECK-LLVM:   %9 = extractvalue [[structtype_5]] %7, 1
+; CHECK-LLVM:   %10 = icmp ne <4 x i32> %9, zeroinitializer
+; CHECK-LLVM:   %11 = insertvalue [[structtype_6]] undef, <4 x i32> %8, 0
+; CHECK-LLVM:   %12 = insertvalue [[structtype_6]] %11, <4 x i1> %10, 1
+; CHECK-LLVM:   %13 = extractvalue [[structtype_6]] %12, 0
+; CHECK-LLVM:   %14 = extractvalue [[structtype_6]] %12, 1
+; CHECK-LLVM:   ret <4 x i1> %14
 declare {i16, i1} @llvm.uadd.with.overflow.i16(i16 %a, i16 %b)
 declare {i32, i1} @llvm.uadd.with.overflow.i32(i32 %a, i32 %b)
 declare {i64, i1} @llvm.uadd.with.overflow.i64(i64 %a, i64 %b)

--- a/test/llvm-intrinsics/usub.with.overflow.ll
+++ b/test/llvm-intrinsics/usub.with.overflow.ll
@@ -1,51 +1,196 @@
+; REQUIRES: spirv-dis
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck --check-prefix CHECK-SPIRV %s
 ; RUN: llvm-spirv %t.bc -o %t.spv
-; Current implementation doesn't comply with specification and should be fixed in future.
-; TODO: spirv-val %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis -o - %t.rev.bc | FileCheck --check-prefix CHECK-LLVM %s
 
 target triple = "spir64-unknown-unknown"
 
-; CHECK-SPIRV: TypeInt [[#I16TYPE:]] 16
-; CHECK-SPIRV: TypeInt [[#I32TYPE:]] 32
-; CHECK-SPIRV: TypeInt [[#I64TYPE:]] 64
-; CHECK-SPIRV: TypeBool [[#BTYPE:]]
-; CHECK-SPIRV: TypeStruct [[#S0TYPE:]] [[#I16TYPE]] [[#BTYPE]]
-; CHECK-SPIRV: TypeStruct [[#S1TYPE:]] [[#I32TYPE]] [[#BTYPE]]
-; CHECK-SPIRV: TypeStruct [[#S2TYPE:]] [[#I64TYPE]] [[#BTYPE]]
-; CHECK-SPIRV: TypeVector [[#V4XI32TYPE:]] [[#I32TYPE]] 4
-; CHECK-SPIRV: TypeVector [[#V4XBTYPE:]] [[#BTYPE]] 4
-; CHECK-SPIRV: TypeStruct [[#S3TYPE:]] [[#V4XI32TYPE]] [[#V4XBTYPE]]
-; CHECK-SPIRV: ISubBorrow [[#S0TYPE]]
-; CHECK-SPIRV: ISubBorrow [[#S1TYPE]]
-; CHECK-SPIRV: ISubBorrow [[#S2TYPE]]
-; CHECK-SPIRV: ISubBorrow [[#S3TYPE]]
+; CHECK-SPIRV-DAG:                   [[ushort:%[a-z0-9_.]+]] = OpTypeInt 16 0
+; CHECK-SPIRV-DAG:                     [[uint:%[a-z0-9_.]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG:                    [[ulong:%[a-z0-9_.]+]] = OpTypeInt 64 0
+; CHECK-SPIRV-DAG:                 [[ushort_0:%[a-z0-9_.]+]] = OpConstant [[ushort]] 0
+; CHECK-SPIRV-DAG:                   [[uint_0:%[a-z0-9_.]+]] = OpConstant [[uint]] 0
+; CHECK-SPIRV-DAG:                  [[ulong_0:%[a-z0-9_.]+]] = OpConstant [[ulong]] 0
+; CHECK-SPIRV-DAG:                     [[bool:%[a-z0-9_.]+]] = OpTypeBool
+; CHECK-SPIRV-DAG:                    [[var_4:%[a-z0-9_.]+]] = OpTypeFunction [[bool]] [[ushort]] [[ushort]]
+; CHECK-SPIRV-DAG:                [[_struct_9:%[a-z0-9_.]+]] = OpTypeStruct [[ushort]] [[ushort]]
+; CHECK-SPIRV-DAG:  [[_ptr_Function__struct_9:%[a-z0-9_.]+]] = OpTypePointer Function [[_struct_9]]
+; CHECK-SPIRV-DAG:               [[_struct_18:%[a-z0-9_.]+]] = OpTypeStruct [[ushort]] [[bool]]
+; CHECK-SPIRV-DAG:                   [[var_25:%[a-z0-9_.]+]] = OpTypeFunction [[bool]] [[uint]] [[uint]]
+; CHECK-SPIRV-DAG:               [[_struct_30:%[a-z0-9_.]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_30:%[a-z0-9_.]+]] = OpTypePointer Function [[_struct_30]]
+; CHECK-SPIRV-DAG:               [[_struct_39:%[a-z0-9_.]+]] = OpTypeStruct [[uint]] [[bool]]
+; CHECK-SPIRV-DAG:                   [[var_46:%[a-z0-9_.]+]] = OpTypeFunction [[bool]] [[ulong]] [[ulong]]
+; CHECK-SPIRV-DAG:               [[_struct_51:%[a-z0-9_.]+]] = OpTypeStruct [[ulong]] [[ulong]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_51:%[a-z0-9_.]+]] = OpTypePointer Function [[_struct_51]]
+; CHECK-SPIRV-DAG:               [[_struct_60:%[a-z0-9_.]+]] = OpTypeStruct [[ulong]] [[bool]]
+; CHECK-SPIRV-DAG:                   [[v4bool:%[a-z0-9_.]+]] = OpTypeVector [[bool]] 4
+; CHECK-SPIRV-DAG:                   [[v4uint:%[a-z0-9_.]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV-DAG:                   [[var_68:%[a-z0-9_.]+]] = OpTypeFunction [[v4bool]] [[v4uint]] [[v4uint]]
+; CHECK-SPIRV-DAG:               [[_struct_73:%[a-z0-9_.]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV-DAG: [[_ptr_Function__struct_73:%[a-z0-9_.]+]] = OpTypePointer Function [[_struct_73]]
+; CHECK-SPIRV-DAG:               [[_struct_82:%[a-z0-9_.]+]] = OpTypeStruct [[v4uint]] [[v4bool]]
+; CHECK-SPIRV-DAG:                   [[var_19:%[a-z0-9_.]+]] = OpUndef [[_struct_18]]
+; CHECK-SPIRV-DAG:                   [[var_40:%[a-z0-9_.]+]] = OpUndef [[_struct_39]]
+; CHECK-SPIRV-DAG:                   [[var_61:%[a-z0-9_.]+]] = OpUndef [[_struct_60]]
+; CHECK-SPIRV-DAG:                   [[var_80:%[a-z0-9_.]+]] = OpConstantNull [[v4uint]]
+; CHECK-SPIRV-DAG:                   [[var_83:%[a-z0-9_.]+]] = OpUndef [[_struct_82]]
 
-define spir_func void @test_usub_with_overflow_i16(i16 %a, i16 %b) {
+; CHECK-LLVM-DAG: [[structtype:%[a-z0-9._]+]] = type { i16, i16 }
+; CHECK-LLVM-DAG: [[structtype_0:%[a-z0-9._]+]] = type { i16, i1 }
+; CHECK-LLVM-DAG: [[structtype_1:%[a-z0-9._]+]] = type { i32, i32 }
+; CHECK-LLVM-DAG: [[structtype_2:%[a-z0-9._]+]] = type { i32, i1 }
+; CHECK-LLVM-DAG: [[structtype_3:%[a-z0-9._]+]] = type { i64, i64 }
+; CHECK-LLVM-DAG: [[structtype_4:%[a-z0-9._]+]] = type { i64, i1 }
+; CHECK-LLVM-DAG: [[structtype_5:%[a-z0-9._]+]] = type { <4 x i32>, <4 x i32> }
+; CHECK-LLVM-DAG: [[structtype_6:%[a-z0-9._]+]] = type { <4 x i32>, <4 x i1> }
+
+define spir_func i1 @test_usub_with_overflow_i16(i16 %a, i16 %b) {
 entry:
   %res = call {i16, i1} @llvm.usub.with.overflow.i16(i16 %a, i16 %b)
-  ret void
+  %0 = extractvalue {i16, i1} %res, 0
+  %1 = extractvalue {i16, i1} %res, 1
+  ret i1 %1
 }
 
-define spir_func void @test_usub_with_overflow_i32(i32 %a, i32 %b) {
+; CHECK-SPIRV:               [[a:%[a-z0-9_.]+]] = OpFunctionParameter [[ushort]]
+; CHECK-SPIRV:               [[b:%[a-z0-9_.]+]] = OpFunctionParameter [[ushort]]
+; CHECK-SPIRV:           [[entry:%[a-z0-9_.]+]] = OpLabel
+; CHECK-SPIRV:          [[var_11:%[a-z0-9_.]+]] = OpVariable [[_ptr_Function__struct_9]] Function
+; CHECK-SPIRV:          [[var_12:%[a-z0-9_.]+]] = OpISubBorrow [[_struct_9]] [[a]] [[b]]
+; CHECK-SPIRV:                                    OpStore [[var_11]] [[var_12]]
+; CHECK-SPIRV:          [[var_13:%[a-z0-9_.]+]] = OpLoad [[_struct_9]] [[var_11]] Aligned 2
+; CHECK-SPIRV:          [[var_14:%[a-z0-9_.]+]] = OpCompositeExtract [[ushort]] [[var_13]] 0
+; CHECK-SPIRV:          [[var_15:%[a-z0-9_.]+]] = OpCompositeExtract [[ushort]] [[var_13]] 1
+; CHECK-SPIRV:          [[var_17:%[a-z0-9_.]+]] = OpINotEqual [[bool]] [[var_15]] [[ushort_0]]
+; CHECK-SPIRV:          [[var_20:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_18]] [[var_14]] [[var_19]] 0
+; CHECK-SPIRV:          [[var_21:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_18]] [[var_17]] [[var_20]] 1
+; CHECK-SPIRV:          [[var_22:%[a-z0-9_.]+]] = OpCompositeExtract [[ushort]] [[var_21]] 0
+; CHECK-SPIRV:          [[var_23:%[a-z0-9_.]+]] = OpCompositeExtract [[bool]] [[var_21]] 1
+; CHECK-SPIRV:                                    OpReturnValue [[var_23]]
+
+; CHECK-LLVM:   %0 = alloca [[structtype]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowss(ptr sret([[structtype]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   %1 = load [[structtype]], ptr %0, align 2
+; CHECK-LLVM:   %2 = extractvalue [[structtype]] %1, 0
+; CHECK-LLVM:   %3 = extractvalue [[structtype]] %1, 1
+; CHECK-LLVM:   %4 = icmp ne i16 %3, 0
+; CHECK-LLVM:   %5 = insertvalue [[structtype_0]] undef, i16 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_0]] %5, i1 %4, 1
+; CHECK-LLVM:   %7 = extractvalue [[structtype_0]] %6, 0
+; CHECK-LLVM:   %8 = extractvalue [[structtype_0]] %6, 1
+; CHECK-LLVM:   ret i1 %8
+define spir_func i1 @test_usub_with_overflow_i32(i32 %a, i32 %b) {
 entry:
   %res = call {i32, i1} @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
-  ret void
+  %0 = extractvalue {i32, i1} %res, 0
+  %1 = extractvalue {i32, i1} %res, 1
+  ret i1 %1
 }
 
-define spir_func void @test_usub_with_overflow_i64(i64 %a, i64 %b) {
+; CHECK-SPIRV:             [[a_0:%[a-z0-9_.]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:             [[b_0:%[a-z0-9_.]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:         [[entry_0:%[a-z0-9_.]+]] = OpLabel
+; CHECK-SPIRV:          [[var_32:%[a-z0-9_.]+]] = OpVariable [[_ptr_Function__struct_30]] Function
+; CHECK-SPIRV:          [[var_33:%[a-z0-9_.]+]] = OpISubBorrow [[_struct_30]] [[a_0]] [[b_0]]
+; CHECK-SPIRV:                                    OpStore [[var_32]] [[var_33]]
+; CHECK-SPIRV:          [[var_34:%[a-z0-9_.]+]] = OpLoad [[_struct_30]] [[var_32]] Aligned 4
+; CHECK-SPIRV:          [[var_35:%[a-z0-9_.]+]] = OpCompositeExtract [[uint]] [[var_34]] 0
+; CHECK-SPIRV:          [[var_36:%[a-z0-9_.]+]] = OpCompositeExtract [[uint]] [[var_34]] 1
+; CHECK-SPIRV:          [[var_38:%[a-z0-9_.]+]] = OpINotEqual [[bool]] [[var_36]] [[uint_0]]
+; CHECK-SPIRV:          [[var_41:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_39]] [[var_35]] [[var_40]] 0
+; CHECK-SPIRV:          [[var_42:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_39]] [[var_38]] [[var_41]] 1
+; CHECK-SPIRV:          [[var_43:%[a-z0-9_.]+]] = OpCompositeExtract [[uint]] [[var_42]] 0
+; CHECK-SPIRV:          [[var_44:%[a-z0-9_.]+]] = OpCompositeExtract [[bool]] [[var_42]] 1
+; CHECK-SPIRV:                                    OpReturnValue [[var_44]]
+
+
+; CHECK-LLVM:   %0 = alloca [[structtype_1]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowii(ptr sret([[structtype_1]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   %1 = load [[structtype_1]], ptr %0, align 4
+; CHECK-LLVM:   %2 = extractvalue [[structtype_1]] %1, 0
+; CHECK-LLVM:   %3 = extractvalue [[structtype_1]] %1, 1
+; CHECK-LLVM:   %4 = icmp ne i32 %3, 0
+; CHECK-LLVM:   %5 = insertvalue [[structtype_2]] undef, i32 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_2]] %5, i1 %4, 1
+; CHECK-LLVM:   %7 = extractvalue [[structtype_2]] %6, 0
+; CHECK-LLVM:   %8 = extractvalue [[structtype_2]] %6, 1
+; CHECK-LLVM:   ret i1 %8
+define spir_func i1 @test_usub_with_overflow_i64(i64 %a, i64 %b) {
 entry:
   %res = call {i64, i1} @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
-  ret void
+  %0 = extractvalue {i64, i1} %res, 0
+  %1 = extractvalue {i64, i1} %res, 1
+  ret i1 %1
 }
 
-define spir_func void @test_usub_with_overflow_v4i32(<4 x i32> %a, <4 x i32> %b) {
+; CHECK-SPIRV:             [[a_1:%[a-z0-9_.]+]] = OpFunctionParameter [[ulong]]
+; CHECK-SPIRV:             [[b_1:%[a-z0-9_.]+]] = OpFunctionParameter [[ulong]]
+; CHECK-SPIRV:         [[entry_1:%[a-z0-9_.]+]] = OpLabel
+; CHECK-SPIRV:          [[var_53:%[a-z0-9_.]+]] = OpVariable [[_ptr_Function__struct_51]] Function
+; CHECK-SPIRV:          [[var_54:%[a-z0-9_.]+]] = OpISubBorrow [[_struct_51]] [[a_1]] [[b_1]]
+; CHECK-SPIRV:                                    OpStore [[var_53]] [[var_54]]
+; CHECK-SPIRV:          [[var_55:%[a-z0-9_.]+]] = OpLoad [[_struct_51]] [[var_53]] Aligned 4
+; CHECK-SPIRV:          [[var_56:%[a-z0-9_.]+]] = OpCompositeExtract [[ulong]] [[var_55]] 0
+; CHECK-SPIRV:          [[var_57:%[a-z0-9_.]+]] = OpCompositeExtract [[ulong]] [[var_55]] 1
+; CHECK-SPIRV:          [[var_59:%[a-z0-9_.]+]] = OpINotEqual [[bool]] [[var_57]] [[ulong_0]]
+; CHECK-SPIRV:          [[var_62:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_60]] [[var_56]] [[var_61]] 0
+; CHECK-SPIRV:          [[var_63:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_60]] [[var_59]] [[var_62]] 1
+; CHECK-SPIRV:          [[var_64:%[a-z0-9_.]+]] = OpCompositeExtract [[ulong]] [[var_63]] 0
+; CHECK-SPIRV:          [[var_65:%[a-z0-9_.]+]] = OpCompositeExtract [[bool]] [[var_63]] 1
+; CHECK-SPIRV:                                    OpReturnValue [[var_65]]
+
+; CHECK-LLVM:   %0 = alloca [[structtype_3]], align 8
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowll(ptr sret([[structtype_3]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   %1 = load [[structtype_3]], ptr %0, align 4
+; CHECK-LLVM:   %2 = extractvalue [[structtype_3]] %1, 0
+; CHECK-LLVM:   %3 = extractvalue [[structtype_3]] %1, 1
+; CHECK-LLVM:   %4 = icmp ne i64 %3, 0
+; CHECK-LLVM:   %5 = insertvalue [[structtype_4]] undef, i64 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_4]] %5, i1 %4, 1
+; CHECK-LLVM:   %7 = extractvalue [[structtype_4]] %6, 0
+; CHECK-LLVM:   %8 = extractvalue [[structtype_4]] %6, 1
+; CHECK-LLVM:   ret i1 %8
+define spir_func <4 x i1> @test_usub_with_overflow_v4i32(<4 x i32> %a, <4 x i32> %b) {
 entry:
- %res = call {<4 x i32>, <4 x i1>} @llvm.usub.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
- ret void
+  %res = call {<4 x i32>, <4 x i1>} @llvm.usub.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b) 
+  %0 = extractvalue {<4 x i32>, <4 x i1>} %res, 0
+  %1 = extractvalue {<4 x i32>, <4 x i1>} %res, 1
+  ret <4 x i1> %1
 }
 
+; CHECK-SPIRV:             [[a_2:%[a-z0-9_.]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:             [[b_2:%[a-z0-9_.]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:         [[entry_2:%[a-z0-9_.]+]] = OpLabel
+; CHECK-SPIRV:          [[var_75:%[a-z0-9_.]+]] = OpVariable [[_ptr_Function__struct_73]] Function
+; CHECK-SPIRV:          [[var_76:%[a-z0-9_.]+]] = OpISubBorrow [[_struct_73]] [[a_2]] [[b_2]]
+; CHECK-SPIRV:                                    OpStore [[var_75]] [[var_76]]
+; CHECK-SPIRV:          [[var_77:%[a-z0-9_.]+]] = OpLoad [[_struct_73]] [[var_75]] Aligned 16
+; CHECK-SPIRV:          [[var_78:%[a-z0-9_.]+]] = OpCompositeExtract [[v4uint]] [[var_77]] 0
+; CHECK-SPIRV:          [[var_79:%[a-z0-9_.]+]] = OpCompositeExtract [[v4uint]] [[var_77]] 1
+; CHECK-SPIRV:          [[var_81:%[a-z0-9_.]+]] = OpINotEqual [[v4bool]] [[var_79]] [[var_80]]
+; CHECK-SPIRV:          [[var_84:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_82]] [[var_78]] [[var_83]] 0
+; CHECK-SPIRV:          [[var_85:%[a-z0-9_.]+]] = OpCompositeInsert [[_struct_82]] [[var_81]] [[var_84]] 1
+; CHECK-SPIRV:          [[var_86:%[a-z0-9_.]+]] = OpCompositeExtract [[v4uint]] [[var_85]] 0
+; CHECK-SPIRV:          [[var_87:%[a-z0-9_.]+]] = OpCompositeExtract [[v4bool]] [[var_85]] 1
+; CHECK-SPIRV:                                    OpReturnValue [[var_87]]
+
+; CHECK-LLVM:   %0 = alloca [[structtype_5]], align 16
+; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret([[structtype_5]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %1 = load [[structtype_5]], ptr %0, align 16
+; CHECK-LLVM:   %2 = extractvalue [[structtype_5]] %1, 0
+; CHECK-LLVM:   %3 = extractvalue [[structtype_5]] %1, 1
+; CHECK-LLVM:   %4 = icmp ne <4 x i32> %3, zeroinitializer
+; CHECK-LLVM:   %5 = insertvalue [[structtype_6]] undef, <4 x i32> %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_6]] %5, <4 x i1> %4, 1
+; CHECK-LLVM:   %7 = extractvalue [[structtype_6]] %6, 0
+; CHECK-LLVM:   %8 = extractvalue [[structtype_6]] %6, 1
+; CHECK-LLVM:   ret <4 x i1> %8
 declare {i16, i1} @llvm.usub.with.overflow.i16(i16 %a, i16 %b)
 declare {i32, i1} @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
 declare {i64, i1} @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
 declare {<4 x i32>, <4 x i1>} @llvm.usub.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+declare void @_Z18__spirv_ISubBorrowii(ptr sret({i32, i32}), i32, i32)

--- a/test/llvm-intrinsics/usub.with.overflow.ll
+++ b/test/llvm-intrinsics/usub.with.overflow.ll
@@ -73,16 +73,22 @@ entry:
 ; CHECK-SPIRV:                                    OpReturnValue [[var_23]]
 
 ; CHECK-LLVM:   %0 = alloca [[structtype]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowss(ptr sret([[structtype]]) %0, i16 %a, i16 %b)
-; CHECK-LLVM:   %1 = load [[structtype]], ptr %0, align 2
-; CHECK-LLVM:   %2 = extractvalue [[structtype]] %1, 0
-; CHECK-LLVM:   %3 = extractvalue [[structtype]] %1, 1
-; CHECK-LLVM:   %4 = icmp ne i16 %3, 0
-; CHECK-LLVM:   %5 = insertvalue [[structtype_0]] undef, i16 %2, 0
-; CHECK-LLVM:   %6 = insertvalue [[structtype_0]] %5, i1 %4, 1
-; CHECK-LLVM:   %7 = extractvalue [[structtype_0]] %6, 0
-; CHECK-LLVM:   %8 = extractvalue [[structtype_0]] %6, 1
-; CHECK-LLVM:   ret i1 %8
+; CHECK-LLVM:   %1 = call { i16, i1 } @llvm.usub.with.overflow.i16(i16 %a, i16 %b)
+; CHECK-LLVM:   %2 = extractvalue { i16, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i16, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i16
+; CHECK-LLVM:   %5 = insertvalue [[structtype]] undef, i16 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype]] %5, i16 %4, 1
+; CHECK-LLVM:   store [[structtype]] %6, ptr %0, align 2
+; CHECK-LLVM:   %7 = load [[structtype]], ptr %0, align 2
+; CHECK-LLVM:   %8 = extractvalue [[structtype]] %7, 0
+; CHECK-LLVM:   %9 = extractvalue [[structtype]] %7, 1
+; CHECK-LLVM:   %10 = icmp ne i16 %9, 0
+; CHECK-LLVM:   %11 = insertvalue [[structtype_0]] undef, i16 %8, 0
+; CHECK-LLVM:   %12 = insertvalue [[structtype_0]] %11, i1 %10, 1
+; CHECK-LLVM:   %13 = extractvalue [[structtype_0]] %12, 0
+; CHECK-LLVM:   %14 = extractvalue [[structtype_0]] %12, 1
+; CHECK-LLVM:   ret i1 %14
 define spir_func i1 @test_usub_with_overflow_i32(i32 %a, i32 %b) {
 entry:
   %res = call {i32, i1} @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
@@ -109,16 +115,22 @@ entry:
 
 
 ; CHECK-LLVM:   %0 = alloca [[structtype_1]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowii(ptr sret([[structtype_1]]) %0, i32 %a, i32 %b)
-; CHECK-LLVM:   %1 = load [[structtype_1]], ptr %0, align 4
-; CHECK-LLVM:   %2 = extractvalue [[structtype_1]] %1, 0
-; CHECK-LLVM:   %3 = extractvalue [[structtype_1]] %1, 1
-; CHECK-LLVM:   %4 = icmp ne i32 %3, 0
-; CHECK-LLVM:   %5 = insertvalue [[structtype_2]] undef, i32 %2, 0
-; CHECK-LLVM:   %6 = insertvalue [[structtype_2]] %5, i1 %4, 1
-; CHECK-LLVM:   %7 = extractvalue [[structtype_2]] %6, 0
-; CHECK-LLVM:   %8 = extractvalue [[structtype_2]] %6, 1
-; CHECK-LLVM:   ret i1 %8
+; CHECK-LLVM:   %1 = call { i32, i1 } @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
+; CHECK-LLVM:   %2 = extractvalue { i32, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i32, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i32
+; CHECK-LLVM:   %5 = insertvalue [[structtype_1]] undef, i32 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_1]] %5, i32 %4, 1
+; CHECK-LLVM:   store [[structtype_1]] %6, ptr %0, align 4
+; CHECK-LLVM:   %7 = load [[structtype_1]], ptr %0, align 4
+; CHECK-LLVM:   %8 = extractvalue [[structtype_1]] %7, 0
+; CHECK-LLVM:   %9 = extractvalue [[structtype_1]] %7, 1
+; CHECK-LLVM:   %10 = icmp ne i32 %9, 0
+; CHECK-LLVM:   %11 = insertvalue [[structtype_2]] undef, i32 %8, 0
+; CHECK-LLVM:   %12 = insertvalue [[structtype_2]] %11, i1 %10, 1
+; CHECK-LLVM:   %13 = extractvalue [[structtype_2]] %12, 0
+; CHECK-LLVM:   %14 = extractvalue [[structtype_2]] %12, 1
+; CHECK-LLVM:   ret i1 %14
 define spir_func i1 @test_usub_with_overflow_i64(i64 %a, i64 %b) {
 entry:
   %res = call {i64, i1} @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
@@ -144,16 +156,22 @@ entry:
 ; CHECK-SPIRV:                                    OpReturnValue [[var_65]]
 
 ; CHECK-LLVM:   %0 = alloca [[structtype_3]], align 8
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowll(ptr sret([[structtype_3]]) %0, i64 %a, i64 %b)
-; CHECK-LLVM:   %1 = load [[structtype_3]], ptr %0, align 4
-; CHECK-LLVM:   %2 = extractvalue [[structtype_3]] %1, 0
-; CHECK-LLVM:   %3 = extractvalue [[structtype_3]] %1, 1
-; CHECK-LLVM:   %4 = icmp ne i64 %3, 0
-; CHECK-LLVM:   %5 = insertvalue [[structtype_4]] undef, i64 %2, 0
-; CHECK-LLVM:   %6 = insertvalue [[structtype_4]] %5, i1 %4, 1
-; CHECK-LLVM:   %7 = extractvalue [[structtype_4]] %6, 0
-; CHECK-LLVM:   %8 = extractvalue [[structtype_4]] %6, 1
-; CHECK-LLVM:   ret i1 %8
+; CHECK-LLVM:   %1 = call { i64, i1 } @llvm.usub.with.overflow.i64(i64 %a, i64 %b)
+; CHECK-LLVM:   %2 = extractvalue { i64, i1 } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { i64, i1 } %1, 1
+; CHECK-LLVM:   %4 = zext i1 %3 to i64
+; CHECK-LLVM:   %5 = insertvalue [[structtype_3]] undef, i64 %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_3]] %5, i64 %4, 1
+; CHECK-LLVM:   store [[structtype_3]] %6, ptr %0, align 8
+; CHECK-LLVM:   %7 = load [[structtype_3]], ptr %0, align 4
+; CHECK-LLVM:   %8 = extractvalue [[structtype_3]] %7, 0
+; CHECK-LLVM:   %9 = extractvalue [[structtype_3]] %7, 1
+; CHECK-LLVM:   %10 = icmp ne i64 %9, 0
+; CHECK-LLVM:   %11 = insertvalue [[structtype_4]] undef, i64 %8, 0
+; CHECK-LLVM:   %12 = insertvalue [[structtype_4]] %11, i1 %10, 1
+; CHECK-LLVM:   %13 = extractvalue [[structtype_4]] %12, 0
+; CHECK-LLVM:   %14 = extractvalue [[structtype_4]] %12, 1
+; CHECK-LLVM:   ret i1 %14
 define spir_func <4 x i1> @test_usub_with_overflow_v4i32(<4 x i32> %a, <4 x i32> %b) {
 entry:
   %res = call {<4 x i32>, <4 x i1>} @llvm.usub.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b) 
@@ -179,16 +197,22 @@ entry:
 ; CHECK-SPIRV:                                    OpReturnValue [[var_87]]
 
 ; CHECK-LLVM:   %0 = alloca [[structtype_5]], align 16
-; CHECK-LLVM:   call spir_func void @_Z18__spirv_ISubBorrowDv4_iS_(ptr sret([[structtype_5]]) %0, <4 x i32> %a, <4 x i32> %b)
-; CHECK-LLVM:   %1 = load [[structtype_5]], ptr %0, align 16
-; CHECK-LLVM:   %2 = extractvalue [[structtype_5]] %1, 0
-; CHECK-LLVM:   %3 = extractvalue [[structtype_5]] %1, 1
-; CHECK-LLVM:   %4 = icmp ne <4 x i32> %3, zeroinitializer
-; CHECK-LLVM:   %5 = insertvalue [[structtype_6]] undef, <4 x i32> %2, 0
-; CHECK-LLVM:   %6 = insertvalue [[structtype_6]] %5, <4 x i1> %4, 1
-; CHECK-LLVM:   %7 = extractvalue [[structtype_6]] %6, 0
-; CHECK-LLVM:   %8 = extractvalue [[structtype_6]] %6, 1
-; CHECK-LLVM:   ret <4 x i1> %8
+; CHECK-LLVM:   %1 = call { <4 x i32>, <4 x i1> } @llvm.usub.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   %2 = extractvalue { <4 x i32>, <4 x i1> } %1, 0
+; CHECK-LLVM:   %3 = extractvalue { <4 x i32>, <4 x i1> } %1, 1
+; CHECK-LLVM:   %4 = zext <4 x i1> %3 to <4 x i32>
+; CHECK-LLVM:   %5 = insertvalue [[structtype_5]] undef, <4 x i32> %2, 0
+; CHECK-LLVM:   %6 = insertvalue [[structtype_5]] %5, <4 x i32> %4, 1
+; CHECK-LLVM:   store [[structtype_5]] %6, ptr %0, align 16
+; CHECK-LLVM:   %7 = load [[structtype_5]], ptr %0, align 16
+; CHECK-LLVM:   %8 = extractvalue [[structtype_5]] %7, 0
+; CHECK-LLVM:   %9 = extractvalue [[structtype_5]] %7, 1
+; CHECK-LLVM:   %10 = icmp ne <4 x i32> %9, zeroinitializer
+; CHECK-LLVM:   %11 = insertvalue [[structtype_6]] undef, <4 x i32> %8, 0
+; CHECK-LLVM:   %12 = insertvalue [[structtype_6]] %11, <4 x i1> %10, 1
+; CHECK-LLVM:   %13 = extractvalue [[structtype_6]] %12, 0
+; CHECK-LLVM:   %14 = extractvalue [[structtype_6]] %12, 1
+; CHECK-LLVM:   ret <4 x i1> %14
 declare {i16, i1} @llvm.usub.with.overflow.i16(i16 %a, i16 %b)
 declare {i32, i1} @llvm.usub.with.overflow.i32(i32 %a, i32 %b)
 declare {i64, i1} @llvm.usub.with.overflow.i64(i64 %a, i64 %b)

--- a/test/smulextended_builtin.ll
+++ b/test/smulextended_builtin.ll
@@ -59,7 +59,7 @@ define spir_func void @test_builtin_smulextcc(i8 %a, i8 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i8struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedcc(%i8struct* sret([[i8struct]]) %0, i8 %a, i8 %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedcc(ptr sret([[i8struct]]) %0, i8 %a, i8 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_smulextss(i16 %a, i16 %b) {
   entry:
@@ -77,7 +77,7 @@ define spir_func void @test_builtin_smulextss(i16 %a, i16 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i16struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedss(%i16struct* sret([[i16struct]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedss(ptr sret([[i16struct]]) %0, i16 %a, i16 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_smulextii(i32 %a, i32 %b) {
   entry:
@@ -95,7 +95,7 @@ define spir_func void @test_builtin_smulextii(i32 %a, i32 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i32struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedii(%i32struct* sret([[i32struct]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedii(ptr sret([[i32struct]]) %0, i32 %a, i32 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_smulextll(i64 %a, i64 %b) {
   entry:
@@ -113,7 +113,7 @@ define spir_func void @test_builtin_smulextll(i64 %a, i64 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i64struct]]
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedll(%i64struct* sret([[i64struct]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedll(ptr sret([[i64struct]]) %0, i64 %a, i64 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_smulextDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
   entry:
@@ -131,14 +131,14 @@ define spir_func void @test_builtin_smulextDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[vecstruct]]
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedDv4_iS_(%vecstruct* sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_SMulExtendedDv4_iS_(ptr sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
 ; CHECK-LLVM:   ret void
 
 
 define spir_func void @test_builtin_smulext_anon(i32 %a, i32 %b) {
   entry:
   %0 = alloca %struct.anon
-  %1 = addrspacecast %struct.anon* %0 to %struct.anon addrspace(4)*
+  %1 = addrspacecast ptr %0 to ptr addrspace(4)
   call spir_func void @_Z20__spirv_SMulExtendedIiiE4anonIT_T0_ES1_S2_(%struct.anon addrspace(4)* sret(%struct.anon) align 4 %1, i32 %a, i32 %b)
   ret void
 }
@@ -151,8 +151,8 @@ define spir_func void @test_builtin_smulext_anon(i32 %a, i32 %b) {
 ; CHECK-SPIRV:                              OpStore [[var_61]] [[var_62]]
 
 ; CHECK-LLVM:  %0 = alloca [[struct_anon]], align 8
-; CHECK-LLVM:  %1 = addrspacecast %struct.anon* %0 to %struct.anon addrspace(4)*
-; CHECK-LLVM:  call spir_func void @_Z20__spirv_SMulExtendedii.1(%struct.anon addrspace(4)* sret([[struct_anon]]) %1, i32 %a, i32 %b)
+; CHECK-LLVM:  %1 = addrspacecast ptr %0 to ptr addrspace(4)
+; CHECK-LLVM:  call spir_func void @_Z20__spirv_SMulExtendedii.1(ptr addrspace(4) sret([[struct_anon]]) %1, i32 %a, i32 %b)
 ; CHECK-LLVM:  ret void
 
 declare void @_Z20__spirv_SMulExtendedIiiE4anonIT_T0_ES1_S2_(%struct.anon addrspace(4)* sret(%struct.anon) align 4, i32, i32)

--- a/test/transcoding/unused-sret-opaque-ptr.ll
+++ b/test/transcoding/unused-sret-opaque-ptr.ll
@@ -1,0 +1,30 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: Name [[#Fun:]] "_Z3booi"
+; CHECK-SPIRV-DAG: Decorate [[#Param:]] FuncParamAttr 3
+; CHECK-SPIRV-DAG: TypePointer [[#PtrTy:]] [[#]] [[#StructTy:]]
+; CHECK-SPIRV-DAG: TypeStruct [[#StructTy]]
+; CHECK-SPIRV: Function [[#]] [[#Fun]]
+; CHECK-SPIRV: FunctionParameter [[#PtrTy:]] [[#Param]]
+
+; CHECK-LLVM: call spir_func void @_Z3booi(ptr sret(%struct.Example) align 8
+
+source_filename = "/app/example.cpp"
+target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "spir-unknown-unknown"
+
+%struct.Example = type { }
+
+define spir_func i32 @foo() {
+  %1 = alloca %struct.Example, align 8
+  call void @_Z3booi(ptr sret(%struct.Example) align 8 %1, i32 noundef 42)
+  ret i32 0
+}
+
+declare void @_Z3booi(ptr sret(%struct.Example) align 8, i32 noundef)

--- a/test/umulextended_builtin.ll
+++ b/test/umulextended_builtin.ll
@@ -59,7 +59,7 @@ define spir_func void @test_builtin_umulextcc(i8 %a, i8 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i8struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedcc(%i8struct* sret([[i8struct]]) %0, i8 %a, i8 %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedcc(ptr sret([[i8struct]]) %0, i8 %a, i8 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_umulextss(i16 %a, i16 %b) {
   entry:
@@ -77,7 +77,7 @@ define spir_func void @test_builtin_umulextss(i16 %a, i16 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i16struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedss(%i16struct* sret([[i16struct]]) %0, i16 %a, i16 %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedss(ptr sret([[i16struct]]) %0, i16 %a, i16 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_umulextii(i32 %a, i32 %b) {
   entry:
@@ -95,7 +95,7 @@ define spir_func void @test_builtin_umulextii(i32 %a, i32 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i32struct]], align 8
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedii(%i32struct* sret([[i32struct]]) %0, i32 %a, i32 %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedii(ptr sret([[i32struct]]) %0, i32 %a, i32 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_umulextll(i64 %a, i64 %b) {
   entry:
@@ -113,7 +113,7 @@ define spir_func void @test_builtin_umulextll(i64 %a, i64 %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[i64struct]]
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedll(%i64struct* sret([[i64struct]]) %0, i64 %a, i64 %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedll(ptr sret([[i64struct]]) %0, i64 %a, i64 %b)
 ; CHECK-LLVM:   ret void
 define spir_func void @test_builtin_umulextDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
   entry:
@@ -131,14 +131,14 @@ define spir_func void @test_builtin_umulextDv4_xS_(<4 x i32> %a, <4 x i32> %b) {
 ; CHECK-SPIRV:                               OpFunctionEnd
 
 ; CHECK-LLVM:   %0 = alloca [[vecstruct]]
-; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedDv4_iS_(%vecstruct* sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
+; CHECK-LLVM:   call spir_func void @_Z20__spirv_UMulExtendedDv4_iS_(ptr sret([[vecstruct]]) %0, <4 x i32> %a, <4 x i32> %b)
 ; CHECK-LLVM:   ret void
 
 
 define spir_func void @test_builtin_umulext_anon(i32 %a, i32 %b) {
   entry:
   %0 = alloca %struct.anon
-  %1 = addrspacecast %struct.anon* %0 to %struct.anon addrspace(4)*
+  %1 = addrspacecast ptr %0 to ptr addrspace(4)
   call spir_func void @_Z20__spirv_UMulExtendedIiiE4anonIT_T0_ES1_S2_(%struct.anon addrspace(4)* sret(%struct.anon) align 4 %1, i32 %a, i32 %b)
   ret void
 }
@@ -151,8 +151,8 @@ define spir_func void @test_builtin_umulext_anon(i32 %a, i32 %b) {
 ; CHECK-SPIRV:                              OpStore [[var_61]] [[var_62]]
 
 ; CHECK-LLVM:  %0 = alloca [[struct_anon]], align 8
-; CHECK-LLVM:  %1 = addrspacecast %struct.anon* %0 to %struct.anon addrspace(4)*
-; CHECK-LLVM:  call spir_func void @_Z20__spirv_UMulExtendedii.1(%struct.anon addrspace(4)* sret([[struct_anon]]) %1, i32 %a, i32 %b)
+; CHECK-LLVM:  %1 = addrspacecast ptr %0 to ptr addrspace(4)
+; CHECK-LLVM:  call spir_func void @_Z20__spirv_UMulExtendedii.1(ptr addrspace(4) sret([[struct_anon]]) %1, i32 %a, i32 %b)
 ; CHECK-LLVM:  ret void
 
 declare void @_Z20__spirv_UMulExtendedIiiE4anonIT_T0_ES1_S2_(%struct.anon addrspace(4)* sret(%struct.anon) align 4, i32, i32)


### PR DESCRIPTION
Backport of #2877.