### PR TITLE
Replace removed GlobalVariable::getAlignment() with getAlign()

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -3473,7 +3473,8 @@ bool LLVMToSPIRVBase::transAlign(Value *V, SPIRVValue *BV) {
     return true;
   }
   if (auto *GV = dyn_cast<GlobalVariable>(V)) {
-    BM->setAlignment(BV, GV->getAlignment());
+    if (MaybeAlign Alignment = GV->getAlign())
+      BM->setAlignment(BV, Alignment->value());
     return true;
   }
   return true;


### PR DESCRIPTION
llvm/llvm-project@b71ce8f has removed `GlobalVariable::getAlignment()` (long marked *"FIXME: Remove this function once transition to Align is over"*), which breaks the build of `transAlign()` in `SPIRVWriter.cpp`.

This replicates the old behavior via the stable `getAlign()` API, returning 0 when the global has no explicit alignment — matching the removed helper exactly. `getAlign()`/`MaybeAlign` has existed for years, so it compiles against both older and newer LLVM.