### PR TITLE
Use OpImageQuerySize for multisampled image size queries

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.cpp
+++ b/lib/SPIRV/OCLToSPIRV.cpp
@@ -1141,11 +1141,15 @@ void OCLToSPIRVBase::visitCallGetImageSize(CallInst *CI,
                                                 : Type::getInt32Ty(*Ctx);
   if (Dim > 1)
     NewRet = FixedVectorType::get(NewRet, Dim);
-  auto Mutator = mutateCallInst(CI, getSPIRVFuncName(Desc.Dim == DimBuffer
-                                                         ? OpImageQuerySize
-                                                         : OpImageQuerySizeLod,
-                                                     CI->getType()));
-  if (Desc.Dim != DimBuffer)
+  // OpImageQuerySizeLod requires the image to have MS = 0, so multisampled
+  // images (like buffer images) must use OpImageQuerySize without a LOD
+  // operand.
+  bool UseQuerySizeLod = Desc.Dim != DimBuffer && !Desc.MS;
+  auto Mutator =
+      mutateCallInst(CI, getSPIRVFuncName(UseQuerySizeLod ? OpImageQuerySizeLod
+                                                          : OpImageQuerySize,
+                                          CI->getType()));
+  if (UseQuerySizeLod)
     Mutator.appendArg(getInt32(M, 0));
   Mutator.changeReturnType(
       NewRet, [&](IRBuilder<> &, CallInst *NCI) -> Value * {

--- a/test/transcoding/OpImageReadMS.ll
+++ b/test/transcoding/OpImageReadMS.ll
@@ -11,6 +11,10 @@
 
 ; CHECK-LLVM: call spir_func <4 x float> @_Z11read_imagef19ocl_image2d_msaa_roDv2_ii(target("spirv.Image", void, 1, 0, 0, 1, 0, 0, 0)
 
+; CHECK-SPIRV: TypeImage [[#ImgTy:]] {{[0-9]+}} 1 0 0 1 0 0 0
+; CHECK-SPIRV-NOT: ImageQuerySizeLod
+; CHECK-SPIRV: 4 ImageQuerySize {{[0-9]+}} {{[0-9]+}} [[#Img:]]
+; CHECK-SPIRV: 4 ImageQuerySize {{[0-9]+}} {{[0-9]+}} [[#Img]]
 ; CHECK-SPIRV: 7 ImageRead {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} {{[0-9]+}} 64 {{[0-9]+}}
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
OpImageQuerySizeLod requires the image to have MS = 0, so size queries on multisampled images must use OpImageQuerySize without a LOD operand

Inspired by the change in LLVM SPIR-V backend: https://github.com/llvm/llvm-project/pull/190767