### PR TITLE
[SPIRV] Translate llvm.sincos intrinsic to OpenCL sincos

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4571,8 +4571,8 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
   case Intrinsic::sincos: {
     // llvm.sincos(x) returns {sin(x), cos(x)}, while OpenCLLIB::Sincos takes
     // (x, cos_ptr) and returns sin(x), storing cos(x) via the pointer.
-    // Create a temporary function variable for the cos output, call OpenCL sincos, load
-    // the cos value, then construct the result struct.
+    // Create a temporary function variable for the cos output, call OpenCL
+    // sincos, load the cos value, then construct the result struct.
     SPIRVType *CosTy = transType(II->getType()->getStructElementType(1));
     SPIRVType *CosPtrTy = BM->addPointerType(StorageClassFunction, CosTy);
     SPIRVBasicBlock *EntryBB = BB->getParent()->getBasicBlock(0);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4571,7 +4571,7 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
   case Intrinsic::sincos: {
     // llvm.sincos(x) returns {sin(x), cos(x)}, while OpenCLLIB::Sincos takes
     // (x, cos_ptr) and returns sin(x), storing cos(x) via the pointer.
-    // Create a temporary alloca for the cos output, call OpenCL sincos, load
+    // Create a temporary function variable for the cos output, call OpenCL sincos, load
     // the cos value, then construct the result struct.
     SPIRVType *CosTy = transType(II->getType()->getStructElementType(1));
     SPIRVType *CosPtrTy = BM->addPointerType(StorageClassFunction, CosTy);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4153,6 +4153,7 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::round:
   case Intrinsic::roundeven:
   case Intrinsic::sin:
+  case Intrinsic::sincos:
   case Intrinsic::sqrt:
   case Intrinsic::tan:
   case Intrinsic::trunc:
@@ -4565,6 +4566,32 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     // Create the struct.
     SPIRVType *STy = transType(II->getType());
     std::vector<SPIRVId> StructVals{Modf->getId(), IntegralVal->getId()};
+    return BM->addCompositeConstructInst(STy, StructVals, BB);
+  }
+  case Intrinsic::sincos: {
+    // llvm.sincos(x) returns {sin(x), cos(x)}, while OpenCLLIB::Sincos takes
+    // (x, cos_ptr) and returns sin(x), storing cos(x) via the pointer.
+    // Create a temporary alloca for the cos output, call OpenCL sincos, load
+    // the cos value, then construct the result struct.
+    SPIRVType *CosTy = transType(II->getType()->getStructElementType(1));
+    SPIRVType *CosPtrTy = BM->addPointerType(StorageClassFunction, CosTy);
+    SPIRVBasicBlock *EntryBB = BB->getParent()->getBasicBlock(0);
+    SPIRVValue *CosPtr =
+        BM->addVariable(static_cast<SPIRVTypePointer *>(CosPtrTy), nullptr,
+                        false, spv::internal::LinkageTypeInternal, nullptr, "",
+                        StorageClassFunction, EntryBB);
+
+    SPIRVType *SinTy = transType(II->getType()->getStructElementType(0));
+    SPIRVValue *Arg = transValue(II->getArgOperand(0), BB);
+    std::vector<SPIRVValue *> Ops{Arg, CosPtr};
+    SPIRVValue *SinVal =
+        BM->addExtInst(SinTy, BM->getExtInstSetId(SPIRVEIS_OpenCL),
+                       OpenCLLIB::Sincos, Ops, BB);
+
+    SPIRVValue *CosVal = BM->addLoadInst(CosPtr, {}, BB, CosTy);
+
+    SPIRVType *STy = transType(II->getType());
+    std::vector<SPIRVId> StructVals{SinVal->getId(), CosVal->getId()};
     return BM->addCompositeConstructInst(STy, StructVals, BB);
   }
   // Binary FP intrinsics

--- a/test/llvm-intrinsics/fp-intrinsics.ll
+++ b/test/llvm-intrinsics/fp-intrinsics.ll
@@ -508,3 +508,20 @@ entry:
 }
 
 declare float @llvm.ldexp.f32.i32(float, i32)
+
+; CHECK: Function [[ResTy2:[0-9]+]]
+; CHECK: FunctionParameter {{[0-9]+}} [[xsincos:[0-9]+]]
+; CHECK: Variable [[PtrTy2:[0-9]+]] [[CosPtr:[0-9]+]] 7
+; CHECK: ExtInst [[var2]] [[SinVal:[0-9]+]] [[extinst_id]] sincos [[xsincos]] [[CosPtr]]
+; CHECK: Load [[var2]] [[CosVal:[0-9]+]] [[CosPtr]]
+; CHECK: CompositeConstruct [[ResTy2]] [[RetVal2:[0-9]+]] [[SinVal]] [[CosVal]]
+; CHECK: ReturnValue [[RetVal2]]
+; CHECK: FunctionEnd
+
+define spir_func {double, double} @TestSincos(double %x) {
+entry:
+  %t = tail call {double, double} @llvm.sincos.f64(double %x)
+  ret {double, double} %t
+}
+
+declare {double, double} @llvm.sincos.f64(double)


### PR DESCRIPTION
llvm.sincos(x) returns {sin(x), cos(x)}, but OpenCL sincos(x, &cos) returns sin(x) and stores cos(x) via pointer. Bridge this by allocating a Function-storage pointer for the cos output, calling OpenCL sincos, loading the cos value, and constructing the result. Register llvm.sincos in isKnownIntrinsic so
-spirv-allow-unknown-intrinsics does not erroneously treat it as unknown.

Exposed by https://github.com/llvm/llvm-project/commit/0e877fd1a637 ("Reland '[InstCombine] Combine llvm.sin/llvm.cos libcall pairs into llvm.sincos' (#194616)"), which caused llvm-spirv to reject the intrinsic as unknown in our downstream tests.

Co-Authored-By: Claude Sonnet 4.6 (1M context)