### PR TITLE
[CI] Switch lit to internal shell

### DIFF
--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -13,9 +13,6 @@ from lit.llvm.subst import FindTool
 config.name = 'LLVM_SPIRV'
 
 # testFormat: The test format to use to interpret tests.
-# Use lit's internal shell. ShTest(execute_external=True) is rejected
-# starting with LLVM-23 (commit 57109befac92, "[lit] Deprecate
-# execute_external=True in ShTest").
 config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -13,7 +13,10 @@ from lit.llvm.subst import FindTool
 config.name = 'LLVM_SPIRV'
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+# Use lit's internal shell. ShTest(execute_external=True) is rejected
+# starting with LLVM-23 (commit 57109befac92, "[lit] Deprecate
+# execute_external=True in ShTest").
+config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.cl', '.ll', '.spt', '.spvasm']


### PR DESCRIPTION
llvm/llvm-project@57109befac92 `"[lit] Deprecate execute_external=True in ShTest"` makes `execute_external=True` a fatal error. 
Our previous setting (`ShTest(not llvm_config.use_lit_shell)`) evaluated to `True` on Linux/macOS (positional argument is `execute_external`), so test discovery now fails with: `ValueError: execute_external=True is deprected as of LLVM-23 ...`

AI-assisted: Claude Opus 4.7 (commercial SaaS)