### PR TITLE
[Backport to 16] Add 2 opcodes back from old SPV_INTEL_fp_conversions spec

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1079,8 +1079,10 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
   case OpUConvert:
     CO = IsExt ? Instruction::ZExt : Instruction::Trunc;
     break;
+  case internal::OpClampConvertFToFINTEL:
   case internal::OpClampConvertFToSINTEL:
   case internal::OpStochasticRoundFToFINTEL:
+  case internal::OpClampStochasticRoundFToFINTEL:
   case internal::OpClampStochasticRoundFToSINTEL:
   case OpConvertSToF:
   case OpConvertFToS:
@@ -1088,6 +1090,12 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
   case OpConvertFToU:
   case OpFConvert: {
     const auto OC = BC->getOpCode();
+    // These 2 old opcodes should follow exactly the same translation
+    // path as OpFConvert/OpStochasticRoundFToFINTEL with
+    // SaturatedToLargestFloat8NormalConversionEXT
+    const bool IsOldConvertFToFOp =
+        OC == internal::OpClampConvertFToFINTEL ||
+        OC == internal::OpClampStochasticRoundFToFINTEL;
     {
       auto SPVOps = BC->getOperands();
       auto *SPVSrcTy = SPVOps[0]->getType();
@@ -1106,9 +1114,17 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
 
       FPEncodingWrap SrcEnc = GetEncodingAndUpdateType(SPVSrcTy);
       FPEncodingWrap DstEnc = GetEncodingAndUpdateType(SPVDstTy);
-      bool IsSaturatedFP8 = BC->hasDecorate(
+      const bool HasSaturatedFP8Decor = BC->hasDecorate(
           DecorationSaturatedToLargestFloat8NormalConversionEXT);
-      if (IsSaturatedFP8) {
+      bool IsSaturatedFP8 = false;
+      if (IsOldConvertFToFOp) {
+        BM->getErrorLog().checkError(
+            !HasSaturatedFP8Decor, SPIRVEC_InvalidInstruction,
+            "SaturatedToLargestFloat8NormalConversionEXT is not valid on "
+            "OpClampConvertFToFINTEL or OpClampStochasticRoundFToFINTEL.\n");
+        IsSaturatedFP8 =
+            DstEnc == FPEncodingWrap::E4M3 || DstEnc == FPEncodingWrap::E5M2;
+      } else if (HasSaturatedFP8Decor) {
         BM->getErrorLog().checkError(
             (OC == OpFConvert || OC == OpConvertSToF || OC == OpConvertUToF ||
              OC == internal::OpStochasticRoundFToFINTEL) &&
@@ -1119,10 +1135,19 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
             "valid on OpFConvert/OpConvertSToF/OpConvertUToF/"
             "OpStochasticRoundFToFINTEL whose Result Type uses Float8E4M3EXT "
             "or Float8E5M2EXT encoding.\n");
+        IsSaturatedFP8 = true;
       }
       if (IsFP4OrFP8Encoding(SrcEnc) || IsFP4OrFP8Encoding(DstEnc) ||
           SPVSrcTy->isTypeInt(4) || SPVDstTy->isTypeInt(4)) {
-        FPConversionDesc FPDesc = {SrcEnc, DstEnc, OC,
+        // The old opcodes share the encoding map with their surviving
+        // equivalents: OpClampConvertFToFINTEL with OpFConvert and
+        // OpClampStochasticRoundFToFINTEL with OpStochasticRoundFToFINTEL.
+        SPIRVWord LookupOC = OC;
+        if (OC == internal::OpClampConvertFToFINTEL)
+          LookupOC = OpFConvert;
+        else if (OC == internal::OpClampStochasticRoundFToFINTEL)
+          LookupOC = internal::OpStochasticRoundFToFINTEL;
+        FPConversionDesc FPDesc = {SrcEnc, DstEnc, LookupOC,
                                    /*Saturate=*/IsSaturatedFP8};
         auto Conv = SPIRV::FPConvertToEncodingMap::rmap(FPDesc);
         std::vector<Value *> Ops = {Src};
@@ -1134,6 +1159,7 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         std::string MangledName;
         // Translate additional Ops for stochastic conversions.
         if (OC == internal::OpStochasticRoundFToFINTEL ||
+            OC == internal::OpClampStochasticRoundFToFINTEL ||
             OC == internal::OpClampStochasticRoundFToSINTEL) {
           // Seed.
           Ops.emplace_back(transValue(SPVOps[1], F, BB, true));
@@ -1165,11 +1191,12 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
         return CI;
       }
     }
-    // OpStochasticRoundFToFINTEL has no native LLVM cast equivalent.
-    // For fp4/fp8/int4 types, it is handled via the __builtin_spirv path above.
-    // For the remaining types it is emitted as an
-    // __spirv_StochasticRoundFToFINTEL_R<type> builtin call.
-    if (OC == internal::OpStochasticRoundFToFINTEL)
+    // OpStochasticRoundFToFINTEL and the old OpClampConvertFToFINTEL /
+    // OpClampStochasticRoundFToFINTEL opcodes have no native LLVM cast
+    // equivalent. For fp4/fp8/int4 types, they are handled via the
+    // __builtin_spirv path above. For the remaining types they are emitted as
+    // an __spirv_<OpName>_R<type> builtin call.
+    if (OC == internal::OpStochasticRoundFToFINTEL || IsOldConvertFToFOp)
       return mapValue(BV, transSPIRVBuiltinFromInst(
                               static_cast<SPIRVInstruction *>(BV), BB));
 
@@ -3807,6 +3834,9 @@ Instruction *SPIRVToLLVM::transSPIRVBuiltinFromInst(SPIRVInstruction *BI,
   case internal::OpClampConvertFToSINTEL:
   case internal::OpStochasticRoundFToFINTEL:
   case internal::OpClampStochasticRoundFToSINTEL:
+  // Old opcodes, for backward compatibility.
+  case internal::OpClampConvertFToFINTEL:
+  case internal::OpClampStochasticRoundFToFINTEL:
     AddRetTypePostfix = true;
     break;
   default: {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -4389,7 +4389,9 @@ public:
   typedef SPIRVInstTemplate<SPIRVFPConversionFtoFINTELInstBase,                \
                             internal::Op##x##INTEL, __VA_ARGS__>               \
       SPIRV##x##INTEL;
+_SPIRV_OP_FTOF(ClampConvertFToF, true, 4, false)
 _SPIRV_OP_FTOF(StochasticRoundFToF, true, 5, true)
+_SPIRV_OP_FTOF(ClampStochasticRoundFToF, true, 5, true)
 #undef _SPIRV_OP_FTOF
 
 class SPIRVFPConversionFtoSINTELInstBase : public SPIRVInstTemplateBase {

--- a/lib/SPIRV/libSPIRV/SPIRVOpCode.h
+++ b/lib/SPIRV/libSPIRV/SPIRVOpCode.h
@@ -116,8 +116,10 @@ inline bool isCvtOpCode(Op OpCode) {
 }
 
 inline bool isIntelCvtOpCode(Op OpCode) {
-  return OpCode == internal::OpClampConvertFToSINTEL ||
+  return OpCode == internal::OpClampConvertFToFINTEL ||
+         OpCode == internal::OpClampConvertFToSINTEL ||
          OpCode == internal::OpStochasticRoundFToFINTEL ||
+         OpCode == internal::OpClampStochasticRoundFToFINTEL ||
          OpCode == internal::OpClampStochasticRoundFToSINTEL;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVOpCodeEnumInternal.h
+++ b/lib/SPIRV/libSPIRV/SPIRVOpCodeEnumInternal.h
@@ -35,8 +35,11 @@ _SPIRV_OP_INTERNAL(ConvertHandleToSamplerINTEL,
 _SPIRV_OP_INTERNAL(ConvertHandleToSampledImageINTEL,
                    internal::ConvertHandleToSampledImageINTEL)
 _SPIRV_OP_INTERNAL(FSigmoidINTEL, internal::FSigmoidINTEL)
+_SPIRV_OP_INTERNAL(ClampConvertFToFINTEL, internal::OpClampConvertFToFINTEL)
 _SPIRV_OP_INTERNAL(StochasticRoundFToFINTEL,
                    internal::OpStochasticRoundFToFINTEL)
+_SPIRV_OP_INTERNAL(ClampStochasticRoundFToFINTEL,
+                   internal::OpClampStochasticRoundFToFINTEL)
 _SPIRV_OP_INTERNAL(ClampConvertFToSINTEL,
                    internal::OpClampConvertFToSINTEL)
 _SPIRV_OP_INTERNAL(ClampStochasticRoundFToSINTEL,

--- a/lib/SPIRV/libSPIRV/spirv_internal.hpp
+++ b/lib/SPIRV/libSPIRV/spirv_internal.hpp
@@ -71,7 +71,9 @@ enum InternalOp {
   IOpCooperativeMatrixLoadCheckedINTEL = 6193,
   IOpCooperativeMatrixStoreCheckedINTEL = 6194,
   IOpCooperativeMatrixConstructCheckedINTEL = 6195,
+  IOpClampConvertFToFINTEL = 6216, // old op, for backward compatibility
   IOpStochasticRoundFToFINTEL = 6217,
+  IOpClampStochasticRoundFToFINTEL = 6218, // old op, for backward compatibility
   IOpClampStochasticRoundFToSINTEL = 6219,
   IOpSubgroupScaledMatrixMultiplyAccumulateINTEL = 6264,
   IOpJointMatrixWorkItemLengthINTEL = 6410,
@@ -217,7 +219,9 @@ _SPIRV_OP(Capability, Float4E2M1INTEL)
 _SPIRV_OP(Capability, Float4E2M1CooperativeMatrixINTEL)
 
 _SPIRV_OP(Capability, FloatConversionsFtoFINTEL)
+_SPIRV_OP(Op, ClampConvertFToFINTEL)
 _SPIRV_OP(Op, StochasticRoundFToFINTEL)
+_SPIRV_OP(Op, ClampStochasticRoundFToFINTEL)
 _SPIRV_OP(Capability, FloatConversionsFtoSINTEL)
 _SPIRV_OP(Op, ClampConvertFToSINTEL)
 _SPIRV_OP(Op, ClampStochasticRoundFToSINTEL)

--- a/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_ftos_old_cap.spt
+++ b/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_ftos_old_cap.spt
@@ -1,0 +1,46 @@
+; Backward-compatibility test: used as regression to test that
+; the Reader must not require the FloatConversionsFToSINTEL capability (6216)
+; when OpClampConvertFToSINTEL or OpClampStochasticRoundFToSINTEL is used,
+; since the capability didn't exist in the old spec of SPV_INTEL_fp_conversions.
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: call spir_func i4 @_Z43__builtin_spirv_ClampConvertFP16ToInt4INTELDh(half 0xH3C00)
+; CHECK-LLVM: call spir_func i4 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToInt4INTELDhi(half 0xH3C00, i32 1)
+
+119734787 65536 393230 14 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+2 Capability Float16Buffer
+2 Capability Int4TypeINTEL
+8 Extension "SPV_INTEL_fp_conversions"
+5 Extension "SPV_INTEL_int4"
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 1 2
+3 Source 0 0
+6 Name 4 "hf16_int4_clamp"
+4 Name 5 "entry"
+8 Name 9 "hf16_int4_stochastic"
+4 Name 10 "entry"
+8 Decorate 4 LinkageAttributes "hf16_int4_clamp" Export
+10 Decorate 9 LinkageAttributes "hf16_int4_stochastic" Export
+4 TypeInt 2 4 0
+4 TypeInt 11 32 0
+4 Constant 11 12 1
+3 TypeFunction 3 2
+3 TypeFloat 6 16
+4 Constant 6 7 15360
+5 Function 2 4 0 3
+2 Label 5
+4 ClampConvertFToSINTEL 2 8 7
+2 ReturnValue 8
+1 FunctionEnd
+5 Function 2 9 0 3
+2 Label 10
+5 ClampStochasticRoundFToSINTEL 2 13 7 12
+2 ReturnValue 13
+1 FunctionEnd

--- a/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_old_spec.spt
+++ b/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_old_spec.spt
@@ -1,0 +1,92 @@
+; Backward-compatibility test: the SPIR-V Reader must still consume modules that
+; use the OLD SPV_INTEL_fp_conversions spec revision, i.e. the removed
+; OpClampConvertFToFINTEL (6216) and OpClampStochasticRoundFToFINTEL (6218)
+; instructions. For FP8 destinations they must lower to the SAME __builtin_spirv_*
+; calls that the new spec (OpFConvert / OpStochasticRoundFToFINTEL +
+; SaturatedToLargestFloat8NormalConversionEXT) lowers to, since the LLVM IR
+; representation did not change. For other (non-fp4/fp8/int4) destinations they
+; are emitted as __spirv_<OpName>_R<type> builtin calls.
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; CHECK-LLVM: call spir_func i8 @_Z43__builtin_spirv_ClampConvertFP16ToE4M3INTELDh(half 0xH3C00)
+; CHECK-LLVM: call spir_func i8 @_Z51__builtin_spirv_ClampStochasticRoundFP16ToE5M2INTELDhi(half 0xH3C00, i32 1)
+; CHECK-LLVM: call spir_func float @_Z36__spirv_ClampConvertFToFINTEL_RfloatDh(half 0xH3C00)
+; CHECK-LLVM: call spir_func float @_Z44__spirv_ClampStochasticRoundFToFINTEL_RfloatDhi(half 0xH3C00, i32 1)
+; CHECK-LLVM: call spir_func half @_Z35__spirv_ClampConvertFToFINTEL_Rhalff(float 1.000000e+00)
+; CHECK-LLVM: call spir_func half @_Z43__spirv_ClampStochasticRoundFToFINTEL_Rhalffi(float 1.000000e+00, i32 1)
+
+119734787 65536 393230 34 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+2 Capability Float16Buffer
+2 Capability Int8
+2 Capability Float8EXT
+2 Capability FloatConversionsFtoFINTEL
+5 Extension "SPV_EXT_float8"
+8 Extension "SPV_INTEL_fp_conversions"
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 1 2
+3 Source 0 0
+6 Name 4 "hf16_hf8_clamp"
+4 Name 5 "entry"
+9 Name 11 "hf16_bf8_clamp_stochastic"
+4 Name 12 "entry"
+6 Name 20 "hf16_fp32_clamp"
+9 Name 23 "hf16_fp32_clamp_stochastic"
+6 Name 28 "fp32_hf16_clamp"
+9 Name 31 "fp32_hf16_clamp_stochastic"
+8 Decorate 4 LinkageAttributes "hf16_hf8_clamp" Export
+11 Decorate 11 LinkageAttributes "hf16_bf8_clamp_stochastic" Export
+8 Decorate 20 LinkageAttributes "hf16_fp32_clamp" Export
+11 Decorate 23 LinkageAttributes "hf16_fp32_clamp_stochastic" Export
+8 Decorate 28 LinkageAttributes "fp32_hf16_clamp" Export
+11 Decorate 31 LinkageAttributes "fp32_hf16_clamp_stochastic" Export
+4 TypeInt 2 8 0
+4 TypeInt 14 32 0
+4 Constant 14 15 1
+3 TypeFunction 3 2
+3 TypeFloat 6 16
+4 TypeFloat 8 8 4214
+4 TypeFloat 13 8 4215
+3 TypeFloat 18 32
+3 TypeFunction 19 18
+4 Constant 6 7 15360
+3 TypeFunction 27 6
+4 Constant 18 26 1065353216
+5 Function 2 4 0 3
+2 Label 5
+4 ClampConvertFToFINTEL 8 9 7
+4 Bitcast 2 10 9
+2 ReturnValue 10
+1 FunctionEnd
+5 Function 2 11 0 3
+2 Label 12
+5 ClampStochasticRoundFToFINTEL 13 16 7 15
+4 Bitcast 2 17 16
+2 ReturnValue 17
+1 FunctionEnd
+5 Function 18 20 0 19
+2 Label 21
+4 ClampConvertFToFINTEL 18 22 7
+2 ReturnValue 22
+1 FunctionEnd
+5 Function 18 23 0 19
+2 Label 24
+5 ClampStochasticRoundFToFINTEL 18 25 7 15
+2 ReturnValue 25
+1 FunctionEnd
+5 Function 6 28 0 27
+2 Label 29
+4 ClampConvertFToFINTEL 6 30 26
+2 ReturnValue 30
+1 FunctionEnd
+5 Function 6 31 0 27
+2 Label 32
+5 ClampStochasticRoundFToFINTEL 6 33 26 15
+2 ReturnValue 33
+1 FunctionEnd

--- a/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_old_spec_sat_decor.spt
+++ b/test/extensions/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_old_spec_sat_decor.spt
@@ -1,0 +1,38 @@
+; Negative test: The SaturatedToLargestFloat8NormalConversionEXT decoration
+; must not be placed on the old SPV_INTEL_fp_conversions opcodes OpClampConvertFToFINTEL
+; (6216) and OpClampStochasticRoundFToFINTEL (6218).
+
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: not llvm-spirv -r %t.spv -o %t.rev.bc 2>&1 | FileCheck %s
+
+; CHECK: InvalidInstruction
+; CHECK: SaturatedToLargestFloat8NormalConversionEXT is not valid on OpClampConvertFToFINTEL or OpClampStochasticRoundFToFINTEL.
+
+119734787 65536 393230 11 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+2 Capability Float16Buffer
+2 Capability Int8
+2 Capability Float8EXT
+2 Capability FloatConversionsFtoFINTEL
+5 Extension "SPV_EXT_float8"
+8 Extension "SPV_INTEL_fp_conversions"
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 1 2
+3 Source 0 0
+6 Name 4 "clamp_with_sat_decor"
+4 Name 5 "entry"
+8 Decorate 4 LinkageAttributes "clamp_with_sat_decor" Export
+3 Decorate 9 SaturatedToLargestFloat8NormalConversionEXT
+4 TypeInt 2 8 0
+3 TypeFunction 3 2
+3 TypeFloat 6 16
+4 TypeFloat 8 8 4214
+4 Constant 6 7 15360
+5 Function 2 4 0 3
+2 Label 5
+4 ClampConvertFToFINTEL 8 9 7
+4 Bitcast 2 10 9
+2 ReturnValue 10
+1 FunctionEnd


### PR DESCRIPTION
Backport of #3868