### PR TITLE
[CI] Use llvm-toolchain-plucky instead of noble for out-of-tree nightly

### DIFF
--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         build_type: [Release, Debug]
       fail-fast: false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install dependencies
         run: |

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -64,7 +64,7 @@ jobs:
           # Use llvm-toolchain-plucky (Ubuntu 25.04 packages) instead of noble —
           # the noble snapshot has been stuck since 2026-08-11, while plucky is current.
           # Note: installing 25.04 packages on the 24.04 runner may cause dependency issues.
-          echo "deb https://apt.llvm.org/plucky/ llvm-toolchain-plucky main" | sudo tee -a /etc/apt/sources.list
+          echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \

--- a/.github/workflows/check-out-of-tree-build.yml
+++ b/.github/workflows/check-out-of-tree-build.yml
@@ -61,7 +61,10 @@ jobs:
       - name: Install dependencies
         run: |
           curl -L "https://apt.llvm.org/llvm-snapshot.gpg.key" | sudo apt-key add -
-          echo "deb https://apt.llvm.org/noble/ llvm-toolchain-noble main" | sudo tee -a /etc/apt/sources.list
+          # Use llvm-toolchain-plucky (Ubuntu 25.04 packages) instead of noble —
+          # the noble snapshot has been stuck since 2026-08-11, while plucky is current.
+          # Note: installing 25.04 packages on the 24.04 runner may cause dependency issues.
+          echo "deb https://apt.llvm.org/plucky/ llvm-toolchain-plucky main" | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get -yq --no-install-suggests --no-install-recommends install \
             clang-${{ env.LLVM_VERSION }} \


### PR DESCRIPTION
The noble (Ubuntu 24.04) snapshot on apt.llvm.org has been stuck at a commit from 2026-08-10 since 2026-08-11, causing the out-of-tree nightly to fail with CASPluginTest export errors even though the underlying issue was fixed upstream in llvm/llvm-project#215292

Switch to plucky (Ubuntu 25.04) packages, which are publishing fresh snapshots daily and include the fix.

Note: This installs 25.04 packages on the 24.04 runner, which may cause dependency issues if the ABI has changed. 
If this fails, we can either revert to noble once the snapshot resumes or switch the runner to 22.04 and use llvm-toolchain-jammy instead.

W/A for https://github.com/llvm/llvm-project/issues/216102