### PR TITLE
[Backport to 19] .clang-tidy: disable conflicting misc-use-anonymous-namespaces (#3286)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: |
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
   readability-identifier-naming
 WarningsAsErrors: |
   llvm-*,
@@ -19,6 +20,7 @@ WarningsAsErrors: |
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
   readability-identifier-naming
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase


### PR DESCRIPTION
Backport of #3286.

Remove checks `misc-use-anonymous-namespace`, otherwise we'll be forced to place static functions into anonymous namespace, which contridicts with current LLVM practice and leads to inconsistent style across release branches during backporting.