### PR TITLE
[Backport to 17] Skip unknown nonsemantic instructions and sets (#3744)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2843,6 +2843,10 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_100:
     case SPIRVEIS_NonSemantic_Shader_DebugInfo_200:
       return mapValue(BV, DbgTran->transDebugIntrinsic(ExtInst, BB));
+    case SPIRVEIS_NonSemantic_Unknown:
+      // Non-semantic instruction sets unknown to the translator are
+      // silently skipped.
+      return mapValue(BV, nullptr);
     default:
       llvm_unreachable("Unknown extended instruction set!");
     }
@@ -5306,6 +5310,13 @@ void SPIRVToLLVM::transAuxDataInst(SPIRVExtInst *BC) {
   assert(BC->getExtSetKind() == SPIRV::SPIRVEIS_NonSemantic_AuxData);
   if (!BC->getModule()->preserveAuxData())
     return;
+  switch (BC->getExtOp()) {
+  case NonSemanticAuxData::FunctionAttribute:
+  case NonSemanticAuxData::FunctionMetadata:
+    break;
+  default:
+    return;
+  }
   auto Args = BC->getArguments();
   // Args 0 and 1 are common between attributes and metadata.
   // 0 is the function, 1 is the name of the attribute/metadata as a string
@@ -5358,7 +5369,7 @@ void SPIRVToLLVM::transAuxDataInst(SPIRVExtInst *BC) {
     break;
   }
   default:
-    llvm_unreachable("Invalid op");
+    break;
   }
 }
 

--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1531,6 +1531,15 @@ MDNode *SPIRVToLLVMDbgTran::transDebugInstImpl(const SPIRVExtInst *DebugInst) {
     return transTypeArrayDynamic(DebugInst);
 
   default:
+    // Non-semantic shader debug info opcodes that are unknown to this
+    // translator are silently ignored to avoid crashing on modules produced
+    // by newer producers. The semantic OpenCL/SPIRV.debug paths still
+    // require every opcode to be implemented.
+    // TODO: since introduction of rolling version of NonSemanticDebugInfo, we
+    // must no longer just ignore unknown debug info set, but instead process
+    // instructions, that the translator know.
+    if (isNonSemanticDebugInfo(DebugInst->getExtSetKind()))
+      return nullptr;
     llvm_unreachable("Not implemented SPIR-V debug instruction!");
   }
 }
@@ -1598,6 +1607,8 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
     return DbgValIntr;
   }
   default:
+    if (isNonSemanticDebugInfo(DebugInst->getExtSetKind()))
+      return nullptr;
     llvm_unreachable("Unknown debug intrinsic!");
   }
 }

--- a/lib/SPIRV/libSPIRV/SPIRVEnum.h
+++ b/lib/SPIRV/libSPIRV/SPIRVEnum.h
@@ -81,6 +81,9 @@ enum SPIRVExtInstSetKind {
   SPIRVEIS_NonSemantic_Shader_DebugInfo_100,
   SPIRVEIS_NonSemantic_Shader_DebugInfo_200,
   SPIRVEIS_NonSemantic_AuxData,
+  // Sentinel kind for any "NonSemantic.*" extended instruction set the
+  // translator does not recognize.
+  SPIRVEIS_NonSemantic_Unknown,
   SPIRVEIS_Count,
 };
 

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -1849,7 +1849,8 @@ public:
             ExtSetKind == SPIRVEIS_OpenCL_DebugInfo_100 ||
             ExtSetKind == SPIRVEIS_NonSemantic_Shader_DebugInfo_100 ||
             ExtSetKind == SPIRVEIS_NonSemantic_Shader_DebugInfo_200 ||
-            ExtSetKind == SPIRVEIS_NonSemantic_AuxData) &&
+            ExtSetKind == SPIRVEIS_NonSemantic_AuxData ||
+            ExtSetKind == SPIRVEIS_NonSemantic_Unknown) &&
            "not supported");
   }
   void encode(spv_ostream &O) const override {
@@ -1866,6 +1867,9 @@ public:
       break;
     case SPIRVEIS_NonSemantic_AuxData:
       getEncoder(O) << ExtOpNonSemanticAuxData;
+      break;
+    case SPIRVEIS_NonSemantic_Unknown:
+      getEncoder(O) << ExtOp;
       break;
     default:
       assert(0 && "not supported");
@@ -1888,6 +1892,9 @@ public:
       break;
     case SPIRVEIS_NonSemantic_AuxData:
       getDecoder(I) >> ExtOpNonSemanticAuxData;
+      break;
+    case SPIRVEIS_NonSemantic_Unknown:
+      getDecoder(I) >> ExtOp;
       break;
     default:
       assert(0 && "not supported");
@@ -1945,9 +1952,11 @@ public:
   }
 
   std::optional<ExtensionID> getRequiredExtension() const override {
-    if (SPIRVBuiltinSetNameMap::map(ExtSetKind).find("NonSemantic.") == 0 &&
-        !Module->isAllowedToUseVersion(VersionNumber::SPIRV_1_6))
-      return ExtensionID::SPV_KHR_non_semantic_info;
+    if (ExtSetKind == SPIRVEIS_NonSemantic_Unknown ||
+        SPIRVBuiltinSetNameMap::map(ExtSetKind).find("NonSemantic.") == 0) {
+      if (!Module->isAllowedToUseVersion(VersionNumber::SPIRV_1_6))
+        return ExtensionID::SPV_KHR_non_semantic_info;
+    }
     return {};
   }
 

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -1038,8 +1038,16 @@ bool SPIRVModuleImpl::importBuiltinSet(const std::string &BuiltinSetName,
 bool SPIRVModuleImpl::importBuiltinSetWithId(const std::string &BuiltinSetName,
                                              SPIRVId BuiltinSetId) {
   SPIRVExtInstSetKind BuiltinSet = SPIRVEIS_Count;
-  SPIRVCKRT(SPIRVBuiltinSetNameMap::rfind(BuiltinSetName, &BuiltinSet),
-            InvalidBuiltinSetName, "Actual is " + BuiltinSetName);
+  if (!SPIRVBuiltinSetNameMap::rfind(BuiltinSetName, &BuiltinSet)) {
+    // Per the non-semantic principle, a consumer may safely ignore any
+    // "NonSemantic.*" extended instruction set it does not recognize.
+    // Accept the import and tag it with a sentinel kind.
+    if (BuiltinSetName.find("NonSemantic.") == 0) {
+      IdToInstSetMap[BuiltinSetId] = SPIRVEIS_NonSemantic_Unknown;
+      return true;
+    }
+    SPIRVCKRT(false, InvalidBuiltinSetName, "Actual is " + BuiltinSetName);
+  }
   IdToInstSetMap[BuiltinSetId] = BuiltinSet;
   ExtInstSetIds[BuiltinSet] = BuiltinSetId;
   return true;

--- a/test/extensions/KHR/SPV_KHR_non_semantic_info/skip-unknown-nonsemantic.spvasm
+++ b/test/extensions/KHR/SPV_KHR_non_semantic_info/skip-unknown-nonsemantic.spvasm
@@ -1,0 +1,40 @@
+; REQUIRES: spirv-as
+
+; The translator must silently ignore any "NonSemantic.*" extended
+; instruction set it does not recognize, and any opcode unknown to it
+; inside a recognized non-semantic set. Neither case may cause a crash
+; or a hard error during reverse translation.
+
+; RUN: spirv-as %s --target-env spv1.0 -o %t.spv
+; RUN: llvm-spirv -r --spirv-preserve-auxdata %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
+
+; Same module without --spirv-preserve-auxdata: the AuxData and unknown
+; non-semantic OpExtInst instructions must still be tolerated.
+; RUN: llvm-spirv -r %t.spv -o %t.noaux.rev.bc
+; RUN: llvm-dis %t.noaux.rev.bc -o - | FileCheck %s
+
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpExtension "SPV_KHR_non_semantic_info"
+       %aux  = OpExtInstImport "NonSemantic.AuxData"
+       %ukn  = OpExtInstImport "NonSemantic.UnknownVendor.Something"
+               OpMemoryModel Physical64 OpenCL
+               OpName %fn "f"
+               OpDecorate %fn LinkageAttributes "f" Export
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+        %u42 = OpConstant %uint 42
+       %ustr = OpString "some_attr"
+       %fnTy = OpTypeFunction %void
+        %nop1 = OpExtInst %void %aux 99 %fn %ustr
+        %nop2 = OpExtInst %void %ukn 1 %fn
+         %fn = OpFunction %void None %fnTy
+        %ent = OpLabel
+                OpReturn
+                OpFunctionEnd
+
+; CHECK-LABEL: define spir_func void @f()
+; CHECK-NEXT:    ret void
+; CHECK-NOT: "some_attr"

--- a/test/extensions/KHR/SPV_KHR_non_semantic_info/skip-unknown-shader-debuginfo.spvasm
+++ b/test/extensions/KHR/SPV_KHR_non_semantic_info/skip-unknown-shader-debuginfo.spvasm
@@ -1,0 +1,35 @@
+; REQUIRES: spirv-as
+
+; NonSemantic.Shader.DebugInfo.300 is unknown to this translator. Check if we
+; skip it.
+
+; RUN: spirv-as %s --target-env spv1.0 -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s
+
+               OpCapability Addresses
+               OpCapability Linkage
+               OpCapability Kernel
+               OpExtension "SPV_KHR_non_semantic_info"
+       %dbg  = OpExtInstImport "NonSemantic.Shader.DebugInfo.300"
+               OpMemoryModel Physical64 OpenCL
+               OpName %fn "f"
+               OpDecorate %fn LinkageAttributes "f" Export
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+     %u_lang = OpConstant %uint 6
+     %u_ver  = OpConstant %uint 65536
+     %u_dwv  = OpConstant %uint 4
+       %file = OpString "test.cpp"
+       %fnTy = OpTypeFunction %void
+        %src = OpExtInst %void %dbg 35 %file
+         %cu = OpExtInst %void %dbg 1 %u_ver %u_dwv %src %u_lang
+         %fn = OpFunction %void None %fnTy
+        %ent = OpLabel
+                OpReturn
+                OpFunctionEnd
+
+; CHECK-LABEL: define spir_func void @f()
+; CHECK-NEXT:    ret void
+; CHECK-NOT: !DICompileUnit
+; CHECK-NOT: !llvm.dbg.cu


### PR DESCRIPTION
Backport of #3744.