### PR TITLE
[Backport to 14][LLVM->SPV-IR] Add const to pointer arg of prefetch, change num_elements arg type to unsigned (#3188)

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2687,6 +2687,10 @@ public:
     case OpenCLLIB::Nan:
       addUnsignedArg(0);
       break;
+    case OpenCLLIB::Prefetch:
+      setArgAttr(0, SPIR::ATTR_CONST);
+      addUnsignedArg(1);
+      break;
     case OpenCLLIB::Shuffle:
       addUnsignedArg(1);
       break;

--- a/test/extensions/INTEL/SPV_INTEL_cache_controls/decorate-prefetch-w-cache-controls.ll
+++ b/test/extensions/INTEL/SPV_INTEL_cache_controls/decorate-prefetch-w-cache-controls.ll
@@ -29,13 +29,13 @@ $_ZTSZ4mainEUlvE_ = comdat any
 
 ; CHECK-LLVM: %[[CALL1:.*]] = call spir_func i8 addrspace(1)* @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}
 ; CHECK-LLVM: %[[CALL1P4:.*]] = addrspacecast i8 addrspace(1)* %[[CALL1]] to i8 addrspace(4)*
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetch{{.*}}(i8 addrspace(4)* %[[CALL1P4]], i64 1)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS4Kcm(i8 addrspace(4)* %[[CALL1P4]], i64 1)
 ; CHECK-LLVM: %[[CALL2:.*]] = call spir_func i8 addrspace(1)* @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}
 ; CHECK-LLVM: %[[CALL2P4:.*]] = addrspacecast i8 addrspace(1)* %[[CALL2]] to i8 addrspace(4)*
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetch{{.*}}(i8 addrspace(4)* %[[CALL2P4]], i64 1)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS4Kcm(i8 addrspace(4)* %[[CALL2P4]], i64 1)
 ; CHECK-LLVM: %[[CALL3:.*]] = call spir_func i8 addrspace(1)* @_Z41__spirv_GenericCastToPtrExplicit_ToGlobal{{.*}}
 ; CHECK-LLVM: %[[CALL3P4:.*]] = addrspacecast i8 addrspace(1)* %[[CALL3]] to i8 addrspace(4)*
-; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetch{{.*}}(i8 addrspace(4)* %[[CALL3P4]], i64 2)
+; CHECK-LLVM: call spir_func void @_Z20__spirv_ocl_prefetchPU3AS4Kcm(i8 addrspace(4)* %[[CALL3P4]], i64 2)
 
 
 ; Function Attrs: convergent norecurse nounwind


### PR DESCRIPTION
Per SPIR-V OpenCL.ExtendedInstructionSet spec, the num_elements arg must
be size_t. So this PR changes its type to unsigned in SPV-IR.
Adding const to pointer arg aligns with OpenCL spec and allows const
pointer input.