### PR TITLE
Enforce decoder stream-state integrity at runtime

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -406,7 +406,7 @@ public:
   /// Checks the integrity of the object.
   virtual void validate() const {
     assert(Module && "Invalid module");
-    assert(OpCode != OpNop && "Invalid op code");
+    SPIRVCK(OpCode != OpNop, InvalidModule, "Invalid op code");
     assert((!hasId() || isValidId(Id)) && "Invalid Id");
     if (WordCount > 65535) {
       std::stringstream SS;

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -2531,7 +2531,11 @@ static SPIRVEntry *parseAndCreateSPIRVEntry(SPIRVWord &WordCount, Op &OpCode,
     M.setInvalid();
   }
 
-  assert(!IS.bad() && !IS.fail() && "SPIRV stream fails");
+  if (!M.getErrorLog().checkError(!IS.bad() && !IS.fail(),
+                                  SPIRVEC_InvalidModule, "SPIRV stream fails",
+                                  "!IS.bad() && !IS.fail()")) {
+    M.setInvalid();
+  }
   return Entry;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -171,7 +171,9 @@ const SPIRVDecoder &operator>>(const SPIRVDecoder &I, std::string &Str) {
   Count = Count ? 4 - Count : 0;
   for (; Count; --Count) {
     I.IS >> Ch;
-    assert(Ch == '\0' && "Invalid string in SPIRV");
+    const_cast<SPIRVModule &>(I.M).getErrorLog().checkError(
+        Ch == '\0', SPIRVEC_InvalidModule, "Invalid string in SPIRV",
+        "Ch == '\\0'");
   }
   SPIRVDBG(spvdbgs() << "Read string: \"" << Str << "\"\n");
   return I;
@@ -206,7 +208,9 @@ bool SPIRVDecoder::getWordCountAndOpCode() {
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
   if (SPIRVUseTextFormat) {
     *this >> WordCount;
-    assert(!IS.bad() && "SPIRV stream is bad");
+    if (!M.getErrorLog().checkError(!IS.bad(), SPIRVEC_InvalidModule,
+                                    "SPIRV stream is bad", "!IS.bad()"))
+      return false;
     if (IS.fail()) {
       WordCount = 0;
       OpCode = OpNop;
@@ -224,7 +228,9 @@ bool SPIRVDecoder::getWordCountAndOpCode() {
 #ifdef _SPIRV_SUPPORT_TEXT_FMT
   }
 #endif
-  assert(!IS.bad() && "SPIRV stream is bad");
+  if (!M.getErrorLog().checkError(!IS.bad(), SPIRVEC_InvalidModule,
+                                  "SPIRV stream is bad", "!IS.bad()"))
+    return false;
   if (IS.fail()) {
     WordCount = 0;
     OpCode = OpNop;
@@ -291,14 +297,20 @@ SPIRVEntry *SPIRVDecoder::getEntry() {
     M.setInvalid();
   }
 
-  assert(!IS.bad() && !IS.fail() && "SPIRV stream fails");
+  if (!M.getErrorLog().checkError(!IS.bad() && !IS.fail(),
+                                  SPIRVEC_InvalidModule, "SPIRV stream fails",
+                                  "!IS.bad() && !IS.fail()")) {
+    M.setInvalid();
+  }
   return Entry;
 }
 
 void SPIRVDecoder::validate() const {
-  assert(OpCode != OpNop && "Invalid op code");
+  M.getErrorLog().checkError(OpCode != OpNop, SPIRVEC_InvalidModule,
+                             "Invalid op code", "OpCode != OpNop");
   assert(WordCount && "Invalid word count");
-  assert(!IS.bad() && "Bad iInput stream");
+  M.getErrorLog().checkError(!IS.bad(), SPIRVEC_InvalidModule,
+                             "Bad input stream", "!IS.bad()");
 }
 
 // Skip \param n words in SPIR-V binary stream.


### PR DESCRIPTION
### Summary
Asserts on raw decoder stream state, `!IS.bad()/!IS.fail()`, string padding byte
`== '\0'`, `OpCode != OpNop`, are the truncated/garbage-input signals. Compiled out
under `-DNDEBUG`, decoding continues on a broken stream.

### Changes
- 8 sites converted. Bool-returning decoder helpers (`getWordCountAndOpCode`) now
  `return false` on bad stream; entry-returning decoders log + `setInvalid()`.
- Files: SPIRVStream.cpp, SPIRVModule.cpp, SPIRVEntry.h. Error code `InvalidModule`.

### Notes
- `SPIRVDecoder`/free-function scope has no `getErrorLog()` member, so the existing
  manual `M.getErrorLog().checkError(...)` form is used (mirrors current code).
