### PR TITLE
Lower `llvm.umul.with.overflow` via `OpUMulExtended`

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -208,46 +208,6 @@ void SPIRVRegularizeLLVMBase::lowerFunnelShift(IntrinsicInst *FSHIntrinsic) {
   FSHIntrinsic->setCalledFunction(FSHFunc);
 }
 
-void SPIRVRegularizeLLVMBase::buildUMulWithOverflowFunc(Function *UMulFunc) {
-  if (!UMulFunc->empty())
-    return;
-
-  BasicBlock *EntryBB = BasicBlock::Create(M->getContext(), "entry", UMulFunc);
-  IRBuilder<> Builder(EntryBB);
-  // Build the actual unsigned multiplication logic with the overflow
-  // indication.
-  auto *FirstArg = UMulFunc->getArg(0);
-  auto *SecondArg = UMulFunc->getArg(1);
-
-  // Do unsigned multiplication Mul = A * B.
-  // Then check if unsigned division Div = Mul / A is not equal to B.
-  // If so, then overflow has happened.
-  auto *Mul = Builder.CreateNUWMul(FirstArg, SecondArg);
-  auto *Div = Builder.CreateUDiv(Mul, FirstArg);
-  auto *Overflow = Builder.CreateICmpNE(FirstArg, Div);
-
-  // umul.with.overflow intrinsic return a structure, where the first element
-  // is the multiplication result, and the second is an overflow bit.
-  auto *StructTy = UMulFunc->getReturnType();
-  auto *Agg = Builder.CreateInsertValue(PoisonValue::get(StructTy), Mul, {0});
-  auto *Res = Builder.CreateInsertValue(Agg, Overflow, {1});
-  Builder.CreateRet(Res);
-}
-
-void SPIRVRegularizeLLVMBase::lowerUMulWithOverflow(
-    IntrinsicInst *UMulIntrinsic) {
-  // Get a separate function - otherwise, we'd have to rework the CFG of the
-  // current one. Then simply replace the intrinsic uses with a call to the new
-  // function.
-  FunctionType *UMulFuncTy = UMulIntrinsic->getFunctionType();
-  Type *FSHLRetTy = UMulFuncTy->getReturnType();
-  const std::string FuncName = lowerLLVMIntrinsicName(UMulIntrinsic);
-  Function *UMulFunc =
-      getOrCreateFunction(M, FSHLRetTy, UMulFuncTy->params(), FuncName);
-  buildUMulWithOverflowFunc(UMulFunc);
-  UMulIntrinsic->setCalledFunction(UMulFunc);
-}
-
 void SPIRVRegularizeLLVMBase::expandVEDWithSYCLTypeSRetArg(Function *F) {
   auto Attrs = F->getAttributes();
   StructType *SRetTy = cast<StructType>(Attrs.getParamStructRetType(0));
@@ -520,7 +480,7 @@ void regularizeWithOverflowInstrinsics(StringRef MangledName, CallInst *Call,
   Value *V1 = Builder.CreateExtractValue(L, {1});
   Value *V2 = Builder.CreateICmpNE(V1, ConstZero);
   Type *StructI32I1Ty =
-      StructType::create(Call->getContext(), {RetTy, V2->getType()});
+      StructType::get(Call->getContext(), {RetTy, V2->getType()});
   Value *Undef = PoisonValue::get(StructI32I1Ty);
   Value *V3 = Builder.CreateInsertValue(Undef, V0, {0});
   Value *V4 = Builder.CreateInsertValue(V3, V2, {1});
@@ -642,8 +602,6 @@ bool SPIRVRegularizeLLVMBase::regularize() {
             else if (II->getIntrinsicID() == Intrinsic::fshl ||
                      II->getIntrinsicID() == Intrinsic::fshr)
               lowerFunnelShift(II);
-            else if (II->getIntrinsicID() == Intrinsic::umul_with_overflow)
-              lowerUMulWithOverflow(II);
             else if (II->getIntrinsicID() == Intrinsic::uadd_with_overflow) {
               BuiltinFuncMangleInfo Info;
               std::string MangledName =
@@ -656,6 +614,14 @@ bool SPIRVRegularizeLLVMBase::regularize() {
               BuiltinFuncMangleInfo Info;
               std::string MangledName =
                   mangleBuiltin("__spirv_ISubBorrow",
+                                {Call->getArgOperand(0)->getType(),
+                                 Call->getArgOperand(1)->getType()},
+                                &Info);
+              regularizeWithOverflowInstrinsics(MangledName, Call, M, ToErase);
+            } else if (II->getIntrinsicID() == Intrinsic::umul_with_overflow) {
+              BuiltinFuncMangleInfo Info;
+              std::string MangledName =
+                  mangleBuiltin("__spirv_UMulExtended",
                                 {Call->getArgOperand(0)->getType(),
                                  Call->getArgOperand(1)->getType()},
                                 &Info);

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -76,9 +76,6 @@ public:
   /// simplification purposes.
   void lowerFunnelShift(llvm::IntrinsicInst *FSHIntrinsic);
 
-  void lowerUMulWithOverflow(llvm::IntrinsicInst *UMulIntrinsic);
-  void buildUMulWithOverflowFunc(llvm::Function *UMulFunc);
-
   // For some cases Clang emits VectorExtractDynamic as:
   // void @_Z28__spirv_VectorExtractDynamic(<Ty>* sret(<Ty>), jointMatrix, idx);
   // Instead of:

--- a/test/llvm-intrinsics/umul.with.overflow.ll
+++ b/test/llvm-intrinsics/umul.with.overflow.ll
@@ -21,9 +21,13 @@ target triple = "spir"
 define dso_local spir_func void @_Z4foo8hhPh(i8 zeroext %a, i8 zeroext %b, ptr captures(none) %c) local_unnamed_addr #0 {
 entry:
   ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedhh(ptr sret(%[[STRUCT8]]) %{{.*}}, i8 %a, i8 %b)
-  ; CHECK-SPIRV: UMulExtended [[#]] [[#]] [[#]] [[#]]
-  ; CHECK-SPIRV: CompositeExtract [[#]] [[#HI:]] [[#]] 1
-  ; CHECK-SPIRV: INotEqual [[#]] [[#]] [[#HI]] [[#]]
+  ; CHECK-SPIRV: Constant [[#]] [[#ZERO8:]] 0
+  ; CHECK-SPIRV: Function
+  ; CHECK-SPIRV: UMulExtended [[#]] [[#MUL:]] [[#]] [[#]]
+  ; CHECK-SPIRV: Store [[#PTR:]] [[#MUL]]
+  ; CHECK-SPIRV: Load [[#]] [[#LOADED:]] [[#PTR]]
+  ; CHECK-SPIRV: CompositeExtract [[#]] [[#HI:]] [[#LOADED]] 1
+  ; CHECK-SPIRV: INotEqual [[#]] [[#]] [[#HI]] [[#ZERO8]]
   %umul = tail call { i8, i1 } @llvm.umul.with.overflow.i8(i8 %a, i8 %b)
   %cmp = extractvalue { i8, i1 } %umul, 1
   %umul.value = extractvalue { i8, i1 } %umul, 0

--- a/test/llvm-intrinsics/umul.with.overflow.ll
+++ b/test/llvm-intrinsics/umul.with.overflow.ll
@@ -20,7 +20,7 @@ target triple = "spir"
 ; Function Attrs: nofree nounwind writeonly
 define dso_local spir_func void @_Z4foo8hhPh(i8 zeroext %a, i8 zeroext %b, ptr captures(none) %c) local_unnamed_addr #0 {
 entry:
-  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedcc(ptr sret(%[[STRUCT8]]) %{{.*}}, i8 %a, i8 %b)
+  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedhh(ptr sret(%[[STRUCT8]]) %{{.*}}, i8 %a, i8 %b)
   ; CHECK-SPIRV: UMulExtended [[#]] [[#]] [[#]] [[#]]
   ; CHECK-SPIRV: CompositeExtract [[#]] [[#HI:]] [[#]] 1
   ; CHECK-SPIRV: INotEqual [[#]] [[#]] [[#HI]] [[#]]
@@ -37,7 +37,7 @@ entry:
 ; Function Attrs: nofree nounwind writeonly
 define dso_local spir_func void @_Z5foo32jjPj(i32 %a, i32 %b, ptr captures(none) %c) local_unnamed_addr #0 {
 entry:
-  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedii(ptr sret(%[[STRUCT32]]) %{{.*}}, i32 %b, i32 %a)
+  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedjj(ptr sret(%[[STRUCT32]]) %{{.*}}, i32 %b, i32 %a)
   ; CHECK-SPIRV: UMulExtended [[#]] [[#]] [[#]] [[#]]
   %umul = tail call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %b, i32 %a)
   %umul.val = extractvalue { i32, i1 } %umul, 0
@@ -49,7 +49,7 @@ entry:
 
 ; Function Attrs: nofree nounwind writeonly
 define dso_local spir_func void @umulo_v2i64(<2 x i64> %a, <2 x i64> %b, ptr %p) nounwind {
-  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedDv2_lS_(ptr sret(%[[STRUCTV2I64]]) %{{.*}}, <2 x i64> %a, <2 x i64> %b)
+  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedDv2_mS_(ptr sret(%[[STRUCTV2I64]]) %{{.*}}, <2 x i64> %a, <2 x i64> %b)
   ; CHECK-SPIRV: UMulExtended [[#]] [[#]] [[#]] [[#]]
   %umul = call {<2 x i64>, <2 x i1>} @llvm.umul.with.overflow.v2i64(<2 x i64> %a, <2 x i64> %b)
   %umul.val = extractvalue {<2 x i64>, <2 x i1>} %umul, 0

--- a/test/llvm-intrinsics/umul.with.overflow.ll
+++ b/test/llvm-intrinsics/umul.with.overflow.ll
@@ -10,9 +10,9 @@
 ; RUN:   "--implicit-check-not=old_llvm.umul.with.overflow.{{.*}}"
 ; FIXME: LLVM_SPIRV_REVERSE_FAIL for llc compilation flow
 
-; CHECK-SPIRV: Name [[NAME_UMUL_FUNC_8:[0-9]+]] "spirv.llvm_umul_with_overflow_i8"
-; CHECK-SPIRV: Name [[NAME_UMUL_FUNC_32:[0-9]+]] "spirv.llvm_umul_with_overflow_i32"
-; CHECK-SPIRV: Name [[NAME_UMUL_FUNC_VEC_I64:[0-9]+]] "spirv.llvm_umul_with_overflow_v2i64"
+; CHECK-LLVM: %[[STRUCT8:.*]] = type { i8, i8 }
+; CHECK-LLVM: %[[STRUCT32:.*]] = type { i32, i32 }
+; CHECK-LLVM: %[[STRUCTV2I64:.*]] = type { <2 x i64>, <2 x i64> }
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"
@@ -20,8 +20,10 @@ target triple = "spir"
 ; Function Attrs: nofree nounwind writeonly
 define dso_local spir_func void @_Z4foo8hhPh(i8 zeroext %a, i8 zeroext %b, ptr captures(none) %c) local_unnamed_addr #0 {
 entry:
-  ; CHECK-LLVM: call { i8, i1 } @llvm.umul.with.overflow.i8
-  ; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[NAME_UMUL_FUNC_8]]
+  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedcc(ptr sret(%[[STRUCT8]]) %{{.*}}, i8 %a, i8 %b)
+  ; CHECK-SPIRV: UMulExtended [[#]] [[#]] [[#]] [[#]]
+  ; CHECK-SPIRV: CompositeExtract [[#]] [[#HI:]] [[#]] 1
+  ; CHECK-SPIRV: INotEqual [[#]] [[#]] [[#HI]] [[#]]
   %umul = tail call { i8, i1 } @llvm.umul.with.overflow.i8(i8 %a, i8 %b)
   %cmp = extractvalue { i8, i1 } %umul, 1
   %umul.value = extractvalue { i8, i1 } %umul, 0
@@ -32,21 +34,11 @@ entry:
   ret void
 }
 
-; CHECK-SPIRV: Function [[#]] [[NAME_UMUL_FUNC_8]]
-; CHECK-SPIRV: FunctionParameter [[#]] [[VAR_A:[0-9]+]]
-; CHECK-SPIRV: FunctionParameter [[#]] [[VAR_B:[0-9]+]]
-; CHECK-SPIRV: IMul [[#]] [[MUL_RES:[0-9]+]] [[VAR_A]] [[VAR_B]]
-; CHECK-SPIRV: UDiv [[#]] [[DIV_RES:[0-9]+]] [[MUL_RES]] [[VAR_A]]
-; CHECK-SPIRV: INotEqual [[#]] [[CMP_RES:[0-9]+]] [[VAR_A]] [[DIV_RES]]
-; CHECK-SPIRV: CompositeInsert [[#]] [[INSERT_RES:[0-9]+]] [[MUL_RES]]
-; CHECK-SPIRV: CompositeInsert [[#]] [[INSERT_RES_1:[0-9]+]] [[CMP_RES]] [[INSERT_RES]]
-; CHECK-SPIRV: ReturnValue [[INSERT_RES_1]]
-
 ; Function Attrs: nofree nounwind writeonly
 define dso_local spir_func void @_Z5foo32jjPj(i32 %a, i32 %b, ptr captures(none) %c) local_unnamed_addr #0 {
 entry:
-  ; CHECK-LLVM: call { i32, i1 } @llvm.umul.with.overflow.i32
-  ; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[NAME_UMUL_FUNC_32]]
+  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedii(ptr sret(%[[STRUCT32]]) %{{.*}}, i32 %b, i32 %a)
+  ; CHECK-SPIRV: UMulExtended [[#]] [[#]] [[#]] [[#]]
   %umul = tail call { i32, i1 } @llvm.umul.with.overflow.i32(i32 %b, i32 %a)
   %umul.val = extractvalue { i32, i1 } %umul, 0
   %umul.ov = extractvalue { i32, i1 } %umul, 1
@@ -57,8 +49,8 @@ entry:
 
 ; Function Attrs: nofree nounwind writeonly
 define dso_local spir_func void @umulo_v2i64(<2 x i64> %a, <2 x i64> %b, ptr %p) nounwind {
-  ; CHECK-LLVM: call { <2 x i64>, <2 x i1> } @llvm.umul.with.overflow.v2i64
-  ; CHECK-SPIRV: FunctionCall [[#]] [[#]] [[NAME_UMUL_FUNC_VEC_I64]]
+  ; CHECK-LLVM: call spir_func void @_Z20__spirv_UMulExtendedDv2_lS_(ptr sret(%[[STRUCTV2I64]]) %{{.*}}, <2 x i64> %a, <2 x i64> %b)
+  ; CHECK-SPIRV: UMulExtended [[#]] [[#]] [[#]] [[#]]
   %umul = call {<2 x i64>, <2 x i1>} @llvm.umul.with.overflow.v2i64(<2 x i64> %a, <2 x i64> %b)
   %umul.val = extractvalue {<2 x i64>, <2 x i1>} %umul, 0
   %umul.ov = extractvalue {<2 x i64>, <2 x i1>} %umul, 1


### PR DESCRIPTION
The previous emulation could divide by zero and checked the wrong operand, so it sometimes reported incorrect overflow.
Use `OpUMulExtended`'s high word instead, the same way `uadd`/`usub` use `OpIAddCarry`/`OpISubBorrow`.

Also fixes the rebuilt result struct not matching the intrinsic's actual return type.
