### PR TITLE
Fix invalid OpIMul emitted for i1 multiplication

### DIFF
--- a/lib/SPIRV/SPIRVInternal.h
+++ b/lib/SPIRV/SPIRVInternal.h
@@ -156,6 +156,7 @@ typedef SPIRVMap<CmpInst::Predicate, Op> CmpMap;
 class IntBoolOpMapId;
 template <> inline void SPIRVMap<Op, Op, IntBoolOpMapId>::init() {
   add(OpNot, OpLogicalNot);
+  add(OpIMul, OpLogicalAnd);
   add(OpBitwiseAnd, OpLogicalAnd);
   add(OpBitwiseOr, OpLogicalOr);
   add(OpBitwiseXor, OpLogicalNotEqual);

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3274,7 +3274,8 @@ bool LLVMToSPIRVBase::transDecoration(Value *V, SPIRVValue *BV) {
       (isa<AtomicRMWInst>(V) && cast<AtomicRMWInst>(V)->isVolatile()))
     BV->setVolatile(true);
 
-  if (auto *BVO = dyn_cast_or_null<OverflowingBinaryOperator>(V)) {
+  if (auto *BVO = dyn_cast_or_null<OverflowingBinaryOperator>(V);
+      BVO && !BVO->getType()->isIntOrIntVectorTy(1)) {
     if (BVO->hasNoSignedWrap()) {
       BV->setNoIntegerDecorationWrap<DecorationNoSignedWrap>(true);
     }

--- a/test/transcoding/mul_i1.ll
+++ b/test/transcoding/mul_i1.ll
@@ -1,7 +1,6 @@
 ; Multiplication of two boolean values must be translated to OpLogicalAnd,
 ; since OpIMul requires integer operands and OpTypeBool is not an integer type.
-; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %s -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
@@ -15,30 +14,38 @@ define spir_func i1 @bool_mul(i1 %a, i1 %b) {
   %c = mul i1 %a, %b
   ret i1 %c
 }
-; CHECK-SPIRV: LogicalAnd
-; CHECK-LLVM: define spir_func i1 @bool_mul(i1 %a, i1 %b)
-; CHECK-LLVM: and i1 %a, %b
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[A1:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[B1:[0-9]+]]
+; CHECK-SPIRV: LogicalAnd {{[0-9]+}} {{[0-9]+}} [[A1]] [[B1]]
+; CHECK-LLVM: define spir_func i1 @bool_mul(i1 [[A1:%[a-zA-Z0-9_.]+]], i1 [[B1:%[a-zA-Z0-9_.]+]])
+; CHECK-LLVM: and i1 [[A1]], [[B1]]
 
 define spir_func i1 @bool_mul_nsw(i1 %a, i1 %b) {
   %c = mul nsw i1 %a, %b
   ret i1 %c
 }
-; CHECK-SPIRV: LogicalAnd
-; CHECK-LLVM: define spir_func i1 @bool_mul_nsw(i1 %a, i1 %b)
-; CHECK-LLVM: and i1 %a, %b
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[A2:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[B2:[0-9]+]]
+; CHECK-SPIRV: LogicalAnd {{[0-9]+}} {{[0-9]+}} [[A2]] [[B2]]
+; CHECK-LLVM: define spir_func i1 @bool_mul_nsw(i1 [[A2:%[a-zA-Z0-9_.]+]], i1 [[B2:%[a-zA-Z0-9_.]+]])
+; CHECK-LLVM: and i1 [[A2]], [[B2]]
 
 define spir_func i1 @bool_mul_nuw(i1 %a, i1 %b) {
   %c = mul nuw i1 %a, %b
   ret i1 %c
 }
-; CHECK-SPIRV: LogicalAnd
-; CHECK-LLVM: define spir_func i1 @bool_mul_nuw(i1 %a, i1 %b)
-; CHECK-LLVM: and i1 %a, %b
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[A3:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[B3:[0-9]+]]
+; CHECK-SPIRV: LogicalAnd {{[0-9]+}} {{[0-9]+}} [[A3]] [[B3]]
+; CHECK-LLVM: define spir_func i1 @bool_mul_nuw(i1 [[A3:%[a-zA-Z0-9_.]+]], i1 [[B3:%[a-zA-Z0-9_.]+]])
+; CHECK-LLVM: and i1 [[A3]], [[B3]]
 
 define spir_func <4 x i1> @vec_bool_mul(<4 x i1> %a, <4 x i1> %b) {
   %c = mul <4 x i1> %a, %b
   ret <4 x i1> %c
 }
-; CHECK-SPIRV: LogicalAnd
-; CHECK-LLVM: define spir_func <4 x i1> @vec_bool_mul(<4 x i1> %a, <4 x i1> %b)
-; CHECK-LLVM: and <4 x i1> %a, %b
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[A4:[0-9]+]]
+; CHECK-SPIRV: FunctionParameter {{[0-9]+}} [[B4:[0-9]+]]
+; CHECK-SPIRV: LogicalAnd {{[0-9]+}} {{[0-9]+}} [[A4]] [[B4]]
+; CHECK-LLVM: define spir_func <4 x i1> @vec_bool_mul(<4 x i1> [[A4:%[a-zA-Z0-9_.]+]], <4 x i1> [[B4:%[a-zA-Z0-9_.]+]])
+; CHECK-LLVM: and <4 x i1> [[A4]], [[B4]]

--- a/test/transcoding/mul_i1.ll
+++ b/test/transcoding/mul_i1.ll
@@ -1,0 +1,44 @@
+; Multiplication of two boolean values must be translated to OpLogicalAnd,
+; since OpIMul requires integer operands and OpTypeBool is not an integer type.
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-NOT: IMul
+
+define spir_func i1 @bool_mul(i1 %a, i1 %b) {
+  %c = mul i1 %a, %b
+  ret i1 %c
+}
+; CHECK-SPIRV: LogicalAnd
+; CHECK-LLVM: define spir_func i1 @bool_mul(i1 %a, i1 %b)
+; CHECK-LLVM: and i1 %a, %b
+
+define spir_func i1 @bool_mul_nsw(i1 %a, i1 %b) {
+  %c = mul nsw i1 %a, %b
+  ret i1 %c
+}
+; CHECK-SPIRV: LogicalAnd
+; CHECK-LLVM: define spir_func i1 @bool_mul_nsw(i1 %a, i1 %b)
+; CHECK-LLVM: and i1 %a, %b
+
+define spir_func i1 @bool_mul_nuw(i1 %a, i1 %b) {
+  %c = mul nuw i1 %a, %b
+  ret i1 %c
+}
+; CHECK-SPIRV: LogicalAnd
+; CHECK-LLVM: define spir_func i1 @bool_mul_nuw(i1 %a, i1 %b)
+; CHECK-LLVM: and i1 %a, %b
+
+define spir_func <4 x i1> @vec_bool_mul(<4 x i1> %a, <4 x i1> %b) {
+  %c = mul <4 x i1> %a, %b
+  ret <4 x i1> %c
+}
+; CHECK-SPIRV: LogicalAnd
+; CHECK-LLVM: define spir_func <4 x i1> @vec_bool_mul(<4 x i1> %a, <4 x i1> %b)
+; CHECK-LLVM: and <4 x i1> %a, %b


### PR DESCRIPTION
OpIMul requires integer scalar/vector operands

OpTypeBool is not considered an integer type and causes spirv-val failure

Inspired by https://github.com/llvm/llvm-project/pull/207388 