### PR TITLE
Temporarily resort to llvm 23 packages

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -39,7 +39,7 @@ env:
   # We need compile command database in order to perform clang-tidy check. So,
   # in order to perform configure step we need to setup llvm-dev package. This
   # env variable used to specify desired version of it
-  LLVM_VERSION: 24
+  LLVM_VERSION: 23
 
 jobs:
   clang-format-and-tidy:

--- a/.github/workflows/check-in-tree-build.yml
+++ b/.github/workflows/check-in-tree-build.yml
@@ -50,7 +50,7 @@ on:
     - cron: 0 0 * * *
 
 env:
-  LLVM_VERSION: 24
+  LLVM_VERSION: 23
   SPIRV_TOOLS_INSTALL: ${{ github.workspace }}/spirv-tools-install
 
 jobs:


### PR DESCRIPTION
As apt packages for llvm 24 are not available yet, temporarily switch the code style and in-tree build checks back to llvm 23.

Revert this commit once llvm 24 packages are available.