### PR TITLE
Translate {uinc/udec}_wrap as opaque intrinsics and preserve AMDGPU metadata through NonSemantic.AuxData

### DIFF
--- a/docs/NonSemantic.AuxData.asciidoc
+++ b/docs/NonSemantic.AuxData.asciidoc
@@ -33,8 +33,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2026-05-05
-| Revision           | 2
+| Last Modified Date | 2026-07-30
+| Revision           | 3
 |========================================
 
 Dependencies
@@ -49,10 +49,10 @@ Overview
 --------
 
 The *NonSemantic.AuxData* extended instruction set encodes auxiliary
-data attached to LLVM IR `Function` and `GlobalVariable` objects
-specifically, LLVM *attributes* and LLVM *metadata*, so that this
-information can survive a round trip through SPIR-V and be restored
-on reverse translation.
+data attached to LLVM IR `Function`, `GlobalVariable`, and
+`Instruction` objects -- specifically, LLVM *attributes* and LLVM
+*metadata* -- so that this information can survive a round trip
+through SPIR-V and be restored on reverse translation.
 
 The information described by these instructions is, by construction,
 *non-semantic*: a SPIR-V consumer that does not understand or does not
@@ -86,6 +86,11 @@ Manual (https://llvm.org/docs/LangRef.html):
   as enumerated by `llvm::GlobalValue::LinkageTypes` and described in
   the "Linkage Types" section of the LLVM Language Reference Manual.
 
+- *Instruction metadata* - a named LLVM `MDNode` attached to an LLVM
+  `Instruction` (for example an `atomicrmw` instruction). Unlike
+  function or global variable metadata, this metadata is attached to
+  an instruction within a function body, not to a global object.
+
 The phrase "global object" refers collectively to either an LLVM
 `Function` or an LLVM `GlobalVariable`.
 
@@ -100,9 +105,17 @@ All instructions in this set:
 - have no associated capability and require no capability beyond
   what is required to use `OpExtInst` against a non-semantic
   extended instruction set;
-- may appear at module scope, after all type, constant, and global
-  declarations they reference have been declared, in the locations
-  permitted for non-semantic instructions by *SPV_KHR_non_semantic_info*.
+- may appear at module scope, in the locations permitted for
+  non-semantic instructions by *SPV_KHR_non_semantic_info*. When the
+  'Target' is a global object (*OpFunction* or module-scope
+  *OpVariable*), the instruction must appear after all type, constant,
+  and global declarations it references have been declared. When the
+  'Target' is an instruction result '<id>' defined inside a function
+  body (as with
+  <<NonSemanticAuxDataInstructionMetadata,*NonSemanticAuxDataInstructionMetadata*>>),
+  the 'Target' operand is a forward reference to an '<id>' that will
+  be defined later in the module; this is permitted because the
+  instruction is non-semantic and its result is never consumed.
 
 A producer should emit all *NonSemantic.AuxData* instructions in the
 section of the module reserved for debug / non-semantic instructions
@@ -140,6 +153,7 @@ extended instruction set:
 |  2 | <<NonSemanticAuxDataGlobalVariableMetadata,*NonSemanticAuxDataGlobalVariableMetadata*>>
 |  3 | <<NonSemanticAuxDataGlobalVariableAttribute,*NonSemanticAuxDataGlobalVariableAttribute*>>
 |  4 | <<NonSemanticAuxDataLinkage,*NonSemanticAuxDataLinkage*>>
+|  5 | <<NonSemanticAuxDataInstructionMetadata,*NonSemanticAuxDataInstructionMetadata*>>
 |========================================
 
 [[LinkageType]]
@@ -329,6 +343,43 @@ instruction.
 | '<id>' 'Linkage Type'
 |======
 
+
+[cols="2*1,3*2,1,3,3,3"]
+|======
+9+a|[[NonSemanticAuxDataInstructionMetadata]]*NonSemanticAuxDataInstructionMetadata* +
+ +
+Record one named LLVM-IR metadata attachment on an instruction. +
+ +
+Unlike the other instructions in this set, the 'Target' of an
+*NonSemanticAuxDataInstructionMetadata* is the result '<id>' of an
+instruction defined inside a function body (for example an
+*OpAtomicIAdd* or an *OpFunctionCall*), not an *OpFunction* or
+module-scope *OpVariable*. When this instruction is emitted at module
+scope (as recommended), the 'Target' operand is a forward reference. +
+ +
+'Result Type' must be *OpTypeVoid*. +
+ +
+'Target' is the '<id>' of the instruction the metadata is attached
+to. The referenced instruction must produce a result '<id>'. +
+ +
+'Metadata Name' and 'Metadata Value' operands have the same form,
+the same encoding rules, the same exclusions, and the same
+duplicate-skip recommendation as the corresponding operands of
+<<NonSemanticAuxDataFunctionMetadata,*NonSemanticAuxDataFunctionMetadata*>>. +
+ +
+A consumer must skip a *NonSemanticAuxDataInstructionMetadata*
+instruction whose 'Target' does not resolve to an instruction, or
+whose 'Metadata Name' is already attached to 'Target' through some
+other reverse-translation path, to avoid creating duplicate metadata
+attachments.
+
+| 7 + 'variable' | 12 | '<id>' +
+'Result Type' | 'Result <id>' | '<id> Set' | 5
+| '<id>' 'Target'
+| '<id>' 'Metadata Name'
+| 'Metadata Value', 'Metadata Value', ... (zero or more)
+|======
+
 2. Encoding Notes
 -----------------
 
@@ -345,9 +396,11 @@ walks `Function::getAttributes().getFnAttrs()` (or
 `...Attribute` instruction per attribute, then walks
 `GlobalObject::getAllMetadata()` once and emits one `...Metadata`
 instruction per metadata attachment, in the order the LLVM data
-structures yield them. The reverse path performs the inverse
+structures yield them. For instructions that carry metadata, the translator emits one
+*NonSemanticAuxDataInstructionMetadata* instruction per metadata
+attachment. The reverse path performs the inverse
 operation, calling the LLVM API that adds an attribute or sets a
-metadata kind on the corresponding global object.
+metadata kind on the corresponding object.
 
 The specification sets no restrictions regarding how much
 `NonSemanticAuxData` instructions can annotate a single 'Target' nor
@@ -382,4 +435,5 @@ Revision History
 |Rev|Date|Author|Changes
 |1|xxxx-xx-xx|Nick Sarnie|Initial draft
 |2|2026-05-05|Dmitry Sidorov|Finalize spec, add available_externally
+|3|2026-07-30|Marcos Maronas|Add InstructionMetadata (opcode 5) for instruction-level metadata
 |========================================

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -5659,6 +5659,24 @@ void SPIRVToLLVM::transAuxDataInst(SPIRVExtInst *BC) {
   assert(BC->getExtSetKind() == SPIRV::SPIRVEIS_NonSemantic_AuxData);
   if (!BC->getModule()->preserveAuxData())
     return;
+  auto Args = BC->getArguments();
+
+  // InstructionMetadata targets an instruction, not a global object, so it
+  // is handled separately before the GlobalObject-based switch below.
+  if (BC->getExtOp() == NonSemanticAuxData::InstructionMetadata) {
+    auto *Target = BC->getModule()->getValue(Args[0]);
+    Value *V = getTranslatedValue(Target);
+    if (auto *Inst = dyn_cast_or_null<Instruction>(V)) {
+      const std::string &MDName =
+          BC->getModule()->get<SPIRVString>(Args[1])->getStr();
+      Inst->setMetadata(MDName, MDNode::get(Inst->getContext(), {}));
+    } else {
+      LLVM_DEBUG(dbgs() << "InstructionMetadata target is not an Instruction; "
+                           "ignoring.\n");
+    }
+    return;
+  }
+
   switch (BC->getExtOp()) {
   case NonSemanticAuxData::FunctionAttribute:
   case NonSemanticAuxData::GlobalVariableAttribute:
@@ -5669,7 +5687,6 @@ void SPIRVToLLVM::transAuxDataInst(SPIRVExtInst *BC) {
   default:
     return;
   }
-  auto Args = BC->getArguments();
   // Arg 0 is common to all instructions in this set: it identifies the
   // global object the auxiliary data is attached to.
   auto *Arg0 = BC->getModule()->getValue(Args[0]);

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -87,6 +87,11 @@ void SPIRVToOCLBase::visitCallInst(CallInst &CI) {
   }
 
   auto MangledName = F->getName();
+  if (MangledName == "__spirv_AtomicUIncWrap" ||
+      MangledName == "__spirv_AtomicUDecWrap") {
+    visitCallSPIRVAtomicUIncDecWrap(&CI, MangledName);
+    return;
+  }
   StringRef DemangledName;
   Op OC = OpNop;
   SPIRVBuiltinVariableKind BuiltinKind = SPIRVBuiltinVariableKind::BuiltInMax;
@@ -1193,6 +1198,64 @@ SPIRVToOCLBase::getOCLPipeOpaqueType(SmallVector<std::string, 8> &Postfixes) {
           PipeAccess == AccessQualifierWriteOnly) &&
          "Invalid access qualifier");
   return PipeAccess ? kSPR2TypeName::PipeWO : kSPR2TypeName::PipeRO;
+}
+
+static AtomicOrdering mapSPIRVMemSemToAtomicOrdering(uint32_t MemSem) {
+  // Mask out storage-class bits, keep only ordering bits.
+  if (MemSem & 0x10)
+    return AtomicOrdering::SequentiallyConsistent;
+  if (MemSem & 0x08)
+    return AtomicOrdering::AcquireRelease;
+  if (MemSem & 0x04)
+    return AtomicOrdering::Release;
+  if (MemSem & 0x02)
+    return AtomicOrdering::Acquire;
+  return AtomicOrdering::Monotonic;
+}
+
+static SyncScope::ID mapSPIRVScopeToLLVM(LLVMContext &Ctx, uint32_t Scope) {
+  switch (Scope) {
+  case 4: // Invocation
+    return SyncScope::SingleThread;
+  case 3: // Subgroup
+    return Ctx.getOrInsertSyncScopeID("subgroup");
+  case 2: // Workgroup
+    return Ctx.getOrInsertSyncScopeID("workgroup");
+  case 1: // Device
+    return Ctx.getOrInsertSyncScopeID("device");
+  case 0: // CrossDevice
+  default:
+    return SyncScope::System;
+  }
+}
+
+void SPIRVToOCLBase::visitCallSPIRVAtomicUIncDecWrap(CallInst *CI,
+                                                     StringRef FuncName) {
+  // __spirv_AtomicUIncWrap(ptr, scope, memsem, val)
+  // __spirv_AtomicUDecWrap(ptr, scope, memsem, val)
+  // -> atomicrmw uinc_wrap/udec_wrap ptr, val ordering, syncscope
+  auto Op = (FuncName == "__spirv_AtomicUIncWrap") ? AtomicRMWInst::UIncWrap
+                                                   : AtomicRMWInst::UDecWrap;
+
+  Value *Ptr = CI->getArgOperand(0);
+  auto Scope = cast<ConstantInt>(CI->getArgOperand(1))->getZExtValue();
+  auto MemSem = cast<ConstantInt>(CI->getArgOperand(2))->getZExtValue();
+  Value *Val = CI->getArgOperand(3);
+
+  AtomicOrdering Ordering = mapSPIRVMemSemToAtomicOrdering(MemSem);
+  SyncScope::ID SSID = mapSPIRVScopeToLLVM(CI->getContext(), Scope);
+
+  IRBuilder<> Builder(CI);
+  auto *RMW = Builder.CreateAtomicRMW(Op, Ptr, Val, {}, Ordering, SSID);
+
+  SmallVector<std::pair<unsigned, MDNode *>> MDs;
+  CI->getAllMetadata(MDs);
+  for (const auto &MD : MDs)
+    RMW->setMetadata(MD.first, MD.second);
+
+  CI->replaceAllUsesWith(RMW);
+  CI->dropAllReferences();
+  CI->eraseFromParent();
 }
 
 void SPIRVToOCLBase::translateOpaqueTypes() {

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -1257,8 +1257,8 @@ void SPIRVToOCLBase::visitCallSPIRVAtomicUIncDecWrap(CallInst *CI,
 
   AtomicOrdering Ordering = mapSPIRVMemSemToAtomicOrdering(MemSem);
   SyncScope::ID SSID = M->getTargetTriple().isAMDGCN()
-                            ? mapSPIRVScopeToAMDGPU(CI->getContext(), Scope)
-                            : mapSPIRVScopeToLLVM(CI->getContext(), Scope);
+                           ? mapSPIRVScopeToAMDGPU(CI->getContext(), Scope)
+                           : mapSPIRVScopeToLLVM(CI->getContext(), Scope);
 
   IRBuilder<> Builder(CI);
   auto *RMW = Builder.CreateAtomicRMW(Op, Ptr, Val, {}, Ordering, SSID);

--- a/lib/SPIRV/SPIRVToOCL.cpp
+++ b/lib/SPIRV/SPIRVToOCL.cpp
@@ -1229,11 +1229,24 @@ static SyncScope::ID mapSPIRVScopeToLLVM(LLVMContext &Ctx, uint32_t Scope) {
   }
 }
 
+static SyncScope::ID mapSPIRVScopeToAMDGPU(LLVMContext &Ctx, uint32_t Scope) {
+  switch (Scope) {
+  case 4: // Invocation
+    return SyncScope::SingleThread;
+  case 3: // Subgroup
+    return Ctx.getOrInsertSyncScopeID("wavefront");
+  case 2: // Workgroup
+    return Ctx.getOrInsertSyncScopeID("workgroup");
+  case 1: // Device
+    return Ctx.getOrInsertSyncScopeID("agent");
+  case 0: // CrossDevice
+  default:
+    return SyncScope::System;
+  }
+}
+
 void SPIRVToOCLBase::visitCallSPIRVAtomicUIncDecWrap(CallInst *CI,
                                                      StringRef FuncName) {
-  // __spirv_AtomicUIncWrap(ptr, scope, memsem, val)
-  // __spirv_AtomicUDecWrap(ptr, scope, memsem, val)
-  // -> atomicrmw uinc_wrap/udec_wrap ptr, val ordering, syncscope
   auto Op = (FuncName == "__spirv_AtomicUIncWrap") ? AtomicRMWInst::UIncWrap
                                                    : AtomicRMWInst::UDecWrap;
 
@@ -1243,7 +1256,9 @@ void SPIRVToOCLBase::visitCallSPIRVAtomicUIncDecWrap(CallInst *CI,
   Value *Val = CI->getArgOperand(3);
 
   AtomicOrdering Ordering = mapSPIRVMemSemToAtomicOrdering(MemSem);
-  SyncScope::ID SSID = mapSPIRVScopeToLLVM(CI->getContext(), Scope);
+  SyncScope::ID SSID = M->getTargetTriple().isAMDGCN()
+                            ? mapSPIRVScopeToAMDGPU(CI->getContext(), Scope)
+                            : mapSPIRVScopeToLLVM(CI->getContext(), Scope);
 
   IRBuilder<> Builder(CI);
   auto *RMW = Builder.CreateAtomicRMW(Op, Ptr, Val, {}, Ordering, SSID);

--- a/lib/SPIRV/SPIRVToOCL.h
+++ b/lib/SPIRV/SPIRVToOCL.h
@@ -219,6 +219,10 @@ public:
   ///      atomic_*(atomic_op, ops, ..., order(sema), map(scope))
   virtual void visitCallSPIRVAtomicBuiltin(CallInst *CI, Op OC) = 0;
 
+  /// Transform __spirv_AtomicUIncWrap/__spirv_AtomicUDecWrap to
+  /// atomicrmw uinc_wrap/udec_wrap, propagating metadata from the call.
+  void visitCallSPIRVAtomicUIncDecWrap(CallInst *CI, StringRef FuncName);
+
   /// Transform __spirv_MemoryBarrier to:
   /// - OCL2.0: atomic_work_item_fence.__spirv_MemoryBarrier(scope, sema) =>
   ///       atomic_work_item_fence(flag(sema), order(sema), map(scope))

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1369,13 +1369,13 @@ void LLVMToSPIRVBase::transAuxDataInst(SPIRVValue *BV, Value *V) {
 }
 
 void LLVMToSPIRVBase::transAMDGPUAtomicMetadata(SPIRVValue *BV,
-                                                 Instruction *I) {
+                                                Instruction *I) {
   if (!BM->preserveAuxData())
     return;
   bool HasAny = false;
-  for (StringRef MDName : {"amdgpu.no.fine.grained.memory",
-                           "amdgpu.no.remote.memory",
-                           "amdgpu.ignore.denormal.mode"}) {
+  for (StringRef MDName :
+       {"amdgpu.no.fine.grained.memory", "amdgpu.no.remote.memory",
+        "amdgpu.ignore.denormal.mode"}) {
     if (!I->getMetadata(MDName))
       continue;
     if (!HasAny) {
@@ -2869,8 +2869,8 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       SPIRVFunction *BFunc = BM->addFunction(SpvFT);
       BFunc->setFunctionControlMask(FunctionControlMaskNone);
       BM->setName(BFunc, FuncName.str());
-      BFunc->addDecorate(new SPIRVDecorateLinkageAttr(
-          BFunc, FuncName.str(), LinkageTypeImport));
+      BFunc->addDecorate(new SPIRVDecorateLinkageAttr(BFunc, FuncName.str(),
+                                                      LinkageTypeImport));
       SPIRVValue *BV = mapValue(V, BM->addCallInst(BFunc, Ops, BB));
       transAMDGPUAtomicMetadata(BV, ARMW);
       return BV;

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1368,6 +1368,30 @@ void LLVMToSPIRVBase::transAuxDataInst(SPIRVValue *BV, Value *V) {
   }
 }
 
+void LLVMToSPIRVBase::transAMDGPUAtomicMetadata(SPIRVValue *BV,
+                                                 Instruction *I) {
+  if (!BM->preserveAuxData())
+    return;
+  bool HasAny = false;
+  for (StringRef MDName : {"amdgpu.no.fine.grained.memory",
+                           "amdgpu.no.remote.memory",
+                           "amdgpu.ignore.denormal.mode"}) {
+    if (!I->getMetadata(MDName))
+      continue;
+    if (!HasAny) {
+      if (!BM->isAllowedToUseVersion(VersionNumber::SPIRV_1_6))
+        BM->addExtension(SPIRV::ExtensionID::SPV_KHR_non_semantic_info);
+      else
+        BM->setMinSPIRVVersion(VersionNumber::SPIRV_1_6);
+      HasAny = true;
+    }
+    std::vector<SPIRVWord> Ops = {BV->getId(),
+                                  BM->getString(MDName.str())->getId()};
+    BM->addAuxData(NonSemanticAuxData::InstructionMetadata,
+                   transType(Type::getVoidTy(I->getContext())), Ops);
+  }
+}
+
 SPIRVValue *LLVMToSPIRVBase::transConstantUse(Constant *C,
                                               SPIRVType *ExpectedType) {
   // Constant expressions expect their pointer types to be i8* in opaque pointer
@@ -2832,10 +2856,30 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       // Implement FSub through FNegate and AtomicFAddExt
       Ops[3] = BM->addUnaryInst(OpFNegate, Ty, OpVals[3], BB)->getId();
       OC = OpAtomicFAddEXT;
+    } else if (Op == AtomicRMWInst::UIncWrap || Op == AtomicRMWInst::UDecWrap) {
+      StringRef FuncName = (Op == AtomicRMWInst::UIncWrap)
+                               ? "__spirv_AtomicUIncWrap"
+                               : "__spirv_AtomicUDecWrap";
+      SPIRVType *SpvValTy = Ty;
+      SPIRVType *SpvPtrTy = transType(ARMW->getPointerOperand()->getType());
+      SPIRVType *SpvI32Ty = transType(Type::getInt32Ty(M->getContext()));
+      std::vector<SPIRVType *> ParamTys = {SpvPtrTy, SpvI32Ty, SpvI32Ty,
+                                           SpvValTy};
+      SPIRVTypeFunction *SpvFT = BM->addFunctionType(SpvValTy, ParamTys);
+      SPIRVFunction *BFunc = BM->addFunction(SpvFT);
+      BFunc->setFunctionControlMask(FunctionControlMaskNone);
+      BM->setName(BFunc, FuncName.str());
+      BFunc->addDecorate(new SPIRVDecorateLinkageAttr(
+          BFunc, FuncName.str(), LinkageTypeImport));
+      SPIRVValue *BV = mapValue(V, BM->addCallInst(BFunc, Ops, BB));
+      transAMDGPUAtomicMetadata(BV, ARMW);
+      return BV;
     } else
       OC = LLVMSPIRVAtomicRmwOpCodeMap::map(Op);
 
-    return mapValue(V, BM->addInstTemplate(OC, Ops, BB, Ty));
+    SPIRVValue *BV = mapValue(V, BM->addInstTemplate(OC, Ops, BB, Ty));
+    transAMDGPUAtomicMetadata(BV, ARMW);
+    return BV;
   }
 
   if (IntrinsicInst *II = dyn_cast<IntrinsicInst>(V)) {

--- a/lib/SPIRV/SPIRVWriter.h
+++ b/lib/SPIRV/SPIRVWriter.h
@@ -139,6 +139,7 @@ public:
   void transFunctionMetadataAsUserSemanticDecoration(SPIRVFunction *BF,
                                                      Function *F);
   void transAuxDataInst(SPIRVValue *BV, Value *V);
+  void transAMDGPUAtomicMetadata(SPIRVValue *BV, Instruction *I);
 
   bool transGlobalVariables();
 

--- a/lib/SPIRV/libSPIRV/NonSemantic.AuxData.h
+++ b/lib/SPIRV/libSPIRV/NonSemantic.AuxData.h
@@ -30,7 +30,8 @@ enum Instruction {
   FunctionAttribute = 1,
   GlobalVariableMetadata = 2,
   GlobalVariableAttribute = 3,
-  Linkage = 4
+  Linkage = 4,
+  InstructionMetadata = 5
 };
 
 enum LinkageType { AvailableExternally = 0 };

--- a/lib/SPIRV/libSPIRV/SPIRVExtInst.h
+++ b/lib/SPIRV/libSPIRV/SPIRVExtInst.h
@@ -285,6 +285,8 @@ inline void SPIRVMap<NonSemanticAuxDataOpKind, std::string>::init() {
   add(NonSemanticAuxData::GlobalVariableAttribute,
       "NonSemanticAuxDataGlobalVariableAttribute");
   add(NonSemanticAuxData::Linkage, "NonSemanticAuxDataLinkage");
+  add(NonSemanticAuxData::InstructionMetadata,
+      "NonSemanticAuxDataInstructionMetadata");
 }
 SPIRV_DEF_NAMEMAP(NonSemanticAuxDataOpKind, NonSemanticAuxDataOpMap)
 

--- a/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-auxdata-amdgpu-atomic-metadata.ll
+++ b/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-auxdata-amdgpu-atomic-metadata.ll
@@ -66,19 +66,19 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-amd-amdhsa"
 
-; CHECK-LLVM: call i32 @_Z10atomic_addPU3AS1Vii({{.*}}) {{.*}}!amdgpu.no.fine.grained.memory ![[#]]{{.*}}!amdgpu.no.remote.memory ![[#]]
+; CHECK-LLVM: call spir_func i32 @_Z10atomic_addPU3AS1Vii({{.*}}){{.*}}!amdgpu.no.fine.grained.memory ![[#]]{{.*}}!amdgpu.no.remote.memory ![[#]]
 define amdgpu_kernel void @test_iadd(ptr addrspace(1) %ptr) {
   %add = atomicrmw add ptr addrspace(1) %ptr, i32 1 syncscope("agent") monotonic, !amdgpu.no.fine.grained.memory !0, !amdgpu.no.remote.memory !0
   ret void
 }
 
-; CHECK-LLVM: call float @_Z10atomic_addPU3AS1Vff({{.*}}) {{.*}}!amdgpu.no.fine.grained.memory ![[#]]{{.*}}!amdgpu.no.remote.memory ![[#]]{{.*}}!amdgpu.ignore.denormal.mode ![[#]]
+; CHECK-LLVM: call spir_func float @_Z10atomic_addPU3AS1Vff({{.*}}){{.*}}!amdgpu.no.fine.grained.memory ![[#]]{{.*}}!amdgpu.no.remote.memory ![[#]]{{.*}}!amdgpu.ignore.denormal.mode ![[#]]
 define amdgpu_kernel void @test_fadd(ptr addrspace(1) %ptr) {
   %fadd = atomicrmw fadd ptr addrspace(1) %ptr, float 1.0 syncscope("agent") monotonic, !amdgpu.no.fine.grained.memory !0, !amdgpu.no.remote.memory !0, !amdgpu.ignore.denormal.mode !0
   ret void
 }
 
-; CHECK-LLVM: call i32 @_Z11atomic_xchgPU3AS1Vii({{.*}}) {{.*}}!amdgpu.no.fine.grained.memory ![[#]]
+; CHECK-LLVM: call spir_func i32 @_Z11atomic_xchgPU3AS1Vii({{.*}}){{.*}}!amdgpu.no.fine.grained.memory ![[#]]
 ; CHECK-LLVM-NOT: !amdgpu.no.remote.memory
 ; CHECK-LLVM-NOT: !amdgpu.ignore.denormal.mode
 define amdgpu_kernel void @test_xchg(ptr addrspace(1) %ptr) {

--- a/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-auxdata-amdgpu-atomic-metadata.ll
+++ b/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-auxdata-amdgpu-atomic-metadata.ll
@@ -1,0 +1,89 @@
+; Test AMDGPU atomic metadata roundtrip via NonSemantic.AuxData InstructionMetadata.
+
+; RUN: llvm-as < %s -o %t.bc
+
+; Forward: LLVM IR -> SPIR-V text (SPIR-V 1.5 + extension)
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_shader_atomic_float_add %t.bc -spirv-text --spirv-preserve-auxdata --spirv-max-version=1.5 -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-EXT
+
+; Roundtrip with auxdata (SPIR-V 1.5 + extension): metadata restored.
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_shader_atomic_float_add %t.bc -o %t.spv --spirv-preserve-auxdata --spirv-max-version=1.5
+; RUN: llvm-spirv -r --spirv-preserve-auxdata %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.without.bc
+; RUN: llvm-dis %t.rev.without.bc -o - | FileCheck %s --implicit-check-not="{{amdgpu.no.fine.grained.memory|amdgpu.no.remote.memory|amdgpu.ignore.denormal.mode}}"
+
+; Forward: LLVM IR -> SPIR-V text (SPIR-V 1.6, no explicit extension)
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_shader_atomic_float_add %t.bc -spirv-text --spirv-preserve-auxdata -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-NOEXT
+
+; Roundtrip with auxdata (SPIR-V 1.6): metadata restored.
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_shader_atomic_float_add %t.bc -o %t.spv --spirv-preserve-auxdata
+; RUN: llvm-spirv -r --spirv-preserve-auxdata %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.without.bc
+; RUN: llvm-dis %t.rev.without.bc -o - | FileCheck %s --implicit-check-not="{{amdgpu.no.fine.grained.memory|amdgpu.no.remote.memory|amdgpu.ignore.denormal.mode}}"
+
+; Negative: without --spirv-preserve-auxdata, no AuxData in SPIR-V output.
+; RUN: llvm-spirv --spirv-ext=+SPV_EXT_shader_atomic_float_add %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-NO-AUXDATA
+
+; Negative: --spirv-preserve-auxdata with extension explicitly disabled should error.
+; RUN: not llvm-spirv --spirv-ext=+SPV_EXT_shader_atomic_float_add,-SPV_KHR_non_semantic_info %t.bc -spirv-text --spirv-preserve-auxdata --spirv-max-version=1.5 -o - 2>&1 | FileCheck %s --check-prefix=CHECK-EXT-DISABLED
+
+; CHECK-NO-AUXDATA-NOT: NonSemantic.AuxData
+; CHECK-NO-AUXDATA-NOT: amdgpu.no.fine.grained.memory
+; CHECK-NO-AUXDATA-NOT: amdgpu.no.remote.memory
+; CHECK-NO-AUXDATA-NOT: amdgpu.ignore.denormal.mode
+; CHECK-NO-AUXDATA-NOT: NonSemanticAuxDataInstructionMetadata
+
+; CHECK-EXT-DISABLED: RequiresExtension: Feature requires the following SPIR-V extension:
+; CHECK-EXT-DISABLED-NEXT: SPV_KHR_non_semantic_info
+
+; SPIR-V version checks.
+; CHECK-SPIRV-EXT: 119734787 65536
+; CHECK-SPIRV-EXT: Extension "SPV_KHR_non_semantic_info"
+; CHECK-SPIRV-NOEXT: 119734787 67072
+
+; CHECK-SPIRV: ExtInstImport [[#Import:]] "NonSemantic.AuxData"
+
+; CHECK-SPIRV-DAG: String [[#MD_NFG:]] "amdgpu.no.fine.grained.memory"
+; CHECK-SPIRV-DAG: String [[#MD_NRM:]] "amdgpu.no.remote.memory"
+; CHECK-SPIRV-DAG: String [[#MD_IDN:]] "amdgpu.ignore.denormal.mode"
+
+; CHECK-SPIRV: TypeVoid [[#VoidT:]]
+
+; InstructionMetadata records for the atomics.
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#AddRes:]] [[#MD_NFG]]
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#AddRes]] [[#MD_NRM]]
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#FAddRes:]] [[#MD_NFG]]
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#FAddRes]] [[#MD_NRM]]
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#FAddRes]] [[#MD_IDN]]
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#XchgRes:]] [[#MD_NFG]]
+
+; The atomic instructions themselves.
+; CHECK-SPIRV: AtomicIAdd [[#]] [[#AddRes]]
+; CHECK-SPIRV: AtomicFAddEXT [[#]] [[#FAddRes]]
+; CHECK-SPIRV: AtomicExchange [[#]] [[#XchgRes]]
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-amd-amdhsa"
+
+; CHECK-LLVM: call i32 @_Z10atomic_addPU3AS1Vii({{.*}}) {{.*}}!amdgpu.no.fine.grained.memory ![[#]]{{.*}}!amdgpu.no.remote.memory ![[#]]
+define amdgpu_kernel void @test_iadd(ptr addrspace(1) %ptr) {
+  %add = atomicrmw add ptr addrspace(1) %ptr, i32 1 syncscope("agent") monotonic, !amdgpu.no.fine.grained.memory !0, !amdgpu.no.remote.memory !0
+  ret void
+}
+
+; CHECK-LLVM: call float @_Z10atomic_addPU3AS1Vff({{.*}}) {{.*}}!amdgpu.no.fine.grained.memory ![[#]]{{.*}}!amdgpu.no.remote.memory ![[#]]{{.*}}!amdgpu.ignore.denormal.mode ![[#]]
+define amdgpu_kernel void @test_fadd(ptr addrspace(1) %ptr) {
+  %fadd = atomicrmw fadd ptr addrspace(1) %ptr, float 1.0 syncscope("agent") monotonic, !amdgpu.no.fine.grained.memory !0, !amdgpu.no.remote.memory !0, !amdgpu.ignore.denormal.mode !0
+  ret void
+}
+
+; CHECK-LLVM: call i32 @_Z11atomic_xchgPU3AS1Vii({{.*}}) {{.*}}!amdgpu.no.fine.grained.memory ![[#]]
+; CHECK-LLVM-NOT: !amdgpu.no.remote.memory
+; CHECK-LLVM-NOT: !amdgpu.ignore.denormal.mode
+define amdgpu_kernel void @test_xchg(ptr addrspace(1) %ptr) {
+  %xchg = atomicrmw xchg ptr addrspace(1) %ptr, i32 1 syncscope("agent") monotonic, !amdgpu.no.fine.grained.memory !0
+  ret void
+}
+
+!0 = !{}

--- a/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-auxdata-uinc-udec-wrap-metadata.ll
+++ b/test/extensions/KHR/SPV_KHR_non_semantic_info/preserve-auxdata-uinc-udec-wrap-metadata.ll
@@ -1,0 +1,82 @@
+; Test atomicrmw uinc_wrap/udec_wrap with AMDGPU metadata roundtrip.
+; The writer emits FunctionCall to __spirv_AtomicUIncWrap/__spirv_AtomicUDecWrap
+; with InstructionMetadata AuxData. The reader's OCL lowering converts them back
+; to atomicrmw uinc_wrap/udec_wrap, and metadata is restored from AuxData.
+
+; RUN: llvm-as < %s -o %t.bc
+
+; Forward: LLVM IR -> SPIR-V text (SPIR-V 1.5 + extension)
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-preserve-auxdata --spirv-max-version=1.5 -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-EXT
+
+; Roundtrip with auxdata (SPIR-V 1.5 + extension): metadata restored.
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-preserve-auxdata --spirv-max-version=1.5
+; RUN: llvm-spirv -r --spirv-preserve-auxdata %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.without.bc
+; RUN: llvm-dis %t.rev.without.bc -o - | FileCheck %s --implicit-check-not="{{amdgpu.no.fine.grained.memory|amdgpu.no.remote.memory}}"
+
+; Forward: LLVM IR -> SPIR-V text (SPIR-V 1.6, no explicit extension)
+; RUN: llvm-spirv %t.bc -spirv-text --spirv-preserve-auxdata -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-NOEXT
+
+; Roundtrip with auxdata (SPIR-V 1.6): metadata restored.
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-preserve-auxdata
+; RUN: llvm-spirv -r --spirv-preserve-auxdata %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefix=CHECK-LLVM
+; RUN: llvm-spirv -r %t.spv -o %t.rev.without.bc
+; RUN: llvm-dis %t.rev.without.bc -o - | FileCheck %s --implicit-check-not="{{amdgpu.no.fine.grained.memory|amdgpu.no.remote.memory}}"
+
+; Negative: without --spirv-preserve-auxdata, no AuxData in SPIR-V output.
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-NO-AUXDATA
+
+; Negative: --spirv-preserve-auxdata with extension explicitly disabled should error.
+; RUN: not llvm-spirv %t.bc -spirv-text --spirv-preserve-auxdata --spirv-max-version=1.5 --spirv-ext=-SPV_KHR_non_semantic_info -o - 2>&1 | FileCheck %s --check-prefix=CHECK-EXT-DISABLED
+
+; CHECK-NO-AUXDATA-NOT: NonSemantic.AuxData
+; CHECK-NO-AUXDATA-NOT: amdgpu.no.fine.grained.memory
+; CHECK-NO-AUXDATA-NOT: amdgpu.no.remote.memory
+; CHECK-NO-AUXDATA-NOT: NonSemanticAuxDataInstructionMetadata
+
+; CHECK-EXT-DISABLED: RequiresExtension: Feature requires the following SPIR-V extension:
+; CHECK-EXT-DISABLED-NEXT: SPV_KHR_non_semantic_info
+
+; SPIR-V version checks.
+; CHECK-SPIRV-EXT: 119734787 65536
+; CHECK-SPIRV-EXT: Extension "SPV_KHR_non_semantic_info"
+; CHECK-SPIRV-NOEXT: 119734787 67072
+
+; CHECK-SPIRV-DAG: ExtInstImport [[#Import:]] "NonSemantic.AuxData"
+; CHECK-SPIRV-DAG: String [[#MD_NFG:]] "amdgpu.no.fine.grained.memory"
+; CHECK-SPIRV-DAG: String [[#MD_NRM:]] "amdgpu.no.remote.memory"
+; CHECK-SPIRV-DAG: TypeVoid [[#VoidT:]]
+; CHECK-SPIRV-DAG: Decorate [[#UIncFn:]] LinkageAttributes "__spirv_AtomicUIncWrap" Import
+; CHECK-SPIRV-DAG: Decorate [[#UDecFn:]] LinkageAttributes "__spirv_AtomicUDecWrap" Import
+
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#UIncRes:]] [[#MD_NFG]]
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#UIncRes]] [[#MD_NRM]]
+; CHECK-SPIRV-DAG: ExtInst [[#VoidT]] [[#]] [[#Import]] NonSemanticAuxDataInstructionMetadata [[#UDecRes:]] [[#MD_NFG]]
+
+; CHECK-SPIRV: FunctionCall [[#]] [[#UIncRes]] [[#UIncFn]]
+; CHECK-SPIRV: FunctionCall [[#]] [[#UDecRes]] [[#UDecFn]]
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spirv64-amd-amdhsa"
+
+@ui = common dso_local addrspace(1) global i32 0, align 4
+
+; CHECK-LLVM: atomicrmw uinc_wrap ptr addrspace(1) @ui, i32 42 seq_cst
+; CHECK-LLVM-SAME: !amdgpu.no.fine.grained.memory ![[#]]
+; CHECK-LLVM-SAME: !amdgpu.no.remote.memory ![[#]]
+define amdgpu_kernel void @test_uinc_wrap() {
+  %uinc = atomicrmw uinc_wrap ptr addrspace(1) @ui, i32 42 seq_cst, !amdgpu.no.fine.grained.memory !0, !amdgpu.no.remote.memory !0
+  ret void
+}
+
+; CHECK-LLVM: atomicrmw udec_wrap ptr addrspace(1) @ui, i32 42 seq_cst
+; CHECK-LLVM-SAME: !amdgpu.no.fine.grained.memory ![[#]]
+; CHECK-LLVM-NOT: !amdgpu.no.remote.memory
+define amdgpu_kernel void @test_udec_wrap() {
+  %udec = atomicrmw udec_wrap ptr addrspace(1) @ui, i32 42 seq_cst, !amdgpu.no.fine.grained.memory !0
+  ret void
+}
+
+!0 = !{}


### PR DESCRIPTION
The PR includes an extension to `NonSemantic.AuxData` spec to add `NonSemanticAuxDataInstructionMetadata`, which enables preservation of metadata for instructions other than `GlobalVariable` and `Function` objects. At the same time, it includes the implementation of this mechanism for some AMDGPU metadata. Finally, it includes the translation of `uinc_wrap` and `udec_wrap` as if they were opaque llvm intrinsics, so that they can be restored in the reverse translation to the exact original code. 