### PR TITLE
DO NOT MERGE: comment only change to probe CI

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVStream.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVStream.cpp
@@ -377,3 +377,6 @@ std::vector<SPIRVEntry *> SPIRVDecoder::getSourceContinuedInstructions() {
 }
 
 } // namespace SPIRV
+
+// Intentionally empty change to exercise CI. This branch is a throwaway
+// probe and is not proposed for merge.


### PR DESCRIPTION
Please ignore, closing shortly.

Comment only change on top of current main, opened to confirm whether the Out-of-tree Linux jobs fail independently of any code change. Related to #3941.