### PR TITLE
Error handling for malformed SPIRV input

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVEntry.cpp
@@ -95,8 +95,7 @@ SPIRVEntry *SPIRVEntry::create(Op OpCode) {
     return Loc->second();
 
   SPIRVDBG(spvdbgs() << "No factory for OpCode " << (unsigned)OpCode << '\n';)
-  assert(0 && "Not implemented");
-  return 0;
+  return nullptr;
 }
 
 std::unique_ptr<SPIRV::SPIRVEntry> SPIRVEntry::createUnique(Op OC) {

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -116,7 +116,12 @@ void SPIRVFunction::decode(std::istream &I) {
       break;
     }
     default:
-      assert(0 && "Invalid SPIRV format");
+      Module->getErrorLog().checkError(false, SPIRVEC_InvalidModule,
+                                       "unexpected opcode " +
+                                           std::to_string(Decoder.OpCode) +
+                                           " in function definition");
+      Module->setInvalid();
+      return;
     }
   }
 }
@@ -142,6 +147,10 @@ bool SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
     }
 
     SPIRVEntry *Entry = Decoder.getEntry();
+    if (!Entry) {
+      Module->setInvalid();
+      return false;
+    }
 
     if (Decoder.OpCode == OpLine) {
       std::shared_ptr<const SPIRVLine> L(static_cast<SPIRVLine *>(Entry));

--- a/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVFunction.cpp
@@ -148,6 +148,9 @@ bool SPIRVFunction::decodeBB(SPIRVDecoder &Decoder) {
 
     SPIRVEntry *Entry = Decoder.getEntry();
     if (!Entry) {
+      Module->getErrorLog().checkError(false, SPIRVEC_InvalidInstruction,
+                                       "failed to decode instruction in "
+                                       "basic block");
       Module->setInvalid();
       return false;
     }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1007,7 +1007,14 @@ SPIRVEntry *SPIRVModuleImpl::getEntry(SPIRVId Id) const {
 
 SPIRVExtInstSetKind SPIRVModuleImpl::getBuiltinSet(SPIRVId SetId) const {
   auto Loc = IdToInstSetMap.find(SetId);
-  assert(Loc != IdToInstSetMap.end() && "Invalid builtin set id");
+  if (Loc == IdToInstSetMap.end()) {
+    const_cast<SPIRVModuleImpl *>(this)->getErrorLog().checkError(
+        false, SPIRVEC_InvalidModule,
+        "input SPIR-V module references an unknown extended instruction set "
+        "id " +
+            std::to_string(SetId));
+    return SPIRVEIS_Count;
+  }
   return Loc->second;
 }
 

--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -297,7 +297,13 @@ SPIRVEntry *SPIRVDecoder::getEntry() {
     M.setInvalid();
   }
 
-  assert(!IS.bad() && !IS.fail() && "SPIRV stream fails");
+  if (IS.bad() || IS.fail()) {
+    M.getErrorLog().checkError(false, SPIRVEC_InvalidModule,
+                               "input SPIR-V module has a truncated "
+                               "instruction (stream failed mid-read)");
+    M.setInvalid();
+    return nullptr;
+  }
   return Entry;
 }
 

--- a/test/negative/malformed-invalid-opcode-function-scope.spvasm
+++ b/test/negative/malformed-invalid-opcode-function-scope.spvasm
@@ -1,0 +1,22 @@
+; Test that llvm-spirv gracefully rejects a SPIR-V module where a
+; module-scope instruction (OpDecorate) appears directly after OpFunction
+; instead of OpFunctionParameter or OpLabel.
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: not llvm-spirv -r %t.spv -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: unexpected opcode {{[0-9]+}} in function definition
+
+; SPIR-V
+; Version: 1.0
+               OpCapability Kernel
+               OpCapability Addresses
+               OpMemoryModel Physical32 OpenCL
+       %void = OpTypeVoid
+    %fn_type = OpTypeFunction %void
+       %func = OpFunction %void None %fn_type
+               OpDecorate %void RelaxedPrecision
+      %label = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/test/negative/malformed-multiple-unknown-opcodes.spvasm
+++ b/test/negative/malformed-multiple-unknown-opcodes.spvasm
@@ -1,0 +1,27 @@
+; Test that llvm-spirv gracefully rejects a SPIR-V module with multiple
+; unknown opcodes (7777, 7778, 7779) in a row at module scope. Verifies
+; that the module is correctly marked invalid after the first error and
+; does not produce cascading null dereferences.
+;
+; Raw words: !73313 = (1<<16)|7777, !73314 = (1<<16)|7778, !73315 = (1<<16)|7779
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: not llvm-spirv -r %t.spv -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: input SPIR-V module has an invalid or unknown opcode 7777
+
+; SPIR-V
+; Version: 1.0
+               OpCapability Kernel
+               OpCapability Addresses
+               OpMemoryModel Physical32 OpenCL
+       %void = OpTypeVoid
+               !73313
+               !73314
+               !73315
+    %fn_type = OpTypeFunction %void
+       %func = OpFunction %void None %fn_type
+      %label = OpLabel
+               OpReturn
+               OpFunctionEnd

--- a/test/negative/malformed-truncated-instruction.spvasm
+++ b/test/negative/malformed-truncated-instruction.spvasm
@@ -1,0 +1,21 @@
+; Test that llvm-spirv gracefully rejects a SPIR-V module truncated
+; mid-instruction. The raw words inject an OpVariable header claiming
+; WordCount=5 (!327739 = (5<<16)|59) followed by only 1 operand word,
+; then the file ends — 3 words short.
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: not llvm-spirv -r %t.spv -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: input SPIR-V module has a truncated instruction
+
+; SPIR-V
+; Version: 1.0
+               OpCapability Kernel
+               OpCapability Addresses
+               OpMemoryModel Physical32 OpenCL
+       %void = OpTypeVoid
+    %fn_type = OpTypeFunction %void
+       %func = OpFunction %void None %fn_type
+      %label = OpLabel
+               !327739 !1

--- a/test/negative/malformed-unknown-opcode-function-body.spvasm
+++ b/test/negative/malformed-unknown-opcode-function-body.spvasm
@@ -1,0 +1,25 @@
+; Test that llvm-spirv gracefully rejects a SPIR-V module with an unknown
+; opcode (8888) inside a function body instead of crashing. This exercises
+; the SPIRVDecoder::getEntry() path (SPIRVStream.cpp) rather than the
+; parseAndCreateSPIRVEntry path (SPIRVModule.cpp).
+;
+; The raw word !74424 encodes WordCount=1, OpCode=8888.
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: not llvm-spirv -r %t.spv -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: input SPIR-V module has an invalid or unknown opcode 8888
+
+; SPIR-V
+; Version: 1.0
+               OpCapability Kernel
+               OpCapability Addresses
+               OpMemoryModel Physical32 OpenCL
+       %void = OpTypeVoid
+    %fn_type = OpTypeFunction %void
+       %func = OpFunction %void None %fn_type
+      %label = OpLabel
+               !74424
+               OpReturn
+               OpFunctionEnd

--- a/test/negative/malformed-unknown-opcode-module-scope.spvasm
+++ b/test/negative/malformed-unknown-opcode-module-scope.spvasm
@@ -1,0 +1,23 @@
+; Test that llvm-spirv gracefully rejects a SPIR-V module with an unknown
+; opcode (9999) at module scope.
+;
+; The raw word !75535 encodes WordCount=1, OpCode=9999.
+
+; REQUIRES: spirv-as
+; RUN: spirv-as --target-env spv1.0 -o %t.spv %s
+; RUN: not llvm-spirv -r %t.spv -o /dev/null 2>&1 | FileCheck %s
+
+; CHECK: input SPIR-V module has an invalid or unknown opcode 9999
+
+; SPIR-V
+; Version: 1.0
+               OpCapability Kernel
+               OpCapability Addresses
+               OpMemoryModel Physical32 OpenCL
+       %void = OpTypeVoid
+               !75535
+    %fn_type = OpTypeFunction %void
+       %func = OpFunction %void None %fn_type
+      %label = OpLabel
+               OpReturn
+               OpFunctionEnd


### PR DESCRIPTION
Further hardening of the translator against malformed input to prevent crashes. Specifically, this PR:
- Reports an error and invalidates module in `SPIRVFunction::decode()` for opcodes that don't belong in function scope.
- Adds null check with module invalidation and early exit after `Decoder.getEntry()` in `SPIRVFunction::decodeBB()` because it can return `nullptr` and it was otherwise dereferenced down the line.
- Reports an error and invalidates module for unknown extended instruction set IDs.
- Reports an  error and invalidates module for truncated instructions.

5 new lit tests are added that were crashing before this patch. These new tests are a bit special, they need to feed deliberately malformed SPIR-V to the translator, including opcodes that don't exist, instructions in the wrong scope or truncated streams. Since spirv-as normally validates its input, the tests use its `!<integer>` syntax to inject raw 32-bit words directly into the binary output, bypassing validation. For example, `!75535` emits the raw word `(1<<16)|9999`, which encodes a single-word instruction with unknown opcode 9999. Care must be taken with placement: `!` words after variadic instructions (like OpTypeFunction) get absorbed as extra operands rather than emitted as standalone instructions.