### PR TITLE
[NFC] Fix backend checks in spirv_param_decorations_quals.ll

### DIFF
--- a/test/spirv_param_decorations_quals.ll
+++ b/test/spirv_param_decorations_quals.ll
@@ -49,9 +49,6 @@ entry:
 ; CHECK-SPV-IR-DAG: ![[VolatileDecoId]] = !{i32 21}
 ; CHECK-SPV-IR-DAG: ![[KernelArgTypeQual]] = !{!"volatile restrict"}
 
-; The SPIR-V backend stopped deriving a Volatile decoration from
-; !kernel_arg_type_qual in llvm/llvm-project#215790, so its output carries only
-; the NoAlias decoration spelled out in !spirv.ParameterDecorations.
 ; CHECK-BACKEND: define spir_kernel void @k(ptr addrspace(1) noalias %a)
 ; CHECK-BACKEND-SAME: !kernel_arg_type_qual ![[BEKernelArgTypeQual:[0-9]+]]
 ; CHECK-BACKEND-SAME: !spirv.ParameterDecorations ![[BEParamDecoListId:[0-9]+]]

--- a/test/spirv_param_decorations_quals.ll
+++ b/test/spirv_param_decorations_quals.ll
@@ -8,7 +8,7 @@
 ; RUN: %if spirv-backend %{ llc -O0 -mtriple=spirv64-unknown-unknown -filetype=obj %s -o %t.llc.spv %}
 ; RUN: %if spirv-backend %{ llvm-spirv -r --spirv-target-env=SPV-IR %t.llc.spv -o %t.llc.rev.bc %}
 ; RUN: %if spirv-backend %{ llvm-dis %t.llc.rev.bc -o %t.llc.rev.ll %}
-; RUN: %if spirv-backend %{ FileCheck %s --check-prefix=CHECK-SPV-IR < %t.llc.rev.ll %}
+; RUN: %if spirv-backend %{ FileCheck %s --check-prefix=CHECK-BACKEND < %t.llc.rev.ll %}
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir"
@@ -48,6 +48,17 @@ entry:
 ; CHECK-SPV-IR-DAG: ![[NoAliasDecoId]] = !{i32 38, i32 4}
 ; CHECK-SPV-IR-DAG: ![[VolatileDecoId]] = !{i32 21}
 ; CHECK-SPV-IR-DAG: ![[KernelArgTypeQual]] = !{!"volatile restrict"}
+
+; The SPIR-V backend stopped deriving a Volatile decoration from
+; !kernel_arg_type_qual in llvm/llvm-project#215790, so its output carries only
+; the NoAlias decoration spelled out in !spirv.ParameterDecorations.
+; CHECK-BACKEND: define spir_kernel void @k(ptr addrspace(1) noalias %a)
+; CHECK-BACKEND-SAME: !kernel_arg_type_qual ![[BEKernelArgTypeQual:[0-9]+]]
+; CHECK-BACKEND-SAME: !spirv.ParameterDecorations ![[BEParamDecoListId:[0-9]+]]
+; CHECK-BACKEND-DAG: ![[BEParamDecoListId]] = !{![[BEParamDecoId:[0-9]+]]}
+; CHECK-BACKEND-DAG: ![[BEParamDecoId]] = !{![[BENoAliasDecoId:[0-9]+]]}
+; CHECK-BACKEND-DAG: ![[BENoAliasDecoId]] = !{i32 38, i32 4}
+; CHECK-BACKEND-DAG: ![[BEKernelArgTypeQual]] = !{!"restrict"}
 
 ; CHECK-LLVM-NOT: !spirv.ParameterDecorations
 ; CHECK-LLVM: define spir_kernel void @k(ptr addrspace(1) noalias %a) {{.*}} !kernel_arg_type_qual ![[KernelArgTypeQual:[0-9]+]] {{.*}} {


### PR DESCRIPTION
llvm/llvm-project#215790 removed the backend's Volatile parameter decoration
derived from `!kernel_arg_type_qual`, so the `llc` legs can no longer share
`CHECK-SPV-IR` with the translator legs, which still expect it.

Give them a `CHECK-BACKEND` prefix matching current output, keeping the
cross-compilation coverage from #3564. Fixes the nightly `main` failure.
