### PR TITLE
Prevent TopologicalSort from serializing functions into the constants section

### DIFF
--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1911,7 +1911,8 @@ class TopologicalSort {
             static_cast<SPIRVTypeForwardPointer *>(Op)->getPointerId());
         Op = FP;
       }
-      if (EntryStateMap[Op] == Visited)
+      auto It = EntryStateMap.find(Op);
+      if (It == EntryStateMap.end() || It->second == Visited)
         continue;
       if (visit(Op)) {
         // We've found a recursive data type, e.g. a structure having a member

--- a/test/SpecConstants/specconstantop-func-ref.spvasm
+++ b/test/SpecConstants/specconstantop-func-ref.spvasm
@@ -1,0 +1,26 @@
+; Test that a SpecConstantOp referencing a forward-declared function does not
+; cause the function to be serialized twice by TopologicalSort.
+
+; RUN: llvm-spirv -to-binary -o %t.spv %s
+; RUN: llvm-spirv -r %t.spv -o %t.bc
+; RUN: llvm-dis %t.bc -o - | FileCheck %s
+
+; CHECK-COUNT-1: define {{.*}} @foo
+
+119734787 67072 65535 8 0
+2 Capability Kernel
+2 Capability Linkage
+3 MemoryModel 2 2
+3 Name 6 "foo"
+5 Decorate 6 LinkageAttributes "foo" Export
+
+4 TypeInt 2 32 0
+2 TypeVoid 3
+3 TypeFunction 4 3
+
+5 SpecConstantOp 2 5 124 6
+
+5 Function 3 6 0 4
+2 Label 7
+1 Return
+1 FunctionEnd


### PR DESCRIPTION
The use of `EntryStateMap[Op]` for operands outside the sort domain (e.g. a function referenced by `SpecConstantOp`) silently inserts a new intro into `EntryStateMap`, and ends up pushed back to `ConstAndVarVec` in the catch-all else. As a result, it gets serialized in the types/constants/variables section, and later in the functions section. The resulting binary contains a duplicate ID, and raises `Id used twice` assertion if enabled, or silently produces an invalid module. 

The fix replaces `EntryStateMap[Op]` with `find()`, so entries outside the sort domain are skipped. A test is added to showcase the problematic scenario.