### PR TITLE
Prefer RequiredPassInfoMixin

### DIFF
--- a/lib/SPIRV/OCLToSPIRV.h
+++ b/lib/SPIRV/OCLToSPIRV.h
@@ -304,12 +304,10 @@ public:
 };
 
 class OCLToSPIRVPass : public OCLToSPIRVBase,
-                       public llvm::PassInfoMixin<OCLToSPIRVPass> {
+                       public llvm::RequiredPassInfoMixin<OCLToSPIRVPass> {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/PreprocessMetadata.h
+++ b/lib/SPIRV/PreprocessMetadata.h
@@ -78,13 +78,11 @@ public:
 };
 
 class PreprocessMetadataPass
-    : public llvm::PassInfoMixin<PreprocessMetadataPass>,
+    : public llvm::RequiredPassInfoMixin<PreprocessMetadataPass>,
       public PreprocessMetadataBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.h
+++ b/lib/SPIRV/SPIRVLowerBitCastToNonStandardType.h
@@ -43,15 +43,14 @@
 namespace SPIRV {
 
 class SPIRVLowerBitCastToNonStandardTypePass
-    : public llvm::PassInfoMixin<SPIRVLowerBitCastToNonStandardTypePass> {
+    : public llvm::RequiredPassInfoMixin<
+          SPIRVLowerBitCastToNonStandardTypePass> {
 public:
   SPIRVLowerBitCastToNonStandardTypePass(const SPIRV::TranslatorOpts &Opts)
       : Opts(Opts) {}
 
   llvm::PreservedAnalyses run(llvm::Function &F,
                               llvm::FunctionAnalysisManager &FAM);
-
-  static bool isRequired() { return true; }
 
 private:
   SPIRV::TranslatorOpts Opts;

--- a/lib/SPIRV/SPIRVLowerBool.h
+++ b/lib/SPIRV/SPIRVLowerBool.h
@@ -65,13 +65,12 @@ private:
   llvm::LLVMContext *Context;
 };
 
-class SPIRVLowerBoolPass : public llvm::PassInfoMixin<SPIRVLowerBoolPass>,
-                           public SPIRVLowerBoolBase {
+class SPIRVLowerBoolPass
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerBoolPass>,
+      public SPIRVLowerBoolBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerBoolLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerConstExpr.h
+++ b/lib/SPIRV/SPIRVLowerConstExpr.h
@@ -36,7 +36,7 @@ private:
 };
 
 class SPIRVLowerConstExprPass
-    : public llvm::PassInfoMixin<SPIRVLowerConstExprPass>,
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerConstExprPass>,
       public SPIRVLowerConstExprBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -44,8 +44,6 @@ public:
     return runLowerConstExpr(M) ? llvm::PreservedAnalyses::none()
                                 : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 };
 
 } // namespace SPIRV

--- a/lib/SPIRV/SPIRVLowerLLVMIntrinsic.h
+++ b/lib/SPIRV/SPIRVLowerLLVMIntrinsic.h
@@ -62,14 +62,12 @@ private:
 };
 
 class SPIRVLowerLLVMIntrinsicPass
-    : public llvm::PassInfoMixin<SPIRVLowerLLVMIntrinsicPass>,
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerLLVMIntrinsicPass>,
       public SPIRVLowerLLVMIntrinsicBase {
 public:
   SPIRVLowerLLVMIntrinsicPass(const SPIRV::TranslatorOpts &Opts);
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerLLVMIntrinsicLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerMemmove.h
+++ b/lib/SPIRV/SPIRVLowerMemmove.h
@@ -58,13 +58,12 @@ private:
   llvm::LLVMContext *Context;
 };
 
-class SPIRVLowerMemmovePass : public llvm::PassInfoMixin<SPIRVLowerMemmovePass>,
-                              public SPIRVLowerMemmoveBase {
+class SPIRVLowerMemmovePass
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerMemmovePass>,
+      public SPIRVLowerMemmoveBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerMemmoveLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVLowerOCLBlocks.h
+++ b/lib/SPIRV/SPIRVLowerOCLBlocks.h
@@ -48,13 +48,11 @@ public:
 };
 
 class SPIRVLowerOCLBlocksPass
-    : public llvm::PassInfoMixin<SPIRVLowerOCLBlocksPass>,
+    : public llvm::RequiredPassInfoMixin<SPIRVLowerOCLBlocksPass>,
       public SPIRVLowerOCLBlocksBase {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
                               llvm::ModuleAnalysisManager &MAM);
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVLowerOCLBlocksLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -122,7 +122,7 @@ private:
 };
 
 class SPIRVRegularizeLLVMPass
-    : public llvm::PassInfoMixin<SPIRVRegularizeLLVMPass>,
+    : public llvm::RequiredPassInfoMixin<SPIRVRegularizeLLVMPass>,
       public SPIRVRegularizeLLVMBase {
 public:
   explicit SPIRVRegularizeLLVMPass(const SPIRV::TranslatorOpts &Opts = {})
@@ -133,8 +133,6 @@ public:
     return runRegularizeLLVM(M) ? llvm::PreservedAnalyses::none()
                                 : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVRegularizeLLVMLegacy : public llvm::ModulePass,

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -383,7 +383,7 @@ public:
   std::string mapAtomicName(Op OC, Type *Ty);
 };
 
-class SPIRVToOCL12Pass : public llvm::PassInfoMixin<SPIRVToOCL12Pass>,
+class SPIRVToOCL12Pass : public llvm::RequiredPassInfoMixin<SPIRVToOCL12Pass>,
                          public SPIRVToOCL12Base {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -391,8 +391,6 @@ public:
     return runSPIRVToOCL(M) ? llvm::PreservedAnalyses::none()
                             : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVToOCL12Legacy : public SPIRVToOCL12Base, public SPIRVToOCLLegacy {
@@ -456,7 +454,7 @@ public:
   void visitCallSPIRVAtomicCmpExchg(CallInst *CI) override;
 };
 
-class SPIRVToOCL20Pass : public llvm::PassInfoMixin<SPIRVToOCL20Pass>,
+class SPIRVToOCL20Pass : public llvm::RequiredPassInfoMixin<SPIRVToOCL20Pass>,
                          public SPIRVToOCL20Base {
 public:
   llvm::PreservedAnalyses run(llvm::Module &M,
@@ -464,8 +462,6 @@ public:
     return runSPIRVToOCL(M) ? llvm::PreservedAnalyses::none()
                             : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 };
 
 class SPIRVToOCL20Legacy : public SPIRVToOCLLegacy, public SPIRVToOCL20Base {

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -270,7 +270,7 @@ private:
                                                    Function *F);
 };
 
-class LLVMToSPIRVPass : public PassInfoMixin<LLVMToSPIRVPass> {
+class LLVMToSPIRVPass : public RequiredPassInfoMixin<LLVMToSPIRVPass> {
 public:
   LLVMToSPIRVPass(SPIRVModule *SMod) : SMod(SMod) {}
 
@@ -281,8 +281,6 @@ public:
     return PassInstance.runLLVMToSPIRV(M) ? llvm::PreservedAnalyses::none()
                                           : llvm::PreservedAnalyses::all();
   }
-
-  static bool isRequired() { return true; }
 
 private:
   SPIRVModule *SMod;


### PR DESCRIPTION
In LLVM 23, {Optional,Required}PassInfoMixin became preferred for creating passes instead of raw PassInfoMixin with isRequired. In LLVM 24, PassInfoMixin will be moved to a detail namespace, causing compilation failures.