### PR TITLE
Temporarily resort to llvm 23 for code style check

### DIFF
--- a/.github/workflows/check-code-style.yml
+++ b/.github/workflows/check-code-style.yml
@@ -91,7 +91,8 @@ jobs:
       if: ${{ steps.gather-list-of-changes.outputs.HAS_CHANGES }}
       run: |
         mkdir build && cd build
-        cmake -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }} \
+        cmake -DBASE_LLVM_VERSION=23.0.0 \
+            -DCMAKE_CXX_COMPILER=clang++-${{ env.LLVM_VERSION }} \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" ${{ github.workspace }}
 
     - name: Run clang-format


### PR DESCRIPTION
As apt packages for llvm 24 are not available yet, temporarily switch the code style check compile command db generation back to llvm 23.

Revert this commit once llvm 24 packages are available, together with ca6c23d3 ("Temporarily resort to llvm 23 packages (#3914)", 2026-07-27).