### PR TITLE
[Backport to 14] Add missing coverage for SPV_EXT_long_vector

### DIFF
--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.cpp
@@ -127,11 +127,12 @@ SPIRVLowerBitCastToNonStandardTypePass::run(Function &F,
   // parameter, since it added by an optimization.
   bool Changed = false;
 
-  // SPV_INTEL_vector_compute allows to use vectors with any number of
-  // components. Since this method only lowers vectors with non-standard
-  // in pure SPIR-V number of components, there is no need to do anything in
-  // case SPV_INTEL_vector_compute is enabled.
-  if (Opts.isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
+  // SPV_EXT_long_vector and SPV_INTEL_vector_compute allow to use vectors with
+  // any number of components. Since this method only lowers vectors with
+  // non-standard in pure SPIR-V number of components, there is no need to do
+  // anything in case any of them is enabled.
+  if (Opts.isAllowedToUseExtension(ExtensionID::SPV_EXT_long_vector) ||
+      Opts.isAllowedToUseExtension(ExtensionID::SPV_INTEL_vector_compute))
     return PreservedAnalyses::all();
 
   // The basic pattern we're trying to fix is this InstCombine pattern:

--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -1965,6 +1965,7 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
       return true;
     if ((!Ty->isFloatTy() && !Ty->isDoubleTy() && !Ty->isHalfTy()) ||
         (!BM->hasCapability(CapabilityVectorAnyINTEL) &&
+         !BM->hasCapability(CapabilityLongVectorEXT) &&
          ((NumElems > 4) && (NumElems != 8) && (NumElems != 16)))) {
       BM->SPIRVCK(
           false, InvalidFunctionCall, II->getCalledOperand()->getName().str());
@@ -1984,6 +1985,7 @@ bool checkTypeForSPIRVExtendedInstLowering(IntrinsicInst *II, SPIRVModule *BM) {
       return true;
     if ((!Ty->isIntegerTy()) ||
         (!BM->hasCapability(CapabilityVectorAnyINTEL) &&
+         !BM->hasCapability(CapabilityLongVectorEXT) &&
          ((NumElems > 4) && (NumElems != 8) && (NumElems != 16)))) {
       BM->SPIRVCK(
           false, InvalidFunctionCall, II->getCalledOperand()->getName().str());

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-abs-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-abs-with-ext.ll
@@ -1,0 +1,24 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not --crash llvm-spirv -s %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector %t.bc
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK-ERROR: Unsupported vector type with 5 elements
+
+; CHECK: ExtInstImport [[ExtInstSetId:[0-9]+]] "OpenCL.std"
+; CHECK: TypeInt [[Int:[0-9]+]] 32
+; CHECK: TypeVector [[Int5:[0-9]+]] [[Int]] 5
+
+; ModuleID = 'lower-non-standard-vec-with-ext'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+declare <5 x i32> @llvm.abs.v5i32(<5 x i32> %x, i1 %is_int_min_poison)
+
+; Function Attrs: convergent norecurse
+define dso_local spir_func <5 x i32> @test_abs(<5 x i32> %src) local_unnamed_addr {
+entry:
+  %res = call <5 x i32> @llvm.abs.v5i32(<5 x i32> %src, i1 false)
+; CHECK: ExtInst [[Int5]] {{[0-9]+}} [[ExtInstSetId]] s_abs
+  ret <5 x i32> %res
+}

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-sqrt-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-sqrt-with-ext.ll
@@ -1,0 +1,24 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not --crash llvm-spirv -s %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector %t.bc
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK-ERROR: Unsupported vector type with 5 elements
+
+; CHECK: ExtInstImport [[ExtInstSetId:[0-9]+]] "OpenCL.std"
+; CHECK: TypeFloat [[Float:[0-9]+]] 32
+; CHECK: TypeVector [[Float5:[0-9]+]] [[Float]] 5
+
+; ModuleID = 'lower-non-standard-vec-with-ext'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+declare <5 x float> @llvm.sqrt.f32(<5 x float> %x)
+
+; Function Attrs: convergent norecurse
+define dso_local spir_func <5 x float> @test_sqrt(<5 x float> %src) local_unnamed_addr {
+entry:
+  %res = call <5 x float> @llvm.sqrt.f32(<5 x float> %src)
+; CHECK: ExtInst [[Float5]] {{[0-9]+}} [[ExtInstSetId]] sqrt
+  ret <5 x float> %res
+}

--- a/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-with-ext.ll
+++ b/test/extensions/EXT/SPV_EXT_long_vector/lower-non-standard-vec-with-ext.ll
@@ -1,0 +1,30 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not --crash llvm-spirv -s %t.bc 2>&1 | FileCheck %s --check-prefix=CHECK-ERROR
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_long_vector %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s
+
+; CHECK-ERROR: Unsupported vector type with 20 elements
+
+; CHECK-DAG: Capability LongVectorEXT
+; CHECK-DAG: Extension "SPV_EXT_long_vector"
+; CHECK-DAG: TypeInt [[#I32:]] 32 0
+; CHECK-DAG: TypeInt [[#I8:]] 8 0
+; CHECK-DAG: TypeVector [[#]] [[#I32]] 1
+; CHECK-DAG: TypeVector [[#]] [[#I8]] 4
+; CHECK-DAG: TypeVector [[#]] [[#I32]] 5
+; CHECK-DAG: TypeVector [[#]] [[#I8]] 20
+
+; ModuleID = 'lower-non-standard-vec-with-ext'
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: convergent norecurse
+define dso_local spir_func void @vmult2() local_unnamed_addr {
+entry:
+  %0 = bitcast <1 x i32> <i32 65793> to <4 x i8>
+  %1 = extractelement <4 x i8> %0, i32 0
+  %2 = bitcast <1 x i32> <i32 131586> to <4 x i8>
+  %3 = extractelement <4 x i8> %2, i32 0
+  %4 = bitcast <5 x i32> <i32 1, i32 1, i32 1, i32 1, i32 1> to <20 x i8>
+  ret void
+}


### PR DESCRIPTION
Backport of #3869

Note: on the LLVM 14 branch, the "Unsupported vector type" diagnostic is emitted via `report_fatal_error` with a crash trace (abort), so the error-check `RUN` lines use `not --crash llvm-spirv -s` instead of `not llvm-spirv -s` — mirroring the existing `test/lower-non-standard-vec-with-ext.ll` on this branch.