### PR TITLE
[CI] Mark failing tests as expected-fail to keep CI green

### DIFF
--- a/test/DebugInfo/LocalAddressSpace.ll
+++ b/test/DebugInfo/LocalAddressSpace.ll
@@ -1,5 +1,5 @@
 ; XFAIL: *
-; ISSUE #
+; ISSUE #3899
 ; Source:
 ;__kernel void foo(void) {
 ;  __local int a;

--- a/test/DebugInfo/LocalAddressSpace.ll
+++ b/test/DebugInfo/LocalAddressSpace.ll
@@ -1,3 +1,5 @@
+; XFAIL: *
+; ISSUE #
 ; Source:
 ;__kernel void foo(void) {
 ;  __local int a;

--- a/test/DebugInfo/NonSemantic/Shader200/DebugInfoStringType.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugInfoStringType.ll
@@ -1,5 +1,5 @@
 ; XFAIL: *
-; ISSUE #
+; ISSUE #3899
 ; RUN: llvm-spirv -spirv-text %s -o %t.spt --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -to-binary %t.spt -o %t.spv

--- a/test/DebugInfo/NonSemantic/Shader200/DebugInfoStringType.ll
+++ b/test/DebugInfo/NonSemantic/Shader200/DebugInfoStringType.ll
@@ -1,3 +1,5 @@
+; XFAIL: *
+; ISSUE #
 ; RUN: llvm-spirv -spirv-text %s -o %t.spt --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: FileCheck < %t.spt %s -check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -to-binary %t.spt -o %t.spv

--- a/test/DebugInfo/X86/DW_AT_specification.ll
+++ b/test/DebugInfo/X86/DW_AT_specification.ll
@@ -1,3 +1,5 @@
+; XFAIL: *
+; ISSUE #
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/DW_AT_specification.ll
+++ b/test/DebugInfo/X86/DW_AT_specification.ll
@@ -1,5 +1,5 @@
 ; XFAIL: *
-; ISSUE #
+; ISSUE #3899
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll

--- a/test/DebugInfo/X86/dimodule-external-fortran.ll
+++ b/test/DebugInfo/X86/dimodule-external-fortran.ll
@@ -1,3 +1,5 @@
+; XFAIL: *
+; ISSUE #
 ; This test verifies that the debug info for an external Fortran module
 ; is correctly generated.
 ;

--- a/test/DebugInfo/X86/dimodule-external-fortran.ll
+++ b/test/DebugInfo/X86/dimodule-external-fortran.ll
@@ -1,5 +1,5 @@
 ; XFAIL: *
-; ISSUE #
+; ISSUE #3899
 ; This test verifies that the debug info for an external Fortran module
 ; is correctly generated.
 ;

--- a/test/transcoding/dbginfo-bug-on-bool-converts.ll
+++ b/test/transcoding/dbginfo-bug-on-bool-converts.ll
@@ -1,5 +1,5 @@
 ; XFAIL: *
-; ISSUE #
+; ISSUE #3899
 ; RUN: llvm-spirv %s -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s

--- a/test/transcoding/dbginfo-bug-on-bool-converts.ll
+++ b/test/transcoding/dbginfo-bug-on-bool-converts.ll
@@ -1,3 +1,5 @@
+; XFAIL: *
+; ISSUE #
 ; RUN: llvm-spirv %s -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s


### PR DESCRIPTION
Mark broken tests as expected fail to unblock CI
Created issue: https://github.com/KhronosGroup/SPIRV-LLVM-Translator/issues/3899