### PR TITLE
Translate MaximumRegisters MD through SPV_INTEL_maximum_registers

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -1063,8 +1063,8 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
 
   if (BM->isAllowedToUseExtension(ExtensionID::SPV_INTEL_maximum_registers))
     transFunctionMetadataAsExecutionMode(BF, F);
-  else
-    transFunctionMetadataAsUserSemanticDecoration(BF, F);
+
+  transFunctionMetadataAsUserSemanticDecoration(BF, F);
 
   transAuxDataInst(BF, F);
 
@@ -1207,32 +1207,32 @@ void LLVMToSPIRVBase::transFPGAFunctionMetadata(SPIRVFunction *BF,
 
 void LLVMToSPIRVBase::transFunctionMetadataAsExecutionMode(SPIRVFunction *BF,
                                                            Function *F) {
-  SmallVector<MDNode *, 1> RegisterAllocModeMDs;
-  F->getMetadata("RegisterAllocMode", RegisterAllocModeMDs);
+  SmallVector<MDNode *, 1> MaximumRegistersMDs;
+  F->getMetadata("MaximumRegisters", MaximumRegistersMDs);
 
-  for (unsigned I = 0; I < RegisterAllocModeMDs.size(); I++) {
-    auto *RegisterAllocMode = RegisterAllocModeMDs[I]->getOperand(0).get();
-    if (isa<MDString>(RegisterAllocMode)) {
-      StringRef Str = getMDOperandAsString(RegisterAllocModeMDs[I], 0);
+  for (unsigned I = 0; I < MaximumRegistersMDs.size(); I++) {
+    auto *MaximumRegisters = MaximumRegistersMDs[I]->getOperand(0).get();
+    if (isa<MDString>(MaximumRegisters)) {
+      StringRef Str = getMDOperandAsString(MaximumRegistersMDs[I], 0);
       NamedMaximumNumberOfRegisters NamedValue =
           SPIRVNamedMaximumNumberOfRegistersNameMap::rmap(Str.str());
       BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
           OpExecutionMode, BF, ExecutionModeNamedMaximumRegistersINTEL,
           NamedValue)));
-    } else if (isa<MDNode>(RegisterAllocMode)) {
-      auto *RegisterAllocNodeMDOp =
-          getMDOperandAsMDNode(RegisterAllocModeMDs[I], 0);
-      int Num = getMDOperandAsInt(RegisterAllocNodeMDOp, 0);
+    } else if (isa<MDNode>(MaximumRegisters)) {
+      auto *MaxRegNodeMDOp =
+          getMDOperandAsMDNode(MaximumRegistersMDs[I], 0);
+      int Num = getMDOperandAsInt(MaxRegNodeMDOp, 0);
       auto *Const =
           BM->addConstant(transType(Type::getInt32Ty(F->getContext())), Num);
       BF->addExecutionMode(BM->add(new SPIRVExecutionModeId(
           BF, ExecutionModeMaximumRegistersIdINTEL, Const->getId())));
     } else {
-      int64_t RegisterAllocVal =
-          mdconst::dyn_extract<ConstantInt>(RegisterAllocMode)->getZExtValue();
+      int64_t MaxRegVal =
+          mdconst::dyn_extract<ConstantInt>(MaximumRegisters)->getZExtValue();
       BF->addExecutionMode(BM->add(new SPIRVExecutionMode(
           OpExecutionMode, BF, ExecutionModeMaximumRegistersINTEL,
-          RegisterAllocVal)));
+          MaxRegVal)));
     }
   }
 }

--- a/test/extensions/INTEL/SPV_INTEL_maximum_registers/maxreg_extension.ll
+++ b/test/extensions/INTEL/SPV_INTEL_maximum_registers/maxreg_extension.ll
@@ -11,45 +11,45 @@
 ; CHECK-SPIRV: EntryPoint [[#]] [[#FUNC3:]] "main_l13"
 ; CHECK-SPIRV: EntryPoint [[#]] [[#FUNC4:]] "main_l19"
 
-; CHECK-SPIRV: ExecutionMode [[#FUNC0]] 6461 2
-; CHECK-SPIRV: ExecutionMode [[#FUNC1]] 6461 1
+; CHECK-SPIRV: ExecutionMode [[#FUNC0]] 6461 256
+; CHECK-SPIRV: ExecutionMode [[#FUNC1]] 6461 128
 ; CHECK-SPIRV: ExecutionMode [[#FUNC2]] 6463 0
 ; CHECK-SPIRV: ExecutionModeId [[#FUNC3]] 6462 [[#Const3:]]
 ; CHECK-SPIRV: TypeInt [[#TypeInt:]] 32 0
-; CHECK-SPIRV: Constant [[#TypeInt]] [[#Const3]] 3
+; CHECK-SPIRV: Constant [[#TypeInt]] [[#Const3]] 512
 
 ; CHECK-SPIRV-NOT: ExecutionMode [[#FUNC4]]
 
 ; CHECK-LLVM: !spirv.ExecutionMode = !{![[#FLAG0:]], ![[#FLAG1:]], ![[#FLAG2:]], ![[#FLAG3:]]}
-; CHECK-LLVM: ![[#FLAG0]] = !{ptr @main_l3, i32 6461, i32 2}
-; CHECK-LLVM: ![[#FLAG1]] = !{ptr @main_l6, i32 6461, i32 1}
+; CHECK-LLVM: ![[#FLAG0]] = !{ptr @main_l3, i32 6461, i32 256}
+; CHECK-LLVM: ![[#FLAG1]] = !{ptr @main_l6, i32 6461, i32 128}
 ; CHECK-LLVM: ![[#FLAG2]] = !{ptr @main_l9, i32 6463, !"AutoINTEL"}
 ; CHECK-LLVM: ![[#FLAG3]] = !{ptr @main_l13, i32 6462, ![[#VAL:]]}
-; CHECK-LLVM: ![[#VAL]] = !{i32 3}
+; CHECK-LLVM: ![[#VAL]] = !{i32 512}
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64"
 
 ; Function Attrs: noinline nounwind optnone
-define weak dso_local spir_kernel void @main_l3() #0 !RegisterAllocMode !10 {
+define weak dso_local spir_kernel void @main_l3() #0 !MaximumRegisters !10 {
 newFuncRoot:
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone
-define weak dso_local spir_kernel void @main_l6() #0 !RegisterAllocMode !11 {
+define weak dso_local spir_kernel void @main_l6() #0 !MaximumRegisters !11 {
 newFuncRoot:
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone
-define weak dso_local spir_kernel void @main_l9() #0 !RegisterAllocMode !12 {
+define weak dso_local spir_kernel void @main_l9() #0 !MaximumRegisters !12 {
 newFuncRoot:
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone
-define weak dso_local spir_kernel void @main_l13() #0 !RegisterAllocMode !13 {
+define weak dso_local spir_kernel void @main_l13() #0 !MaximumRegisters !13 {
 newFuncRoot:
   ret void
 }
@@ -78,8 +78,8 @@ attributes #0 = { noinline nounwind optnone }
 !7 = !{i32 8, !"PIC Level", i32 2}
 !8 = !{i32 7, !"frame-pointer", i32 2}
 !9 = !{i32 2, i32 2}
-!10 = !{i32 2}
-!11 = !{i32 1}
+!10 = !{i32 256}
+!11 = !{i32 128}
 !12 = !{!"AutoINTEL"}
 !13 = !{!14}
-!14 = !{i32 3}
+!14 = !{i32 512}

--- a/test/transcoding/registerallocmode.ll
+++ b/test/transcoding/registerallocmode.ll
@@ -3,6 +3,15 @@
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-val %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+; Verify we don't use SPV_INTEL_maximum_registers even if it is allowed.
+; The MaximumRegisters metadata should be used for SPV_INTEL_maximum_registers.
+
+; RUN: llvm-as %s -o %t2.bc
+; RUN: llvm-spirv --spirv-ext=+SPV_INTEL_maximum_registers -spirv-text %t2.bc -o - | FileCheck %s --check-prefix=CHECK-SPIRV -implicit-check-not=SPV_INTEL_maximum_registers
+; RUN: llvm-spirv %t2.bc -o %t2.spv
+; RUN: spirv-val %t2.spv
+; RUN: llvm-spirv -r %t2.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM -implicit-check-not=spirv.ExecutionMode
 ; FIXME: llc does not emit UserSemantic decorations for RegisterAllocMode/num-thread-per-eu annotations, so these are lost in the roundtrip
 
 ; CHECK-SPIRV: EntryPoint [[#]] [[#FUNC0:]] "main_l3"


### PR DESCRIPTION
Currently we translate the `RegisterAllocMode` metadata through `SPV_INTEL_maximum_registers` if available, and the user semantic `num-thread-per-eu` otherwise.

If we always translate `RegisterAllocMode` through `SPV_INTEL_maximum_registers` if it is available, it will break users who are using a consumer that doesn't support this extension as it will error on seeing this SPIR-V.

Instead, we rework 92ea64b77207d28e0318950358276747220b6e22 and introduce new metadata,`MaximumRegisters`, that is always translated through `SPV_INTEL_maximum_registers`, and always translate `RegisterAllocMode` through `num-threads-per-eu`.

The format of the new metadata is closer to the `SPV_INTEL_maximum_registers` extension. If it's a numeric literal, that is the literal number of registers requested. If it's a string, it must be `AutoINTEL`, the only one allowed by the spec, to request the consumer choose the maximum number of registers.

This allows Intel's SYCL compiler (which will generate the IR with this metadata) to choose if it wants to require the `SPV_INTEL_maximum_registers` extension or not.

For some background, we plan to enable `SPV_INTEL_maximum_registers` in Intel's SYCL compiler by default, and we will introduce a new SYCL language mechanism that will end up generating the `MaximumRegisters` metadata, and keep using the `RegisterAllocMode` metadata if the user does not opt in. This allows us to not break existing users while still allowing those who want to use the extension to use it.
