### PR TITLE
Validate decoded WordCount consistency at runtime

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVAsm.h
+++ b/lib/SPIRV/libSPIRV/SPIRVAsm.h
@@ -46,7 +46,7 @@ public:
 protected:
   void validate() const override {
     SPIRVEntry::validate();
-    assert(WordCount > FixedWC);
+    SPIRVCK(WordCount > FixedWC, InvalidWordCount, "");
     assert(OpCode == OC);
   }
   _SPIRV_DEF_ENCDEC2(Id, Target)
@@ -86,7 +86,7 @@ protected:
   _SPIRV_DEF_ENCDEC6(Type, Id, FunctionType, Target, Instructions, Constraints)
   void validate() const override {
     SPIRVValue::validate();
-    assert(WordCount > FixedWC);
+    SPIRVCK(WordCount > FixedWC, InvalidWordCount, "");
     assert(OpCode == OC);
   }
   SPIRVAsmTargetINTEL *Target = nullptr;
@@ -130,7 +130,7 @@ protected:
   _SPIRV_DEF_ENCDEC4(Type, Id, Asm, Args)
   void validate() const override {
     SPIRVInstruction::validate();
-    assert(WordCount >= FixedWC);
+    SPIRVCK(WordCount >= FixedWC, InvalidWordCount, "");
     assert(OpCode == OC);
     assert(getBasicBlock() && "Invalid BB");
     assert(getBasicBlock()->getModule() == Asm->getModule());

--- a/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -230,7 +230,7 @@ public:
   void setWordCount(SPIRVWord) override;
   void validate() const override {
     SPIRVDecorateGeneric::validate();
-    assert(WordCount == Literals.size() + FixedWC);
+    SPIRVCK(WordCount == Literals.size() + FixedWC, InvalidWordCount, "");
   }
 };
 
@@ -260,7 +260,7 @@ public:
   void setWordCount(SPIRVWord) override;
   void validate() const override {
     SPIRVDecorateGeneric::validate();
-    assert(WordCount == Literals.size() + FixedWC);
+    SPIRVCK(WordCount == Literals.size() + FixedWC, InvalidWordCount, "");
   }
 };
 
@@ -389,7 +389,7 @@ public:
 
   void validate() const override {
     SPIRVDecorateGeneric::validate();
-    assert(WordCount == Literals.size() + FixedWC);
+    SPIRVCK(WordCount == Literals.size() + FixedWC, InvalidWordCount, "");
   }
 
 protected:
@@ -425,7 +425,7 @@ protected:
   SPIRVDecorateVec Decorations;
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == WC);
+    SPIRVCK(WordCount == WC, InvalidWordCount, "");
   }
 };
 

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -723,7 +723,8 @@ void SPIRVName::decode(std::istream &I) {
 }
 
 void SPIRVName::validate() const {
-  assert(WordCount == getSizeInWords(Str) + 2 && "Incorrect word count");
+  SPIRVCK(WordCount == getSizeInWords(Str) + 2, InvalidWordCount,
+          "Incorrect word count");
 }
 
 _SPIRV_IMP_ENCDEC2(SPIRVString, Id, Str)
@@ -739,7 +740,7 @@ void SPIRVLine::decode(std::istream &I) {
 
 void SPIRVLine::validate() const {
   assert(OpCode == OpLine);
-  assert(WordCount == 4);
+  SPIRVCK(WordCount == 4, InvalidWordCount, "");
   assert(get<SPIRVEntry>(FileName)->getOpCode() == OpString);
   assert(Line != SPIRVWORD_MAX);
   assert(Column != SPIRVWORD_MAX);
@@ -748,7 +749,7 @@ void SPIRVLine::validate() const {
 
 void SPIRVMemberName::validate() const {
   assert(OpCode == OpMemberName);
-  assert(WordCount == getSizeInWords(Str) + FixedWC);
+  SPIRVCK(WordCount == getSizeInWords(Str) + FixedWC, InvalidWordCount, "");
   assert(get<SPIRVEntry>(Target)->getOpCode() == OpTypeStruct);
   assert(MemberNumber < get<SPIRVTypeStruct>(Target)->getStructMemberCount());
 }
@@ -858,8 +859,8 @@ SPIRVType *SPIRVTypeStructContinuedINTEL::getMemberType(size_t I) const {
 }
 
 void SPIRVModuleProcessed::validate() const {
-  assert(WordCount == FixedWC + getSizeInWords(ProcessStr) &&
-         "Incorrect word count in OpModuleProcessed");
+  SPIRVCK(WordCount == FixedWC + getSizeInWords(ProcessStr), InvalidWordCount,
+          "Incorrect word count in OpModuleProcessed");
 }
 
 void SPIRVModuleProcessed::encode(spv_ostream &O) const {

--- a/lib/SPIRV/libSPIRV/SPIRVFnVar.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFnVar.h
@@ -181,10 +181,10 @@ protected:
     size_t TypeOpCode = this->getType()->getOpCode();
     assert(TypeOpCode != OpTypeVoid && "Conditional copy type cannot be void");
     (void)(TypeOpCode);
-    assert(Constituents.size() % 2 == 0 &&
-           "Conditional copy requires condition-operand pairs");
-    assert(Constituents.size() >= 2 &&
-           "Conditional copy requires at least one condition-operand pair");
+    SPIRVCK(Constituents.size() % 2 == 0, InvalidWordCount,
+            "Conditional copy requires condition-operand pairs");
+    SPIRVCK(Constituents.size() >= 2, InvalidWordCount,
+            "Conditional copy requires at least one condition-operand pair");
   }
   std::vector<SPIRVId> Constituents;
 };

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -517,7 +517,8 @@ protected:
   void validate() const override {
     SPIRVValue::validate();
     assert(isValid(StorageClass));
-    SPIRVCK(Initializer.size() == 1 || Initializer.empty(), InvalidWordCount, "");
+    SPIRVCK(Initializer.size() == 1 || Initializer.empty(), InvalidWordCount,
+            "");
     assert(getType()->isTypePointer());
   }
   void setWordCount(SPIRVWord TheWordCount) override {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -248,7 +248,7 @@ public:
   /// \return Expected number of operands. If the instruction has variable
   /// number of words, return the minimum.
   SPIRVWord getExpectedNumOperands() const {
-    assert(WordCount > 0 && "Word count not initialized");
+    SPIRVCK(WordCount > 0, InvalidWordCount, "Word count not initialized");
     auto Exp = WordCount - 1;
     if (hasId())
       --Exp;
@@ -517,7 +517,7 @@ protected:
   void validate() const override {
     SPIRVValue::validate();
     assert(isValid(StorageClass));
-    assert(Initializer.size() == 1 || Initializer.empty());
+    SPIRVCK(Initializer.size() == 1 || Initializer.empty(), InvalidWordCount, "");
     assert(getType()->isTypePointer());
   }
   void setWordCount(SPIRVWord TheWordCount) override {
@@ -588,7 +588,7 @@ public:
 protected:
   void validate() const override {
     SPIRVVariableBase::validate();
-    assert(DataType.size() == 1 || DataType.empty());
+    SPIRVCK(DataType.size() == 1 || DataType.empty(), InvalidWordCount, "");
   }
   void setWordCount(SPIRVWord TheWordCount) override {
     SPIRVEntry::setWordCount(TheWordCount);
@@ -949,7 +949,7 @@ protected:
   _SPIRV_DEF_ENCDEC1(TargetLabelId)
   void validate() const override {
     SPIRVInstruction::validate();
-    assert(WordCount == 2);
+    SPIRVCK(WordCount == 2, InvalidWordCount, "");
     assert(OpCode == OC);
     assert(getTargetLabel()->isLabel() || getTargetLabel()->isForward());
   }
@@ -999,8 +999,9 @@ protected:
   _SPIRV_DEF_ENCDEC4(ConditionId, TrueLabelId, FalseLabelId, BranchWeights)
   void validate() const override {
     SPIRVInstruction::validate();
-    assert(WordCount == FixedWC || WordCount == FixedWC + 2);
-    assert(WordCount == BranchWeights.size() + FixedWC);
+    SPIRVCK(WordCount == FixedWC || WordCount == FixedWC + 2, InvalidWordCount,
+            "");
+    SPIRVCK(WordCount == BranchWeights.size() + FixedWC, InvalidWordCount, "");
     assert(OpCode == OC);
     assert(getCondition()->isForward() ||
            getCondition()->getType()->isTypeBool());
@@ -1069,7 +1070,7 @@ public:
   }
   _SPIRV_DEF_ENCDEC3(Type, Id, Pairs)
   void validate() const override {
-    assert(WordCount == Pairs.size() + FixedWordCount);
+    SPIRVCK(WordCount == Pairs.size() + FixedWordCount, InvalidWordCount, "");
     assert(OpCode == OC);
     assert(Pairs.size() % 2 == 0);
     foreachPair([this](SPIRVValue *IncomingV, SPIRVBasicBlock *IncomingBB) {
@@ -1342,7 +1343,7 @@ public:
   }
   _SPIRV_DEF_ENCDEC3(Select, Default, Pairs)
   void validate() const override {
-    assert(WordCount == Pairs.size() + FixedWordCount);
+    SPIRVCK(WordCount == Pairs.size() + FixedWordCount, InvalidWordCount, "");
     assert(OpCode == OC);
     assert(Pairs.size() % getPairSize() == 0);
     foreachPair([=](LiteralTy Literals, SPIRVBasicBlock *BB) {
@@ -2568,7 +2569,7 @@ protected:
   _SPIRV_DEF_ENCDEC3(ExecScope, MemScope, MemSema)
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == 4);
+    SPIRVCK(WordCount == 4, InvalidWordCount, "");
     SPIRVInstruction::validate();
   }
 
@@ -2683,7 +2684,7 @@ protected:
                      Stride, Event)
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == WC);
+    SPIRVCK(WordCount == WC, InvalidWordCount, "");
     SPIRVInstruction::validate();
   }
   SPIRVId ExecScope;

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -297,7 +297,8 @@ SPIRVEntry *SPIRVDecoder::getEntry() {
 
 void SPIRVDecoder::validate() const {
   assert(OpCode != OpNop && "Invalid op code");
-  assert(WordCount && "Invalid word count");
+  M.getErrorLog().checkError(WordCount, SPIRVEC_InvalidWordCount,
+                             "Invalid word count", "WordCount");
   assert(!IS.bad() && "Bad iInput stream");
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -286,7 +286,7 @@ protected:
   }
 
   void decode(std::istream &I) override {
-    assert(WordCount == 3 || WordCount == 4);
+    SPIRVCK(WordCount == 3 || WordCount == 4, InvalidWordCount, "");
     auto Decoder = getDecoder(I);
     Decoder >> Id >> BitWidth;
     if (WordCount == 4)
@@ -661,7 +661,7 @@ protected:
                      Desc.MS, Desc.Sampled, Desc.Format, Acc)
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == FixedWC + Acc.size());
+    SPIRVCK(WordCount == FixedWC + Acc.size(), InvalidWordCount, "");
     assert(SampledType != SPIRVID_INVALID && "Invalid sampled type");
     assert(Desc.Dim <= 5);
     assert(Desc.Depth <= 2);
@@ -669,7 +669,7 @@ protected:
     assert(Desc.MS <= 1);
     assert(Desc.Sampled <= 2);
     assert(Desc.Format <= ImageFormatR64i);
-    assert(Acc.size() <= 1);
+    SPIRVCK(Acc.size() <= 1, InvalidWordCount, "");
   }
   void setWordCount(SPIRVWord TheWC) override {
     SPIRVEntry::setWordCount(TheWC);
@@ -697,7 +697,7 @@ protected:
   _SPIRV_DEF_ENCDEC1(Id)
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == FixedWC);
+    SPIRVCK(WordCount == FixedWC, InvalidWordCount, "");
   }
 };
 
@@ -724,7 +724,7 @@ protected:
   _SPIRV_DEF_ENCDEC2(Id, ImgTy)
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == FixedWC);
+    SPIRVCK(WordCount == FixedWC, InvalidWordCount, "");
     assert(ImgTy && ImgTy->isTypeImage());
   }
 };
@@ -743,7 +743,7 @@ protected:
   _SPIRV_DEF_ENCDEC1(Id)
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == FixedWC);
+    SPIRVCK(WordCount == FixedWC, InvalidWordCount, "");
   }
 };
 
@@ -1041,7 +1041,7 @@ protected:
   _SPIRV_DEF_ENCDEC2(Id, AccessKind)
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == FixedWC + (AccessKind ? 1 : 0));
+    SPIRVCK(WordCount == FixedWC + (AccessKind ? 1 : 0), InvalidWordCount, "");
   }
   void setWordCount(SPIRVWord TheWC) override {
     if (TheWC > FixedWC)
@@ -1087,7 +1087,7 @@ protected:
 
   void validate() const override {
     assert(OpCode == OC);
-    assert(WordCount == FixedWC);
+    SPIRVCK(WordCount == FixedWC, InvalidWordCount, "");
     assert(ImgTy && ImgTy->isTypeImage());
   }
 };

--- a/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -201,7 +201,7 @@ protected:
   }
   void validate() const override {
     SPIRVValue::validate();
-    assert(NumWords >= 1 && "Invalid constant size");
+    SPIRVCK(NumWords >= 1, InvalidWordCount, "Invalid constant size");
   }
   void encode(spv_ostream &O) const override {
     getEncoder(O) << Type << Id;
@@ -427,7 +427,7 @@ protected:
   void validate() const override {
     SPIRVValue::validate();
     assert(OpCode == OC);
-    assert(WordCount == WC);
+    SPIRVCK(WordCount == WC, InvalidWordCount, "");
     assert(Type->isTypeSampler());
   }
   _SPIRV_DEF_ENCDEC5(Type, Id, AddrMode, Normalized, FilterMode)
@@ -465,7 +465,7 @@ protected:
   void validate() const override {
     SPIRVValue::validate();
     assert(OpCode == OC);
-    assert(WordCount == WC);
+    SPIRVCK(WordCount == WC, InvalidWordCount, "");
     assert(Type->isTypePipeStorage());
   }
   _SPIRV_DEF_ENCDEC5(Type, Id, PacketSize, PacketAlign, Capacity)


### PR DESCRIPTION
### Summary
`assert(WordCount == FixedWC + ...)` / `WordCount > FixedWC` / `NumWords >= 1` and sizes
of vectors resized from the decoded word count. `WordCount` comes straight from the
stream header; compiled out, wrong-sized buffers are used downstream.

### Changes
- 35 sites converted to `SPIRVCK(..., InvalidWordCount)`, the exact pattern already
  used by the `setWordCount` overrides and SPIRVType.h:676/799/880.
- Includes SPIRVInstruction.h:251 `WordCount > 0` guard that feeds `WordCount - 1`
  (prevents unsigned underflow).
- Files: SPIRVInstruction.h, SPIRVType.h, SPIRVDecorate.h, SPIRVValue.h, SPIRVEntry.cpp,
  SPIRVAsm.h, SPIRVFnVar.h, SPIRVStream.cpp.
