### PR TITLE
Add missing coverage for SPV_EXT_long_vector

### DIFF
--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -122,11 +122,12 @@ SPIRVLowerBitCastToNonStandardTypePass::run(Function &F,
   // parameter, since it added by an optimization.
   bool Changed = false;
 
-  // SPV_INTEL_vector_compute allows to use vectors with any number of
-  // components. Since this method only lowers vectors with non-standard
-  // in pure SPIR-V number of components, there is no need to do anything in
-  // case SPV_INTEL_vector_compute is enabled.
-  if (Opts.isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
+  // SPV_EXT_long_vector and SPV_INTEL_vector_compute allow to use vectors with
+  // any number of components. Since this method only lowers vectors with
+  // non-standard in pure SPIR-V number of components, there is no need to do
+  // anything in case any of them is enabled.
+  if (Opts.isAllowedToUseExtension(ExtensionID::SPV_EXT_long_vector) ||
+      Opts.isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
     return PreservedAnalyses::all();
 
   // The basic pattern we're trying to fix is this InstCombine pattern:

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2001,6 +2001,7 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
       return true;
     if ((!Ty->isFloatTy() && !Ty->isDoubleTy() && !Ty->isHalfTy()) ||
         (!BM->hasCapability(CapabilityVectorAnyINTEL) &&
+         !BM->hasCapability(CapabilityLongVectorEXT) &&
          ((NumElems > 4) && (NumElems != 8) && (NumElems != 16)))) {
       BM->SPIRVCK(false, InvalidFunctionCall,
                   II->getCalledOperand()->getName().str());
@@ -2020,6 +2021,7 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
       return true;
     if ((!Ty->isIntegerTy()) ||
         (!BM->hasCapability(CapabilityVectorAnyINTEL) &&
+         !BM->hasCapability(CapabilityLongVectorEXT) &&
          ((NumElems > 4) && (NumElems != 8) && (NumElems != 16)))) {
       BM->SPIRVCK(false, InvalidFunctionCall,
                   II->getCalledOperand()->getName().str());

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-abs-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-abs-with-ext.ll
@@ -1,0 +1,42 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not llvm-spirv -s %t.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector %t.bc
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK: ExtInstImport [[ExtInstSetId:[0-9]+]] "OpenCL.std"
+; CHECK: TypeInt [[Int:[0-9]+]] 32
+; CHECK: TypeVector [[Int5:[0-9]+]] [[Int]] 5
+
+; ModuleID = 'lower-non-standard-vec-with-ext'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@Id = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+declare <5 x i32> @llvm.abs.v5i32(<5 x i32> %x, i1 %is_int_min_poison)
+
+; Function Attrs: convergent norecurse
+define dso_local spir_func <5 x i32> @test_abs(<5 x i32> %src) local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
+entry:
+  %res = call <5 x i32> @llvm.abs.v5i32(<5 x i32> %src, i1 false)
+; CHECK: ExtInst [[Int5]] {{[0-9]+}} [[ExtInstSetId]] s_abs
+  ret <5 x i32> %res
+}
+
+attributes #0 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-width"="256" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="lower-external-funcs-with-z.cpp" }
+
+!llvm.module.flags = !{!0, !1}
+!opencl.spir.version = !{!2}
+!spirv.Source = !{!3}
+!opencl.used.extensions = !{!4}
+!opencl.used.optional.core.features = !{!4}
+!opencl.compiler.options = !{!4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{i32 1, i32 2}
+!3 = !{i32 0, i32 100000}
+!4 = !{}
+!5 = !{!"Compiler"}
+!6 = !{i32 1}

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-abs-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-abs-with-ext.ll
@@ -1,7 +1,9 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: not llvm-spirv -s %t.bc
+; RUN: not llvm-spirv -s %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector %t.bc
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK-ERROR: Unsupported vector type with 5 elements
 
 ; CHECK: ExtInstImport [[ExtInstSetId:[0-9]+]] "OpenCL.std"
 ; CHECK: TypeInt [[Int:[0-9]+]] 32
@@ -11,32 +13,12 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-@Id = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
-
 declare <5 x i32> @llvm.abs.v5i32(<5 x i32> %x, i1 %is_int_min_poison)
 
 ; Function Attrs: convergent norecurse
-define dso_local spir_func <5 x i32> @test_abs(<5 x i32> %src) local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
+define dso_local spir_func <5 x i32> @test_abs(<5 x i32> %src) local_unnamed_addr {
 entry:
   %res = call <5 x i32> @llvm.abs.v5i32(<5 x i32> %src, i1 false)
 ; CHECK: ExtInst [[Int5]] {{[0-9]+}} [[ExtInstSetId]] s_abs
   ret <5 x i32> %res
 }
-
-attributes #0 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-width"="256" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="lower-external-funcs-with-z.cpp" }
-
-!llvm.module.flags = !{!0, !1}
-!opencl.spir.version = !{!2}
-!spirv.Source = !{!3}
-!opencl.used.extensions = !{!4}
-!opencl.used.optional.core.features = !{!4}
-!opencl.compiler.options = !{!4}
-!llvm.ident = !{!5}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 7, !"frame-pointer", i32 2}
-!2 = !{i32 1, i32 2}
-!3 = !{i32 0, i32 100000}
-!4 = !{}
-!5 = !{!"Compiler"}
-!6 = !{i32 1}

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-sqrt-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-sqrt-with-ext.ll
@@ -1,7 +1,9 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: not llvm-spirv -s %t.bc
+; RUN: not llvm-spirv -s %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
 ; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector %t.bc
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK-ERROR: Unsupported vector type with 5 elements
 
 ; CHECK: ExtInstImport [[ExtInstSetId:[0-9]+]] "OpenCL.std"
 ; CHECK: TypeFloat [[Float:[0-9]+]] 32
@@ -11,32 +13,12 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-@Id = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
-
 declare <5 x float> @llvm.sqrt.f32(<5 x float> %x)
 
 ; Function Attrs: convergent norecurse
-define dso_local spir_func <5 x float> @test_sqrt(<5 x float> %src) local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
+define dso_local spir_func <5 x float> @test_sqrt(<5 x float> %src) local_unnamed_addr {
 entry:
   %res = call <5 x float> @llvm.sqrt.f32(<5 x float> %src)
 ; CHECK: ExtInst [[Float5]] {{[0-9]+}} [[ExtInstSetId]] sqrt
   ret <5 x float> %res
 }
-
-attributes #0 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-width"="256" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="lower-external-funcs-with-z.cpp" }
-
-!llvm.module.flags = !{!0, !1}
-!opencl.spir.version = !{!2}
-!spirv.Source = !{!3}
-!opencl.used.extensions = !{!4}
-!opencl.used.optional.core.features = !{!4}
-!opencl.compiler.options = !{!4}
-!llvm.ident = !{!5}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 7, !"frame-pointer", i32 2}
-!2 = !{i32 1, i32 2}
-!3 = !{i32 0, i32 100000}
-!4 = !{}
-!5 = !{!"Compiler"}
-!6 = !{i32 1}

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-sqrt-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-sqrt-with-ext.ll
@@ -1,0 +1,42 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not llvm-spirv -s %t.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector %t.bc
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK: ExtInstImport [[ExtInstSetId:[0-9]+]] "OpenCL.std"
+; CHECK: TypeFloat [[Float:[0-9]+]] 32
+; CHECK: TypeVector [[Float5:[0-9]+]] [[Float]] 5
+
+; ModuleID = 'lower-non-standard-vec-with-ext'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@Id = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+declare <5 x float> @llvm.sqrt.f32(<5 x float> %x)
+
+; Function Attrs: convergent norecurse
+define dso_local spir_func <5 x float> @test_sqrt(<5 x float> %src) local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
+entry:
+  %res = call <5 x float> @llvm.sqrt.f32(<5 x float> %src)
+; CHECK: ExtInst [[Float5]] {{[0-9]+}} [[ExtInstSetId]] sqrt
+  ret <5 x float> %res
+}
+
+attributes #0 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-width"="256" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="lower-external-funcs-with-z.cpp" }
+
+!llvm.module.flags = !{!0, !1}
+!opencl.spir.version = !{!2}
+!spirv.Source = !{!3}
+!opencl.used.extensions = !{!4}
+!opencl.used.optional.core.features = !{!4}
+!opencl.compiler.options = !{!4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{i32 1, i32 2}
+!3 = !{i32 0, i32 100000}
+!4 = !{}
+!5 = !{!"Compiler"}
+!6 = !{i32 1}

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-with-ext.ll
@@ -1,0 +1,38 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not llvm-spirv -s %t.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector -s %t.bc
+
+; ModuleID = 'lower-non-standard-vec-with-ext'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@Id = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+; Function Attrs: convergent norecurse
+define dso_local spir_func void @vmult2() local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
+entry:
+  %0 = bitcast <1 x i32> <i32 65793> to <4 x i8>
+  %1 = extractelement <4 x i8> %0, i32 0
+  %2 = bitcast <1 x i32> <i32 131586> to <4 x i8>
+  %3 = extractelement <4 x i8> %2, i32 0
+  %4 = bitcast <5 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1> to <20 x i8>
+  ret void
+}
+
+attributes #0 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-width"="256" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="lower-external-funcs-with-z.cpp" }
+
+!llvm.module.flags = !{!0, !1}
+!opencl.spir.version = !{!2}
+!spirv.Source = !{!3}
+!opencl.used.extensions = !{!4}
+!opencl.used.optional.core.features = !{!4}
+!opencl.compiler.options = !{!4}
+!llvm.ident = !{!5}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"frame-pointer", i32 2}
+!2 = !{i32 1, i32 2}
+!3 = !{i32 0, i32 100000}
+!4 = !{}
+!5 = !{!"Compiler"}
+!6 = !{i32 1}

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-with-ext.ll
@@ -1,15 +1,25 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: not llvm-spirv -s %t.bc
-; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector -s %t.bc
+; RUN: not llvm-spirv -s %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK-ERROR: Unsupported vector type with 20 elements
+
+; CHECK-DAG: Capability LongVectorEXT
+; CHECK-DAG: Extension "SPV_EXT_long_vector"
+; CHECK-DAG: TypeInt [[#I32:]] 32 0
+; CHECK-DAG: TypeInt [[#I8:]] 8 0
+; CHECK-DAG: TypeVector [[#]] [[#I32]] 1
+; CHECK-DAG: TypeVector [[#]] [[#I8]] 4
+; CHECK-DAG: TypeVector [[#]] [[#I32]] 5
+; CHECK-DAG: TypeVector [[#]] [[#I8]] 20
 
 ; ModuleID = 'lower-non-standard-vec-with-ext'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-@Id = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
-
 ; Function Attrs: convergent norecurse
-define dso_local spir_func void @vmult2() local_unnamed_addr #0 !sycl_explicit_simd !4 !intel_reqd_sub_group_size !6 {
+define dso_local spir_func void @vmult2() local_unnamed_addr {
 entry:
   %0 = bitcast <1 x i32> <i32 65793> to <4 x i8>
   %1 = extractelement <4 x i8> %0, i32 0
@@ -18,21 +28,3 @@ entry:
   %4 = bitcast <5 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1> to <20 x i8>
   ret void
 }
-
-attributes #0 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-width"="256" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="lower-external-funcs-with-z.cpp" }
-
-!llvm.module.flags = !{!0, !1}
-!opencl.spir.version = !{!2}
-!spirv.Source = !{!3}
-!opencl.used.extensions = !{!4}
-!opencl.used.optional.core.features = !{!4}
-!opencl.compiler.options = !{!4}
-!llvm.ident = !{!5}
-
-!0 = !{i32 1, !"wchar_size", i32 4}
-!1 = !{i32 7, !"frame-pointer", i32 2}
-!2 = !{i32 1, i32 2}
-!3 = !{i32 0, i32 100000}
-!4 = !{}
-!5 = !{!"Compiler"}
-!6 = !{i32 1}


### PR DESCRIPTION
This is a quick bug fix PR, as a follow-up of https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/3777, which didn't cover the early-out path in  SPIRVLowerBitCastToNonStandardType.cpp. As a consequence, if the pass has vector with non-standard size as input but with only `SPV_EXT_long_vector` enabled, it will crash later.

Also added missing coverage in SPIRVUtils.cpp when handling intrinsics.

The new tests simply mirror the ones in `extensions/INTEL/SPV_INTEL_vector_compute`.