### PR TITLE
Avoid per-instruction stream seeks in validateWordCount

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -110,6 +110,8 @@ public:
 
   // Error handling functions
   SPIRVErrorLog &getErrorLog() override { return ErrLog; }
+  // Total size of the input stream, cached once by parseSPIRV.
+  std::streamoff getInputStreamSize() const { return InputStreamSize; }
   SPIRVErrorCode getError(std::string &ErrMsg) override {
     return ErrLog.getError(ErrMsg);
   }
@@ -623,6 +625,8 @@ private:
   SPIRVIdToInstructionSetMap IdToInstSetMap;
   SPIRVIdToBuiltinSetMap IdBuiltinMap;
   SPIRVIdSet NamedId;
+  // Cached total byte size of the input stream.
+  std::streamoff InputStreamSize = 0;
   SPIRVStringVec StringVec;
   SPIRVMemberNameVec MemberNameVec;
   std::shared_ptr<const SPIRVLine> CurrentLine;
@@ -2450,11 +2454,9 @@ void SPIRVModuleImpl::addUnknownStructField(SPIRVTypeStruct *Struct, unsigned I,
 static void validateWordCount(SPIRVModuleImpl &M, std::istream &IS,
                               SPIRVWord WordCount) {
   if (!SPIRVUseTextFormat) {
-    std::streampos CurrentPos = IS.tellg();
-    IS.seekg(0, std::ios::end);
-    std::streamoff RemainingBytes = IS.tellg() - CurrentPos;
-    IS.clear();
-    IS.seekg(CurrentPos);
+    // Bounds-check against the total stream size.
+    std::streamoff RemainingBytes =
+        M.getInputStreamSize() - static_cast<std::streamoff>(IS.tellg());
 
     std::streamoff ExpectedBytes =
         static_cast<std::streamoff>((WordCount - 1) * sizeof(SPIRVWord));
@@ -2696,6 +2698,16 @@ std::istream &SPIRVModuleImpl::parseSPIRV(std::istream &I) {
   MI.GeneratorVer = Header[2] & 0xFFFF;
   MI.NextId = Header[3];
   MI.InstSchema = static_cast<SPIRVInstructionSchemaKind>(Header[4]);
+
+  // Cache the total stream size once so validateWordCount can bounds-check each
+  // instruction with a single tellg() instead of seeking to the end and back.
+  if (!SPIRVUseTextFormat) {
+    std::streampos HeaderEnd = I.tellg();
+    I.seekg(0, std::ios::end);
+    MI.InputStreamSize = static_cast<std::streamoff>(I.tellg());
+    I.clear();
+    I.seekg(HeaderEnd);
+  }
 
   SPIRVEntry *Scope = nullptr;
   while (true) {

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -625,7 +625,6 @@ private:
   SPIRVIdToInstructionSetMap IdToInstSetMap;
   SPIRVIdToBuiltinSetMap IdBuiltinMap;
   SPIRVIdSet NamedId;
-  // Cached total byte size of the input stream.
   std::streamoff InputStreamSize = 0;
   SPIRVStringVec StringVec;
   SPIRVMemberNameVec MemberNameVec;
@@ -2455,8 +2454,7 @@ static void validateWordCount(SPIRVModuleImpl &M, std::istream &IS,
                               SPIRVWord WordCount) {
   if (!SPIRVUseTextFormat) {
     // Bounds-check against the total stream size.
-    std::streamoff RemainingBytes =
-        M.getInputStreamSize() - static_cast<std::streamoff>(IS.tellg());
+    std::streamoff RemainingBytes = M.getInputStreamSize() - IS.tellg();
 
     std::streamoff ExpectedBytes =
         static_cast<std::streamoff>((WordCount - 1) * sizeof(SPIRVWord));
@@ -2699,12 +2697,10 @@ std::istream &SPIRVModuleImpl::parseSPIRV(std::istream &I) {
   MI.NextId = Header[3];
   MI.InstSchema = static_cast<SPIRVInstructionSchemaKind>(Header[4]);
 
-  // Cache the total stream size once so validateWordCount can bounds-check each
-  // instruction with a single tellg() instead of seeking to the end and back.
   if (!SPIRVUseTextFormat) {
     std::streampos HeaderEnd = I.tellg();
     I.seekg(0, std::ios::end);
-    MI.InputStreamSize = static_cast<std::streamoff>(I.tellg());
+    MI.InputStreamSize = I.tellg();
     I.clear();
     I.seekg(HeaderEnd);
   }


### PR DESCRIPTION
validateWordCount() seeked the input stream to its end and back on every module-scope instruction just to bounds-check the word count.

Cache the total stream size once in parseSPIRV() and bounds-check each instruction with a single tellg().

AI-assisted: Claude Fable 5