### PR TITLE
[Backport to 21] .clang-tidy: disable conflicting misc-use-anonymous-namespaces (#3286)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: |
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
   readability-identifier-naming
 WarningsAsErrors: |
   llvm-*,
@@ -19,6 +20,7 @@ WarningsAsErrors: |
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
   readability-identifier-naming
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase


### PR DESCRIPTION
Backport of #3286 .

In R21, there are 2 conflicting clang-tidy checks `llvm-prefer-static-over-anonymous-namespace` and `misc-use-anonymous-namespace`, and both warnings are treated as error. This causes clang-tidy checks to fail, no matter what you do with a `static` function and prevents backporting.