### PR TITLE
Drop constant zero-sized memcpy/memmove/memset before selection

### DIFF
--- a/lib/SPIRV/SPIRVLowerMemmove.cpp
+++ b/lib/SPIRV/SPIRVLowerMemmove.cpp
@@ -107,7 +107,12 @@ bool SPIRVLowerMemmoveBase::expandMemMoveIntrinsicUses(Function &F) {
 
   for (User *U : make_early_inc_range(F.users())) {
     MemMoveInst *Inst = cast<MemMoveInst>(U);
-    if (!isa<ConstantInt>(Inst->getLength())) {
+    if (auto *Len = dyn_cast<ConstantInt>(Inst->getLength());
+        Len && Len->isZero()) {
+      // A zero-sized memmove is a no-op. Drop it instead of lowering to avoid
+      // emitting an invalid OpCopyMemorySized with a Size operand of 0.
+      Inst->eraseFromParent();
+    } else if (!isa<ConstantInt>(Inst->getLength())) {
       expandMemMoveAsLoop(Inst,
                           TargetTransformInfo(F.getParent()->getDataLayout()));
       Inst->eraseFromParent();

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -5031,6 +5031,10 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
       return nullptr;
     }
     uint64_t NumElements = static_cast<ConstantInt *>(Len)->getZExtValue();
+    // A zero-sized memset is a no-op. Emitting OpCopyMemorySized with a Size
+    // operand of 0 is invalid SPIR-V, so drop the intrinsic entirely.
+    if (NumElements == 0)
+      return nullptr;
     auto *AT = ArrayType::get(Val->getType(), NumElements);
     SPIRVTypeArray *CompositeTy = static_cast<SPIRVTypeArray *>(transType(AT));
     SPIRVValue *Init;
@@ -5062,6 +5066,11 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
                                       MemAccess, BB);
   } break;
   case Intrinsic::memcpy:
+    // A zero-sized memcpy is a no-op. Emitting OpCopyMemorySized with a Size
+    // operand of 0 is invalid SPIR-V, so drop the intrinsic entirely.
+    if (auto *CI = dyn_cast<ConstantInt>(II->getOperand(2)))
+      if (CI->isZero())
+        return nullptr;
     return BM->addCopyMemorySizedInst(
         transValue(II->getOperand(0), BB), transValue(II->getOperand(1), BB),
         transValue(II->getOperand(2), BB),

--- a/test/llvm-intrinsics/zero-length-mem-intrinsics.ll
+++ b/test/llvm-intrinsics/zero-length-mem-intrinsics.ll
@@ -1,0 +1,44 @@
+; Constant zero-sized memcpy/memmove/memset are no-ops. Emitting
+; OpCopyMemorySized with a Size operand of 0 is invalid SPIR-V, so the
+; translator must drop these intrinsics. A non-zero copy is unaffected.
+
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir-unknown-unknown"
+
+; A single CopyMemorySized is emitted, for the non-zero memcpy only.
+; CHECK-SPIRV: CopyMemorySized
+; CHECK-SPIRV-NOT: CopyMemorySized
+
+define spir_func void @zero_memcpy(ptr %dst, ptr %src) {
+entry:
+  call void @llvm.memcpy.p0.p0.i32(ptr align 4 %dst, ptr align 4 %src, i32 0, i1 false)
+  ret void
+}
+
+define spir_func void @zero_memmove(ptr %dst, ptr %src) {
+entry:
+  call void @llvm.memmove.p0.p0.i32(ptr align 4 %dst, ptr align 4 %src, i32 0, i1 false)
+  ret void
+}
+
+define spir_func void @zero_memset(ptr %dst) {
+entry:
+  call void @llvm.memset.p0.i32(ptr align 4 %dst, i8 7, i32 0, i1 false)
+  ret void
+}
+
+define spir_func void @nonzero_memcpy(ptr %dst, ptr %src) {
+entry:
+  call void @llvm.memcpy.p0.p0.i32(ptr align 4 %dst, ptr align 4 %src, i32 16, i1 false)
+  ret void
+}
+
+declare void @llvm.memcpy.p0.p0.i32(ptr captures(none), ptr captures(none) readonly, i32, i1)
+declare void @llvm.memmove.p0.p0.i32(ptr captures(none), ptr captures(none) readonly, i32, i1)
+declare void @llvm.memset.p0.i32(ptr captures(none), i8, i32, i1)

--- a/test/llvm-intrinsics/zero-length-mem-intrinsics.ll
+++ b/test/llvm-intrinsics/zero-length-mem-intrinsics.ll
@@ -2,18 +2,15 @@
 ; OpCopyMemorySized with a Size operand of 0 is invalid SPIR-V, so the
 ; translator must drop these intrinsics. A non-zero copy is unaffected.
 
-; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
-; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %s -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %s -o %t.spv
 ; RUN: spirv-val %t.spv
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir-unknown-unknown"
 
 ; A single CopyMemorySized is emitted, for the non-zero memcpy only.
-; CHECK-SPIRV: CopyMemorySized
-; CHECK-SPIRV-NOT: CopyMemorySized
+; CHECK-SPIRV-COUNT-1: CopyMemorySized
 
 define spir_func void @zero_memcpy(ptr %dst, ptr %src) {
 entry:


### PR DESCRIPTION
A constant zero Size operand is invalid for OpCopyMemorySized, and these intrinsics are no-ops, so erase them instead of lowering

Inspired by https://github.com/llvm/llvm-project/pull/201904