### PR TITLE
Re-enable spirv-val for some tests

### DIFF
--- a/test/extensions/KHR/SPV_KHR_abort/abort-conditional.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-conditional.ll
@@ -13,10 +13,7 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; ---- SPIR-V with extension ----
 ; CHECK-SPIRV-DAG: Extension "SPV_KHR_abort"

--- a/test/extensions/KHR/SPV_KHR_abort/abort-in-kernel.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-in-kernel.ll
@@ -13,10 +13,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort-multiple-blocks.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-multiple-blocks.ll
@@ -9,10 +9,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort-post-terminator-suppression.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort-post-terminator-suppression.ll
@@ -16,10 +16,7 @@
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; Round-trip
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc

--- a/test/extensions/KHR/SPV_KHR_abort/abort.ll
+++ b/test/extensions/KHR/SPV_KHR_abort/abort.ll
@@ -6,10 +6,7 @@
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
-; FIXME: enable the following run when the translator CI is updated to a new
-; version of the SPIR-V Tools that includes the support for the SPV_KHR_abort
-; extension.
-; TODO: RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; RUN: not llvm-spirv %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; CHECK-ERROR: RequiresExtension: Feature requires the following SPIR-V extension:

--- a/test/extensions/KHR/SPV_KHR_fma/fma.ll
+++ b/test/extensions/KHR/SPV_KHR_fma/fma.ll
@@ -1,6 +1,5 @@
 ; RUN: llvm-spirv %s --spirv-ext=+SPV_KHR_fma -o %t.spv
-; TODO: enable once spirv-val supports the extension.
-; RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.rev.ll

--- a/test/llvm-intrinsics/bitreverse_small_type.ll
+++ b/test/llvm-intrinsics/bitreverse_small_type.ll
@@ -22,9 +22,7 @@
 ; RUN: llvm-spirv -spirv-ext=+SPV_INTEL_arbitrary_precision_integers %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
-; TODO: There is no validation for SPV_INTEL_arbitrary_precision_integers implemented in
-; SPIRV-Tools. Enable after SPIR-V Tools are ready.
-; RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 
 ; CHECK-SPIRV: Name [[BR_2:[0-9]+]] "llvm_bitreverse_i2"
 ; CHECK-SPIRV: Name [[BR_4:[0-9]+]] "llvm_bitreverse_i4"

--- a/test/transcoding/OpenCL/math-builtins.ll
+++ b/test/transcoding/OpenCL/math-builtins.ll
@@ -12,8 +12,7 @@
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 ; RUN: llvm-spirv %s -o %t.spv --spirv-ext=+SPV_KHR_untyped_pointers
-; TODO: enable back once spirv-tools are updated
-; RUNx: spirv-val %t.spv
+; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM


### PR DESCRIPTION
Now that CI is using a more recent SPIRV-Tools revision, re-enable spirv-val for tests that had their validation disabled and do not require any changes to pass validation.