### PR TITLE
Skip empty LinkageAttributes decoration for numeric-named functions

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -964,7 +964,8 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
           SPIRVEC_RequiresExtension, "SPV_KHR_uniform_group_instructions\n");
     BM->setName(BF, F->getName().str());
   }
-  if (!isKernel(F) && F->getLinkage() != GlobalValue::InternalLinkage)
+  if (!isKernel(F) && F->hasName() &&
+      F->getLinkage() != GlobalValue::InternalLinkage)
     BF->setLinkageType(transLinkageType(F));
 
   // Translate OpenCL/SYCL buffer_location metadata if it's attached to the
@@ -6496,6 +6497,8 @@ void LLVMToSPIRVBase::transFunction(Function *I) {
   fpContractUpdateRecursive(I, getFPContract(I));
 
   if (isKernel(I)) {
+    BM->getErrorLog().checkError(I->hasName(), SPIRVEC_InvalidLlvmModule,
+                                 "Entry point function must have a name");
     auto Interface = collectEntryPointInterfaces(BF, I);
     BM->addEntryPoint(ExecutionModelKernel, BF->getId(), I->getName().str(),
                       Interface);

--- a/test/link-attribute-numeric-name.ll
+++ b/test/link-attribute-numeric-name.ll
@@ -1,0 +1,21 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: FileCheck < %t.txt %s
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-val %t.spv
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; A numeric-named function has no meaningful linkage name, so no
+; LinkageAttributes decoration should be emitted for it.
+; CHECK-NOT: LinkageAttributes
+
+define spir_func void @0() {
+  ret void
+}
+
+define spir_kernel void @kernel() {
+  call spir_func void @0()
+  ret void
+}

--- a/test/link-attribute-numeric-name.ll
+++ b/test/link-attribute-numeric-name.ll
@@ -1,7 +1,6 @@
-; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t.txt
+; RUN: llvm-spirv %s -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s
-; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %s -o %t.spv
 ; RUN: spirv-val %t.spv
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/negative/nameless-kernel-error.ll
+++ b/test/negative/nameless-kernel-error.ll
@@ -1,5 +1,4 @@
-; RUN: llvm-as %s -o %t.bc
-; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+; RUN: not llvm-spirv %s -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidLlvmModule: Invalid LLVM module: Entry point function must have a name
 

--- a/test/negative/nameless-kernel-error.ll
+++ b/test/negative/nameless-kernel-error.ll
@@ -1,0 +1,11 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+
+; CHECK: InvalidLlvmModule: Invalid LLVM module: Entry point function must have a name
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+define spir_kernel void @0() {
+  ret void
+}


### PR DESCRIPTION
Numeric-named LLVM functions (e.g. @0) have no meaningful linkage name, so LinkageAttributes for them is dropped