### PR TITLE
Fix type confusion in SPIRVEntry downcasts

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVBasicBlock.h
+++ b/lib/SPIRV/libSPIRV/SPIRVBasicBlock.h
@@ -54,6 +54,8 @@ public:
 
   SPIRVBasicBlock() : SPIRVValue(OpLabel), ParentF(NULL) { setAttr(); }
 
+  static bool classof(const SPIRVEntry *E) { return E->getOpCode() == OpLabel; }
+
   SPIRVDecoder getDecoder(std::istream &IS) override;
   SPIRVFunction *getParent() const { return ParentF; }
   size_t getNumInst() const { return InstVec.size(); }

--- a/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -269,7 +269,7 @@ public:
 
   bool exist(SPIRVId) const;
   template <class T> T *get(SPIRVId TheId) const {
-    // NOLINTNEXTLINE
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
     return static_cast<T *>(getEntry(TheId));
   }
   SPIRVEntry *getEntry(SPIRVId) const;
@@ -598,6 +598,7 @@ public:
       : SPIRVEntry(M, FixedWC + getSizeInWords(TheStr), OC, TheId),
         Str(TheStr) {}
   SPIRVString() : SPIRVEntry(OC) {}
+  static bool classof(const SPIRVEntry *E) { return E->getOpCode() == OC; }
   _SPIRV_DCL_ENCDEC
   const std::string &getStr() const { return Str; }
 
@@ -966,6 +967,15 @@ private:
   SPIRVCapabilityKind Kind;
 };
 
+// Checked downcast: asserts T::classof(E) to catch type confusion on malformed
+// SPIR-V inputs. Use instead of bcast<T> when T is a concrete leaf type and
+// E comes from an untrusted/decoded SPIR-V module.
+template <class T> T *opcodeCast(SPIRVEntry *E) {
+  assert(E && T::classof(E) && "SPIR-V type confusion: unexpected OpCode");
+  return static_cast<T *>(E);
+}
+
+// NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
 template <class T> T *bcast(SPIRVEntry *E) { return static_cast<T *>(E); }
 
 template <spv::Op OC> bool isa(SPIRVEntry *E) {

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.h
@@ -96,6 +96,9 @@ public:
       : SPIRVValue(OpFunction), FuncType(NULL),
         FCtrlMask(FunctionControlMaskNone) {}
 
+  static bool classof(const SPIRVEntry *E) {
+    return E->getOpCode() == OpFunction;
+  }
   SPIRVDecoder getDecoder(std::istream &IS) override;
   SPIRVTypeFunction *getFunctionType() const { return FuncType; }
   SPIRVWord getFuncCtlMask() const { return FCtrlMask; }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -2320,10 +2320,12 @@ spv_ostream &operator<<(spv_ostream &O, SPIRVModule &M) {
   O << MI.ConditionalEntryPointVec;
 
   for (auto &I : MI.EntryPointVec)
-    MI.get<SPIRVFunction>(I->getTargetId())->encodeExecutionModes(O);
+    opcodeCast<SPIRVFunction>(MI.getEntry(I->getTargetId()))
+        ->encodeExecutionModes(O);
 
   for (auto &I : MI.ConditionalEntryPointVec)
-    MI.get<SPIRVFunction>(I->getTargetId())->encodeExecutionModes(O);
+    opcodeCast<SPIRVFunction>(MI.getEntry(I->getTargetId()))
+        ->encodeExecutionModes(O);
 
   O << MI.StringVec;
 

--- a/lib/SPIRV/libSPIRV/SPIRVType.h
+++ b/lib/SPIRV/libSPIRV/SPIRVType.h
@@ -45,6 +45,7 @@
 #define SPIRV_LIBSPIRV_SPIRVTYPE_H
 
 #include "SPIRVEntry.h"
+#include "SPIRVOpCode.h"
 #include "SPIRVStream.h"
 
 #include <cassert>
@@ -60,6 +61,10 @@ public:
       : SPIRVEntry(M, TheWordCount, TheOpCode, TheId) {}
   // Incomplete constructor
   SPIRVType(Op TheOpCode) : SPIRVEntry(TheOpCode) {}
+
+  static bool classof(const SPIRVEntry *E) {
+    return isTypeOpCode(E->getOpCode());
+  }
 
   SPIRVType *getArrayElementType() const;
   uint64_t getArrayLength() const;


### PR DESCRIPTION
Replace unchecked static_cast in bcast<T>() and get<T>() with an opcode_cast<T>() helper that asserts T::classof() before casting