### PR TITLE
[DebugInfo] Distinguish absent and empty DIFile source on round-trip

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -79,11 +79,14 @@ void SPIRVToLLVMDbgTran::addDbgInfoVersion() {
 DIFile *
 SPIRVToLLVMDbgTran::getDIFile(const std::string &FileName,
                               std::optional<DIFile::ChecksumInfo<StringRef>> CS,
-                              std::optional<StringRef> Source) {
+                              std::optional<std::string> Source) {
   return getOrInsert(FileMap, FileName, [this, FileName, CS, Source]() {
     SplitFileName Split(FileName);
-    // Use the first builder from the map to crete DIFile since it's
+    // Use the first builder from the map to create DIFile since it's
     // relations with other debug metadata is not going through DICompileUnit
+    // Pass nullopt (not an empty string) when the SPIR-V has no Source
+    // operand: LLVM/DWARF preserve "absent" and "present-but-empty"
+    // distinctly.
     if (!Split.BaseName.empty())
       return BuilderMap.begin()->second->createFile(Split.BaseName, Split.Path,
                                                     CS, Source);
@@ -136,11 +139,11 @@ const std::string &SPIRVToLLVMDbgTran::getString(const SPIRVId Id) {
   return String->getStr();
 }
 
-const std::string
+std::optional<std::string>
 SPIRVToLLVMDbgTran::getStringSourceContinued(const SPIRVId Id,
                                              SPIRVExtInst *DebugInst) {
   if (!isValidId(Id) || getDbgInst<SPIRVDebug::DebugInfoNone>(Id))
-    return "";
+    return std::nullopt;
   std::string Str = BM->get<SPIRVString>(Id)->getStr();
   using namespace SPIRVDebug::Operand::SourceContinued;
   for (auto *I : DebugInst->getContinuedInstructions()) {

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -84,9 +84,6 @@ SPIRVToLLVMDbgTran::getDIFile(const std::string &FileName,
     SplitFileName Split(FileName);
     // Use the first builder from the map to create DIFile since it's
     // relations with other debug metadata is not going through DICompileUnit
-    // Pass nullopt (not an empty string) when the SPIR-V has no Source
-    // operand: LLVM/DWARF preserve "absent" and "present-but-empty"
-    // distinctly.
     if (!Split.BaseName.empty())
       return BuilderMap.begin()->second->createFile(Split.BaseName, Split.Path,
                                                     CS, Source);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -94,7 +94,7 @@ private:
   DIFile *
   getDIFile(const std::string &FileName,
             std::optional<DIFile::ChecksumInfo<StringRef>> CS = std::nullopt,
-            std::optional<StringRef> Source = std::nullopt);
+            std::optional<std::string> Source = std::nullopt);
   DIFile *getDIFile(const SPIRVEntry *E);
   unsigned getLineNo(const SPIRVEntry *E);
 
@@ -219,8 +219,8 @@ private:
     return nullptr;
   }
   const std::string &getString(const SPIRVId Id);
-  const std::string getStringSourceContinued(const SPIRVId Id,
-                                             SPIRVExtInst *DebugInst);
+  std::optional<std::string>
+  getStringSourceContinued(const SPIRVId Id, SPIRVExtInst *DebugInst);
   SPIRVWord getConstantValueOrLiteral(const std::vector<SPIRVWord> &,
                                       const SPIRVWord,
                                       const SPIRVExtInstSetKind);

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.h
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.h
@@ -219,8 +219,8 @@ private:
     return nullptr;
   }
   const std::string &getString(const SPIRVId Id);
-  std::optional<std::string>
-  getStringSourceContinued(const SPIRVId Id, SPIRVExtInst *DebugInst);
+  std::optional<std::string> getStringSourceContinued(const SPIRVId Id,
+                                                      SPIRVExtInst *DebugInst);
   SPIRVWord getConstantValueOrLiteral(const std::vector<SPIRVWord> &,
                                       const SPIRVWord,
                                       const SPIRVExtInstSetKind);

--- a/test/DebugInfo/DebugInfoChecksum.ll
+++ b/test/DebugInfo/DebugInfoChecksum.ll
@@ -47,6 +47,8 @@ attributes #0 = { noinline norecurse nounwind optnone "correctly-rounded-divide-
 
 ; CHECK-LLVM: !DIFile(filename: "main.cpp"
 ; CHECK-LLVM-SAME: checksumkind: CSK_MD5, checksum: "7bb56387968a9caa6e9e35fff94eaf7b"
+; The IR has no `source:` field; round-tripping must not introduce one.
+; CHECK-LLVM-NOT: source:
 
 ; CHECK-SPIRV-OCL: String [[#REG:]] "//__CSK_MD5:7bb56387968a9caa6e9e35fff94eaf7b"
 ; CHECK-SPIRV-OCL: DebugSource [[#]] [[#REG]]
@@ -55,7 +57,8 @@ attributes #0 = { noinline norecurse nounwind optnone "correctly-rounded-divide-
 ; CHECK-SPIRV-200: String [[#Val:]] "7bb56387968a9caa6e9e35fff94eaf7b"
 ; CHECK-SPIRV-200: TypeInt [[#TypeInt32:]] 32
 ; CHECK-SPIRV-200: Constant [[#TypeInt32]] [[#Kind:]] 0
-; CHECK-SPIRV-200: DebugSource [[#]] [[#Kind]] [[#Val]]
+; The DebugSource has File + ChecksumKind + ChecksumValue and nothing more.
+; CHECK-SPIRV-200: DebugSource [[#]] [[#Kind]] [[#Val]] {{$}}
 
 !0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 13.0.0 (https://github.com/llvm/llvm-project.git 7d09e1d7cf27ce781e83f9d388a7a3e1e6487ead)", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
 !1 = !DIFile(filename: "<stdin>", directory: "oneAPI", checksumkind: CSK_MD5, checksum: "7bb56387968a9caa6e9e35fff94eaf7b")


### PR DESCRIPTION
`DebugSource` with no source text was translated into a DIFile with `source: ""` instead of no `source:` field at all. 
LLVM preserves the two distinctly: an empty source becomes `DW_AT_LLVM_source = "\n"` in DWARF, which GDB and other consumers prefer over the on-disk file, displaying a blank line at kernel breakpoints in place of the real source.

Round-trip an absent SPIR-V Source operand to an absent DIFile `source:` field.

AI-assisted: Claude Opus 4.7 (commercial SaaS)