### PR TITLE
Make `this` captures explicit for C++20; NFC

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -700,7 +700,7 @@ void OCLToSPIRVBase::visitCallAtomicLegacy(CallInst *CI, StringRef MangledName,
     PostOps.push_back(OCLLegacyAtomicMemOrder);
   PostOps.push_back(OCLLegacyAtomicMemScope);
 
-  Info.PostProc = [=](BuiltinCallMutator &Mutator) {
+  Info.PostProc = [this, PostOps](BuiltinCallMutator &Mutator) {
     for (auto &I : PostOps) {
       Mutator.appendArg(addInt32(I));
     }
@@ -744,7 +744,7 @@ void OCLToSPIRVBase::visitCallAtomicCpp11(CallInst *CI, StringRef MangledName,
 
   OCLBuiltinTransInfo Info;
   Info.UniqName = std::string("atomic_") + NewStem;
-  Info.PostProc = [=](BuiltinCallMutator &Mutator) {
+  Info.PostProc = [this, PostOps](BuiltinCallMutator &Mutator) {
     for (auto &I : PostOps) {
       Mutator.appendArg(addInt32(I));
     }
@@ -1125,7 +1125,7 @@ void OCLToSPIRVBase::visitCallReadImageWithSampler(CallInst *CI,
   // SPIR-V instruction always returns 4-element vector
   if (IsRetScalar)
     Mutator.changeReturnType(FixedVectorType::get(Ret, 4),
-                             [=](IRBuilder<> &Builder, CallInst *NewCI) {
+                             [this](IRBuilder<> &Builder, CallInst *NewCI) {
                                return Builder.CreateExtractElement(
                                    NewCI, getSizet(M, 0));
                              });
@@ -1279,7 +1279,7 @@ void OCLToSPIRVBase::visitCallRelational(CallInst *CI,
   // i1 or <i1 x N>, depending on whether it returns a vector type.
   Type *BoolTy = CI->getType()->getWithNewType(Type::getInt1Ty(*Ctx));
   mutateCallInst(CI, OC).changeReturnType(
-      BoolTy, [=](IRBuilder<> &Builder, CallInst *NewCI) {
+      BoolTy, [this, CI](IRBuilder<> &Builder, CallInst *NewCI) {
         Value *TrueOp = CI->getType()->isVectorTy()
                             ? Constant::getAllOnesValue(CI->getType())
                             : getInt32(M, 1);
@@ -1697,7 +1697,8 @@ void OCLToSPIRVBase::visitCallKernelQuery(CallInst *CI,
   AttributeList Attrs = CI->getCalledFunction()->getAttributes();
   ::mutateCallInst(
       M, CI,
-      [=](CallInst *CI, std::vector<Value *> &Args) {
+      [this, DemangledName, DL, BlockFIdx, BlockF](CallInst *CI,
+                                                   std::vector<Value *> &Args) {
         Value *Param = *Args.rbegin();
         Type *ParamType = getBlockStructType(Param);
         // Last arg corresponds to SPIRV Param operand.

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1347,7 +1347,7 @@ SPIRVToLLVM::expandOCLBuiltinWithScalarArg(CallInst *CI,
     auto VecElemCount =
         cast<VectorType>(CI->getOperand(1)->getType())->getElementCount();
     auto Mutator = mutateCallInst(CI, FuncName);
-    Mutator.mapArg(0, [=](Value *Arg) {
+    Mutator.mapArg(0, [this, CI, VecElemCount](Value *Arg) {
       Value *NewVec = nullptr;
       if (auto *CA = dyn_cast<Constant>(Arg))
         NewVec = ConstantVector::getSplat(VecElemCount, CA);
@@ -4866,7 +4866,7 @@ void SPIRVToLLVM::transFunctionDecorationsToMetadata(SPIRVFunction *BF,
 
   // Generate metadata for spirv.ParameterDecorations
   addKernelArgumentMetadata(Context, SPIRV_MD_PARAMETER_DECORATIONS, BF, F,
-                            [=](SPIRVFunctionParameter *Arg) {
+                            [this](SPIRVFunctionParameter *Arg) {
                               return transDecorationsToMetadataList(
                                   Context, Arg->getDecorations());
                             });
@@ -5109,7 +5109,7 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
   // Generate metadata for kernel_arg_addr_space
   addKernelArgumentMetadata(
       Context, SPIR_MD_KERNEL_ARG_ADDR_SPACE, BF, F,
-      [=](SPIRVFunctionParameter *Arg) {
+      [this](SPIRVFunctionParameter *Arg) {
         SPIRVType *ArgTy = Arg->getType();
         SPIRAddressSpace AS = SPIRAS_Private;
         if (ArgTy->isTypePointer())
@@ -5121,7 +5121,7 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
       });
   // Generate metadata for kernel_arg_access_qual
   addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_ACCESS_QUAL, BF, F,
-                            [=](SPIRVFunctionParameter *Arg) {
+                            [this](SPIRVFunctionParameter *Arg) {
                               std::string Qual;
                               auto *T = Arg->getType();
                               if (T->isTypeOCLImage()) {
@@ -5138,7 +5138,7 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
   if (!transKernelArgTypeMedataFromString(Context, BM, F,
                                           SPIR_MD_KERNEL_ARG_TYPE))
     addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_TYPE, BF, F,
-                              [=](SPIRVFunctionParameter *Arg) {
+                              [this](SPIRVFunctionParameter *Arg) {
                                 return transOCLKernelArgTypeName(Arg);
                               });
   // Generate metadata for kernel_arg_type_qual
@@ -5146,7 +5146,7 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
                                           SPIR_MD_KERNEL_ARG_TYPE_QUAL))
     addKernelArgumentMetadata(
         Context, SPIR_MD_KERNEL_ARG_TYPE_QUAL, BF, F,
-        [=](SPIRVFunctionParameter *Arg) {
+        [this](SPIRVFunctionParameter *Arg) {
           std::string Qual;
           if (Arg->hasDecorate(DecorationVolatile))
             Qual = kOCLTypeQualifierName::Volatile;
@@ -5163,33 +5163,36 @@ bool SPIRVToLLVM::transOCLMetadata(SPIRVFunction *BF) {
         });
   // Generate metadata for kernel_arg_base_type
   addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_BASE_TYPE, BF, F,
-                            [=](SPIRVFunctionParameter *Arg) {
+                            [this](SPIRVFunctionParameter *Arg) {
                               return transOCLKernelArgTypeName(Arg);
                             });
   // Generate metadata for kernel_arg_name
   if (BM->isGenArgNameMDEnabled()) {
     addKernelArgumentMetadata(Context, SPIR_MD_KERNEL_ARG_NAME, BF, F,
-                              [=](SPIRVFunctionParameter *Arg) {
+                              [this](SPIRVFunctionParameter *Arg) {
                                 return MDString::get(*Context, Arg->getName());
                               });
   }
   // Generate metadata for kernel_arg_buffer_location
-  addBufferLocationMetadata(Context, BF, F, [=](SPIRVFunctionParameter *Arg) {
-    auto Literals = Arg->getDecorationLiterals(DecorationBufferLocationINTEL);
-    assert(Literals.size() == 1 &&
-           "BufferLocationINTEL decoration shall have 1 ID literal");
+  addBufferLocationMetadata(
+      Context, BF, F, [this](SPIRVFunctionParameter *Arg) {
+        auto Literals =
+            Arg->getDecorationLiterals(DecorationBufferLocationINTEL);
+        assert(Literals.size() == 1 &&
+               "BufferLocationINTEL decoration shall have 1 ID literal");
 
-    return ConstantAsMetadata::get(
-        ConstantInt::get(Type::getInt32Ty(*Context), Literals[0]));
-  });
+        return ConstantAsMetadata::get(
+            ConstantInt::get(Type::getInt32Ty(*Context), Literals[0]));
+      });
   // Generate metadata for kernel_arg_runtime_aligned
-  addRuntimeAlignedMetadata(Context, BF, F, [=](SPIRVFunctionParameter *Arg) {
-    return ConstantAsMetadata::get(
-        ConstantInt::get(Type::getInt1Ty(*Context), 1));
-  });
+  addRuntimeAlignedMetadata(
+      Context, BF, F, [this](SPIRVFunctionParameter *Arg) {
+        return ConstantAsMetadata::get(
+            ConstantInt::get(Type::getInt1Ty(*Context), 1));
+      });
   // Generate metadata for spirv.ParameterDecorations
   addKernelArgumentMetadata(Context, SPIRV_MD_PARAMETER_DECORATIONS, BF, F,
-                            [=](SPIRVFunctionParameter *Arg) {
+                            [this](SPIRVFunctionParameter *Arg) {
                               return transDecorationsToMetadataList(
                                   Context, Arg->getDecorations());
                             });

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -80,7 +80,7 @@ DIFile *
 SPIRVToLLVMDbgTran::getDIFile(const std::string &FileName,
                               std::optional<DIFile::ChecksumInfo<StringRef>> CS,
                               std::optional<StringRef> Source) {
-  return getOrInsert(FileMap, FileName, [=]() {
+  return getOrInsert(FileMap, FileName, [this, FileName, CS, Source]() {
     SplitFileName Split(FileName);
     // Use the first builder from the map to crete DIFile since it's
     // relations with other debug metadata is not going through DICompileUnit

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6887,7 +6887,7 @@ bool LLVMToSPIRVBase::transOCLMetadata() {
     if (auto *KernelArgName = F.getMetadata(SPIR_MD_KERNEL_ARG_NAME)) {
       foreachKernelArgMD(
           KernelArgName, BF,
-          [=](const std::string &Str, SPIRVFunctionParameter *BA) {
+          [this](const std::string &Str, SPIRVFunctionParameter *BA) {
             BM->setName(BA, Str);
           });
     }

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1072,7 +1072,7 @@ public:
     assert(WordCount == Pairs.size() + FixedWordCount);
     assert(OpCode == OC);
     assert(Pairs.size() % 2 == 0);
-    foreachPair([=](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB) {
+    foreachPair([this](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB) {
       assert(IncomingV->isForward() || IncomingV->getType() == Type);
       assert(IncomingBB->isBasicBlock() || IncomingBB->isForward());
     });


### PR DESCRIPTION
Although LLVM has no immediate plans to switch to C++20, prepare for the deprecation of implicit capture of `this` through `[=]` in lambdas.