### PR TITLE
[Backport to 14] Remove getLifetimeStartIntrinsic function from SPIRVReader (#3373)

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -1976,6 +1976,7 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     if (Size)
       S = Builder.getInt64(Size);
     Value *Var = transValue(LTStart->getObject(), F, BB);
+    Var = Var->stripPointerCasts();
     CallInst *Start = Builder.CreateLifetimeStart(Var, S);
     return mapValue(BV, Start);
   }

--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -244,23 +244,6 @@ translateSEVMetadata(SPIRVValue *BV, llvm::LLVMContext &Context) {
   return RetAttr;
 }
 
-IntrinsicInst *SPIRVToLLVM::getLifetimeStartIntrinsic(Instruction *I) {
-  auto II = dyn_cast<IntrinsicInst>(I);
-  if (II && II->getIntrinsicID() == Intrinsic::lifetime_start)
-    return II;
-  // Bitcast might be inserted during translation of OpLifetimeStart
-  auto BC = dyn_cast<BitCastInst>(I);
-  if (BC) {
-    for (const auto &U : BC->users()) {
-      II = dyn_cast<IntrinsicInst>(U);
-      if (II && II->getIntrinsicID() == Intrinsic::lifetime_start)
-        return II;
-      ;
-    }
-  }
-  return nullptr;
-}
-
 SPIRVErrorLog &SPIRVToLLVM::getErrorLog() { return BM->getErrorLog(); }
 
 void SPIRVToLLVM::setCallingConv(CallInst *Call) {
@@ -2004,10 +1987,8 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
     ConstantInt *S = nullptr;
     if (Size)
       S = Builder.getInt64(Size);
-    auto Var = transValue(LTStop->getObject(), F, BB);
-    for (const auto &I : Var->users())
-      if (auto II = getLifetimeStartIntrinsic(dyn_cast<Instruction>(I)))
-        return mapValue(BV, Builder.CreateLifetimeEnd(II->getOperand(1), S));
+    auto *Var = transValue(LTStop->getObject(), F, BB);
+    Var = Var->stripPointerCasts();
     return mapValue(BV, Builder.CreateLifetimeEnd(Var, S));
   }
 

--- a/test/SpecConstants/OpSpecConstantComposite.spvasm
+++ b/test/SpecConstants/OpSpecConstantComposite.spvasm
@@ -23,7 +23,7 @@
   
 ; CHECK-DEFAULT: store %struct._ZTS3POD.POD { [2 x %struct._ZTS1A.A] [%struct._ZTS1A.A { i32 1, float 0.000000e+00 }, %struct._ZTS1A.A { i32 35, float 0.000000e+00 }], %"class._ZTSN2cl4sycl3vecIiLi2EEE.cl::sycl::vec" { <2 x i32> <i32 45, i32 55> }     }, %struct._ZTS3POD.POD addrspace(4)* %[[#]]
 
-; CHECK-SPEC: store %struct._ZTS3POD.POD { [2 x %struct._ZTS1A.A] [%struct._ZTS1A.A { i32 42, float 0x4005AE1480000000 }, %struct._ZTS1A.A { i32 43, float 0x40091EB860000000 }], %"class._ZTSN2cl4sycl3vecIiLi2EEE.cl::sycl::vec" { <2 x i32> <i32 44, i32 55> } }, %struct._ZTS3POD.POD addrspace(4)* %3
+; CHECK-SPEC: store %struct._ZTS3POD.POD { [2 x %struct._ZTS1A.A] [%struct._ZTS1A.A { i32 42, float 0x4005AE1480000000 }, %struct._ZTS1A.A { i32 43, float 0x40091EB860000000 }], %"class._ZTSN2cl4sycl3vecIiLi2EEE.cl::sycl::vec" { <2 x i32> <i32 44, i32 55> } }, %struct._ZTS3POD.POD addrspace(4)* %[[#]]
 
 ; SPIR-V
 ; Version: 1.1

--- a/test/llvm-intrinsics/lifetime.ll
+++ b/test/llvm-intrinsics/lifetime.ll
@@ -9,9 +9,9 @@
 ; CHECK-SPIRV: 3 LifetimeStart [[tmp:[0-9]+]] 0
 ; CHECK-SPIRV: 3 LifetimeStop [[tmp]] 0
 
-; CHECK-LLVM: %[[tmp1:[0-9]+]] = bitcast i32* %{{[0-9]+}} to i8*
-; CHECK-LLVM: call void @llvm.lifetime.start.p0i8(i64 -1, i8* %[[tmp1]])
-; CHECK-LLVM: call void @llvm.lifetime.end.p0i8(i64 -1, i8* %[[tmp1]])
+; CHECK-LLVM: %[[alloca:[0-9]+]] = alloca i32
+; CHECK-LLVM: call void @llvm.lifetime.start.p0i8(i64 -1, i8* %{{[0-9]+}})
+; CHECK-LLVM: call void @llvm.lifetime.end.p0i8(i64 -1, i8* %{{[0-9]+}})
 ; CHECK-LLVM: declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture)
 ; CHECK-LLVM: declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture)
 

--- a/test/llvm-intrinsics/memmove.ll
+++ b/test/llvm-intrinsics/memmove.ll
@@ -90,54 +90,38 @@
 ; CHECK-LLVM: %[[i8_in:.*]] = bitcast %struct.SomeStruct addrspace(1)* %in to i8 addrspace(1)*
 ; CHECK-LLVM: %[[i8_out:.*]] = bitcast %struct.SomeStruct addrspace(1)* %out to i8 addrspace(1)*
 ; CHECK-LLVM: %[[local:.*]] = alloca [128 x i8]
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast [128 x i8]* %[[local]] to i8*
-; CHECK-LLVM: call void @llvm.lifetime.start.p0i8({{.*}}, i8* %[[i8_local]])
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast [128 x i8]* %[[local]] to i8*
-; CHECK-LLVM: call void @llvm.memcpy.p0i8.p1i8.i32(i8* align 64 %[[i8_local]],
+; CHECK-LLVM: call void @llvm.lifetime.start.p0i8({{.*}}, i8* %{{[0-9]+}})
+; CHECK-LLVM: call void @llvm.memcpy.p0i8.p1i8.i32(i8* align 64 %{{[0-9]+}},
 ; CHECK-LLVM-SAME: i8 addrspace(1)* align 64 %[[i8_in]], i32 128, i1 false)
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast [128 x i8]* %[[local]] to i8*
 ; CHECK-LLVM: call void @llvm.memcpy.p1i8.p0i8.i32(i8 addrspace(1)* align 64 %[[i8_out]],
-; CHECK-LLVM-SAME: i8* align 64 %[[i8_local]], i32 128, i1 false)
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast [128 x i8]* %[[local]] to i8*
-; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{.*}}, i8* %[[i8_local]])
+; CHECK-LLVM-SAME: i8* align 64 %{{[0-9]+}}, i32 128, i1 false)
+; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{.*}}, i8* %{{[0-9]+}})
 
 ; CHECK-LLVM-LABEL: @test_partial_move
 ; CHECK-LLVM: %[[i8_in:.*]] = bitcast %struct.SomeStruct addrspace(1)* %in to i8 addrspace(1)*
 ; CHECK-LLVM: %[[i8_out_generic:.*]] = bitcast %struct.SomeStruct addrspace(4)* %out to i8 addrspace(4)*
 ; CHECK-LLVM: %[[i8_out:.*]] = addrspacecast i8 addrspace(4)* %[[i8_out_generic]] to i8 addrspace(1)*
 ; CHECK-LLVM: %[[local:.*]] = alloca [68 x i8]
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast [68 x i8]* %[[local]] to i8*
-; CHECK-LLVM: call void @llvm.lifetime.start.p0i8({{.*}}, i8* %[[i8_local]])
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast [68 x i8]* %[[local]] to i8*
-; CHECK-LLVM: call void @llvm.memcpy.p0i8.p1i8.i32(i8* align 64 %[[i8_local]],
+; CHECK-LLVM: call void @llvm.lifetime.start.p0i8({{.*}}, i8* %{{[0-9]+}})
+; CHECK-LLVM: call void @llvm.memcpy.p0i8.p1i8.i32(i8* align 64 %{{[0-9]+}},
 ; CHECK-LLVM-SAME: i8 addrspace(1)* align 64 %[[i8_in]], i32 68, i1 false)
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast [68 x i8]* %[[local]] to i8*
 ; CHECK-LLVM: call void @llvm.memcpy.p1i8.p0i8.i32(i8 addrspace(1)* align 64 %[[i8_out]],
-; CHECK-LLVM-SAME: i8* align 64 %[[i8_local]], i32 68, i1 false)
-; CHECK-LLVM: %[[i8_local:.*]] = bitcast [68 x i8]* %[[local]] to i8*
-; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{.*}}, i8* %[[i8_local]])
+; CHECK-LLVM-SAME: i8* align 64 %{{[0-9]+}}, i32 68, i1 false)
+; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{.*}}, i8* %{{[0-9]+}})
 
 ; CHECK-LLVM-LABEL: @test_array
 ; CHECK-LLVM: %[[#ALLOCA:]] = alloca [72 x i8]
-; CHECK-LLVM: %[[#TMP0:]] = bitcast [72 x i8]* %[[#ALLOCA]] to i8*
-; CHECK-LLVM: call void @llvm.lifetime.start.p0i8({{.*}}, i8* %[[#TMP0]])
-; CHECK-LLVM: %[[#TMP1:]] = bitcast [72 x i8]* %[[#ALLOCA]] to i8*
-; CHECK-LLVM: call void @llvm.memcpy.p0i8.p1i8.i32(i8* %[[#TMP1]], i8 addrspace(1)* %in, i32 72, i1 false)
-; CHECK-LLVM: %[[#TMP2:]] = bitcast [72 x i8]* %[[#ALLOCA]] to i8*
-; CHECK-LLVM: call void @llvm.memcpy.p1i8.p0i8.i32(i8 addrspace(1)* %out, i8* %[[#TMP2]], i32 72, i1 false)
-; CHECK-LLVM: %[[#TMP3:]] = bitcast [72 x i8]* %[[#ALLOCA]] to i8*
-; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{.*}}, i8* %[[#TMP3]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0i8({{.*}}, i8* %[[#]])
+; CHECK-LLVM: call void @llvm.memcpy.p0i8.p1i8.i32(i8* %[[#]], i8 addrspace(1)* %in, i32 72, i1 false)
+; CHECK-LLVM: call void @llvm.memcpy.p1i8.p0i8.i32(i8 addrspace(1)* %out, i8* %[[#]], i32 72, i1 false)
+; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{.*}}, i8* %[[#]])
 
 ; CHECK-LLVM-LABEL: @test_phi
 ; CHECK-LLVM: %[[#ALLOCA:]] = alloca [32 x i8]
-; CHECK-LLVM: %[[#TMP0:]] = bitcast [32 x i8]* %[[#ALLOCA]] to i8*
-; CHECK-LLVM: call void @llvm.lifetime.start.p0i8({{.*}}, i8* %[[#TMP0]])
-; CHECK-LLVM: %[[#TMP1:]] = bitcast [32 x i8]* %[[#ALLOCA]] to i8*
-; CHECK-LLVM: call void @llvm.memcpy.p0i8.p4i8.i64(i8* align 8 %[[#TMP1]], i8 addrspace(4)* align 8 %phi, i64 32, i1 false)
-; CHECK-LLVM: %[[#TMP2:]] = bitcast [32 x i8]* %[[#ALLOCA]] to i8*
-; CHECK-LLVM: call void @llvm.memcpy.p4i8.p0i8.i64(i8 addrspace(4)* align 8 %[[#]], i8* align 8 %[[#TMP2]], i64 32, i1 false)
-; CHECK-LLVM: %[[#TMP3:]] = bitcast [32 x i8]* %[[#ALLOCA]] to i8*
-; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{.*}}, i8* %[[#TMP3]])
+; CHECK-LLVM: call void @llvm.lifetime.start.p0i8({{.*}}, i8* %[[#]])
+; CHECK-LLVM: call void @llvm.memcpy.p0i8.p4i8.i64(i8* align 8 %[[#]], i8 addrspace(4)* align 8 %phi, i64 32, i1 false)
+; CHECK-LLVM: call void @llvm.memcpy.p4i8.p0i8.i64(i8 addrspace(4)* align 8 %[[#]], i8* align 8 %[[#]], i64 32, i1 false)
+; CHECK-LLVM: call void @llvm.lifetime.end.p0i8({{.*}}, i8* %[[#]])
 
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"


### PR DESCRIPTION
Backport of #3373.