### PR TITLE
Fix invalid constant composite of untyped pointer variables

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1388,6 +1388,16 @@ SPIRVValue *LLVMToSPIRVBase::transConstantUse(Constant *C,
   return BM->addUnaryInst(OpBitcast, ExpectedType, Trans, nullptr);
 }
 
+SPIRVValue *LLVMToSPIRVBase::transConstantConstituent(Constant *C,
+                                                      SPIRVType *ExpectedType) {
+  SPIRVValue *Trans = transConstantUse(C, ExpectedType);
+  // A variable is not a constant, so it cannot be a constituent of a constant
+  // composite directly. Wrap it so the composite refers to a constant.
+  return Trans->isVariable()
+             ? BM->addUnaryInst(OpBitcast, Trans->getType(), Trans, nullptr)
+             : Trans;
+}
+
 SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
   SPIRVType *ExpectedType = transScavengedType(V);
   if (isa<ConstantPointerNull>(V))
@@ -1427,10 +1437,10 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
       if (ConstFP->isNullValue())
         return BM->addNullConstant(ExpectedType);
       SPIRVType *InnerTy = ExpectedType->getScalarType();
-      SPIRVValue *ScalarVal =
-          transConstantUse(ConstantFP::get(V->getType()->getScalarType(),
-                                           ConstFP->getValueAPF()),
-                           InnerTy);
+      SPIRVValue *ScalarVal = transConstantConstituent(
+          ConstantFP::get(V->getType()->getScalarType(),
+                          ConstFP->getValueAPF()),
+          InnerTy);
       unsigned NumElts = cast<FixedVectorType>(V->getType())->getNumElements();
       std::vector<SPIRVValue *> BV(NumElts, ScalarVal);
       return BM->addCompositeConstant(ExpectedType, BV);
@@ -1444,7 +1454,8 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     SPIRVType *InnerTy = ExpectedType->getArrayElementType();
     std::vector<SPIRVValue *> BV;
     for (unsigned I = 0, E = ConstDA->getNumElements(); I != E; ++I)
-      BV.push_back(transConstantUse(ConstDA->getElementAsConstant(I), InnerTy));
+      BV.push_back(
+          transConstantConstituent(ConstDA->getElementAsConstant(I), InnerTy));
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
@@ -1452,7 +1463,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     SPIRVType *InnerTy = ExpectedType->getArrayElementType();
     std::vector<SPIRVValue *> BV;
     for (auto I = ConstA->op_begin(), E = ConstA->op_end(); I != E; ++I)
-      BV.push_back(transConstantUse(cast<Constant>(*I), InnerTy));
+      BV.push_back(transConstantConstituent(cast<Constant>(*I), InnerTy));
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
@@ -1460,7 +1471,8 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     SPIRVType *InnerTy = ExpectedType->getScalarType();
     std::vector<SPIRVValue *> BV;
     for (unsigned I = 0, E = ConstDV->getNumElements(); I != E; ++I)
-      BV.push_back(transConstantUse(ConstDV->getElementAsConstant(I), InnerTy));
+      BV.push_back(
+          transConstantConstituent(ConstDV->getElementAsConstant(I), InnerTy));
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
@@ -1468,7 +1480,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     SPIRVType *InnerTy = ExpectedType->getScalarType();
     std::vector<SPIRVValue *> BV;
     for (auto I = ConstV->op_begin(), E = ConstV->op_end(); I != E; ++I)
-      BV.push_back(transConstantUse(cast<Constant>(*I), InnerTy));
+      BV.push_back(transConstantConstituent(cast<Constant>(*I), InnerTy));
     return BM->addCompositeConstant(ExpectedType, BV);
   }
 
@@ -1509,7 +1521,7 @@ SPIRVValue *LLVMToSPIRVBase::transConstant(Value *V) {
     std::vector<SPIRVValue *> BV;
     for (auto I = ConstV->op_begin(), E = ConstV->op_end(); I != E; ++I) {
       SPIRVType *InnerTy = ExpectedType->getStructMemberType(BV.size());
-      BV.push_back(transConstantUse(cast<Constant>(*I), InnerTy));
+      BV.push_back(transConstantConstituent(cast<Constant>(*I), InnerTy));
     }
     return BM->addCompositeConstant(ExpectedType, BV);
   }

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -153,9 +153,13 @@ public:
                                     ArrayRef<SPIRVTypeFloat *> FloatSPIRVTypes,
                                     SPIRVWord FlagsLiteral);
   SPIRVValue *transConstant(Value *V);
-  /// Translate a reference to a constant in a constant expression. This may
-  /// involve inserting extra bitcasts to correct type issues.
+  /// Translate a use of a constant where a pointer initializer is expected,
+  /// inserting bitcasts or access chains to reconcile the value's natural type
+  /// with ExpectedType. A variable may be referenced directly here.
   SPIRVValue *transConstantUse(Constant *V, SPIRVType *ExpectedType);
+  /// Translate a constituent of a constant composite. A variable is not a
+  /// constant, so it is wrapped so that the composite refers to a constant.
+  SPIRVValue *transConstantConstituent(Constant *V, SPIRVType *ExpectedType);
   SPIRVValue *transValue(Value *V, SPIRVBasicBlock *BB,
                          bool CreateForward = true,
                          FuncTransMode FuncTrans = FuncTransMode::Decl);

--- a/test/extensions/KHR/SPV_KHR_untyped_pointers/globals.ll
+++ b/test/extensions/KHR/SPV_KHR_untyped_pointers/globals.ll
@@ -41,7 +41,12 @@ target triple = "spir-unknown-unknown"
 ; CHECK-SPIRV: UntypedVariableKHR [[#PTRTY]] [[#VARB:]] 5 [[#I32]]
 ; CHECK-SPIRV: UntypedVariableKHR [[#PTRTY]] [[#VARC:]] 5 [[#PTRTY]] [[#VARA]]
 ; CHECK-SPIRV: UntypedVariableKHR [[#LOCALPTRTY]] [[#VARD:]] 4 [[#PTRTY]]
-; CHECK-SPIRV: Variable [[#ARRAYPTRTY]] [[#VARE:]] 5
+; A variable is not a constant, so each pointer constituent of the array
+; initializer is wrapped before forming the SpecConstantComposite.
+; CHECK-SPIRV: SpecConstantOp [[#PTRTY]] [[#WRAPA:]] {{[0-9]+}} [[#VARA]]
+; CHECK-SPIRV: SpecConstantOp [[#PTRTY]] [[#WRAPB:]] {{[0-9]+}} [[#VARB]]
+; CHECK-SPIRV: SpecConstantComposite [[#ARRAYTY]] [[#COMPE:]] [[#WRAPA]] [[#WRAPB]]
+; CHECK-SPIRV: Variable [[#ARRAYPTRTY]] [[#VARE:]] 5 [[#COMPE]]
 ; CHECK-SPIRV: Variable [[#ARRAY3PTRTY]] [[#VARF:]] 5
 ; CHECK-SPIRV: SpecConstantOp [[#PTRTY]] [[#SPECCONST:]] 4424 [[#ARRAY3TY]] [[#VARF]] [[#CONST0_I64]] [[#CONST1_I64]] [[#CONST2_I64]] [[#CONST3_I64]]
 ; CHECK-SPIRV: UntypedVariableKHR [[#PTRTY]] [[#VARG:]] 5 [[#PTRTY]] [[#SPECCONST]]

--- a/test/transcoding/constant-vars.ll
+++ b/test/transcoding/constant-vars.ll
@@ -46,11 +46,10 @@ target triple = "spir-unknown-unknown"
 @array = addrspace(1) global [3 x ptr addrspace(1)] [ptr addrspace(1) @i64arr, ptr addrspace(1) @struct, ptr addrspace(1) getelementptr ([3 x i64], ptr addrspace(1) @i64arr, i64 0, i64 1) ]
 
 ; CHECK-SPIRV: 5 SpecConstantOp [[AS1]] [[I64ARRC2:[0-9]+]] 124 [[I64ARR]]
-; CHECK-SPIRV-TYPED-PTR: 5 SpecConstantOp [[AS1]] [[STRUCTC:[0-9]+]] 124 [[STRUCT]]
+; CHECK-SPIRV: 5 SpecConstantOp [[AS1]] [[STRUCTC:[0-9]+]] 124 [[STRUCT]]
 ; CHECK-SPIRV-TYPED-PTR: 7 SpecConstantOp {{[0-9]+}} [[GEP:[0-9]+]] 67 [[I64ARR]]
 ; CHECK-SPIRV-UNTYPED-PTR: 8 SpecConstantOp {{[0-9]+}} [[GEP:[0-9]+]] 4423 [[#]] [[I64ARR]]
-; CHECK-SPIRV-TYPED-PTR: 6 SpecConstantComposite [[ARRAYTY]] [[ARRAY_INIT:[0-9]+]] [[I64ARRC2]] [[STRUCTC]] [[GEP]]
-; CHECK-SPIRV-UNTYPED-PTR: 6 SpecConstantComposite [[ARRAYTY]] [[ARRAY_INIT:[0-9]+]] [[I64ARRC2]] [[STRUCT]] [[GEP]]
+; CHECK-SPIRV: 6 SpecConstantComposite [[ARRAYTY]] [[ARRAY_INIT:[0-9]+]] [[I64ARRC2]] [[STRUCTC]] [[GEP]]
 ; CHECK-SPIRV: 5 Variable {{[0-9]+}} [[ARRAY:[0-9]+]] 5 [[ARRAY_INIT]]
 
 ; CHECK-LLVM: %structtype = type { ptr addrspace(2), ptr addrspace(1) }


### PR DESCRIPTION
A module-scope variable is not a constant and cannot be a constituent of a constant composite.
For untyped pointers, a constant array or struct of pointers-to-globals was emitted as an `OpConstantComposite` of the bare `OpUntypedVariableKHR` operands, which is invalid SPIR-V.

Wrap a variable constituent so the composite refers to a constant.

AI-assisted: Claude Opus 4.8 (commercial SaaS)