### PR TITLE
[Backport to 15][LLVM->SPV-IR] Add const to pointer arg of prefetch, change num_elements arg type to unsigned (#3188)

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -2734,6 +2734,10 @@ public:
     case OpenCLLIB::Nan:
       addUnsignedArg(0);
       break;
+    case OpenCLLIB::Prefetch:
+      setArgAttr(0, SPIR::ATTR_CONST);
+      addUnsignedArg(1);
+      break;
     case OpenCLLIB::Shuffle:
       addUnsignedArg(1);
       break;


### PR DESCRIPTION
Per SPIR-V OpenCL.ExtendedInstructionSet spec, the num_elements arg must
be size_t. So this PR changes its type to unsigned in SPV-IR.
Adding const to pointer arg aligns with OpenCL spec and allows const
pointer input.