### PR TITLE
Support for typed pointers for OpTypeBufferSurfaceINTEL type

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -467,6 +467,9 @@ Type *SPIRVToLLVM::transType(SPIRVType *T, bool UseTPT) {
     if (UseTPT) {
       Type *StructTy = getOrCreateOpaqueStructType(M, transVCTypeName(PST));
       Ty = TypedPointerType::get(StructTy, SPIRAS_Global);
+    } else if (Context->supportsTypedPointers()) {
+      Type *StructTy = getOrCreateOpaqueStructType(M, transVCTypeName(PST));
+      Ty = PointerType::get(StructTy, SPIRAS_Global);
     } else {
       std::vector<unsigned> Params;
       if (PST->hasAccessQualifier()) {


### PR DESCRIPTION
This pull request adds missing implementation of OpTypeBufferSurfaceINTEL spirv translation to llvm type in case llvm 16 is set with typed pointers enabled