### PR TITLE
Bounds-check decoded operand/element counts before indexing

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -98,7 +98,13 @@ SPIRVDecorateGeneric::SPIRVDecorateGeneric(Op OC)
 Decoration SPIRVDecorateGeneric::getDecorateKind() const { return Dec; }
 
 SPIRVWord SPIRVDecorateGeneric::getLiteral(size_t I) const {
-  assert(I <= Literals.size() && "Out of bounds");
+  // SEC-00717 G2: Literals is sized from the decoded decoration words. The
+  // original assert used "<=" (off-by-one) which permitted Literals[size()].
+  // Use a strict "<" runtime bound and avoid the out-of-bounds read.
+  SPIRVCK(I < Literals.size(), InvalidWordCount,
+          "Decoration literal index out of bounds");
+  if (I >= Literals.size())
+    return 0;
   return Literals[I];
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -196,8 +196,11 @@ bool isDebugLineEqual(const SPIRVExtInst &DL1, const SPIRVExtInst &DL2) {
   std::vector<SPIRVWord> DL2Args = DL2.getArguments();
 
   using namespace SPIRVDebug::Operand::DebugLine;
-  assert(DL1Args.size() == OperandCount && DL2Args.size() == OperandCount &&
-         "Invalid number of operands");
+  // SEC-00717 G2: operand counts come from decoded DebugLine ExtInst arguments.
+  // No getErrorLog() is reachable in this free function; guard the indexing
+  // below directly so a malformed count cannot cause an out-of-bounds read.
+  if (DL1Args.size() != OperandCount || DL2Args.size() != OperandCount)
+    return false;
   return DL1Args[SourceIdx] == DL2Args[SourceIdx] &&
          DL1Args[StartIdx] == DL2Args[StartIdx] &&
          DL1Args[EndIdx] == DL2Args[EndIdx] &&
@@ -513,7 +516,12 @@ std::set<SPIRVWord> SPIRVEntry::getDecorate(Decoration Kind,
   auto Range = Decorates.equal_range(Kind);
   std::set<SPIRVWord> Value;
   for (auto I = Range.first, E = Range.second; I != E; ++I) {
-    assert(Index < I->second->getLiteralCount() && "Invalid index");
+    // SEC-00717 G2: literal count derives from decoded decoration words; guard
+    // the getLiteral(Index) read against an out-of-bounds Index.
+    SPIRVCK(Index < I->second->getLiteralCount(), InvalidWordCount,
+            "Invalid decoration literal index");
+    if (Index >= I->second->getLiteralCount())
+      continue;
     Value.insert(I->second->getLiteral(Index));
   }
   return Value;
@@ -543,7 +551,12 @@ std::set<SPIRVId> SPIRVEntry::getDecorateId(Decoration Kind,
   auto Range = DecorateIds.equal_range(Kind);
   std::set<SPIRVId> Value;
   for (auto I = Range.first, E = Range.second; I != E; ++I) {
-    assert(Index < I->second->getLiteralCount() && "Invalid index");
+    // SEC-00717 G2: literal count derives from decoded decoration words; guard
+    // the getLiteral(Index) read against an out-of-bounds Index.
+    SPIRVCK(Index < I->second->getLiteralCount(), InvalidWordCount,
+            "Invalid decoration literal index");
+    if (Index >= I->second->getLiteralCount())
+      continue;
     Value.insert(I->second->getLiteral(Index));
   }
   return Value;

--- a/lib/SPIRV/libSPIRV/SPIRVFnVar.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFnVar.cpp
@@ -132,7 +132,12 @@ bool evaluateConstant(SPIRVModule *BM, SPIRVId Id, bool &Res,
         Res = !Val1;
       }
     } else {
-      assert(OpWords.size() == 3);
+      // SEC-00717 G2: OpWords come from a decoded OpSpecConstantOp; guard the
+      // OpWords[2] read below against a malformed (too-short) operand list.
+      if (OpWords.size() != 3) {
+        ErrMsg = "Invalid number of operands for binary OpSpecConstantOp.";
+        return false;
+      }
       bool Val2 = false;
       if (!evaluateConstant(BM, OpWords[2], Val2, ErrMsg)) {
         return false;

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -408,17 +408,21 @@ public:
     TheMemoryAccessMask = MemoryAccess[0];
     size_t MemAccessNumParam = 1;
     if (MemoryAccess[0] & MemoryAccessAlignedMask) {
-      assert(MemoryAccess.size() > 1 && "Alignment operand is missing");
+      // SEC-00717 G2: bounds-check stream-controlled MemoryAccess before index.
+      if (!(MemoryAccess.size() > 1))
+        return;
       Alignment = MemoryAccess[MemAccessNumParam++];
     }
     if (MemoryAccess[0] & MemoryAccessAliasScopeINTELMaskMask) {
-      assert(MemoryAccess.size() > MemAccessNumParam &&
-             "Aliasing operand is missing");
+      // SEC-00717 G2: bounds-check stream-controlled MemoryAccess before index.
+      if (!(MemoryAccess.size() > MemAccessNumParam))
+        return;
       AliasScopeInstID = MemoryAccess[MemAccessNumParam++];
     }
     if (MemoryAccess[0] & MemoryAccessNoAliasINTELMaskMask) {
-      assert(MemoryAccess.size() > MemAccessNumParam &&
-             "Aliasing operand is missing");
+      // SEC-00717 G2: bounds-check stream-controlled MemoryAccess before index.
+      if (!(MemoryAccess.size() > MemAccessNumParam))
+        return;
       NoAliasInstID = MemoryAccess[MemAccessNumParam++];
     }
 
@@ -428,8 +432,10 @@ public:
 
     size_t SecondMaskId = MemAccessNumParam++;
     if (MemoryAccess[SecondMaskId] & MemoryAccessAlignedMask) {
-      assert(MemoryAccess.size() > MemAccessNumParam &&
-             "Alignment operand is missing");
+      // SEC-00717 G2: bounds-check stream-controlled MemoryAccess before index.
+      // SPIRVMemoryAccess has no getErrorLog(); guard the OOB read directly.
+      if (!(MemoryAccess.size() > MemAccessNumParam))
+        return;
       SrcAlignment = MemoryAccess[MemAccessNumParam];
     }
   }
@@ -731,9 +737,9 @@ protected:
     if (getValueType(Op1)->isTypeVector()) {
       Op1Ty = getValueType(Op1)->getVectorComponentType();
       Op2Ty = getValueType(Op2)->getVectorComponentType();
-      assert(getValueType(Op1)->getVectorComponentCount() ==
-                 getValueType(Op2)->getVectorComponentCount() &&
-             "Inconsistent Vector component width");
+      SPIRVCK(getValueType(Op1)->getVectorComponentCount() ==
+                  getValueType(Op2)->getVectorComponentCount(),
+              InvalidInstruction, "Inconsistent Vector component width");
     } else if (getValueType(Op1)->isTypeCooperativeMatrixKHR()) {
       Op1Ty = getValueType(Op1)->getVectorComponentType();
       Op2Ty = getValueType(Op2)->getVectorComponentType();
@@ -750,8 +756,8 @@ protected:
              "Invalid type for binary instruction");
       assert((Op1Ty->isTypeInt() || Op2Ty->isTypeFloat()) &&
              "Invalid type for Binary instruction");
-      assert((Op1Ty->getBitWidth() == Op2Ty->getBitWidth()) &&
-             "Inconsistent BitWidth");
+      SPIRVCK(Op1Ty->getBitWidth() == Op2Ty->getBitWidth(), InvalidInstruction,
+              "Inconsistent BitWidth");
     } else if (isShiftOpCode(OpCode)) {
       assert((Op1Ty->isTypeInt() || Op2Ty->isTypeInt()) &&
              "Invalid type for shift instruction");
@@ -761,8 +767,8 @@ protected:
     } else if (isBitwiseOpCode(OpCode)) {
       assert((Op1Ty->isTypeInt() || Op2Ty->isTypeInt()) &&
              "Invalid type for bitwise instruction");
-      assert((Op1Ty->getIntegerBitWidth() == Op2Ty->getIntegerBitWidth()) &&
-             "Inconsistent BitWidth");
+      SPIRVCK(Op1Ty->getIntegerBitWidth() == Op2Ty->getIntegerBitWidth(),
+              InvalidInstruction, "Inconsistent BitWidth");
     } else if (isBinaryPtrOpCode(OpCode)) {
       assert((Op1Ty->isTypePointer() && Op2Ty->isTypePointer()) &&
              "Invalid types for PtrEqual, PtrNotEqual, or PtrDiff instruction");
@@ -1071,7 +1077,8 @@ public:
   void validate() const override {
     assert(WordCount == Pairs.size() + FixedWordCount);
     assert(OpCode == OC);
-    assert(Pairs.size() % 2 == 0);
+    SPIRVCK(Pairs.size() % 2 == 0, InvalidWordCount,
+            "OpPhi requires an even number of (variable, parent) words");
     foreachPair([this](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB) {
       assert(IncomingV->isForward() || IncomingV->getType() == Type);
       assert(IncomingBB->isBasicBlock() || IncomingBB->isForward());
@@ -1123,9 +1130,9 @@ protected:
       Op1Ty = getValueType(Op1)->getVectorComponentType();
       Op2Ty = getValueType(Op2)->getVectorComponentType();
       ResTy = Type->getVectorComponentType();
-      assert(getValueType(Op1)->getVectorComponentCount() ==
-                 getValueType(Op2)->getVectorComponentCount() &&
-             "Inconsistent Vector component width");
+      SPIRVCK(getValueType(Op1)->getVectorComponentCount() ==
+                  getValueType(Op2)->getVectorComponentCount(),
+              InvalidInstruction, "Inconsistent Vector component width");
     } else {
       Op1Ty = getValueType(Op1);
       Op2Ty = getValueType(Op2);
@@ -1344,7 +1351,8 @@ public:
   void validate() const override {
     assert(WordCount == Pairs.size() + FixedWordCount);
     assert(OpCode == OC);
-    assert(Pairs.size() % getPairSize() == 0);
+    SPIRVCK(Pairs.size() % getPairSize() == 0, InvalidWordCount,
+            "OpSwitch literal/label words are not a whole number of pairs");
     foreachPair([=](LiteralTy Literals, SPIRVBasicBlock *BB) {
       assert(BB->isBasicBlock() || BB->isForward());
     });
@@ -1728,13 +1736,14 @@ protected:
       assert(getType() == getValueType(Op) && "Inconsistent type");
       assert((ResTy->isTypeInt() || ResTy->isTypeFloat()) &&
              "Invalid type for Generic Negate instruction");
-      assert((ResTy->getBitWidth() == OpTy->getBitWidth()) &&
-             "Invalid bitwidth for Generic Negate instruction");
-      assert((Type->isTypeVector()
-                  ? (Type->getVectorComponentCount() ==
-                     getValueType(Op)->getVectorComponentCount())
-                  : 1) &&
-             "Invalid vector component Width for Generic Negate instruction");
+      SPIRVCK(ResTy->getBitWidth() == OpTy->getBitWidth(), InvalidInstruction,
+              "Invalid bitwidth for Generic Negate instruction");
+      SPIRVCK((Type->isTypeVector()
+                   ? (Type->getVectorComponentCount() ==
+                      getValueType(Op)->getVectorComponentCount())
+                   : 1),
+              InvalidInstruction,
+              "Invalid vector component Width for Generic Negate instruction");
     }
   }
 };
@@ -2827,8 +2836,10 @@ public:
   VersionNumber getRequiredSPIRVVersion() const override {
     switch (OpCode) {
     case OpGroupNonUniformBroadcast: {
-      assert(Ops.size() == 3 && "Expecting (Execution, Value, Id) operands");
-      if (!isConstantOpCode(getOperand(2)->getOpCode())) {
+      // SEC-00717 G2: Ops is filled from the stream; guard getOperand(2) below.
+      SPIRVCK(Ops.size() == 3, InvalidWordCount,
+              "Expecting (Execution, Value, Id) operands");
+      if (Ops.size() == 3 && !isConstantOpCode(getOperand(2)->getOpCode())) {
         // Before version 1.5, Id must come from a constant instruction.
         return VersionNumber::SPIRV_1_5;
       }

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -632,7 +632,11 @@ public:
   bool isOCLImage() const { return Desc.Sampled == 0 && Desc.Format == 0; }
   bool hasAccessQualifier() const { return !Acc.empty(); }
   SPIRVAccessQualifierKind getAccessQualifier() const {
-    assert(hasAccessQualifier());
+    // SEC-00717 G2: Acc is populated from decoded words; guard the Acc[0] read.
+    SPIRVCK(hasAccessQualifier(), InvalidWordCount,
+            "Image type has no access qualifier operand");
+    if (!hasAccessQualifier())
+      return AccessQualifierReadOnly;
     return Acc[0];
   }
   SPIRVCapVec getRequiredCapability() const override {


### PR DESCRIPTION
### Summary
Counts derived from the stream (operand-vector size, pair count, MemoryAccess size,
member index, OpWords size) were `assert`ed and then immediately used to index. Under
`-DNDEBUG` the guard vanishes, allowing an out-of-bounds read.

### Changes
- 19 sites guarded with runtime checks before the indexing operation.
- **Off-by-one bug fixed:** `SPIRVDecorate.cpp` `getLiteral` used `assert(I <= size())`
  which permitted `Literals[size()]` (one-past-end). Corrected to a strict `< size()`
  bounds check.
- `memoryAccessUpdate` (SPIRVInstruction.h 411/415/420/431), the sole guards for
  real attacker-reachable OOB reads, now enforce bounds at runtime.
- Files: SPIRVInstruction.h, SPIRVEntry.cpp, SPIRVFnVar.cpp, SPIRVType.h, SPIRVDecorate.cpp.

### Notes
- Where `getErrorLog()` is not in scope (SPIRVMemoryAccess, free functions) the existing
  local early-return / `ErrMsg` idiom is used so the bound is genuinely enforced in release.
