### PR TITLE
Skip writer-only lowering path when reading SPIR-V

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -5963,6 +5963,7 @@ std::unique_ptr<SPIRVModule> readSpirvModule(std::istream &IS,
                                              std::string &ErrMsg) {
   std::unique_ptr<SPIRVModule> BM(SPIRVModule::createSPIRVModule(Opts));
 
+  BM->setReadingModule();
   IS >> *BM;
   if (!BM->isModuleValid()) {
     BM->getError(ErrMsg);

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -108,6 +108,8 @@ public:
     return CurrentLine.get() || !DebugInstVec.empty();
   }
 
+  void setReadingModule() override { IsReading = true; }
+
   // Error handling functions
   SPIRVErrorLog &getErrorLog() override { return ErrLog; }
   SPIRVErrorCode getError(std::string &ErrMsg) override {
@@ -2547,7 +2549,6 @@ std::istream &SPIRVModuleImpl::parseSPT(std::istream &I) {
   SPIRVModuleImpl &MI = *this;
   MI.setAutoAddCapability(false);
   MI.setAutoAddExtensions(false);
-  MI.IsReading = true;
   auto ReadSPIRVWord = [](std::istream &I) {
     uint32_t W;
     I >> skipcomment >> W;
@@ -2669,7 +2670,6 @@ std::istream &SPIRVModuleImpl::parseSPIRV(std::istream &I) {
   SPIRVModuleImpl &MI = *this;
   MI.setAutoAddCapability(false);
   MI.setAutoAddExtensions(false);
-  MI.IsReading = true;
 
   SPIRVWord Header[5] = {0};
   I.read(reinterpret_cast<char *>(&Header), sizeof(Header));

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -623,6 +623,9 @@ private:
   SPIRVIdToInstructionSetMap IdToInstSetMap;
   SPIRVIdToBuiltinSetMap IdBuiltinMap;
   SPIRVIdSet NamedId;
+  // True while the module is being populated by decoding an existing SPIR-V
+  // module. Used to skip writer-only code paths.
+  bool IsReading = false;
   SPIRVStringVec StringVec;
   SPIRVMemberNameVec MemberNameVec;
   std::shared_ptr<const SPIRVLine> CurrentLine;
@@ -1055,6 +1058,9 @@ void SPIRVModuleImpl::setName(SPIRVEntry *E, const std::string &Name) {
   E->setName(Name);
   if (!E->hasId())
     return;
+  // NamedId is consumed only by the writer.
+  if (IsReading)
+    return;
   if (!Name.empty())
     NamedId.insert(E->getId());
   else
@@ -1298,7 +1304,9 @@ SPIRVModuleImpl::addDecorate(SPIRVDecorateGeneric *Dec) {
   assert(Found && "Decorate target does not exist");
   if (!Dec->getOwner())
     DecorateVec.push_back(Dec);
-  addCapabilities(Dec->getRequiredCapability());
+  // Required capabilities are only auto-collected while building a module.
+  if (AutoAddCapability)
+    addCapabilities(Dec->getRequiredCapability());
   return Dec;
 }
 
@@ -2539,6 +2547,7 @@ std::istream &SPIRVModuleImpl::parseSPT(std::istream &I) {
   SPIRVModuleImpl &MI = *this;
   MI.setAutoAddCapability(false);
   MI.setAutoAddExtensions(false);
+  MI.IsReading = true;
   auto ReadSPIRVWord = [](std::istream &I) {
     uint32_t W;
     I >> skipcomment >> W;
@@ -2660,6 +2669,7 @@ std::istream &SPIRVModuleImpl::parseSPIRV(std::istream &I) {
   SPIRVModuleImpl &MI = *this;
   MI.setAutoAddCapability(false);
   MI.setAutoAddExtensions(false);
+  MI.IsReading = true;
 
   SPIRVWord Header[5] = {0};
   I.read(reinterpret_cast<char *>(&Header), sizeof(Header));

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -196,6 +196,7 @@ public:
   virtual void setAutoAddCapability(bool E) { AutoAddCapability = E; }
   virtual void setValidateCapability(bool E) { ValidateCapability = E; }
   virtual void setAutoAddExtensions(bool E) { AutoAddExtensions = E; }
+  virtual void setReadingModule() {}
   virtual void setGeneratorId(unsigned short) = 0;
   virtual void setGeneratorVer(unsigned short) = 0;
   virtual void resolveUnknownStructFields() = 0;


### PR DESCRIPTION
NamedId is consumed only by the writer, so maintaining it while decoding an existing SPIR-V module is dead work. Add an explicit IsReading flag, set by parseSPIRV()/parseSPT().

Also gate addDecorate()'s required-capability collection on AutoAddCapability, mirroring addEntry().

AI-assisted: Claude Fable 5