### PR TITLE
[Backport to 21] Fix spir_func CC, SPV_EXT_float8 saturation decoration, SPV_INTEL_fp_conversions spec update

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -1051,16 +1051,21 @@ enum FPEncodingWrap {
   E2M1 = internal::FPEncodingFloat4E2M1INTEL,
 };
 
-// Structure describing non-trivial conversions (FP8 and int4)
+// Structure describing non-trivial conversions (FP8, FP4 and int4)
 struct FPConversionDesc {
   FPEncodingWrap SrcEncoding;
   FPEncodingWrap DstEncoding;
   SPIRVWord ConvOpCode;
+  // Indicates the SPIR-V conversion instruction must be decorated with
+  // SaturatedToLargestFloat8NormalConversionEXT (SPV_EXT_float8). Used by
+  // SPV_INTEL_fp_conversions ClampConvert*/ClampStochasticRound* builtins.
+  bool Saturate = false;
 
   // To use as a key in std::map
   bool operator==(const FPConversionDesc &Other) const {
     return SrcEncoding == Other.SrcEncoding &&
-           DstEncoding == Other.DstEncoding && ConvOpCode == Other.ConvOpCode;
+           DstEncoding == Other.DstEncoding && ConvOpCode == Other.ConvOpCode &&
+           Saturate == Other.Saturate;
   }
 
   bool operator<(const FPConversionDesc &Other) const {
@@ -1068,7 +1073,9 @@ struct FPConversionDesc {
       return ConvOpCode < Other.ConvOpCode;
     if (SrcEncoding != Other.SrcEncoding)
       return SrcEncoding < Other.SrcEncoding;
-    return DstEncoding < Other.DstEncoding;
+    if (DstEncoding != Other.DstEncoding)
+      return DstEncoding < Other.DstEncoding;
+    return Saturate < Other.Saturate;
   }
 };
 
@@ -1126,24 +1133,18 @@ template <> inline void FPConvertToEncodingMap::init() {
       {FPEncodingWrap::BF16,         FPEncodingWrap::E5M2,         OpFConvert});
 
   // SPV_INTEL_fp_conversions
-  add("ClampConvertFP16ToE2M1INTEL",
-      {FPEncodingWrap::IEEE754,      FPEncodingWrap::E2M1,
-       internal::OpClampConvertFToFINTEL});
-  add("ClampConvertBF16ToE2M1INTEL",
-      {FPEncodingWrap::BF16,         FPEncodingWrap::E2M1,
-       internal::OpClampConvertFToFINTEL});
   add("ClampConvertFP16ToE4M3INTEL",
-      {FPEncodingWrap::IEEE754,      FPEncodingWrap::E4M3,
-       internal::OpClampConvertFToFINTEL});
+      {FPEncodingWrap::IEEE754,      FPEncodingWrap::E4M3,      OpFConvert,
+       /*Saturate=*/true});
   add("ClampConvertBF16ToE4M3INTEL",
-      {FPEncodingWrap::BF16,         FPEncodingWrap::E4M3,
-       internal::OpClampConvertFToFINTEL});
+      {FPEncodingWrap::BF16,         FPEncodingWrap::E4M3,      OpFConvert,
+       /*Saturate=*/true});
   add("ClampConvertFP16ToE5M2INTEL",
-      {FPEncodingWrap::IEEE754,      FPEncodingWrap::E5M2,
-       internal::OpClampConvertFToFINTEL});
+      {FPEncodingWrap::IEEE754,      FPEncodingWrap::E5M2,      OpFConvert,
+       /*Saturate=*/true});
   add("ClampConvertBF16ToE5M2INTEL",
-      {FPEncodingWrap::BF16,         FPEncodingWrap::E5M2,
-       internal::OpClampConvertFToFINTEL});
+      {FPEncodingWrap::BF16,         FPEncodingWrap::E5M2,      OpFConvert,
+       /*Saturate=*/true});
   add("ClampConvertFP16ToInt4INTEL",
       {FPEncodingWrap::IEEE754,      FPEncodingWrap::Integer,
        internal::OpClampConvertFToSINTEL});
@@ -1178,16 +1179,16 @@ template <> inline void FPConvertToEncodingMap::init() {
 
   add("ClampStochasticRoundFP16ToE5M2INTEL",
       {FPEncodingWrap::IEEE754,      FPEncodingWrap::E5M2,
-       internal::OpClampStochasticRoundFToFINTEL});
+       internal::OpStochasticRoundFToFINTEL,                   /*Saturate=*/true});
   add("ClampStochasticRoundFP16ToE4M3INTEL",
       {FPEncodingWrap::IEEE754,      FPEncodingWrap::E4M3,
-       internal::OpClampStochasticRoundFToFINTEL});
+       internal::OpStochasticRoundFToFINTEL,                   /*Saturate=*/true});
   add("ClampStochasticRoundBF16ToE5M2INTEL",
       {FPEncodingWrap::BF16,         FPEncodingWrap::E5M2,
-       internal::OpClampStochasticRoundFToFINTEL});
+       internal::OpStochasticRoundFToFINTEL,                   /*Saturate=*/true});
   add("ClampStochasticRoundBF16ToE4M3INTEL",
       {FPEncodingWrap::BF16,         FPEncodingWrap::E4M3,
-       internal::OpClampStochasticRoundFToFINTEL});
+       internal::OpStochasticRoundFToFINTEL,                   /*Saturate=*/true});
 }
 
 // clang-format on

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1139,10 +1139,29 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
 
       FPEncodingWrap SrcEnc = GetEncodingAndUpdateType(SPVSrcTy);
       FPEncodingWrap DstEnc = GetEncodingAndUpdateType(SPVDstTy);
+      bool IsSaturatedFP8 = BC->hasDecorate(
+          DecorationSaturatedToLargestFloat8NormalConversionEXT);
+      if (IsSaturatedFP8) {
+        BM->getErrorLog().checkError(
+            (OC == OpFConvert || OC == OpConvertSToF || OC == OpConvertUToF) &&
+                (DstEnc == FPEncodingWrap::E4M3 ||
+                 DstEnc == FPEncodingWrap::E5M2),
+            SPIRVEC_InvalidInstruction,
+            "SaturatedToLargestFloat8NormalConversionEXT decoration is only "
+            "valid on OpFConvert/OpConvertSToF/OpConvertUToF whose Result "
+            "Type uses Float8E4M3EXT or Float8E5M2EXT encoding.\n");
+      }
       if (IsFP4OrFP8Encoding(SrcEnc) || IsFP4OrFP8Encoding(DstEnc) ||
           SPVSrcTy->isTypeInt(4) || SPVDstTy->isTypeInt(4)) {
-        FPConversionDesc FPDesc = {
-            SrcEnc, DstEnc, static_cast<SPIRV::SPIRVWord>(BC->getOpCode())};
+        // SPV_EXT_float8: an OpFConvert to E4M3/E5M2 decorated with
+        // SaturatedToLargestFloat8NormalConversionEXT round-trips through the
+        // ClampConvert<Src>To<E4M3|E5M2>INTEL builtin name. Only the FToF
+        // variant has a corresponding SPV_INTEL_fp_conversions builtin name;
+        // for OpConvertSToF/OpConvertUToF the standard mapping is preserved.
+        SPIRV::SPIRVWord LookupOp = (IsSaturatedFP8 && OC == OpFConvert)
+                                        ? internal::OpClampConvertFToFINTEL
+                                        : OC;
+        FPConversionDesc FPDesc = {SrcEnc, DstEnc, LookupOp};
         auto Conv = SPIRV::FPConvertToEncodingMap::rmap(FPDesc);
         std::vector<Value *> Ops = {Src};
         std::vector<Type *> OpsTys = {Src->getType()};

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1110,10 +1110,8 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
   case OpUConvert:
     CO = IsExt ? Instruction::ZExt : Instruction::Trunc;
     break;
-  case internal::OpClampConvertFToFINTEL:
   case internal::OpClampConvertFToSINTEL:
   case internal::OpStochasticRoundFToFINTEL:
-  case internal::OpClampStochasticRoundFToFINTEL:
   case internal::OpClampStochasticRoundFToSINTEL:
   case OpConvertSToF:
   case OpConvertFToS:
@@ -1143,25 +1141,20 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
           DecorationSaturatedToLargestFloat8NormalConversionEXT);
       if (IsSaturatedFP8) {
         BM->getErrorLog().checkError(
-            (OC == OpFConvert || OC == OpConvertSToF || OC == OpConvertUToF) &&
+            (OC == OpFConvert || OC == OpConvertSToF || OC == OpConvertUToF ||
+             OC == internal::OpStochasticRoundFToFINTEL) &&
                 (DstEnc == FPEncodingWrap::E4M3 ||
                  DstEnc == FPEncodingWrap::E5M2),
             SPIRVEC_InvalidInstruction,
             "SaturatedToLargestFloat8NormalConversionEXT decoration is only "
-            "valid on OpFConvert/OpConvertSToF/OpConvertUToF whose Result "
-            "Type uses Float8E4M3EXT or Float8E5M2EXT encoding.\n");
+            "valid on OpFConvert/OpConvertSToF/OpConvertUToF/"
+            "OpStochasticRoundFToFINTEL whose Result Type uses Float8E4M3EXT "
+            "or Float8E5M2EXT encoding.\n");
       }
       if (IsFP4OrFP8Encoding(SrcEnc) || IsFP4OrFP8Encoding(DstEnc) ||
           SPVSrcTy->isTypeInt(4) || SPVDstTy->isTypeInt(4)) {
-        // SPV_EXT_float8: an OpFConvert to E4M3/E5M2 decorated with
-        // SaturatedToLargestFloat8NormalConversionEXT round-trips through the
-        // ClampConvert<Src>To<E4M3|E5M2>INTEL builtin name. Only the FToF
-        // variant has a corresponding SPV_INTEL_fp_conversions builtin name;
-        // for OpConvertSToF/OpConvertUToF the standard mapping is preserved.
-        SPIRV::SPIRVWord LookupOp = (IsSaturatedFP8 && OC == OpFConvert)
-                                        ? internal::OpClampConvertFToFINTEL
-                                        : OC;
-        FPConversionDesc FPDesc = {SrcEnc, DstEnc, LookupOp};
+        FPConversionDesc FPDesc = {SrcEnc, DstEnc, OC,
+                                   /*Saturate=*/IsSaturatedFP8};
         auto Conv = SPIRV::FPConvertToEncodingMap::rmap(FPDesc);
         std::vector<Value *> Ops = {Src};
         std::vector<Type *> OpsTys = {Src->getType()};
@@ -1172,7 +1165,6 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         std::string MangledName;
         // Translate additional Ops for stochastic conversions.
         if (OC == internal::OpStochasticRoundFToFINTEL ||
-            OC == internal::OpClampStochasticRoundFToFINTEL ||
             OC == internal::OpClampStochasticRoundFToSINTEL) {
           // Seed.
           Ops.emplace_back(transValue(SPVOps[1], F, BB, true));
@@ -1204,11 +1196,11 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         return CI;
       }
     }
-    // These conversions can be done without __builtin_spirv prefixed functions
-    // as their operand and result types have native representation in LLVM IR.
-    if (OC == internal::OpClampConvertFToFINTEL ||
-        OC == internal::OpStochasticRoundFToFINTEL ||
-        OC == internal::OpClampStochasticRoundFToFINTEL)
+    // OpStochasticRoundFToFINTEL has no native LLVM cast equivalent.
+    // For fp4/fp8/int4 types, it is handled via the __builtin_spirv path above.
+    // For the remaining types it is emitted as an
+    // __spirv_StochasticRoundFToFINTEL_R<type> builtin call.
+    if (OC == internal::OpStochasticRoundFToFINTEL)
       return mapValue(BV, transSPIRVBuiltinFromInst(
                               static_cast<SPIRVInstruction *>(BV), BB));
 
@@ -4000,10 +3992,8 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   case internal::OpTaskSequenceCreateINTEL:
   case internal::OpConvertHandleToImageINTEL:
   case internal::OpConvertHandleToSampledImageINTEL:
-  case internal::OpClampConvertFToFINTEL:
   case internal::OpClampConvertFToSINTEL:
   case internal::OpStochasticRoundFToFINTEL:
-  case internal::OpClampStochasticRoundFToFINTEL:
   case internal::OpClampStochasticRoundFToSINTEL:
     AddRetTypePostfix = true;
     break;

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1179,9 +1179,10 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         if (MangledName.empty())
           MangledName = mangleBuiltin(BuiltinName, OpsTys, &Info);
 
-        FunctionType *FTy = FunctionType::get(Dst, OpsTys, false);
-        FunctionCallee Func = M->getOrInsertFunction(MangledName, FTy);
-        return CallInst::Create(Func, Ops, "", BB);
+        Function *Func = getOrCreateFunction(M, Dst, OpsTys, MangledName);
+        auto *CI = CallInst::Create(Func, Ops, "", BB);
+        CI->setCallingConv(CallingConv::SPIR_FUNC);
+        return CI;
       }
     }
     // These conversions can be done without __builtin_spirv prefixed functions

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5577,21 +5577,6 @@ SPIRVValue *LLVMToSPIRVBase::transDirectCallInst(CallInst *CI,
     if (SPIRV::FPConvertToEncodingMap::find(DemangledName)) {
       FPConversionDesc FPDesc =
           SPIRV::FPConvertToEncodingMap::map(DemangledName);
-      // SPV_EXT_float8: when SPV_EXT_float8 is enabled and
-      // SPV_INTEL_fp_conversions is not, the
-      // ClampConvert<Src>To<E4M3|E5M2>INTEL builtin maps to OpFConvert
-      // decorated with SaturatedToLargestFloat8NormalConversionEXT instead of
-      // the SPV_INTEL_fp_conversions OpClampConvertFToFINTEL opcode. When both
-      // extensions are enabled, SPV_INTEL_fp_conversions wins to preserve the
-      // pre-existing encoding.
-      bool IsSaturatedFP8 =
-          FPDesc.ConvOpCode == internal::OpClampConvertFToFINTEL &&
-          (FPDesc.DstEncoding == FPEncodingWrap::E4M3 ||
-           FPDesc.DstEncoding == FPEncodingWrap::E5M2) &&
-          BM->isAllowedToUseExtension(ExtensionID::SPV_EXT_float8) &&
-          !BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fp_conversions);
-      if (IsSaturatedFP8)
-        FPDesc.ConvOpCode = OpFConvert;
       Value *Src = CI->getOperand(0);
       Type *LLVMSrcTy = Src->getType();
       Type *LLVMDstTy = CI->getType();
@@ -5670,7 +5655,7 @@ SPIRVValue *LLVMToSPIRVBase::transDirectCallInst(CallInst *CI,
 
       SPIRVValue *Conv = BM->addInstTemplate(OC, BM->getIds(Ops), BB, DstTy);
 
-      if (IsSaturatedFP8)
+      if (FPDesc.Saturate)
         Conv->addDecorate(new SPIRVDecorate(
             DecorationSaturatedToLargestFloat8NormalConversionEXT, Conv));
 

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5577,6 +5577,21 @@ SPIRVValue *LLVMToSPIRVBase::transDirectCallInst(CallInst *CI,
     if (SPIRV::FPConvertToEncodingMap::find(DemangledName)) {
       FPConversionDesc FPDesc =
           SPIRV::FPConvertToEncodingMap::map(DemangledName);
+      // SPV_EXT_float8: when SPV_EXT_float8 is enabled and
+      // SPV_INTEL_fp_conversions is not, the
+      // ClampConvert<Src>To<E4M3|E5M2>INTEL builtin maps to OpFConvert
+      // decorated with SaturatedToLargestFloat8NormalConversionEXT instead of
+      // the SPV_INTEL_fp_conversions OpClampConvertFToFINTEL opcode. When both
+      // extensions are enabled, SPV_INTEL_fp_conversions wins to preserve the
+      // pre-existing encoding.
+      bool IsSaturatedFP8 =
+          FPDesc.ConvOpCode == internal::OpClampConvertFToFINTEL &&
+          (FPDesc.DstEncoding == FPEncodingWrap::E4M3 ||
+           FPDesc.DstEncoding == FPEncodingWrap::E5M2) &&
+          BM->isAllowedToUseExtension(ExtensionID::SPV_EXT_float8) &&
+          !BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_fp_conversions);
+      if (IsSaturatedFP8)
+        FPDesc.ConvOpCode = OpFConvert;
       Value *Src = CI->getOperand(0);
       Type *LLVMSrcTy = Src->getType();
       Type *LLVMDstTy = CI->getType();
@@ -5654,6 +5669,10 @@ SPIRVValue *LLVMToSPIRVBase::transDirectCallInst(CallInst *CI,
         Ops.push_back(transValue(CI->getOperand(I), BB));
 
       SPIRVValue *Conv = BM->addInstTemplate(OC, BM->getIds(Ops), BB, DstTy);
+
+      if (IsSaturatedFP8)
+        Conv->addDecorate(new SPIRVDecorate(
+            DecorationSaturatedToLargestFloat8NormalConversionEXT, Conv));
 
       // Representable in LLVM FP types: bitcast is not needed.
       if (FPDesc.DstEncoding == FPEncodingWrap::IEEE754 ||

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -412,6 +412,8 @@ template <> inline void SPIRVMap<Decoration, SPIRVCapVec>::init() {
   ADD_VEC_INIT(DecorationInvariant, {CapabilityShader});
   ADD_VEC_INIT(DecorationConstant, {CapabilityKernel});
   ADD_VEC_INIT(DecorationSaturatedConversion, {CapabilityKernel});
+  ADD_VEC_INIT(DecorationSaturatedToLargestFloat8NormalConversionEXT,
+               {CapabilityFloat8EXT});
   ADD_VEC_INIT(DecorationStream, {CapabilityGeometryStreams});
   ADD_VEC_INIT(DecorationLocation, {CapabilityShader});
   ADD_VEC_INIT(DecorationComponent, {CapabilityShader});

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -4707,26 +4707,42 @@ public:
 _SPIRV_OP(FSigmoidINTEL)
 #undef _SPIRV_OP
 
-class SPIRVFPConversionINTELInstBase : public SPIRVInstTemplateBase {
+class SPIRVFPConversionFtoFINTELInstBase : public SPIRVInstTemplateBase {
 public:
   SPIRVCapVec getRequiredCapability() const override {
-    return getVec(internal::CapabilityFloatConversionsINTEL);
+    return getVec(internal::CapabilityFloatConversionsFtoFINTEL);
   }
 
   std::optional<ExtensionID> getRequiredExtension() const override {
     return ExtensionID::SPV_INTEL_fp_conversions;
   }
 };
-#define _SPIRV_OP(x, ...)                                                      \
-  typedef SPIRVInstTemplate<SPIRVFPConversionINTELInstBase,                    \
+
+#define _SPIRV_OP_FTOF(x, ...)                                                 \
+  typedef SPIRVInstTemplate<SPIRVFPConversionFtoFINTELInstBase,                \
                             internal::Op##x##INTEL, __VA_ARGS__>               \
       SPIRV##x##INTEL;
-_SPIRV_OP(ClampConvertFToF, true, 4, false)
-_SPIRV_OP(ClampConvertFToS, true, 4, false)
-_SPIRV_OP(StochasticRoundFToF, true, 5, true)
-_SPIRV_OP(ClampStochasticRoundFToF, true, 5, true)
-_SPIRV_OP(ClampStochasticRoundFToS, true, 5, true)
-#undef _SPIRV_OP
+_SPIRV_OP_FTOF(StochasticRoundFToF, true, 5, true)
+#undef _SPIRV_OP_FTOF
+
+class SPIRVFPConversionFtoSINTELInstBase : public SPIRVInstTemplateBase {
+public:
+  SPIRVCapVec getRequiredCapability() const override {
+    return getVec(internal::CapabilityFloatConversionsFtoSINTEL);
+  }
+
+  std::optional<ExtensionID> getRequiredExtension() const override {
+    return ExtensionID::SPV_INTEL_fp_conversions;
+  }
+};
+
+#define _SPIRV_OP_FTOS(x, ...)                                                 \
+  typedef SPIRVInstTemplate<SPIRVFPConversionFtoSINTELInstBase,                \
+                            internal::Op##x##INTEL, __VA_ARGS__>               \
+      SPIRV##x##INTEL;
+_SPIRV_OP_FTOS(ClampConvertFToS, true, 4, false)
+_SPIRV_OP_FTOS(ClampStochasticRoundFToS, true, 5, true)
+#undef _SPIRV_OP_FTOS
 
 class SPIRVFmaKHRInstBase : public SPIRVInstTemplateBase {
 public:

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -705,7 +705,10 @@ template <> inline void SPIRVMap<Capability, std::string>::init() {
   add(internal::CapabilityFloat4E2M1INTEL, "Float4E2M1INTEL");
   add(internal::CapabilityFloat4E2M1CooperativeMatrixINTEL,
       "Float4E2M1CooperativeMatrixINTEL");
-  add(internal::CapabilityFloatConversionsINTEL, "FloatConversionsINTEL");
+  add(internal::CapabilityFloatConversionsFtoFINTEL,
+      "FloatConversionsFtoFINTEL");
+  add(internal::CapabilityFloatConversionsFtoSINTEL,
+      "FloatConversionsFtoSINTEL");
   add(internal::CapabilityAtomicInt16CompareExchangeINTEL,
       "AtomicInt16CompareExchangeINTEL");
   add(internal::CapabilityInt16AtomicsINTEL, "Int16AtomicsINTEL");

--- a/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVNameMapEnum.h
@@ -92,6 +92,8 @@ template <> inline void SPIRVMap<Decoration, std::string>::init() {
   add(DecorationUniform, "Uniform");
   add(DecorationUniformId, "UniformId");
   add(DecorationSaturatedConversion, "SaturatedConversion");
+  add(DecorationSaturatedToLargestFloat8NormalConversionEXT,
+      "SaturatedToLargestFloat8NormalConversionEXT");
   add(DecorationStream, "Stream");
   add(DecorationLocation, "Location");
   add(DecorationComponent, "Component");

--- a/lib/SPIRV/libSPIRV/SPIRVOpCode.h
+++ b/lib/SPIRV/libSPIRV/SPIRVOpCode.h
@@ -123,10 +123,8 @@ inline bool isCvtOpCode(Op OpCode) {
 }
 
 inline bool isIntelCvtOpCode(Op OpCode) {
-  return OpCode == internal::OpClampConvertFToFINTEL ||
-         OpCode == internal::OpClampConvertFToSINTEL ||
+  return OpCode == internal::OpClampConvertFToSINTEL ||
          OpCode == internal::OpStochasticRoundFToFINTEL ||
-         OpCode == internal::OpClampStochasticRoundFToFINTEL ||
          OpCode == internal::OpClampStochasticRoundFToSINTEL;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVOpCodeEnumInternal.h
+++ b/lib/SPIRV/libSPIRV/SPIRVOpCodeEnumInternal.h
@@ -42,12 +42,8 @@ _SPIRV_OP_INTERNAL(ConvertHandleToSamplerINTEL,
 _SPIRV_OP_INTERNAL(ConvertHandleToSampledImageINTEL,
                    internal::ConvertHandleToSampledImageINTEL)
 _SPIRV_OP_INTERNAL(FSigmoidINTEL, internal::FSigmoidINTEL)
-_SPIRV_OP_INTERNAL(ClampConvertFToFINTEL,
-                   internal::OpClampConvertFToFINTEL)
 _SPIRV_OP_INTERNAL(StochasticRoundFToFINTEL,
                    internal::OpStochasticRoundFToFINTEL)
-_SPIRV_OP_INTERNAL(ClampStochasticRoundFToFINTEL,
-                   internal::OpClampStochasticRoundFToFINTEL)
 _SPIRV_OP_INTERNAL(ClampConvertFToSINTEL,
                    internal::OpClampConvertFToSINTEL)
 _SPIRV_OP_INTERNAL(ClampStochasticRoundFToSINTEL,

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -75,9 +75,7 @@ enum InternalOp {
   IOpCooperativeMatrixStoreCheckedINTEL = 6194,
   IOpCooperativeMatrixConstructCheckedINTEL = 6195,
   IOpTypeTaskSequenceINTEL = 6199,
-  IOpClampConvertFToFINTEL = 6216,
   IOpStochasticRoundFToFINTEL = 6217,
-  IOpClampStochasticRoundFToFINTEL = 6218,
   IOpClampStochasticRoundFToSINTEL = 6219,
   IOpCooperativeMatrixLoadOffsetINTEL = 6239,
   IOpCooperativeMatrixStoreOffsetINTEL = 6240,
@@ -116,7 +114,8 @@ enum InternalCapability {
   ICapabilityCooperativeMatrixCheckedInstructionsINTEL = 6192,
   ICapabilityFloat4E2M1INTEL = 6212,
   ICapabilityFloat4E2M1CooperativeMatrixINTEL = 6213,
-  ICapabilityFloatConversionsINTEL = 6215,
+  ICapabilityFloatConversionsFtoFINTEL = 6215,
+  ICapabilityFloatConversionsFtoSINTEL = 6216,
   ICapabilityBFloat16ArithmeticINTEL = 6226,
   ICapabilityCooperativeMatrixOffsetInstructionsINTEL = 6238,
   ICapabilityAtomicBFloat16AddINTEL = 6255,
@@ -248,11 +247,10 @@ _SPIRV_OP(Op, FSigmoidINTEL)
 _SPIRV_OP(Capability, Float4E2M1INTEL)
 _SPIRV_OP(Capability, Float4E2M1CooperativeMatrixINTEL)
 
-_SPIRV_OP(Capability, FloatConversionsINTEL)
-_SPIRV_OP(Op, ClampConvertFToFINTEL)
-_SPIRV_OP(Op, ClampConvertFToSINTEL)
+_SPIRV_OP(Capability, FloatConversionsFtoFINTEL)
 _SPIRV_OP(Op, StochasticRoundFToFINTEL)
-_SPIRV_OP(Op, ClampStochasticRoundFToFINTEL)
+_SPIRV_OP(Capability, FloatConversionsFtoSINTEL)
+_SPIRV_OP(Op, ClampConvertFToSINTEL)
 _SPIRV_OP(Op, ClampStochasticRoundFToSINTEL)
 #undef _SPIRV_OP
 

--- a/test/extensions/EXT/SPV_EXT_float8/clamp_convert_to_fp8.ll
+++ b/test/extensions/EXT/SPV_EXT_float8/clamp_convert_to_fp8.ll
@@ -1,0 +1,57 @@
+; Clamping FP-to-FP8 conversions: when SPV_EXT_float8 is enabled, the
+; __builtin_spirv_ClampConvert<Src>To<E4M3|E5M2>INTEL names map to OpFConvert
+; decorated with SaturatedToLargestFloat8NormalConversionEXT, and round-trip
+; back to the same builtin names.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_EXT_float8,+SPV_KHR_bfloat16
+; TODO: RUNx: spirv-val %t.spv (system spirv-val predates Float8EXT)
+; RUN: llvm-spirv %t.spv --to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -r -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: Capability Float16Buffer
+; CHECK-SPIRV-DAG: Capability Float8EXT
+; CHECK-SPIRV-DAG: Extension "SPV_EXT_float8"
+
+; CHECK-SPIRV-DAG: TypeFloat [[#HalfTy:]] 16 {{$}}
+; CHECK-SPIRV-DAG: TypeFloat [[#BF16Ty:]] 16 0
+; CHECK-SPIRV-DAG: TypeFloat [[#E4M3Ty:]] 8 4214
+; CHECK-SPIRV-DAG: TypeFloat [[#E5M2Ty:]] 8 4215
+
+; CHECK-SPIRV-DAG: Decorate [[#E4M3FromHalf:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV-DAG: Decorate [[#E5M2FromHalf:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV-DAG: Decorate [[#E4M3FromBF:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV-DAG: Decorate [[#E5M2FromBF:]] SaturatedToLargestFloat8NormalConversionEXT
+
+; CHECK-SPIRV: FunctionParameter [[#HalfTy]] [[#H:]]
+; CHECK-SPIRV: FunctionParameter [[#BF16Ty]] [[#B:]]
+; CHECK-SPIRV: FConvert [[#E4M3Ty]] [[#E4M3FromHalf]] [[#H]]
+; CHECK-SPIRV: FConvert [[#E5M2Ty]] [[#E5M2FromHalf]] [[#H]]
+; CHECK-SPIRV: FConvert [[#E4M3Ty]] [[#E4M3FromBF]] [[#B]]
+; CHECK-SPIRV: FConvert [[#E5M2Ty]] [[#E5M2FromBF]] [[#B]]
+
+; CHECK-LLVM: call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half
+; CHECK-LLVM: call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half
+; CHECK-LLVM: call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat
+; CHECK-LLVM: call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_func void @test(half %h, bfloat %b) {
+entry:
+  %h_e4m3 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half %h)
+  %h_e5m2 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half %h)
+  %b_e4m3 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat %b)
+  %b_e5m2 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat %b)
+  store i8 %h_e4m3, ptr addrspace(1) null
+  store i8 %h_e5m2, ptr addrspace(1) null
+  store i8 %b_e4m3, ptr addrspace(1) null
+  store i8 %b_e5m2, ptr addrspace(1) null
+  ret void
+}
+
+declare spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half)
+declare spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half)
+declare spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat)
+declare spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat)

--- a/test/extensions/EXT/SPV_EXT_float8/conversions_matrix.ll
+++ b/test/extensions/EXT/SPV_EXT_float8/conversions_matrix.ll
@@ -28,7 +28,7 @@
 ; CHECK-SPIRV: Bitcast [[#Int8MatrixTy]] [[#]] [[#Conv]]
 
 ; CHECK-LLVM: %[[#M:]] = call spir_func target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) @_Z26__spirv_CompositeConstructDh(half 0xH0000)
-; CHECK-LLVM: call target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) %[[#M]])
+; CHECK-LLVM: call spir_func target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) %[[#M]])
 
 ; ModuleID = 'test.bc'
 target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024-G1"
@@ -38,14 +38,14 @@ target triple = "spir-unknown-unknown"
 define spir_func void @int4_hf8() #0 {
 entry:
   %0 = call spir_func target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) @_Z26__spirv_CompositeConstructDh(half 0.0) #0
-  %1 = call target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) %0)
+  %1 = call spir_func target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) %0)
   ret void
 }
 
 ; Function Attrs: nounwind
 declare spir_func target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2) @_Z26__spirv_CompositeConstructDh(half) #0
 
-declare target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2))
+declare spir_func target("spirv.CooperativeMatrixKHR", i8, 3, 12, 12, 2) @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTPU3AS144__spirv_CooperativeMatrixKHR__half_3_12_12_2(target("spirv.CooperativeMatrixKHR", half, 3, 12, 12, 2))
 
 attributes #0 = { nounwind }
 

--- a/test/extensions/EXT/SPV_EXT_float8/conversions_scalar_vector.ll
+++ b/test/extensions/EXT/SPV_EXT_float8/conversions_scalar_vector.ll
@@ -62,12 +62,12 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e4m3_hf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8 1)
 ; CHECK-LLVM: ret half %[[#Call]]
 
 define spir_func half @e4m3_hf16_scalar() {
 entry:
-  %0 = call half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8 1)
+  %0 = call spir_func half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8 1)
   ret half %0
 }
 
@@ -79,12 +79,12 @@ declare dso_local spir_func half @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTc(i8)
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e4m3_hf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTDv8_c(<8 x i8> splat (i8 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTDv8_c(<8 x i8> splat (i8 1))
 ; CHECK-LLVM: ret <8 x half> %[[#Call]]
 
 define spir_func <8 x half> @e4m3_hf16_vector() {
 entry:
-  %0 = call <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
+  %0 = call spir_func <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
   ret <8 x half> %0
 }
 
@@ -96,12 +96,12 @@ declare dso_local spir_func <8 x half> @_Z36__builtin_spirv_ConvertE4M3ToFP16EXT
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e5m2_hf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8 1)
 ; CHECK-LLVM: ret half %[[#Call]]
 
 define spir_func half @e5m2_hf16_scalar() {
 entry:
-  %0 = call half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8 1)
+  %0 = call spir_func half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8 1)
   ret half %0
 }
 
@@ -113,12 +113,12 @@ declare dso_local spir_func half @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTc(i8)
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e5m2_hf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTDv8_c(<8 x i8> splat (i8 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTDv8_c(<8 x i8> splat (i8 1))
 ; CHECK-LLVM: ret <8 x half> %[[#Call]]
 
 define spir_func <8 x half> @e5m2_hf16_vector() {
 entry:
-  %0 = call <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
+  %0 = call spir_func <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
   ret <8 x half> %0
 }
 
@@ -130,12 +130,12 @@ declare dso_local spir_func <8 x half> @_Z36__builtin_spirv_ConvertE5M2ToFP16EXT
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e4m3_bf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8 1)
 ; CHECK-LLVM: ret bfloat %[[#Call]]
 
 define spir_func bfloat @e4m3_bf16_scalar() {
 entry:
-  %0 = call bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8 1)
+  %0 = call spir_func bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8 1)
   ret bfloat %0
 }
 
@@ -147,12 +147,12 @@ declare dso_local spir_func bfloat @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTc(i8
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e4m3_bf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTDv8_c(<8 x i8> splat (i8 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTDv8_c(<8 x i8> splat (i8 1))
 ; CHECK-LLVM: ret <8 x bfloat> %[[#Call]]
 
 define spir_func <8 x bfloat> @e4m3_bf16_vector() {
 entry:
-  %0 = call <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
+  %0 = call spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
   ret <8 x bfloat> %0
 }
 
@@ -164,12 +164,12 @@ declare dso_local spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE4M3ToBF16E
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e5m2_bf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8 1)
 ; CHECK-LLVM: ret bfloat %[[#Call]]
 
 define spir_func bfloat @e5m2_bf16_scalar() {
 entry:
-  %0 = call bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8 1)
+  %0 = call spir_func bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8 1)
   ret bfloat %0
 }
 
@@ -181,12 +181,12 @@ declare dso_local spir_func bfloat @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTc(i8
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: e5m2_bf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTDv8_c(<8 x i8> splat (i8 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTDv8_c(<8 x i8> splat (i8 1))
 ; CHECK-LLVM: ret <8 x bfloat> %[[#Call]]
 
 define spir_func <8 x bfloat> @e5m2_bf16_vector() {
 entry:
-  %0 = call <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
+  %0 = call spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16EXTDv8_i(<8 x i8> <i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1, i8 1>)
   ret <8 x bfloat> %0
 }
 
@@ -198,12 +198,12 @@ declare dso_local spir_func <8 x bfloat> @_Z36__builtin_spirv_ConvertE5M2ToBF16E
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: hf16_e4m3_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half 0xH3C00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half 0xH3C00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_e4m3_scalar() {
 entry:
-  %0 = call i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half 0xH3C00)
+  %0 = call spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half 0xH3C00)
   ret i8 %0
 }
 
@@ -215,12 +215,12 @@ declare dso_local spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDh(half)
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: hf16_e4m3_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv8_Dh(<8 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv8_Dh(<8 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @hf16_e4m3_vector() {
 entry:
-  %0 = call <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv8_Dh(<8 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>)
+  %0 = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv8_Dh(<8 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>)
   ret <8 x i8> %0
 }
 
@@ -232,12 +232,12 @@ declare dso_local spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE4M3EXTDv
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: hf16_e5m2_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half 0xH3C00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half 0xH3C00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_e5m2_scalar() {
 entry:
-  %0 = call i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half 0xH3C00)
+  %0 = call spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half 0xH3C00)
   ret i8 %0
 }
 
@@ -249,12 +249,12 @@ declare dso_local spir_func i8 @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDh(half)
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: hf16_e5m2_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv8_Dh(<8 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv8_Dh(<8 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @hf16_e5m2_vector() {
 entry:
-  %0 = call <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv8_Dh(<8 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>)
+  %0 = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv8_Dh(<8 x half> <half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00, half 0xH3C00>)
   ret <8 x i8> %0
 }
 
@@ -266,12 +266,12 @@ declare dso_local spir_func <8 x i8> @_Z36__builtin_spirv_ConvertFP16ToE5M2EXTDv
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: bf16_e4m3_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bfloat 0xR3F80)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bfloat 0xR3F80)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_e4m3_scalar() {
 entry:
-  %0 = call i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bfloat 0xR3F80)
+  %0 = call spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bfloat 0xR3F80)
   ret i8 %0
 }
 
@@ -283,12 +283,12 @@ declare dso_local spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDF16b(bf
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: bf16_e4m3_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv8_DF16b(<8 x bfloat> splat (bfloat 0xR3F80))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv8_DF16b(<8 x bfloat> splat (bfloat 0xR3F80))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @bf16_e4m3_vector() {
 entry:
-  %0 = call <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv8_DF16b(<8 x bfloat> <bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80>)
+  %0 = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv8_DF16b(<8 x bfloat> <bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80>)
   ret <8 x i8> %0
 }
 
@@ -300,12 +300,12 @@ declare dso_local spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE4M3EXTDv
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: bf16_e5m2_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bfloat 0xR3F80)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bfloat 0xR3F80)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_e5m2_scalar() {
 entry:
-  %0 = call i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bfloat 0xR3F80)
+  %0 = call spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bfloat 0xR3F80)
   ret i8 %0
 }
 
@@ -317,12 +317,12 @@ declare dso_local spir_func i8 @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDF16b(bf
 ; CHECK-SPIRV: ReturnValue [[#Cast1]]
 
 ; CHECK-LLVM-LABEL: bf16_e5m2_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDv8_DF16b(<8 x bfloat> splat (bfloat 0xR3F80))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDv8_DF16b(<8 x bfloat> splat (bfloat 0xR3F80))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @bf16_e5m2_vector() {
 entry:
-  %0 = call <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDv8_DF16b(<8 x bfloat> <bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80>)
+  %0 = call spir_func <8 x i8> @_Z36__builtin_spirv_ConvertBF16ToE5M2EXTDv8_DF16b(<8 x bfloat> <bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80, bfloat 0xR3F80>)
   ret <8 x i8> %0
 }
 

--- a/test/extensions/INTEL/SPV_INTEL_int4/conversions_packed.ll
+++ b/test/extensions/INTEL/SPV_INTEL_int4/conversions_packed.ll
@@ -92,7 +92,7 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK-LLVM-LABEL: int4_e4m3_32
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i32 1 to <8 x i4>
-; CHECK-LLVM: %[[#Conv:]] = call <8 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv8_i(<8 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Conv:]] = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv8_i(<8 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <8 x i8> %[[#Conv]]
 
 ; Function Attrs: nounwind readnone
@@ -110,7 +110,7 @@ declare dso_local spir_func <8 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_32
-; CHECK-LLVM: %[[#Conv:]] = call <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv8_Dh(<8 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Conv:]] = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv8_Dh(<8 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: [[#Cast:]] = bitcast <8 x i4> %[[#Conv]] to i32
 ; CHECK-LLVM: ret i32 %[[#Cast]]
 
@@ -133,7 +133,7 @@ declare dso_local spir_func i32 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELi(<8 
 
 ; CHECK-LLVM-LABEL: int4_e4m3_8
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i8 1 to <2 x i4>
-; CHECK-LLVM: %[[#Conv:]] = call <2 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv2_i(<2 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Conv:]] = call spir_func <2 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv2_i(<2 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <2 x i8> %[[#Conv]]
 
 ; Function Attrs: nounwind readnone
@@ -151,7 +151,7 @@ declare dso_local spir_func <2 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_8
-; CHECK-LLVM: %[[#Conv:]] = call <2 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv2_Dh(<2 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Conv:]] = call spir_func <2 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv2_Dh(<2 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: [[#Cast:]] = bitcast <2 x i4> %[[#Conv]] to i8
 ; CHECK-LLVM: ret i8 %[[#Cast]]
 
@@ -174,7 +174,7 @@ declare dso_local spir_func i8 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELc(<2 x
 
 ; CHECK-LLVM-LABEL: int4_e4m3_16
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i16 1 to <4 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <4 x i8> %[[#Call]]
 
 define spir_func <4 x i8> @int4_e4m3_16() {
@@ -195,7 +195,7 @@ declare dso_local spir_func <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTEL
 
 ; CHECK-LLVM-LABEL: int4_e4m3_64
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i64 1 to <16 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <16 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv16_i(<16 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <16 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv16_i(<16 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <16 x i8> %[[#Call]]
 
 define spir_func <16 x i8> @int4_e4m3_64() {
@@ -216,7 +216,7 @@ declare dso_local spir_func <16 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTE
 
 ; CHECK-LLVM-LABEL: int4_e4m3_vec2xi8
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <2 x i8> splat (i8 1) to <4 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <4 x i8> %[[#Call]]
 
 define spir_func <4 x i8> @int4_e4m3_vec2xi8() {
@@ -235,13 +235,13 @@ declare dso_local spir_func <4 x i8> @_Z38__builtin_spirv_ConvertInt4ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_16
-; CHECK-LLVM: %[[#Call:]] = call <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <4 x i4> %[[#Call]] to i16
 ; CHECK-LLVM: ret i16 %[[#Cast]]
 
 define spir_func i16 @hf16_int4_16() {
 entry:
-  %0 = call i16 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i16 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i16 %0
 }
 
@@ -255,13 +255,13 @@ declare dso_local spir_func i16 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_D
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_64
-; CHECK-LLVM: %[[#Call:]] = call <16 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_Dh(<16 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <16 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_Dh(<16 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <16 x i4> %[[#Call]] to i64
 ; CHECK-LLVM: ret i64 %[[#Cast]]
 
 define spir_func i64 @hf16_int4_64() {
 entry:
-  %0 = call i64 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_Dh(<16 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i64 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_Dh(<16 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i64 %0
 }
 
@@ -275,13 +275,13 @@ declare dso_local spir_func i64 @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv16_
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_vec2xi8
-; CHECK-LLVM: %[[#Call:]] = call <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELDv4_Dh(<4 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <4 x i4> %[[#Call]] to <2 x i8>
 ; CHECK-LLVM: ret <2 x i8> %[[#Cast]]
 
 define spir_func <2 x i8> @hf16_int4_vec2xi8() {
 entry:
-  %0 = call <2 x i8> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELKDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func <2 x i8> @_Z38__builtin_spirv_ConvertFP16ToInt4INTELKDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
   ret <2 x i8> %0
 }
 

--- a/test/extensions/SPV_INTEL_float4/conversions_packed.ll
+++ b/test/extensions/SPV_INTEL_float4/conversions_packed.ll
@@ -90,7 +90,7 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_32
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i32 1 to <8 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @fp4e2m1_hf8_32() {
@@ -107,13 +107,13 @@ declare dso_local spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_32
-; CHECK-LLVM: %[[#Call:]] = call <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <8 x i4> %[[#Call]] to i32
 ; CHECK-LLVM: ret i32 %[[#Cast]]
 
 define spir_func i32 @hf16_fp4e2m1_32() {
 entry:
-  %0 = call i32 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i32 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i32 %0
 }
 
@@ -129,7 +129,7 @@ declare dso_local spir_func i32 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_D
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_8
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i8 1 to <2 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <2 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv2_i(<2 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <2 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv2_i(<2 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <2 x i8> %[[#Call]]
 
 define spir_func <2 x i8> @fp4e2m1_hf8_8() {
@@ -146,13 +146,13 @@ declare dso_local spir_func <2 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_8
-; CHECK-LLVM: %[[#Call:]] = call <2 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh(<2 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <2 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh(<2 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <2 x i4> %[[#Call]] to i8
 ; CHECK-LLVM: ret i8 %[[#Cast]]
 
 define spir_func i8 @hf16_fp4e2m1_8() {
 entry:
-  %0 = call i8 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh(<2 x half> <half 1.0, half 1.0>)
+  %0 = call spir_func i8 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh(<2 x half> <half 1.0, half 1.0>)
   ret i8 %0
 }
 
@@ -168,7 +168,7 @@ declare dso_local spir_func i8 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv2_Dh
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_16
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i16 1 to <4 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <4 x i8> %[[#Call]]
 
 define spir_func <4 x i8> @fp4e2m1_hf8_16() {
@@ -189,7 +189,7 @@ declare dso_local spir_func <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_64
 ; CHECK-LLVM: %[[#Cast:]] = bitcast i64 1 to <16 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <16 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv16_i(<16 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <16 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv16_i(<16 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <16 x i8> %[[#Call]]
 
 define spir_func <16 x i8> @fp4e2m1_hf8_64() {
@@ -210,7 +210,7 @@ declare dso_local spir_func <16 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTE
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_vec2xi8
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <2 x i8> splat (i8 1) to <4 x i4>
-; CHECK-LLVM: %[[#Call:]] = call <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv4_i(<4 x i4> %[[#Cast]])
 ; CHECK-LLVM: ret <4 x i8> %[[#Call]]
 
 define spir_func <4 x i8> @fp4e2m1_hf8_vec2xi8() {
@@ -229,13 +229,13 @@ declare dso_local spir_func <4 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_16
-; CHECK-LLVM: %[[#Call:]] = call <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <4 x i4> %[[#Call]] to i16
 ; CHECK-LLVM: ret i16 %[[#Cast]]
 
 define spir_func i16 @hf16_fp4e2m1_16() {
 entry:
-  %0 = call i16 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i16 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i16 %0
 }
 
@@ -249,13 +249,13 @@ declare dso_local spir_func i16 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_D
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_64
-; CHECK-LLVM: %[[#Call:]] = call <16 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_Dh(<16 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <16 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_Dh(<16 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <16 x i4> %[[#Call]] to i64
 ; CHECK-LLVM: ret i64 %[[#Cast]]
 
 define spir_func i64 @hf16_fp4e2m1_64() {
 entry:
-  %0 = call i64 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_Dh(<16 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func i64 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_Dh(<16 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
   ret i64 %0
 }
 
@@ -269,13 +269,13 @@ declare dso_local spir_func i64 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv16_
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_vec2xi8
-; CHECK-LLVM: %[[#Call:]] = call <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <4 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv4_Dh(<4 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: %[[#Cast:]] = bitcast <4 x i4> %[[#Call]] to <2 x i8>
 ; CHECK-LLVM: ret <2 x i8> %[[#Cast]]
 
 define spir_func <2 x i8> @hf16_fp4e2m1_vec2xi8() {
 entry:
-  %0 = call <2 x i8> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELKDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func <2 x i8> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELKDv4_Dh(<4 x half> <half 1.0, half 1.0, half 1.0, half 1.0>)
   ret <2 x i8> %0
 }
 

--- a/test/extensions/SPV_INTEL_float4/conversions_scalar_vector.ll
+++ b/test/extensions/SPV_INTEL_float4/conversions_scalar_vector.ll
@@ -71,12 +71,12 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @fp4e2m1_hf8_scalar() {
 entry:
-  %0 = call i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4 1)
+  %0 = call spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4 1)
   ret i8 %0
 }
 
@@ -89,12 +89,12 @@ declare dso_local spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELi(i4)
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf8_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> splat (i4 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> splat (i4 1))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @fp4e2m1_hf8_vector() {
 entry:
-  %0 = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
+  %0 = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
   ret <8 x i8> %0
 }
 
@@ -107,12 +107,12 @@ declare dso_local spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE4M3INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_bf8_scalar
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @fp4e2m1_bf8_scalar() {
 entry:
-  %0 = call i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4 1)
+  %0 = call spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4 1)
   ret i8 %0
 }
 
@@ -125,12 +125,12 @@ declare dso_local spir_func i8 @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELi(i4)
 ; CHECK-SPIRV: ReturnValue [[#Cast2]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_bf8_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELDv8_i(<8 x i4> splat (i4 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELDv8_i(<8 x i4> splat (i4 1))
 ; CHECK-LLVM: ret <8 x i8> %[[#Call]]
 
 define spir_func <8 x i8> @fp4e2m1_bf8_vector() {
 entry:
-  %0 = call <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
+  %0 = call spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
   ret <8 x i8> %0
 }
 
@@ -142,12 +142,12 @@ declare dso_local spir_func <8 x i8> @_Z38__builtin_spirv_ConvertE2M1ToE5M2INTEL
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4 1)
 ; CHECK-LLVM: ret half %[[#Call]]
 
 define spir_func half @fp4e2m1_hf16_scalar() {
 entry:
-  %0 = call half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4 1)
+  %0 = call spir_func half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4 1)
   ret half %0
 }
 
@@ -159,12 +159,12 @@ declare dso_local spir_func half @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELi(i4
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_hf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv8_i(<8 x i4> splat (i4 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv8_i(<8 x i4> splat (i4 1))
 ; CHECK-LLVM: ret <8 x half> %[[#Call]]
 
 define spir_func <8 x half> @fp4e2m1_hf16_vector() {
 entry:
-  %0 = call <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
+  %0 = call spir_func <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
   ret <8 x half> %0
 }
 
@@ -176,12 +176,12 @@ declare dso_local spir_func <8 x half> @_Z38__builtin_spirv_ConvertE2M1ToFP16INT
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_bf16_scalar
-; CHECK-LLVM: %[[#Call:]] = call bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(i4 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(i4 1)
 ; CHECK-LLVM: ret bfloat %[[#Call]]
 
 define spir_func bfloat @fp4e2m1_bf16_scalar() {
 entry:
-  %0 = call bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(i4 1)
+  %0 = call spir_func bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(i4 1)
   ret bfloat %0
 }
 
@@ -193,12 +193,12 @@ declare dso_local spir_func bfloat @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELi(
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: fp4e2m1_bf16_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELDv8_i(<8 x i4> splat (i4 1))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELDv8_i(<8 x i4> splat (i4 1))
 ; CHECK-LLVM: ret <8 x bfloat> %[[#Call]]
 
 define spir_func <8 x bfloat> @fp4e2m1_bf16_vector() {
 entry:
-  %0 = call <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
+  %0 = call spir_func <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16INTELDv8_i(<8 x i4> <i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1, i4 1>)
   ret <8 x bfloat> %0
 }
 
@@ -212,12 +212,12 @@ declare dso_local spir_func <8 x bfloat> @_Z38__builtin_spirv_ConvertE2M1ToBF16I
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_scalar
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(half 0xH3C00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(half 0xH3C00)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @hf16_fp4e2m1_scalar() {
 entry:
-  %0 = call i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(half 1.0)
+  %0 = call spir_func i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(half 1.0)
   ret i4 %0
 }
 
@@ -229,12 +229,12 @@ declare dso_local spir_func i4 @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDh(hal
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> splat (half 0xH3C00))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> splat (half 0xH3C00))
 ; CHECK-LLVM: ret <8 x i4> %[[#Call]]
 
 define spir_func <8 x i4> @hf16_fp4e2m1_vector() {
 entry:
-  %0 = call <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
+  %0 = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTELDv8_Dh(<8 x half> <half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0, half 1.0>)
   ret <8 x i4> %0
 }
 
@@ -246,12 +246,12 @@ declare dso_local spir_func <8 x i4> @_Z38__builtin_spirv_ConvertFP16ToE2M1INTEL
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_fp4e2m1_scalar
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(bfloat 0xR3F80)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(bfloat 0xR3F80)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @bf16_fp4e2m1_scalar() {
 entry:
-  %0 = call i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(bfloat 1.0)
+  %0 = call spir_func i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(bfloat 1.0)
   ret i4 %0
 }
 
@@ -263,12 +263,12 @@ declare dso_local spir_func i4 @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDF16b(
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_fp4e2m1_vector
-; CHECK-LLVM: %[[#Call:]] = call <8 x i4> @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDv8_DF16b(<8 x bfloat> splat (bfloat 0xR3F80))
+; CHECK-LLVM: %[[#Call:]] = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDv8_DF16b(<8 x bfloat> splat (bfloat 0xR3F80))
 ; CHECK-LLVM: ret <8 x i4> %[[#Call]]
 
 define spir_func <8 x i4> @bf16_fp4e2m1_vector() {
 entry:
-  %0 = call <8 x i4> @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDv8_DF16b(<8 x bfloat> <bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0>)
+  %0 = call spir_func <8 x i4> @_Z38__builtin_spirv_ConvertBF16ToE2M1INTELDv8_DF16b(<8 x bfloat> <bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0, bfloat 1.0>)
   ret <8 x i4> %0
 }
 

--- a/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions.ll
+++ b/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions.ll
@@ -1,6 +1,6 @@
 ; This tests checks if FP4 and FP8 conversions specified by
 ; __builtin_spirv_* external function calls translated correctly.
-; This test is for Clamp*, Stochastic*, ClampStochastic* conversions.
+; This test is for Stochastic*, ClampStochastic* conversions.
 ; Packed and vector conversions are tested for general case, this test is only
 ; for scalar
 
@@ -14,12 +14,8 @@
 
 ; CHECK-SPIRV-DAG: Capability Int4TypeINTEL
 ; CHECK-SPIRV-DAG: Capability Float8EXT
-; CHECK-SPIRV-DAG: Capability FloatConversionsINTEL
-
-; When SPV_INTEL_fp_conversions is enabled, ClampConvert<Src>To<E4M3|E5M2>INTEL
-; must use the OpClampConvertFToFINTEL encoding, not the SPV_EXT_float8
-; OpFConvert + SaturatedToLargestFloat8NormalConversionEXT form.
-; CHECK-SPIRV-NOT: SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV-DAG: Capability FloatConversionsFtoFINTEL
+; CHECK-SPIRV-DAG: Capability FloatConversionsFtoSINTEL
 
 ; CHECK-SPIRV-DAG: Extension "SPV_INTEL_int4"
 ; CHECK-SPIRV-DAG: Extension "SPV_EXT_float8"
@@ -30,6 +26,8 @@
 ; CHECK-SPIRV-DAG: Name [[#hf16_bf8_clamp:]] "hf16_bf8_clamp"
 ; CHECK-SPIRV-DAG: Name [[#bf16_hf8_clamp:]] "bf16_hf8_clamp"
 ; CHECK-SPIRV-DAG: Name [[#bf16_bf8_clamp:]] "bf16_bf8_clamp"
+; CHECK-SPIRV-DAG: Name [[#hf16_int4_clamp:]] "hf16_int4_clamp"
+; CHECK-SPIRV-DAG: Name [[#bf16_int4_clamp:]] "bf16_int4_clamp"
 
 ; CHECK-SPIRV-DAG: Name [[#hf16_bf8_stochastic:]] "hf16_bf8_stochastic"
 ; CHECK-SPIRV-DAG: Name [[#hf16_hf8_stochastic:]] "hf16_hf8_stochastic"
@@ -41,10 +39,22 @@
 ; CHECK-SPIRV-DAG: Name [[#bf16_int4_stochastic:]] "bf16_int4_stochastic"
 ; CHECK-SPIRV-DAG: Name [[#hf16_bf8_clamp_stochastic:]] "hf16_bf8_clamp_stochastic"
 ; CHECK-SPIRV-DAG: Name [[#bf16_bf8_clamp_stochastic:]] "bf16_bf8_clamp_stochastic"
+; CHECK-SPIRV-DAG: Name [[#hf16_hf8_clamp_stochastic:]] "hf16_hf8_clamp_stochastic"
+; CHECK-SPIRV-DAG: Name [[#bf16_hf8_clamp_stochastic:]] "bf16_hf8_clamp_stochastic"
 
 ; CHECK-SPIRV-DAG: Name [[#hf16_bf8_stochastic_last_seed:]] "hf16_bf8_stochastic_last_seed"
 ; CHECK-SPIRV-DAG: Name [[#hf16_int4_stochastic_last_seed:]] "hf16_int4_stochastic_last_seed"
 ; CHECK-SPIRV-DAG: Name [[#hf16_bf8_clamp_stochastic_last_seed:]] "hf16_bf8_clamp_stochastic_last_seed"
+
+; CHECK-SPIRV: Decorate [[#SatHfE4M3:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV: Decorate [[#SatHfE5M2:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV: Decorate [[#SatBfE4M3:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV: Decorate [[#SatBfE5M2:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV: Decorate [[#SatStHfE5M2:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV: Decorate [[#SatStBfE5M2:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV: Decorate [[#SatStHfE4M3:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV: Decorate [[#SatStBfE4M3:]] SaturatedToLargestFloat8NormalConversionEXT
+; CHECK-SPIRV: Decorate [[#SatStHfE5M2LS:]] SaturatedToLargestFloat8NormalConversionEXT
 
 ; CHECK-SPIRV-DAG: TypeInt [[#Int8Ty:]] 8 0
 ; CHECK-SPIRV-DAG: TypeInt [[#Int32Ty:]] 32 0
@@ -67,8 +77,8 @@ target triple = "spir-unknown-unknown"
 ; Followings tests are for clamp rounding
 
 ; CHECK-SPIRV: Function [[#]] [[#hf16_hf8_clamp]] [[#]]
-; CHECK-SPIRV: ClampConvertFToFINTEL [[#HFloat8Ty]] [[#Conv:]] [[#HalfConst]]
-; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#Conv]]
+; CHECK-SPIRV: FConvert [[#HFloat8Ty]] [[#SatHfE4M3]] [[#HalfConst]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatHfE4M3]]
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_hf8_clamp
@@ -84,8 +94,8 @@ entry:
 declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half)
 
 ; CHECK-SPIRV: Function [[#]] [[#hf16_bf8_clamp]] [[#]]
-; CHECK-SPIRV: ClampConvertFToFINTEL [[#BFloat8Ty]] [[#Conv:]] [[#HalfConst]]
-; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#Conv]]
+; CHECK-SPIRV: FConvert [[#BFloat8Ty]] [[#SatHfE5M2]] [[#HalfConst]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatHfE5M2]]
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp
@@ -101,8 +111,8 @@ entry:
 declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half)
 
 ; CHECK-SPIRV: Function [[#]] [[#bf16_hf8_clamp]] [[#]]
-; CHECK-SPIRV: ClampConvertFToFINTEL [[#HFloat8Ty]] [[#Conv:]] [[#BfloatConst]]
-; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#Conv]]
+; CHECK-SPIRV: FConvert [[#HFloat8Ty]] [[#SatBfE4M3]] [[#BfloatConst]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatBfE4M3]]
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_hf8_clamp
@@ -118,8 +128,8 @@ entry:
 declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat)
 
 ; CHECK-SPIRV: Function [[#]] [[#bf16_bf8_clamp]] [[#]]
-; CHECK-SPIRV: ClampConvertFToFINTEL [[#BFloat8Ty]] [[#Conv:]] [[#BfloatConst]]
-; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#Conv]]
+; CHECK-SPIRV: FConvert [[#BFloat8Ty]] [[#SatBfE5M2]] [[#BfloatConst]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatBfE5M2]]
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_bf8_clamp
@@ -236,6 +246,38 @@ entry:
 
 declare dso_local spir_func i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat, i32)
 
+; CHECK-SPIRV: Function [[#]] [[#hf16_int4_clamp]] [[#]]
+; CHECK-SPIRV: ClampConvertFToSINTEL [[#Int4Ty]] [[#Conv:]] [[#HalfConst]]
+; CHECK-SPIRV: ReturnValue [[#Conv]]
+
+; CHECK-LLVM-LABEL: hf16_int4_clamp
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z43__builtin_spirv_ClampConvertFP16ToInt4INTELDh(half 0xH3C00)
+; CHECK-LLVM: ret i4 %[[#Call]]
+
+define spir_func i4 @hf16_int4_clamp() {
+entry:
+  %0 = call spir_func i4 @_Z43__builtin_spirv_ClampConvertFP16ToInt4INTELDh(half 1.0)
+  ret i4 %0
+}
+
+declare dso_local spir_func i4 @_Z43__builtin_spirv_ClampConvertFP16ToInt4INTELDh(half)
+
+; CHECK-SPIRV: Function [[#]] [[#bf16_int4_clamp]] [[#]]
+; CHECK-SPIRV: ClampConvertFToSINTEL [[#Int4Ty]] [[#Conv:]] [[#BfloatConst]]
+; CHECK-SPIRV: ReturnValue [[#Conv]]
+
+; CHECK-LLVM-LABEL: bf16_int4_clamp
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z43__builtin_spirv_ClampConvertBF16ToInt4INTELDF16b(bfloat 0xR3F80)
+; CHECK-LLVM: ret i4 %[[#Call]]
+
+define spir_func i4 @bf16_int4_clamp() {
+entry:
+  %0 = call spir_func i4 @_Z43__builtin_spirv_ClampConvertBF16ToInt4INTELDF16b(bfloat 1.0)
+  ret i4 %0
+}
+
+declare dso_local spir_func i4 @_Z43__builtin_spirv_ClampConvertBF16ToInt4INTELDF16b(bfloat)
+
 ; CHECK-SPIRV: Function [[#]] [[#hf16_int4_stochastic]] [[#]]
 ; CHECK-SPIRV: ClampStochasticRoundFToSINTEL [[#Int4Ty]] [[#Conv:]] [[#HalfConst]] [[#Int32Const]]
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
@@ -269,8 +311,8 @@ entry:
 declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat, i32)
 
 ; CHECK-SPIRV: Function [[#]] [[#hf16_bf8_clamp_stochastic]] [[#]]
-; CHECK-SPIRV: ClampStochasticRoundFToFINTEL [[#BFloat8Ty]] [[#Conv:]] [[#HalfConst]] [[#Int32Const]]
-; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#Conv]]
+; CHECK-SPIRV: StochasticRoundFToFINTEL [[#BFloat8Ty]] [[#SatStHfE5M2]] [[#HalfConst]] [[#Int32Const]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatStHfE5M2]]
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp_stochastic
@@ -286,8 +328,8 @@ entry:
 declare dso_local spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half, i32)
 
 ; CHECK-SPIRV: Function [[#]] [[#bf16_bf8_clamp_stochastic]] [[#]]
-; CHECK-SPIRV: ClampStochasticRoundFToFINTEL [[#BFloat8Ty]] [[#Conv:]] [[#BfloatConst]] [[#Int32Const]]
-; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#Conv]]
+; CHECK-SPIRV: StochasticRoundFToFINTEL [[#BFloat8Ty]] [[#SatStBfE5M2]] [[#BfloatConst]] [[#Int32Const]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatStBfE5M2]]
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_bf8_clamp_stochastic
@@ -301,6 +343,40 @@ entry:
 }
 
 declare dso_local spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat, i32)
+
+; CHECK-SPIRV: Function [[#]] [[#hf16_hf8_clamp_stochastic]] [[#]]
+; CHECK-SPIRV: StochasticRoundFToFINTEL [[#HFloat8Ty]] [[#SatStHfE4M3]] [[#HalfConst]] [[#Int32Const]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatStHfE4M3]]
+; CHECK-SPIRV: ReturnValue [[#Cast]]
+
+; CHECK-LLVM-LABEL: hf16_hf8_clamp_stochastic
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE4M3INTELDhi(half 0xH3C00, i32 1)
+; CHECK-LLVM: ret i8 %[[#Call]]
+
+define spir_func i8 @hf16_hf8_clamp_stochastic() {
+entry:
+  %0 = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE4M3INTELDhi(half 1.0, i32 1)
+  ret i8 %0
+}
+
+declare dso_local spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE4M3INTELDhi(half, i32)
+
+; CHECK-SPIRV: Function [[#]] [[#bf16_hf8_clamp_stochastic]] [[#]]
+; CHECK-SPIRV: StochasticRoundFToFINTEL [[#HFloat8Ty]] [[#SatStBfE4M3]] [[#BfloatConst]] [[#Int32Const]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatStBfE4M3]]
+; CHECK-SPIRV: ReturnValue [[#Cast]]
+
+; CHECK-LLVM-LABEL: bf16_hf8_clamp_stochastic
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE4M3INTELDF16bi(bfloat 0xR3F80, i32 1)
+; CHECK-LLVM: ret i8 %[[#Call]]
+
+define spir_func i8 @bf16_hf8_clamp_stochastic() {
+entry:
+  %0 = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE4M3INTELDF16bi(bfloat 1.0, i32 1)
+  ret i8 %0
+}
+
+declare dso_local spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE4M3INTELDF16bi(bfloat, i32)
 
 ; CHECK-SPIRV: Function [[#]] [[#hf16_bf8_stochastic_last_seed]] [[#]]
 ; CHECK-SPIRV: Variable [[#]] [[#Ptr:]]
@@ -343,8 +419,8 @@ declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToIn
 
 ; CHECK-SPIRV: Function [[#]] [[#hf16_bf8_clamp_stochastic_last_seed]] [[#]]
 ; CHECK-SPIRV: Variable [[#]] [[#Ptr:]]
-; CHECK-SPIRV: ClampStochasticRoundFToFINTEL [[#BFloat8Ty]] [[#Conv:]] [[#HalfConst]] [[#Int32Const]] [[#Ptr]]
-; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#Conv]]
+; CHECK-SPIRV: StochasticRoundFToFINTEL [[#BFloat8Ty]] [[#SatStHfE5M2LS]] [[#HalfConst]] [[#Int32Const]] [[#Ptr]]
+; CHECK-SPIRV: Bitcast [[#Int8Ty]] [[#Cast:]] [[#SatStHfE5M2LS]]
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp_stochastic_last_seed

--- a/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions.ll
+++ b/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions.ll
@@ -67,12 +67,12 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_hf8_clamp
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 0xH3C00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 0xH3C00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_hf8_clamp() {
 entry:
-  %0 = call i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 1.0)
+  %0 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 1.0)
   ret i8 %0
 }
 
@@ -84,12 +84,12 @@ declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELD
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half 0xH3C00)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half 0xH3C00)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_clamp() {
 entry:
-  %0 = call i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half 1.0)
+  %0 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELDh(half 1.0)
   ret i8 %0
 }
 
@@ -101,12 +101,12 @@ declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE5M2INTELD
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_hf8_clamp
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat 0xR3F80)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat 0xR3F80)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_hf8_clamp() {
 entry:
-  %0 = call i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat 1.0)
+  %0 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELDF16b(bfloat 1.0)
   ret i8 %0
 }
 
@@ -118,12 +118,12 @@ declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE4M3INTELD
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_bf8_clamp
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat 0xR3F80)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat 0xR3F80)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_bf8_clamp() {
 entry:
-  %0 = call i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat 1.0)
+  %0 = call spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELDF16b(bfloat 1.0)
   ret i8 %0
 }
 
@@ -135,12 +135,12 @@ declare dso_local spir_func i8 @_Z43__builtin_spirv_ClampConvertBF16ToE5M2INTELD
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhi(half 0xH3C00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhi(half 0xH3C00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_stochastic() {
 entry:
-  %0 = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhi(half 1.0, i32 1)
+  %0 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhi(half 1.0, i32 1)
   ret i8 %0
 }
 
@@ -152,12 +152,12 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_hf8_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INTELDhi(half 0xH3C00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INTELDhi(half 0xH3C00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_hf8_stochastic() {
 entry:
-  %0 = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INTELDhi(half 1.0, i32 1)
+  %0 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INTELDhi(half 1.0, i32 1)
   ret i8 %0
 }
 
@@ -169,12 +169,12 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE4M3INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_bf8_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INTELDF16bi(bfloat 0xR3F80, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INTELDF16bi(bfloat 0xR3F80, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_bf8_stochastic() {
 entry:
-  %0 = call i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.0, i32 1)
   ret i8 %0
 }
 
@@ -186,12 +186,12 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE5M2INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_hf8_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INTELDF16bi(bfloat 0xR3F80, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INTELDF16bi(bfloat 0xR3F80, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_hf8_stochastic() {
 entry:
-  %0 = call i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INTELDF16bi(bfloat 1.0, i32 1)
   ret i8 %0
 }
 
@@ -203,12 +203,12 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundBF16ToE4M3INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_fp4e2m1_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 0xH3C00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 0xH3C00, i32 1)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @hf16_fp4e2m1_stochastic() {
 entry:
-  %0 = call i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 1.0, i32 1)
+  %0 = call spir_func i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 1.0, i32 1)
   ret i4 %0
 }
 
@@ -220,12 +220,12 @@ declare dso_local spir_func i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INT
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_fp4e2m1_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 0xR3F80, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 0xR3F80, i32 1)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @bf16_fp4e2m1_stochastic() {
 entry:
-  %0 = call i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 1.0, i32 1)
   ret i4 %0
 }
 
@@ -236,12 +236,12 @@ declare dso_local spir_func i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INT
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: hf16_int4_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhi(half 0xH3C00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhi(half 0xH3C00, i32 1)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @hf16_int4_stochastic() {
 entry:
-  %0 = call i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhs(half 1.0, i32 1)
+  %0 = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhs(half 1.0, i32 1)
   ret i4 %0
 }
 
@@ -252,12 +252,12 @@ declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToIn
 ; CHECK-SPIRV: ReturnValue [[#Conv]]
 
 ; CHECK-LLVM-LABEL: bf16_int4_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat 0xR3F80, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat 0xR3F80, i32 1)
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @bf16_int4_stochastic() {
 entry:
-  %0 = call i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToInt4INTELDF16bi(bfloat 1.0, i32 1)
   ret i4 %0
 }
 
@@ -269,12 +269,12 @@ declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToIn
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 0xH3C00, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 0xH3C00, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_clamp_stochastic() {
 entry:
-  %0 = call i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 1.0, i32 1)
+  %0 = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 1.0, i32 1)
   ret i8 %0
 }
 
@@ -286,12 +286,12 @@ declare dso_local spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5
 ; CHECK-SPIRV: ReturnValue [[#Cast]]
 
 ; CHECK-LLVM-LABEL: bf16_bf8_clamp_stochastic
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat 0xR3F80, i32 1)
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat 0xR3F80, i32 1)
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @bf16_bf8_clamp_stochastic() {
 entry:
-  %0 = call i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.0, i32 1)
+  %0 = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5M2INTELDF16bi(bfloat 1.0, i32 1)
   ret i8 %0
 }
 
@@ -305,13 +305,13 @@ declare dso_local spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundBF16ToE5
 
 ; CHECK-LLVM-LABEL: hf16_bf8_stochastic_last_seed
 ; CHECK-LLVM: %[[#Ptr:]] = alloca i32
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhiPi(half 0xH3C00, i32 1, ptr %[[#Ptr]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhiPi(half 0xH3C00, i32 1, ptr %[[#Ptr]])
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_stochastic_last_seed() {
 entry:
   %0 = alloca i32
-  %1 = call i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhiPi(half 1.0, i32 1, ptr %0)
+  %1 = call spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INTELDhiPi(half 1.0, i32 1, ptr %0)
   ret i8 %1
 }
 
@@ -324,13 +324,13 @@ declare dso_local spir_func i8 @_Z46__builtin_spirv_StochasticRoundFP16ToE5M2INT
 
 ; CHECK-LLVM-LABEL: hf16_int4_stochastic_last_seed
 ; CHECK-LLVM: %[[#Ptr:]] = alloca i32
-; CHECK-LLVM: %[[#Call:]] = call i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhiPi(half 0xH3C00, i32 1, ptr %[[#Ptr]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhiPi(half 0xH3C00, i32 1, ptr %[[#Ptr]])
 ; CHECK-LLVM: ret i4 %[[#Call]]
 
 define spir_func i4 @hf16_int4_stochastic_last_seed() {
 entry:
   %0 = alloca i32
-  %1 = call i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhiPi(half 1.0, i32 1, ptr %0)
+  %1 = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhiPi(half 1.0, i32 1, ptr %0)
   ret i4 %1
 }
 
@@ -344,13 +344,13 @@ declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToIn
 
 ; CHECK-LLVM-LABEL: hf16_bf8_clamp_stochastic_last_seed
 ; CHECK-LLVM: %[[#Ptr:]] = alloca i32
-; CHECK-LLVM: %[[#Call:]] = call i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhiPi(half 0xH3C00, i32 1, ptr %[[#Ptr]])
+; CHECK-LLVM: %[[#Call:]] = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhiPi(half 0xH3C00, i32 1, ptr %[[#Ptr]])
 ; CHECK-LLVM: ret i8 %[[#Call]]
 
 define spir_func i8 @hf16_bf8_clamp_stochastic_last_seed() {
 entry:
   %0 = alloca i32
-  %1 = call i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhiPi(half 1.0, i32 1, ptr %0)
+  %1 = call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhiPi(half 1.0, i32 1, ptr %0)
   ret i8 %1
 }
 

--- a/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions.ll
+++ b/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions.ll
@@ -16,6 +16,11 @@
 ; CHECK-SPIRV-DAG: Capability Float8EXT
 ; CHECK-SPIRV-DAG: Capability FloatConversionsINTEL
 
+; When SPV_INTEL_fp_conversions is enabled, ClampConvert<Src>To<E4M3|E5M2>INTEL
+; must use the OpClampConvertFToFINTEL encoding, not the SPV_EXT_float8
+; OpFConvert + SaturatedToLargestFloat8NormalConversionEXT form.
+; CHECK-SPIRV-NOT: SaturatedToLargestFloat8NormalConversionEXT
+
 ; CHECK-SPIRV-DAG: Extension "SPV_INTEL_int4"
 ; CHECK-SPIRV-DAG: Extension "SPV_EXT_float8"
 ; CHECK-SPIRV-DAG: Extension "SPV_INTEL_float4"

--- a/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_ftos.ll
+++ b/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_ftos.ll
@@ -1,0 +1,39 @@
+; Test that only the FloatConversionsFtoSINTEL capability is declared when
+; the module uses only OpClampConvertFToSINTEL / OpClampStochasticRoundFToSINTEL.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_int4,+SPV_INTEL_fp_conversions
+; RUN: llvm-spirv %t.spv -o %t.spt --to-text
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV --implicit-check-not="Capability FloatConversionsFtoFINTEL"
+; RUN: llvm-spirv %t.spv -o %t.rev.bc -r
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-SPIRV-DAG: Capability FloatConversionsFtoSINTEL
+; CHECK-SPIRV-DAG: Extension "SPV_INTEL_fp_conversions"
+
+; CHECK-SPIRV: ClampConvertFToSINTEL
+; CHECK-SPIRV: ClampStochasticRoundFToSINTEL
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir-unknown-unknown"
+
+; CHECK-LLVM-LABEL: hf16_int4_clamp
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z43__builtin_spirv_ClampConvertFP16ToInt4INTELDh(half 0xH3C00)
+define spir_func i4 @hf16_int4_clamp() {
+entry:
+  %0 = call spir_func i4 @_Z43__builtin_spirv_ClampConvertFP16ToInt4INTELDh(half 1.0)
+  ret i4 %0
+}
+
+declare dso_local spir_func i4 @_Z43__builtin_spirv_ClampConvertFP16ToInt4INTELDh(half)
+
+; CHECK-LLVM-LABEL: hf16_int4_stochastic
+; CHECK-LLVM: %[[#Call:]] = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhi(half 0xH3C00, i32 1)
+define spir_func i4 @hf16_int4_stochastic() {
+entry:
+  %0 = call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhs(half 1.0, i32 1)
+  ret i4 %0
+}
+
+declare dso_local spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELhs(half, i32)

--- a/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_spv_ir.ll
+++ b/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_spv_ir.ll
@@ -1,14 +1,14 @@
-; Test for conversions, that don't require special type interpretation.
+; Test for conversions between LLVM native types.
 
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_fp_conversions
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
-; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV --implicit-check-not="Capability FloatConversionsFtoSINTEL"
 ; RUN: llvm-spirv %t.spv -o %t.rev.bc -r --spirv-target-env=SPV-IR
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
-; CHECK-SPIRV-DAG: Capability FloatConversionsINTEL
+; CHECK-SPIRV-DAG: Capability FloatConversionsFtoFINTEL
 ; CHECK-SPIRV-DAG: Extension "SPV_INTEL_fp_conversions"
 ; CHECK-SPIRV-DAG: TypeFloat [[#HalfTy:]] 16
 ; CHECK-SPIRV-DAG: TypeFloat [[#FloatTy:]] 32
@@ -16,15 +16,11 @@
 ; CHECK-SPIRV-DAG: Constant [[#ShortTy]] [[#IntConst:]] 4
 ; CHECK-SPIRV-DAG: Constant [[#FloatTy]] [[#FPConst:]] 1065353216
 
-; CHECK-SPIRV: ClampConvertFToFINTEL [[#HalfTy]] [[#]] [[#FPConst]]
 ; CHECK-SPIRV: StochasticRoundFToFINTEL [[#HalfTy]] [[#]] [[#FPConst]] [[#IntConst]]
-; CHECK-SPIRV: ClampStochasticRoundFToFINTEL [[#HalfTy]] [[#]] [[#FPConst]] [[#IntConst]]
-; CHECK-SPIRV: ClampStochasticRoundFToFINTEL [[#HalfTy]] [[#]] [[#FPConst]] [[#IntConst]] [[#]]
+; CHECK-SPIRV: StochasticRoundFToFINTEL [[#HalfTy]] [[#]] [[#FPConst]] [[#IntConst]] [[#]]
 
-; CHECK-LLVM: call spir_func half @_Z35__spirv_ClampConvertFToFINTEL_Rhalff(float 1.000000e+00)
 ; CHECK-LLVM: call spir_func half @_Z38__spirv_StochasticRoundFToFINTEL_Rhalffs(float 1.000000e+00, i16 4)
-; CHECK-LLVM: call spir_func half @_Z43__spirv_ClampStochasticRoundFToFINTEL_Rhalffs(float 1.000000e+00, i16 4)
-; CHECK-LLVM: call spir_func half @_Z43__spirv_ClampStochasticRoundFToFINTEL_RhalffsPs(float 1.000000e+00, i16 4, ptr null)
+; CHECK-LLVM: call spir_func half @_Z38__spirv_StochasticRoundFToFINTEL_RhalffsPs(float 1.000000e+00, i16 4, ptr null)
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
@@ -32,17 +28,11 @@ target triple = "spir-unknown-unknown"
 ; Function Attrs: nounwind readnone
 define spir_func void @foo() {
 entry:
-  %0 = call spir_func half @_Z29__spirv_ClampConvertFToFINTELf(float 1.0)
-  %2 = call spir_func half @_Z32__spirv_StochasticRoundFToFINTELfs(float 1.0, i16 4)
-  %3 = call spir_func half @_Z37__spirv_ClampStochasticRoundFToFINTELfs(float 1.0, i16 4)
-  %5 = call spir_func half @_Z37__spirv_ClampStochasticRoundFToFINTELfsPs(float 1.0, i16 4, ptr null)
+  %0 = call spir_func half @_Z32__spirv_StochasticRoundFToFINTELfs(float 1.0, i16 4)
+  %1 = call spir_func half @_Z32__spirv_StochasticRoundFToFINTELfsPs(float 1.0, i16 4, ptr null)
   ret void
 }
 
-declare dso_local spir_func half @_Z29__spirv_ClampConvertFToFINTELf(float)
-
 declare dso_local spir_func half @_Z32__spirv_StochasticRoundFToFINTELfs(float, i16)
 
-declare dso_local spir_func half @_Z37__spirv_ClampStochasticRoundFToFINTELfs(float, i16)
-
-declare dso_local spir_func half @_Z37__spirv_ClampStochasticRoundFToFINTELfsPs(float, i16, ptr)
+declare dso_local spir_func half @_Z32__spirv_StochasticRoundFToFINTELfsPs(float, i16, ptr)


### PR DESCRIPTION
Backport of #3746, #3767, #3782.