### PR TITLE
[Backport to 20] Remove getLifetimeStartIntrinsic function from SPIRVReader (#3373)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -249,23 +249,6 @@ translateSEVMetadata(SPIRVValue *BV, llvm::LLVMContext &Context) {
   return RetAttr;
 }
 
-IntrinsicInst *SPIRVToLLVM::getLifetimeStartIntrinsic(Instruction *I) {
-  auto *II = dyn_cast<IntrinsicInst>(I);
-  if (II && II->getIntrinsicID() == Intrinsic::lifetime_start)
-    return II;
-  // Bitcast might be inserted during translation of OpLifetimeStart
-  auto *BC = dyn_cast<BitCastInst>(I);
-  if (BC) {
-    for (const auto &U : BC->users()) {
-      II = dyn_cast<IntrinsicInst>(U);
-      if (II && II->getIntrinsicID() == Intrinsic::lifetime_start)
-        return II;
-      ;
-    }
-  }
-  return nullptr;
-}
-
 SPIRVErrorLog &SPIRVToLLVM::getErrorLog() { return BM->getErrorLog(); }
 
 void SPIRVToLLVM::setCallingConv(CallInst *Call) {
@@ -2058,9 +2041,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     if (Size)
       S = Builder.getInt64(Size);
     auto *Var = transValue(LTStop->getObject(), F, BB);
-    for (const auto &I : Var->users())
-      if (auto *II = getLifetimeStartIntrinsic(dyn_cast<Instruction>(I)))
-        return mapValue(BV, Builder.CreateLifetimeEnd(II->getOperand(1), S));
+    Var = Var->stripPointerCasts();
     return mapValue(BV, Builder.CreateLifetimeEnd(Var, S));
   }
 

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -2029,6 +2029,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     if (Size)
       S = Builder.getInt64(Size);
     Value *Var = transValue(LTStart->getObject(), F, BB);
+    Var = Var->stripPointerCasts();
     CallInst *Start = Builder.CreateLifetimeStart(Var, S);
     return mapValue(BV, Start);
   }

--- a/test/llvm-intrinsics/lifetime.ll
+++ b/test/llvm-intrinsics/lifetime.ll
@@ -37,9 +37,9 @@
 ; CHECK-SPIRV: LifetimeStop [[#Cast4]] 1
 
 ; CHECK-LLVM-LABEL: lifetime_simple
-; CHECK-LLVM: %[[tmp1:[0-9]+]] = bitcast ptr %{{[0-9]+}} to ptr
-; CHECK-LLVM: call void @llvm.lifetime.start.p0(i64 -1, ptr %[[tmp1]])
-; CHECK-LLVM: call void @llvm.lifetime.end.p0(i64 -1, ptr %[[tmp1]])
+; CHECK-LLVM: %[[#Base:]] = alloca i32
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(i64 -1, ptr %[[#Base]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(i64 -1, ptr %[[#Base]])
 
 ; CHECK-LLVM-LABEL: lifetime_sized
 ; CHECK-LLVM: call void @llvm.lifetime.start.p0(i64 1, ptr %[[#]])
@@ -47,12 +47,8 @@
 
 ; CHECK-LLVM-LABEL: lifetime_generic
 ; CHECK-LLVM: %[[#Alloca:]] = alloca %class.anon
-; CHECK-LLVM: %[[#Cast1:]] = addrspacecast ptr %[[#Alloca]] to ptr addrspace(4)
-; CHECK-LLVM: %[[#Cast2:]] = bitcast ptr addrspace(4) %[[#Cast1]] to ptr addrspace(4)
-; CHECK-LLVM: %[[#Cast3:]] = addrspacecast ptr addrspace(4) %[[#Cast2:]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.start.p0(i64 1, ptr %[[#Cast3]])
-; CHECK-LLVM: %[[#Cast4:]] = addrspacecast ptr addrspace(4) %[[#]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.end.p0(i64 1, ptr %[[#Cast4]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0(i64 1, ptr %[[#Alloca]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0(i64 1, ptr %[[#Alloca]])
 
 ; ModuleID = 'main'
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/test/llvm-intrinsics/memmove.ll
+++ b/test/llvm-intrinsics/memmove.ll
@@ -91,46 +91,38 @@
 ; CHECK-LLVM: %[[local:.*]] = alloca [128 x i8]
 ; CHECK-LLVM: %[[i8_in:.*]] = bitcast ptr addrspace(1) %in to ptr addrspace(1)
 ; CHECK-LLVM: %[[i8_out:.*]] = bitcast ptr addrspace(1) %out to ptr addrspace(1)
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast ptr %[[local]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[i8_local]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[local]])
 ; CHECK-LLVM: call void @llvm.memcpy.p0.p1.i32(ptr align 64 %[[local]],
 ; CHECK-LLVM-SAME: ptr addrspace(1) align 64 %[[i8_in]], i32 128, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p1.p0.i32(ptr addrspace(1) align 64 %[[i8_out]],
 ; CHECK-LLVM-SAME: ptr align 64 %[[local]], i32 128, i1 false)
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast ptr %[[local]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[i8_local]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[local]])
 
 ; CHECK-LLVM-LABEL: @test_partial_move
 ; CHECK-LLVM: %[[local:.*]] = alloca [68 x i8]
 ; CHECK-LLVM: %[[i8_in:.*]] = bitcast ptr addrspace(1) %in to ptr addrspace(1)
 ; CHECK-LLVM: %[[i8_out_generic:.*]] = bitcast ptr addrspace(4) %out to ptr addrspace(4)
 ; CHECK-LLVM: %[[i8_out:.*]] = addrspacecast ptr addrspace(4) %[[i8_out_generic]] to ptr addrspace(1)
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast ptr %[[local]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[i8_local]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[local]])
 ; CHECK-LLVM: call void @llvm.memcpy.p0.p1.i32(ptr align 64 %[[local]],
 ; CHECK-LLVM-SAME: ptr addrspace(1) align 64 %[[i8_in]], i32 68, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p1.p0.i32(ptr addrspace(1) align 64 %[[i8_out]],
 ; CHECK-LLVM-SAME: ptr align 64 %[[local]], i32 68, i1 false)
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast ptr %[[local]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[i8_local]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[local]])
 
 ; CHECK-LLVM-LABEL: @test_array
 ; CHECK-LLVM: %[[#ALLOCA:]] = alloca [72 x i8]
-; CHECK-LLVM: %[[#TMP0:]] = bitcast ptr %[[#ALLOCA]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[#TMP0]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[#ALLOCA]])
 ; CHECK-LLVM: call void @llvm.memcpy.p0.p1.i32(ptr %[[#ALLOCA]], ptr addrspace(1) %in, i32 72, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p1.p0.i32(ptr addrspace(1) %out, ptr %[[#ALLOCA]], i32 72, i1 false)
-; CHECK-LLVM: %[[#TMP3:]] = bitcast ptr %[[#ALLOCA]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[#TMP3]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[#ALLOCA]])
 
 ; CHECK-LLVM-LABEL: @test_phi
 ; CHECK-LLVM: %[[#ALLOCA:]] = alloca [32 x i8]
-; CHECK-LLVM: %[[#TMP0:]] = bitcast ptr %[[#ALLOCA]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[#TMP0]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0({{.*}}, ptr %[[#ALLOCA]])
 ; CHECK-LLVM: call void @llvm.memcpy.p0.p4.i64(ptr align 8 %[[#ALLOCA]], ptr addrspace(4) align 8 %phi, i64 32, i1 false)
 ; CHECK-LLVM: call void @llvm.memcpy.p4.p0.i64(ptr addrspace(4) align 8 %[[#]], ptr align 8 %[[#ALLOCA]], i64 32, i1 false)
-; CHECK-LLVM: %[[#TMP3:]] = bitcast ptr %[[#ALLOCA]] to ptr
-; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[#TMP3]])
+; CHECK-LLVM: call void @llvm.lifetime.end.p0({{.*}}, ptr %[[#ALLOCA]])
 
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"


### PR DESCRIPTION
Backport of #3373.