### PR TITLE
[Backport to 18] Read old SPV_INTEL_float4 type for StochasticRound*ToE2M1INTEL

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1171,7 +1171,11 @@ Value *SPIRVToLLVM::transConvertInst(SPIRVValue *BV, Function *F,
           LookupOC = OpFConvert;
         else if (OC == internal::OpClampStochasticRoundFToFINTEL)
           LookupOC = internal::OpStochasticRoundFToFINTEL;
-        FPConversionDesc FPDesc = {SrcEnc, DstEnc, LookupOC,
+        FPEncodingWrap LookupDstEnc = DstEnc;
+        if (LookupOC == internal::OpStochasticRoundFToFINTEL &&
+            DstEnc == FPEncodingWrap::E2M1INTEL)
+          LookupDstEnc = FPEncodingWrap::E2M1;
+        FPConversionDesc FPDesc = {SrcEnc, LookupDstEnc, LookupOC,
                                    /*Saturate=*/IsSaturatedFP8};
         auto Conv = SPIRV::FPConvertToEncodingMap::rmap(FPDesc);
         std::vector<Value *> Ops = {Src};

--- a/test/extensions/INTEL/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_e2m1intel_reader.spt
+++ b/test/extensions/INTEL/SPV_INTEL_fp_conversions/spv_intel_fp_conversions_e2m1intel_reader.spt
@@ -1,0 +1,51 @@
+; RUN: llvm-spirv %s -to-binary -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck < %t.rev.ll %s
+
+; CHECK: call spir_func i4 @_Z46__builtin_spirv_StochasticRoundFP16ToE2M1INTELDhi(half 0xH3C00, i32 1)
+; CHECK: call spir_func i4 @_Z46__builtin_spirv_StochasticRoundBF16ToE2M1INTELDF16bi(bfloat 0xR3F80, i32 1)
+
+119734787 65536 393230 19 0
+2 Capability Addresses
+2 Capability Linkage
+2 Capability Kernel
+2 Capability Float16Buffer
+2 Capability Int4TypeINTEL
+2 Capability BFloat16TypeKHR
+2 Capability Float4E2M1INTEL
+2 Capability FloatConversionsFtoFINTEL
+6 Extension "SPV_INTEL_float4"
+8 Extension "SPV_INTEL_fp_conversions"
+5 Extension "SPV_INTEL_int4"
+6 Extension "SPV_KHR_bfloat16"
+5 ExtInstImport 1 "OpenCL.std"
+3 MemoryModel 2 2
+3 Source 0 0
+8 Name 4 "hf16_fp4e2m1_stochastic"
+4 Name 5 "entry"
+8 Name 13 "bf16_fp4e2m1_stochastic"
+4 Name 14 "entry"
+10 Decorate 4 LinkageAttributes "hf16_fp4e2m1_stochastic" Export
+10 Decorate 13 LinkageAttributes "bf16_fp4e2m1_stochastic" Export
+4 TypeInt 2 4 0
+4 TypeInt 9 32 0
+4 Constant 9 10 1
+3 TypeFunction 3 2
+3 TypeFloat 6 16
+4 TypeFloat 8 4 6214
+4 TypeFloat 15 16 0
+4 Constant 6 7 15360
+4 Constant 15 16 16256
+5 Function 2 4 0 3
+2 Label 5
+5 StochasticRoundFToFINTEL 8 11 7 10
+4 Bitcast 2 12 11
+2 ReturnValue 12
+1 FunctionEnd
+5 Function 2 13 0 3
+2 Label 14
+5 StochasticRoundFToFINTEL 8 17 16 10
+4 Bitcast 2 18 17
+2 ReturnValue 18
+1 FunctionEnd


### PR DESCRIPTION
For backward compatibility of the SPIRV Reader only: older modules
emitted the `SPV_INTEL_float4` `Float4E2M1INTEL` type (6214) as the
`StochasticRoundFToFINTEL` result. Map it to the same builtin as the
current `SPV_EXT_ocp_microscaling_types` `Float4E2M1EXT` type (4225).

The Writer keeps unchanged and emits the EXT type.