### PR TITLE
Fix memory leak in isInternalSPIRVBuiltin

### DIFF
--- a/lib/SPIRV/SPIRVUtil.cpp
+++ b/lib/SPIRV/SPIRVUtil.cpp
@@ -498,10 +498,13 @@ bool isInternalSPIRVBuiltin(StringRef Name, StringRef &DemangledName) {
     return false;
   constexpr unsigned DemangledNameLenStart = 2;
   size_t Start = Name.find_first_not_of("0123456789", DemangledNameLenStart);
-  if (!Name.substr(Start, Name.size() - 1)
-           .starts_with(kSPIRVName::InternalBuiltinPrefix))
+  if (!Name.substr(Start).starts_with(kSPIRVName::InternalBuiltinPrefix))
     return false;
-  DemangledName = llvm::itaniumDemangle(Name.data(), false);
+  size_t Len = 0;
+  if (Name.substr(DemangledNameLenStart, Start - DemangledNameLenStart)
+          .getAsInteger(10, Len))
+    return false;
+  DemangledName = Name.substr(Start, Len);
   DemangledName.consume_front(kSPIRVName::InternalBuiltinPrefix);
   return true;
 }


### PR DESCRIPTION
itaniumDemangle returns a malloc'd buffer that the caller must free, but
its result was assigned directly to a StringRef, so the buffer was never
released. This leaked on every internal FP4/FP8/int4 conversion builtin
processed by transFunctionDecl and transDirectCallInst.

The demangled name is simply the length-prefixed identifier already
present in the mangled name, so extract it as a substring of Name (the same
pattern used by the other demanglers above) instead of calling
itaniumDemangle. This removes the allocation entirely, so there is nothing
to leak.