### PR TITLE
Diagnose unsupported module level inline assembly instead of silently dropping it

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -6534,6 +6534,11 @@ static bool hasVectorComputeMetadata(Module *M) {
 bool LLVMToSPIRVBase::translate() {
   BM->setGeneratorVer(KTranslatorVer);
 
+  if (!BM->getErrorLog().checkError(
+          M->getModuleInlineAsm().empty(), SPIRVEC_InvalidLlvmModule,
+          "Module-level inline assembly is not supported in SPIR-V"))
+    return false;
+
   if (isEmptyLLVMModule(M))
     BM->addCapability(CapabilityLinkage);
 

--- a/test/negative/module-asm-unsupported.ll
+++ b/test/negative/module-asm-unsupported.ll
@@ -1,5 +1,4 @@
-; RUN: llvm-as < %s -o %t.bc
-; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+; RUN: not llvm-spirv %s -o %t.spv 2>&1 | FileCheck %s
 
 ; CHECK: InvalidLlvmModule: Invalid LLVM module: Module-level inline assembly is not supported in SPIR-V
 

--- a/test/negative/module-asm-unsupported.ll
+++ b/test/negative/module-asm-unsupported.ll
@@ -1,0 +1,13 @@
+; RUN: llvm-as < %s -o %t.bc
+; RUN: not llvm-spirv %t.bc -o %t.spv 2>&1 | FileCheck %s
+
+; CHECK: InvalidLlvmModule: Invalid LLVM module: Module-level inline assembly is not supported in SPIR-V
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
+target triple = "spir64-unknown-unknown"
+
+module asm "foo"
+
+define spir_kernel void @test() {
+  ret void
+}


### PR DESCRIPTION
Inspired by https://github.com/llvm/llvm-project/pull/199992