### PR TITLE
Fix create-placeholders-for-phi-operands.ll when SPIRV backend isn't enabled

### DIFF
--- a/test/create-placeholders-for-phi-operands.ll
+++ b/test/create-placeholders-for-phi-operands.ll
@@ -2,7 +2,7 @@
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
 ; RUN: FileCheck %s --input-file %t.rev.ll --check-prefix CHECK-LLVM
-; RUN: llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj %s -o %t.llc.spv --spirv-ext=+SPV_INTEL_variable_length_array
+; RUN: %if spirv-backend %{ llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj %s -o %t.llc.spv --spirv-ext=+SPV_INTEL_variable_length_array %}
 
 ; CHECK-LLVM: phi ptr [ [[savedstack:%.*]], {{.*}} ], [ [[savedstack_us:%.*]], {{.*}} ]
 


### PR DESCRIPTION
Fix `llc: Unknown command line argument '--spirv-ext=+SPV_INTEL_variable_length_array'`