### PR TITLE
Translate llvm.llround, llvm.lrint and llvm.llrint intrinsics

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -4175,9 +4175,13 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::floor:
   case Intrinsic::fma:
   case Intrinsic::frexp:
+  case Intrinsic::llrint:
+  case Intrinsic::llround:
   case Intrinsic::log:
   case Intrinsic::log10:
   case Intrinsic::log2:
+  case Intrinsic::lrint:
+  case Intrinsic::lround:
   case Intrinsic::maximumnum:
   case Intrinsic::maximum:
   case Intrinsic::maxnum:
@@ -4533,12 +4537,23 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     return BM->addExtInst(STy, BM->getExtInstSetId(SPIRVEIS_OpenCL), ExtOp, Ops,
                           BB);
   }
-  case Intrinsic::lround: {
+  case Intrinsic::lround:
+  case Intrinsic::llround:
+  case Intrinsic::lrint:
+  case Intrinsic::llrint: {
+    // There is no single OpenCL instruction rounding a floating-point value
+    // into an integer of a different width, so round in the source type first
+    // and convert the result afterwards. lround/llround round halfway cases
+    // away from zero, which is OpenCL 'round'; lrint/llrint round to nearest
+    // even, which is OpenCL 'rint'. The result type is signed, hence
+    // OpConvertFToS.
+    bool IsRint = IID == Intrinsic::lrint || IID == Intrinsic::llrint;
     SPIRVType *SourceTy = transType(II->getArgOperand(0)->getType());
     SPIRVType *DestTy = transType(II->getType());
-    SPIRVValue *Rounded = BM->addExtInst(
-        SourceTy, BM->getExtInstSetId(SPIRVEIS_OpenCL), OpenCLLIB::Round,
-        {transValue(II->getArgOperand(0), BB)}, BB);
+    SPIRVValue *Rounded =
+        BM->addExtInst(SourceTy, BM->getExtInstSetId(SPIRVEIS_OpenCL),
+                       IsRint ? OpenCLLIB::Rint : OpenCLLIB::Round,
+                       {transValue(II->getArgOperand(0), BB)}, BB);
     return BM->addUnaryInst(OpConvertFToS, DestTy, Rounded, BB);
   }
   case Intrinsic::frexp: {

--- a/test/llvm-intrinsics/llround.ll
+++ b/test/llvm-intrinsics/llround.ll
@@ -2,9 +2,9 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
-; RUN: spirv-val %t.spv 
+; RUN: spirv-val %t.spv
 
-; The intrinsic is translated inline, so allowing unknown intrinsics to be
+; The intrinsics are translated inline, so allowing unknown intrinsics to be
 ; emitted as calls must not leave an imported declaration behind.
 ; RUN: llvm-spirv -spirv-allow-unknown-intrinsics %t.bc -o %t.unknown.spv
 ; RUN: spirv-dis --raw-id %t.unknown.spv | FileCheck --check-prefix CHECK-SPIRV %s
@@ -14,28 +14,38 @@
 ; CHECK-NO-IMPORT-NOT: LinkageAttributes "llvm.
 
 ; CHECK-SPIRV:          [[opencl:%[0-9]+]] = OpExtInstImport "OpenCL.std"
-; CHECK-SPIRV-DAG:      [[i32:%[0-9]+]] = OpTypeInt 32 0
 ; CHECK-SPIRV-DAG:      [[i64:%[0-9]+]] = OpTypeInt 64 0
 ; CHECK-SPIRV-DAG:      [[f32:%[0-9]+]] = OpTypeFloat 32
 ; CHECK-SPIRV-DAG:      [[f64:%[0-9]+]] = OpTypeFloat 64
+; CHECK-SPIRV-DAG:      [[v4f32:%[0-9]+]] = OpTypeVector [[f32]] 4
+; CHECK-SPIRV-DAG:      [[v4i64:%[0-9]+]] = OpTypeVector [[i64]] 4
 ; CHECK-SPIRV:      [[rounded_f32:%[0-9]+]] = OpExtInst [[f32]] [[opencl]] round
-; CHECK-SPIRV:                        OpConvertFToS [[i32]] [[rounded_f32]]
+; CHECK-SPIRV:                        OpConvertFToS [[i64]] [[rounded_f32]]
 ; CHECK-SPIRV:      [[rounded_f64:%[0-9]+]] = OpExtInst [[f64]] [[opencl]] round
 ; CHECK-SPIRV:                        OpConvertFToS [[i64]] [[rounded_f64]]
+; CHECK-SPIRV:    [[rounded_v4f32:%[0-9]+]] = OpExtInst [[v4f32]] [[opencl]] round
+; CHECK-SPIRV:                        OpConvertFToS [[v4i64]] [[rounded_v4f32]]
 
 target triple = "spir64-unknown-unknown"
 
-define spir_func i32 @test_0(float %arg0) {
+define spir_func i64 @test_0(float %arg0) {
 entry:
-  %0 = call i32 @llvm.lround.i32.f32(float %arg0)
-  ret i32 %0
+  %0 = call i64 @llvm.llround.i64.f32(float %arg0)
+  ret i64 %0
 }
 
 define spir_func i64 @test_1(double %arg0) {
 entry:
-  %0 = call i64 @llvm.lround.i64.f64(double %arg0)
+  %0 = call i64 @llvm.llround.i64.f64(double %arg0)
   ret i64 %0
 }
 
-declare i32 @llvm.lround.i32.f32(float)
-declare i64 @llvm.lround.i64.f64(double)
+define spir_func <4 x i64> @test_2(<4 x float> %arg0) {
+entry:
+  %0 = call <4 x i64> @llvm.llround.v4i64.v4f32(<4 x float> %arg0)
+  ret <4 x i64> %0
+}
+
+declare i64 @llvm.llround.i64.f32(float)
+declare i64 @llvm.llround.i64.f64(double)
+declare <4 x i64> @llvm.llround.v4i64.v4f32(<4 x float>)

--- a/test/llvm-intrinsics/lrint.ll
+++ b/test/llvm-intrinsics/lrint.ll
@@ -1,0 +1,70 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+
+; The intrinsics are translated inline, so allowing unknown intrinsics to be
+; emitted as calls must not leave an imported declaration behind.
+; RUN: llvm-spirv -spirv-allow-unknown-intrinsics %t.bc -o %t.unknown.spv
+; RUN: spirv-dis --raw-id %t.unknown.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-dis --raw-id %t.unknown.spv | FileCheck --check-prefix CHECK-NO-IMPORT %s
+; RUN: spirv-val %t.unknown.spv
+
+; CHECK-NO-IMPORT-NOT: LinkageAttributes "llvm.
+
+; CHECK-SPIRV:          [[opencl:%[0-9]+]] = OpExtInstImport "OpenCL.std"
+; CHECK-SPIRV-DAG:      [[i32:%[0-9]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG:      [[i64:%[0-9]+]] = OpTypeInt 64 0
+; CHECK-SPIRV-DAG:      [[f32:%[0-9]+]] = OpTypeFloat 32
+; CHECK-SPIRV-DAG:      [[f64:%[0-9]+]] = OpTypeFloat 64
+; CHECK-SPIRV-DAG:      [[v4f32:%[0-9]+]] = OpTypeVector [[f32]] 4
+; CHECK-SPIRV-DAG:      [[v4i32:%[0-9]+]] = OpTypeVector [[i32]] 4
+; CHECK-SPIRV:      [[lrint_f32:%[0-9]+]] = OpExtInst [[f32]] [[opencl]] rint
+; CHECK-SPIRV:                        OpConvertFToS [[i32]] [[lrint_f32]]
+; CHECK-SPIRV:      [[lrint_f64:%[0-9]+]] = OpExtInst [[f64]] [[opencl]] rint
+; CHECK-SPIRV:                        OpConvertFToS [[i64]] [[lrint_f64]]
+; CHECK-SPIRV:     [[llrint_f32:%[0-9]+]] = OpExtInst [[f32]] [[opencl]] rint
+; CHECK-SPIRV:                        OpConvertFToS [[i64]] [[llrint_f32]]
+; CHECK-SPIRV:     [[llrint_f64:%[0-9]+]] = OpExtInst [[f64]] [[opencl]] rint
+; CHECK-SPIRV:                        OpConvertFToS [[i64]] [[llrint_f64]]
+; CHECK-SPIRV:   [[lrint_v4f32:%[0-9]+]] = OpExtInst [[v4f32]] [[opencl]] rint
+; CHECK-SPIRV:                        OpConvertFToS [[v4i32]] [[lrint_v4f32]]
+
+target triple = "spir64-unknown-unknown"
+
+define spir_func i32 @test_0(float %arg0) {
+entry:
+  %0 = call i32 @llvm.lrint.i32.f32(float %arg0)
+  ret i32 %0
+}
+
+define spir_func i64 @test_1(double %arg0) {
+entry:
+  %0 = call i64 @llvm.lrint.i64.f64(double %arg0)
+  ret i64 %0
+}
+
+define spir_func i64 @test_2(float %arg0) {
+entry:
+  %0 = call i64 @llvm.llrint.i64.f32(float %arg0)
+  ret i64 %0
+}
+
+define spir_func i64 @test_3(double %arg0) {
+entry:
+  %0 = call i64 @llvm.llrint.i64.f64(double %arg0)
+  ret i64 %0
+}
+
+define spir_func <4 x i32> @test_4(<4 x float> %arg0) {
+entry:
+  %0 = call <4 x i32> @llvm.lrint.v4i32.v4f32(<4 x float> %arg0)
+  ret <4 x i32> %0
+}
+
+declare i32 @llvm.lrint.i32.f32(float)
+declare i64 @llvm.lrint.i64.f64(double)
+declare i64 @llvm.llrint.i64.f32(float)
+declare i64 @llvm.llrint.i64.f64(double)
+declare <4 x i32> @llvm.lrint.v4i32.v4f32(<4 x float>)


### PR DESCRIPTION
llvm.lround gained translation support in #2904 as an OpenCL.std round followed by OpConvertFToS. Its three siblings were left out, so a module containing any of them still stops with `InvalidFunctionCall: Unexpected llvm intrinsic`. This completes that set.

llround reuses the existing shape unchanged. The destination type is taken from the intrinsic result type, so the wider return type needs no special handling and the vector overloads fall out for free. lrint and llrint use the same shape with OpenCLLIB::Rint in place of OpenCLLIB::Round.

One caveat is worth stating plainly, because the two specifications word rounding differently. OpenCL rint is round to nearest even unconditionally, whereas LangRef defines llvm.lrint and llvm.llrint as returning what the libm functions return, and libm lrint follows the current rounding mode. They coincide here because the OpenCL extended instruction set fixes the mode for its math instructions regardless of the caller. From the Math extended instructions section of the OpenCL extended instruction set specification:

> The math instructions are not affected by the prevailing rounding mode in the calling environment, and always return the same value as they would if called with the round to nearest even rounding mode.

LLVM in turn assumes the default floating point environment unless the constrained intrinsics are used. This is the same reasoning already baked into the tree: in transIntrinsicInst, Intrinsic::rint and Intrinsic::roundeven both map to OpenCLLIB::Rint, as does Intrinsic::nearbyint, which is likewise a current rounding mode libm function.

All four intrinsics are also registered in isKnownIntrinsic. lround was missing there, which looks like an oversight in #2904. Under -spirv-allow-unknown-intrinsics, transFunctionDecl still emitted an imported OpFunction declaration for an intrinsic whose calls transIntrinsicInst had already translated inline, so the output carried a stray

    OpDecorate %5 LinkageAttributes "llvm.lround.i32.f32" Import

alongside the inline OpenCL.std round. Nothing in the suite exercised that mode, so test/llvm-intrinsics/lround.ll now translates a second time with -spirv-allow-unknown-intrinsics and asserts that no such decoration survives. The two new tests assert the same for the three added intrinsics. Keeping the translation case but removing the isKnownIntrinsic entries reproduces all ten spurious Import decorations across the three files, so the assertions are not vacuous.

Known follow up, deliberately not addressed here. The lround family does not call checkTypeForSPIRVExtendedInstLowering, so an unsupported floating point argument such as x86_fp80 reaches transType and trips the assert at lib/SPIRV/libSPIRV/SPIRVType.h:302 instead of producing a diagnostic. That is existing behaviour of the lround case and this change does not alter it. It is left alone because the obvious one line guard is not a correct fix. The shared math case block in checkTypeForSPIRVExtendedInstLowering begins by requiring the argument type to equal the result type, which is never true for these intrinsics, so adding them to its case list makes it return false for every call, and since it returns false without calling SPIRVCK there is no diagnostic either: the translator drops the call and exits 0 having emitted a function body with no rounding in it at all. A correct fix needs a new case in that function that validates the argument type rather than the result type, with its own tests, which belongs in a separate change. Worth noting too that when x86_fp80 appears in a function signature the same assert fires for llvm.rint.f80, which does have the guard, so the guard is not the whole story.

The branch was built and tested against a local LLVM 23.1.0-rc2, not the LLVM 24 trunk that upstream CI builds against, because no LLVM 24 was available on the machine used. CI is therefore the first real check on the intended toolchain. Locally the three rounding tests pass, and the full lit suite goes from 1088 passed with 24 failed at the base commit to 1090 passed with 24 failed on this branch, with an identical failure list. Those 24 are environmental and reproduce unchanged on the base commit, mostly a local spirv-val that rejects newer capability operands such as 5156 and 6265, plus two OpTypeInt bit width rejections.
