### PR TITLE
[LLVM-15] .clang-tidy: align disabled checks with main

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,27 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
-WarningsAsErrors: 'llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
+Checks: |
+  -*,
+  clang-diagnostic-*,
+  llvm-*,
+  -llvm-header-guard,
+  misc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  readability-identifier-naming
+WarningsAsErrors: |
+  llvm-*,
+  -llvm-header-guard,
+  misc-*,
+  -misc-const-correctness,
+  -misc-include-cleaner,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
+  readability-identifier-naming
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase


### PR DESCRIPTION
The `release/15.x` `.clang-tidy` predates the upstream disabling of `misc-const-correctness` and `misc-non-private-member-variables-in-classes`, so it reports diagnostics that are suppressed project-wide on every newer branch. Align the disabled-check list with `main`.