### PR TITLE
Use poison instead of null for DebugInfoNone declares

### DIFF
--- a/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
+++ b/lib/SPIRV/SPIRVToLLVMDbgTran.cpp
@@ -1675,10 +1675,9 @@ SPIRVToLLVMDbgTran::transDebugIntrinsic(const SPIRVExtInst *DebugInst,
       Loc = LocalVar.second;
     DIBuilder &DIB = getDIBuilder(DebugInst);
     if (getDbgInst<SPIRVDebug::DebugInfoNone>(Ops[VariableIdx])) {
-      auto *Null =
-          ConstantPointerNull::get(PointerType::get(M->getContext(), 0));
+      auto *Poison = PoisonValue::get(PointerType::get(M->getContext(), 0));
       DbgRecord *DbgDeclare = DIB.insertDeclare(
-          Null, LocalVar.first, GetExpression(Ops[ExpressionIdx]), Loc, BB);
+          Poison, LocalVar.first, GetExpression(Ops[ExpressionIdx]), Loc, BB);
       return DbgDeclare;
     }
     return DIB.insertDeclare(GetValue(Ops[VariableIdx]), LocalVar.first,

--- a/test/DebugInfo/DebugDeclareUnused.cl
+++ b/test/DebugInfo/DebugDeclareUnused.cl
@@ -16,4 +16,4 @@ void foo() {
 
 // CHECK-SPIRV: ExtInst [[#]] [[#InfoNone:]] [[#]] DebugInfoNone
 // CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] DebugDeclare [[#]] [[#InfoNone]] [[#]]
-// CHECK-LLVM:  #dbg_declare(ptr null, ![[#]], !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), ![[#]])
+// CHECK-LLVM:  #dbg_declare(ptr poison, ![[#]], !DIExpression(DW_OP_constu, 0, DW_OP_swap, DW_OP_xderef), ![[#]])

--- a/test/DebugInfo/mem2reged_local_var.ll
+++ b/test/DebugInfo/mem2reged_local_var.ll
@@ -25,7 +25,7 @@
 ; CHECK-SPIRV: ExtInst [[#]] [[#LocalVar:]] [[#]] DebugLocalVariable
 ; CHECK-SPIRV: ExtInst [[#]] [[#]] [[#]] DebugDeclare [[#LocalVar]] [[#None]] [[#]]
 
-; CHECK-LLVM: #dbg_declare(ptr null, ![[#LocalVar:]], !DIExpression(DW_OP_constu, 4, DW_OP_swap, DW_OP_xderef), ![[#Loc:]])
+; CHECK-LLVM: #dbg_declare(ptr poison, ![[#LocalVar:]], !DIExpression(DW_OP_constu, 4, DW_OP_swap, DW_OP_xderef), ![[#Loc:]])
 ; CHECK-LLVM-DAG: ![[#LocalVar]] = !DILocalVariable(name: "bar"
 ; CHECK-LLVM-DAG: ![[#Loc]] = !DILocation(line: 23
 


### PR DESCRIPTION
DebugInfoNone in DebugDeclare's Variable operand means the variable has no location. Translating it to a null pointer describes the variable as living at address 0 instead: it is not a kill location per DbgVariableRecord::isKillLocation, so consumers materialize it as a real constant.