### PR TITLE
Preserve signed i1 semantics in sitofp lowering

### DIFF
--- a/lib/SPIRV/SPIRVLowerBool.cpp
+++ b/lib/SPIRV/SPIRVLowerBool.cpp
@@ -99,8 +99,9 @@ void SPIRVLowerBoolBase::handleCastInstructions(Instruction &I) {
     Type *Ty = Type::getInt32Ty(*Context);
     if (auto *VT = dyn_cast<FixedVectorType>(OpTy))
       Ty = llvm::FixedVectorType::get(Ty, VT->getNumElements());
+    bool IsSigned = I.getOpcode() == Instruction::SIToFP;
     auto *Zero = getScalarOrVectorConstantInt(Ty, 0, false);
-    auto *One = getScalarOrVectorConstantInt(Ty, 1, false);
+    auto *One = getScalarOrVectorConstantInt(Ty, IsSigned ? ~0 : 1, IsSigned);
     assert(Zero && One && "Couldn't create constant int");
     auto *Sel = SelectInst::Create(Op, One, Zero, "", I.getIterator());
     Sel->setDebugLoc(I.getDebugLoc());

--- a/test/sitofp-with-bool.ll
+++ b/test/sitofp-with-bool.ll
@@ -5,14 +5,14 @@
 
 ; CHECK: TypeInt [[int_32:[0-9]+]] 32 0
 ; CHECK: Constant  {{[0-9]+}} [[zero:[0-9]+]] 0
-; CHECK: Constant  {{[0-9]+}} [[one:[0-9]+]] 1
+; CHECK: Constant  {{[0-9]+}} [[mone:[0-9]+]] 4294967295
 ; CHECK: TypeBool [[bool:[0-9]+]]
 
 ; CHECK: Function
 ; CHECK: FunctionParameter {{[0-9]+}} [[A:[0-9]+]]
 ; CHECK: FunctionParameter {{[0-9]+}} [[B:[0-9]+]]
 ; CHECK: SGreaterThan [[bool]] [[cmp_res:[0-9]+]] [[B]] [[zero]]
-; CHECK: Select [[int_32]] [[select_res:[0-9]+]] [[cmp_res]] [[one]] [[zero]]
+; CHECK: Select [[int_32]] [[select_res:[0-9]+]] [[cmp_res]] [[mone]] [[zero]]
 ; CHECK: ConvertSToF {{[0-9]+}} [[stof_res:[0-9]+]] [[select_res]]
 ; CHECK: Store [[A]] [[stof_res]]
 

--- a/test/uitofp-with-bool.ll
+++ b/test/uitofp-with-bool.ll
@@ -160,14 +160,14 @@ entry:
 ; LLVM-DAG: %[[ufp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
 ; LLVM-DAG: %ufp2 = uitofp <2 x i32> %[[ufp2_res_llvm]] to <2 x float>
   %ufp2 = uitofp <2 x i1> %i1v to <2 x float>
-; SPV-DAG: Select [[int_32]] [[sfp1_res:[0-9]+]] [[i1s]] [[one_32]] [[zero_32]]
+; SPV-DAG: Select [[int_32]] [[sfp1_res:[0-9]+]] [[i1s]] [[mone_32]] [[zero_32]]
 ; SPV-DAG: ConvertSToF [[float]] [[sfp1]] [[sfp1_res]]
-; LLVM-DAG: %[[sfp1_res_llvm:[0-9]+]] = select i1 %i1s, i32 1, i32 0
+; LLVM-DAG: %[[sfp1_res_llvm:[0-9]+]] = select i1 %i1s, i32 -1, i32 0
 ; LLVM-DAG: %sfp1 = sitofp i32 %[[sfp1_res_llvm:[0-9]+]] to float
   %sfp1 = sitofp i1 %i1s to float
-; SPV-DAG: Select [[vec_32]] [[sfp2_res:[0-9]+]] [[i1v]] [[ones_32]] [[zeros_32]]
+; SPV-DAG: Select [[vec_32]] [[sfp2_res:[0-9]+]] [[i1v]] [[mones_32]] [[zeros_32]]
 ; SPV-DAG: ConvertSToF [[vec_float]] [[sfp2]] [[sfp2_res]]
-; LLVM-DAG: %[[sfp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> splat (i32 1), <2 x i32> zeroinitializer
+; LLVM-DAG: %[[sfp2_res_llvm:[0-9]+]] = select <2 x i1> %i1v, <2 x i32> splat (i32 -1), <2 x i32> zeroinitializer
 ; LLVM-DAG: %sfp2 = sitofp <2 x i32> %[[sfp2_res_llvm]] to <2 x float>
   %sfp2 = sitofp <2 x i1> %i1v to <2 x float>
   ret void


### PR DESCRIPTION
handleCastInstructions materialized the bool operand as unsigned 0/1 for both uitofp and sitofp, so sitofp i1 true was miscompiled as 1.0 instead of -1.0

Inspired by https://github.com/llvm/llvm-project/pull/209232