### PR TITLE
Fix test/transcoding/dbginfo-bug-on-bool-converts.ll test expectations

### DIFF
--- a/test/transcoding/dbginfo-bug-on-bool-converts.ll
+++ b/test/transcoding/dbginfo-bug-on-bool-converts.ll
@@ -61,7 +61,7 @@ define spir_func float @sitofp_b(i1 %barg) #0 !dbg !17 {
 }
 
 ; CHECK-LLC-LABEL: define spir_func float @sitofp_b(i1 %barg)
-; CHECK-LLC: select i1 %barg, i32 1, i32 0
+; CHECK-LLC: select i1 %barg, i32 -1, i32 0
 ; CHECK-LLC: sitofp i32 {{.*}} to float
 ; CHECK-LLC: ret float
 


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/209232 fixed the SPIR-V backend selectIToF to preserve signedness (sitofp i1 true was miscompiled as 1.0 instead of -1.0), so the select now produces -1 rather than 1