### PR TITLE
Translate the signed overflow intrinsics, memcpy.inline, ptrmask and objectsize instead of rejecting them

### DIFF
--- a/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -248,6 +248,27 @@ void SPIRVRegularizeLLVMBase::lowerUMulWithOverflow(
   UMulIntrinsic->setCalledFunction(UMulFunc);
 }
 
+void SPIRVRegularizeLLVMBase::lowerPtrMask(
+    IntrinsicInst *PtrMaskIntrinsic, std::vector<Instruction *> &ToErase) {
+  // The LLVM Language Reference defines ptrmask(%ptr, %mask) to be equivalent
+  // to, with iPtrIdx the index type size of the pointer:
+  //   %intptr = ptrtoint ptr %ptr to iPtrIdx ; this may truncate
+  //   %masked = and iPtrIdx %intptr, %mask
+  //   %diff = sub iPtrIdx %masked, %intptr
+  //   %result = getelementptr i8, ptr %ptr, iPtrIdx %diff
+  // Emitting that expansion rather than an inttoptr of %masked keeps the
+  // result in the address space of the pointer operand.
+  IRBuilder<> Builder(PtrMaskIntrinsic);
+  Value *Ptr = PtrMaskIntrinsic->getArgOperand(0);
+  Value *Mask = PtrMaskIntrinsic->getArgOperand(1);
+  Value *IntPtr = Builder.CreatePtrToInt(Ptr, Mask->getType());
+  Value *Masked = Builder.CreateAnd(IntPtr, Mask);
+  Value *Diff = Builder.CreateSub(Masked, IntPtr);
+  Value *Result = Builder.CreateGEP(Builder.getInt8Ty(), Ptr, Diff);
+  PtrMaskIntrinsic->replaceAllUsesWith(Result);
+  ToErase.push_back(PtrMaskIntrinsic);
+}
+
 void SPIRVRegularizeLLVMBase::expandVEDWithSYCLTypeSRetArg(Function *F) {
   auto Attrs = F->getAttributes();
   StructType *SRetTy = cast<StructType>(Attrs.getParamStructRetType(0));
@@ -644,6 +665,8 @@ bool SPIRVRegularizeLLVMBase::regularize() {
               lowerFunnelShift(II);
             else if (II->getIntrinsicID() == Intrinsic::umul_with_overflow)
               lowerUMulWithOverflow(II);
+            else if (II->getIntrinsicID() == Intrinsic::ptrmask)
+              lowerPtrMask(II, ToErase);
             else if (II->getIntrinsicID() == Intrinsic::uadd_with_overflow) {
               BuiltinFuncMangleInfo Info;
               std::string MangledName =

--- a/lib/SPIRV/SPIRVRegularizeLLVM.h
+++ b/lib/SPIRV/SPIRVRegularizeLLVM.h
@@ -79,6 +79,12 @@ public:
   void lowerUMulWithOverflow(llvm::IntrinsicInst *UMulIntrinsic);
   void buildUMulWithOverflowFunc(llvm::Function *UMulFunc);
 
+  /// SPIR-V has no counterpart for @llvm.ptrmask.*, so it is replaced by the
+  /// expansion the LLVM Language Reference gives for it, which stays inside
+  /// the address space of the pointer operand.
+  void lowerPtrMask(llvm::IntrinsicInst *PtrMaskIntrinsic,
+                    std::vector<llvm::Instruction *> &ToErase);
+
   // For some cases Clang emits VectorExtractDynamic as:
   // void @_Z28__spirv_VectorExtractDynamic(<Ty>* sret(<Ty>), jointMatrix, idx);
   // Instead of:

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -70,6 +70,7 @@
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/Analysis/LoopInfo.h"
+#include "llvm/Analysis/MemoryBuiltins.h"
 #include "llvm/Analysis/ValueTracking.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
@@ -4225,6 +4226,7 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::fmuladd:
   case Intrinsic::memset:
   case Intrinsic::memcpy:
+  case Intrinsic::memcpy_inline:
   case Intrinsic::lifetime_start:
   case Intrinsic::lifetime_end:
   case Intrinsic::dbg_declare:
@@ -4240,6 +4242,10 @@ bool LLVMToSPIRVBase::isKnownIntrinsic(Intrinsic::ID Id) {
   case Intrinsic::debugtrap:
   case Intrinsic::uadd_with_overflow:
   case Intrinsic::usub_with_overflow:
+  case Intrinsic::sadd_with_overflow:
+  case Intrinsic::ssub_with_overflow:
+  case Intrinsic::smul_with_overflow:
+  case Intrinsic::objectsize:
   case Intrinsic::arithmetic_fence:
   case Intrinsic::masked_gather:
   case Intrinsic::masked_scatter:
@@ -5025,6 +5031,78 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
                              transValue(II->getArgOperand(0), BB),
                              transValue(II->getArgOperand(1), BB), BB);
   }
+  case Intrinsic::sadd_with_overflow:
+  case Intrinsic::ssub_with_overflow: {
+    // SPIR-V has OpIAddCarry / OpISubBorrow for the unsigned forms only, so
+    // compute the wrapped result with OpIAdd / OpISub and derive the overflow
+    // flag from the sign bits: an addition overflows when both operands share
+    // a sign that the result does not have, a subtraction when the operands
+    // have different signs and the result does not have the sign of the
+    // minuend. Both conditions are ((X ^ A) & (Y ^ B)) < 0 over the
+    // appropriate operand pairs.
+    bool IsAdd = IID == Intrinsic::sadd_with_overflow;
+    Value *LHSVal = II->getArgOperand(0);
+    Type *OpLLVMTy = LHSVal->getType();
+    SPIRVType *OpTy = transType(OpLLVMTy);
+    SPIRVValue *LHS = transValue(LHSVal, BB);
+    SPIRVValue *RHS = transValue(II->getArgOperand(1), BB);
+    SPIRVValue *Res =
+        BM->addBinaryInst(IsAdd ? OpIAdd : OpISub, OpTy, LHS, RHS, BB);
+    SPIRVValue *Xor1 =
+        BM->addBinaryInst(OpBitwiseXor, OpTy, LHS, IsAdd ? Res : RHS, BB);
+    SPIRVValue *Xor2 =
+        BM->addBinaryInst(OpBitwiseXor, OpTy, IsAdd ? RHS : LHS, Res, BB);
+    SPIRVValue *And = BM->addBinaryInst(OpBitwiseAnd, OpTy, Xor1, Xor2, BB);
+    SPIRVType *FlagTy =
+        transType(cast<StructType>(II->getType())->getElementType(1));
+    SPIRVValue *Zero = transValue(Constant::getNullValue(OpLLVMTy), BB);
+    SPIRVValue *Overflow = BM->addCmpInst(OpSLessThan, FlagTy, And, Zero, BB);
+    return BM->addCompositeConstructInst(transType(II->getType()),
+                                         {Res->getId(), Overflow->getId()}, BB);
+  }
+  case Intrinsic::smul_with_overflow: {
+    // OpSMulExtended produces the low and the high half of the full width
+    // signed product. The product fits into the operand width exactly when
+    // the high half is the sign extension of the low half.
+    Value *LHSVal = II->getArgOperand(0);
+    Type *OpLLVMTy = LHSVal->getType();
+    SPIRVType *OpTy = transType(OpLLVMTy);
+    SPIRVType *ExtTy = transType(StructType::get(OpLLVMTy, OpLLVMTy));
+    SPIRVValue *Ext =
+        BM->addBinaryInst(OpSMulExtended, ExtTy, transValue(LHSVal, BB),
+                          transValue(II->getArgOperand(1), BB), BB);
+    SPIRVValue *Low = BM->addCompositeExtractInst(OpTy, Ext, {0}, BB);
+    SPIRVValue *High = BM->addCompositeExtractInst(OpTy, Ext, {1}, BB);
+    SPIRVValue *ShiftAmount = transValue(
+        ConstantInt::get(OpLLVMTy, OpLLVMTy->getScalarSizeInBits() - 1), BB);
+    SPIRVValue *SignOfLow =
+        BM->addBinaryInst(OpShiftRightArithmetic, OpTy, Low, ShiftAmount, BB);
+    SPIRVType *FlagTy =
+        transType(cast<StructType>(II->getType())->getElementType(1));
+    SPIRVValue *Overflow =
+        BM->addCmpInst(OpINotEqual, FlagTy, High, SignOfLow, BB);
+    return BM->addCompositeConstructInst(transType(II->getType()),
+                                         {Low->getId(), Overflow->getId()}, BB);
+  }
+  case Intrinsic::objectsize: {
+    // llvm.objectsize never reads memory: it must fold to a constant. The
+    // dynamic form (fourth operand set) lets lowerObjectSizeCall() splice an
+    // instruction sequence in front of the call, which is not possible while
+    // the enclosing function is already being translated, so only the static
+    // form is handed to it. For the dynamic form fall back to the answer
+    // LangRef prescribes for an unknown object: -1 when min is false, 0 when
+    // min is true.
+    IntegerType *ResultTy = cast<IntegerType>(II->getType());
+    if (cast<ConstantInt>(II->getArgOperand(3))->isZero())
+      return transValue(lowerObjectSizeCall(II, M->getDataLayout(),
+                                            /*TLI=*/nullptr,
+                                            /*MustSucceed=*/true),
+                        BB);
+    bool MaxVal = cast<ConstantInt>(II->getArgOperand(1))->isZero();
+    return transValue(MaxVal ? Constant::getAllOnesValue(ResultTy)
+                             : Constant::getNullValue(ResultTy),
+                      BB);
+  }
   case Intrinsic::vector_reduce_add:
   case Intrinsic::vector_reduce_mul:
   case Intrinsic::vector_reduce_and:
@@ -5207,6 +5285,11 @@ SPIRVValue *LLVMToSPIRVBase::transIntrinsicInst(IntrinsicInst *II,
     return BM->addCopyMemorySizedInst(Target, Source, CompositeTy->getLength(),
                                       MemAccess, BB);
   } break;
+  // llvm.memcpy.inline carries the extra guarantee that the copy is not
+  // turned into a call to an external function. OpCopyMemorySized is an
+  // instruction rather than a call, so the plain memcpy translation already
+  // satisfies it.
+  case Intrinsic::memcpy_inline:
   case Intrinsic::memcpy:
     // A zero-sized memcpy is a no-op. Emitting OpCopyMemorySized with a Size
     // operand of 0 is invalid SPIR-V, so drop the intrinsic entirely.

--- a/test/llvm-intrinsics/memcpy.inline.ll
+++ b/test/llvm-intrinsics/memcpy.inline.ll
@@ -1,0 +1,48 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis -o - %t.rev.bc | FileCheck --check-prefix CHECK-LLVM %s
+
+; llvm.memcpy.inline differs from llvm.memcpy only in guaranteeing that the
+; copy is not turned into a call to an external function. OpCopyMemorySized is
+; an instruction rather than a call, so the plain memcpy translation already
+; satisfies that guarantee.
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-DAG:  [[ulong:%[a-z0-9_]+]] = OpTypeInt 64 0
+; CHECK-SPIRV-DAG:  [[ulong_16:%[a-z0-9_]+]] = OpConstant [[ulong]] 16
+
+define spir_kernel void @copy(ptr addrspace(1) %dst, ptr addrspace(1) %src) {
+entry:
+  call void @llvm.memcpy.inline.p1.p1.i64(ptr addrspace(1) align 4 %dst, ptr addrspace(1) align 4 %src, i64 16, i1 false)
+  ret void
+}
+
+; CHECK-SPIRV:  [[dst:%[a-z0-9_]+]] = OpFunctionParameter {{%[a-z0-9_]+}}
+; CHECK-SPIRV:  [[src:%[a-z0-9_]+]] = OpFunctionParameter {{%[a-z0-9_]+}}
+; CHECK-SPIRV:  OpCopyMemorySized [[dst]] [[src]] [[ulong_16]] Aligned 4
+
+; CHECK-LLVM-LABEL: define spir_kernel void @copy
+; CHECK-LLVM:  call void @llvm.memcpy.p1.p1.i64(ptr addrspace(1) align 4 %dst, ptr addrspace(1) align 4 %src, i64 16, i1 false)
+
+; A zero length copy is a no-op: OpCopyMemorySized with a Size of 0 is invalid
+; SPIR-V, so nothing at all must be emitted for it.
+define spir_kernel void @copy_zero(ptr addrspace(1) %dst, ptr addrspace(1) %src) {
+entry:
+  call void @llvm.memcpy.inline.p1.p1.i64(ptr addrspace(1) %dst, ptr addrspace(1) %src, i64 0, i1 false)
+  ret void
+}
+
+; CHECK-SPIRV:  OpFunctionParameter
+; CHECK-SPIRV:  OpFunctionParameter
+; CHECK-SPIRV:  OpLabel
+; CHECK-SPIRV-NEXT:  OpReturn
+
+; CHECK-LLVM-LABEL: define spir_kernel void @copy_zero
+; CHECK-LLVM-NEXT:  entry:
+; CHECK-LLVM-NEXT:  ret void
+
+declare void @llvm.memcpy.inline.p1.p1.i64(ptr addrspace(1) noalias nocapture writeonly, ptr addrspace(1) noalias nocapture readonly, i64 immarg, i1 immarg)

--- a/test/llvm-intrinsics/objectsize.ll
+++ b/test/llvm-intrinsics/objectsize.ll
@@ -1,0 +1,80 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis -o - %t.rev.bc | FileCheck --check-prefix CHECK-LLVM %s
+
+; llvm.objectsize reads no memory and always folds to a constant. Clang emits
+; it for _FORTIFY_SOURCE and it survives to the back end at -O0.
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-DAG:  [[ulong:%[a-z0-9_]+]] = OpTypeInt 64 0
+; CHECK-SPIRV-DAG:  [[known:%[a-z0-9_]+]] = OpConstant [[ulong]] 24
+; CHECK-SPIRV-DAG:  [[unknown_max:%[a-z0-9_]+]] = OpConstant [[ulong]] 18446744073709551615
+; CHECK-SPIRV-DAG:  [[unknown_min:%[a-z0-9_]+]] = OpConstant [[ulong]] 0
+
+; The size of an object the module can see is folded to that size.
+define spir_kernel void @known(ptr addrspace(1) %out) {
+entry:
+  %buf = alloca [24 x i8], align 1
+  %size = call i64 @llvm.objectsize.i64.p0(ptr %buf, i1 false, i1 true, i1 false)
+  store i64 %size, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+; CHECK-SPIRV:  [[out:%[a-z0-9_]+]] = OpFunctionParameter {{%[a-z0-9_]+}}
+; CHECK-SPIRV:  OpStore [[out]] [[known]] Aligned 8
+
+; CHECK-LLVM-LABEL: define spir_kernel void @known
+; CHECK-LLVM:  store i64 24, ptr addrspace(1) %out
+
+; An unknown object with min set to false folds to -1 ...
+define spir_kernel void @unknown_max(ptr addrspace(1) %p, ptr addrspace(1) %out) {
+entry:
+  %size = call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) %p, i1 false, i1 true, i1 false)
+  store i64 %size, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+; CHECK-SPIRV:  OpFunctionParameter
+; CHECK-SPIRV:  [[out1:%[a-z0-9_]+]] = OpFunctionParameter {{%[a-z0-9_]+}}
+; CHECK-SPIRV:  OpStore [[out1]] [[unknown_max]] Aligned 8
+
+; CHECK-LLVM-LABEL: define spir_kernel void @unknown_max
+; CHECK-LLVM:  store i64 -1, ptr addrspace(1) %out
+
+; ... and with min set to true it folds to 0.
+define spir_kernel void @unknown_min(ptr addrspace(1) %p, ptr addrspace(1) %out) {
+entry:
+  %size = call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) %p, i1 true, i1 true, i1 false)
+  store i64 %size, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+; CHECK-SPIRV:  OpFunctionParameter
+; CHECK-SPIRV:  [[out2:%[a-z0-9_]+]] = OpFunctionParameter {{%[a-z0-9_]+}}
+; CHECK-SPIRV:  OpStore [[out2]] [[unknown_min]] Aligned 8
+
+; CHECK-LLVM-LABEL: define spir_kernel void @unknown_min
+; CHECK-LLVM:  store i64 0, ptr addrspace(1) %out
+
+; The dynamic form is folded conservatively rather than expanded into an
+; instruction sequence.
+define spir_kernel void @dynamic(ptr addrspace(1) %p, ptr addrspace(1) %out) {
+entry:
+  %size = call i64 @llvm.objectsize.i64.p1(ptr addrspace(1) %p, i1 false, i1 true, i1 true)
+  store i64 %size, ptr addrspace(1) %out, align 8
+  ret void
+}
+
+; CHECK-SPIRV:  OpFunctionParameter
+; CHECK-SPIRV:  [[out3:%[a-z0-9_]+]] = OpFunctionParameter {{%[a-z0-9_]+}}
+; CHECK-SPIRV:  OpStore [[out3]] [[unknown_max]] Aligned 8
+
+; CHECK-LLVM-LABEL: define spir_kernel void @dynamic
+; CHECK-LLVM:  store i64 -1, ptr addrspace(1) %out
+
+declare i64 @llvm.objectsize.i64.p0(ptr, i1 immarg, i1 immarg, i1 immarg)
+declare i64 @llvm.objectsize.i64.p1(ptr addrspace(1), i1 immarg, i1 immarg, i1 immarg)

--- a/test/llvm-intrinsics/ptrmask.ll
+++ b/test/llvm-intrinsics/ptrmask.ll
@@ -1,0 +1,62 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis -o - %t.rev.bc | FileCheck --check-prefix CHECK-LLVM %s
+
+; llvm.ptrmask is replaced by the expansion the LLVM Language Reference gives
+; for it, which keeps the result in the address space of the pointer operand
+; where a ptrtoint / inttoptr round trip would not.
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-DAG:  [[uchar:%[a-z0-9_]+]] = OpTypeInt 8 0
+; CHECK-SPIRV-DAG:  [[ulong:%[a-z0-9_]+]] = OpTypeInt 64 0
+; CHECK-SPIRV-DAG:  [[mask:%[a-z0-9_]+]] = OpConstant [[ulong]] 18446744073709551600
+; CHECK-SPIRV-DAG:  [[global_uchar:%[a-z0-9_]+]] = OpTypePointer CrossWorkgroup [[uchar]]
+
+define spir_kernel void @global_align16(ptr addrspace(1) %p, ptr addrspace(1) %out) {
+entry:
+  %masked = call ptr addrspace(1) @llvm.ptrmask.p1.i64(ptr addrspace(1) %p, i64 -16)
+  %val = load i8, ptr addrspace(1) %masked, align 1
+  store i8 %val, ptr addrspace(1) %out, align 1
+  ret void
+}
+
+; The address space of the pointer operand survives: the access chain and its
+; result are still CrossWorkgroup.
+; CHECK-SPIRV:  [[p:%[a-z0-9_]+]] = OpFunctionParameter [[global_uchar]]
+; CHECK-SPIRV:  [[intptr:%[a-z0-9_]+]] = OpConvertPtrToU [[ulong]] [[p]]
+; CHECK-SPIRV:  [[and:%[a-z0-9_]+]] = OpBitwiseAnd [[ulong]] [[intptr]] [[mask]]
+; CHECK-SPIRV:  [[diff:%[a-z0-9_]+]] = OpISub [[ulong]] [[and]] [[intptr]]
+; CHECK-SPIRV:  {{%[a-z0-9_]+}} = OpPtrAccessChain [[global_uchar]] [[p]] [[diff]]
+
+; CHECK-LLVM-LABEL: define spir_kernel void @global_align16
+; CHECK-LLVM:  [[INTPTR:%[0-9]+]] = ptrtoint ptr addrspace(1) %p to i64
+; CHECK-LLVM:  [[AND:%[0-9]+]] = and i64 [[INTPTR]], -16
+; CHECK-LLVM:  [[DIFF:%[0-9]+]] = sub i64 [[AND]], [[INTPTR]]
+; CHECK-LLVM:  {{%[0-9]+}} = getelementptr i8, ptr addrspace(1) %p, i64 [[DIFF]]
+
+define spir_kernel void @generic_align8(ptr addrspace(4) %p, ptr addrspace(1) %out) {
+entry:
+  %masked = call ptr addrspace(4) @llvm.ptrmask.p4.i64(ptr addrspace(4) %p, i64 -8)
+  %val = load i8, ptr addrspace(4) %masked, align 1
+  store i8 %val, ptr addrspace(1) %out, align 1
+  ret void
+}
+
+; CHECK-SPIRV:  [[gp:%[a-z0-9_]+]] = OpFunctionParameter [[generic_uchar:%[a-z0-9_]+]]
+; CHECK-SPIRV:  [[gintptr:%[a-z0-9_]+]] = OpConvertPtrToU [[ulong]] [[gp]]
+; CHECK-SPIRV:  [[gand:%[a-z0-9_]+]] = OpBitwiseAnd [[ulong]] [[gintptr]] {{%[a-z0-9_]+}}
+; CHECK-SPIRV:  [[gdiff:%[a-z0-9_]+]] = OpISub [[ulong]] [[gand]] [[gintptr]]
+; CHECK-SPIRV:  {{%[a-z0-9_]+}} = OpPtrAccessChain [[generic_uchar]] [[gp]] [[gdiff]]
+
+; CHECK-LLVM-LABEL: define spir_kernel void @generic_align8
+; CHECK-LLVM:  [[GINTPTR:%[0-9]+]] = ptrtoint ptr addrspace(4) %p to i64
+; CHECK-LLVM:  [[GAND:%[0-9]+]] = and i64 [[GINTPTR]], -8
+; CHECK-LLVM:  [[GDIFF:%[0-9]+]] = sub i64 [[GAND]], [[GINTPTR]]
+; CHECK-LLVM:  {{%[0-9]+}} = getelementptr i8, ptr addrspace(4) %p, i64 [[GDIFF]]
+
+declare ptr addrspace(1) @llvm.ptrmask.p1.i64(ptr addrspace(1), i64)
+declare ptr addrspace(4) @llvm.ptrmask.p4.i64(ptr addrspace(4), i64)

--- a/test/llvm-intrinsics/sadd.with.overflow-vector.ll
+++ b/test/llvm-intrinsics/sadd.with.overflow-vector.ll
@@ -1,0 +1,49 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis -o - %t.rev.bc | FileCheck --check-prefix CHECK-LLVM %s
+
+; The scalar overloads of llvm.sadd.with.overflow are replaced by the hand
+; written helper functions in SPIRVLowerLLVMIntrinsic, which are keyed on the
+; exact intrinsic name and therefore do not cover the vector overloads. Those
+; are lowered to an OpIAdd plus the sign comparison that detects the overflow:
+; an addition overflows when both operands share a sign that the result does
+; not have.
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-DAG:  [[uint:%[a-z0-9_]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG:  [[bool:%[a-z0-9_]+]] = OpTypeBool
+; CHECK-SPIRV-DAG:  [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV-DAG:  [[v4bool:%[a-z0-9_]+]] = OpTypeVector [[bool]] 4
+; CHECK-SPIRV-DAG:  [[vstruct:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4bool]]
+; CHECK-SPIRV-DAG:  [[v4uint_0:%[a-z0-9_]+]] = OpConstantNull [[v4uint]]
+
+define spir_func <4 x i32> @sadd_v4i32(<4 x i32> %a, <4 x i32> %b) {
+entry:
+  %res = call { <4 x i32>, <4 x i1> } @llvm.sadd.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+  %val = extractvalue { <4 x i32>, <4 x i1> } %res, 0
+  %ovf = extractvalue { <4 x i32>, <4 x i1> } %res, 1
+  %sel = select <4 x i1> %ovf, <4 x i32> zeroinitializer, <4 x i32> %val
+  ret <4 x i32> %sel
+}
+
+; CHECK-SPIRV:  [[a:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:  [[b:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:  [[sum:%[a-z0-9_]+]] = OpIAdd [[v4uint]] [[a]] [[b]]
+; CHECK-SPIRV:  [[x1:%[a-z0-9_]+]] = OpBitwiseXor [[v4uint]] [[a]] [[sum]]
+; CHECK-SPIRV:  [[x2:%[a-z0-9_]+]] = OpBitwiseXor [[v4uint]] [[b]] [[sum]]
+; CHECK-SPIRV:  [[and:%[a-z0-9_]+]] = OpBitwiseAnd [[v4uint]] [[x1]] [[x2]]
+; CHECK-SPIRV:  [[ovf:%[a-z0-9_]+]] = OpSLessThan [[v4bool]] [[and]] [[v4uint_0]]
+; CHECK-SPIRV:  {{%[a-z0-9_]+}} = OpCompositeConstruct [[vstruct]] [[sum]] [[ovf]]
+
+; CHECK-LLVM-LABEL: define spir_func <4 x i32> @sadd_v4i32
+; CHECK-LLVM:  [[SUM:%[0-9]+]] = add <4 x i32> %a, %b
+; CHECK-LLVM:  [[X1:%[0-9]+]] = xor <4 x i32> %a, [[SUM]]
+; CHECK-LLVM:  [[X2:%[0-9]+]] = xor <4 x i32> %b, [[SUM]]
+; CHECK-LLVM:  [[AND:%[0-9]+]] = and <4 x i32> [[X1]], [[X2]]
+; CHECK-LLVM:  {{%[0-9]+}} = icmp slt <4 x i32> [[AND]], zeroinitializer
+
+declare { <4 x i32>, <4 x i1> } @llvm.sadd.with.overflow.v4i32(<4 x i32>, <4 x i32>)

--- a/test/llvm-intrinsics/smul.with.overflow.ll
+++ b/test/llvm-intrinsics/smul.with.overflow.ll
@@ -1,0 +1,72 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis -o - %t.rev.bc | FileCheck --check-prefix CHECK-LLVM %s
+
+; OpSMulExtended produces the low and the high half of the full width signed
+; product. The product fits into the operand width exactly when the high half
+; is the sign extension of the low half.
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-DAG:  [[uint:%[a-z0-9_]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG:  [[uint_31:%[a-z0-9_]+]] = OpConstant [[uint]] 31
+; CHECK-SPIRV-DAG:  [[bool:%[a-z0-9_]+]] = OpTypeBool
+; CHECK-SPIRV-DAG:  [[ext:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[uint]]
+; CHECK-SPIRV-DAG:  [[struct:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[bool]]
+; CHECK-SPIRV-DAG:  [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV-DAG:  [[v4bool:%[a-z0-9_]+]] = OpTypeVector [[bool]] 4
+; CHECK-SPIRV-DAG:  [[vext:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4uint]]
+; CHECK-SPIRV-DAG:  [[vstruct:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4bool]]
+; CHECK-SPIRV-DAG:  [[v4uint_31:%[a-z0-9_]+]] = OpConstantComposite [[v4uint]] [[uint_31]] [[uint_31]] [[uint_31]] [[uint_31]]
+
+define spir_func i32 @smul_i32(i32 %a, i32 %b) {
+entry:
+  %res = call { i32, i1 } @llvm.smul.with.overflow.i32(i32 %a, i32 %b)
+  %val = extractvalue { i32, i1 } %res, 0
+  %ovf = extractvalue { i32, i1 } %res, 1
+  %sel = select i1 %ovf, i32 0, i32 %val
+  ret i32 %sel
+}
+
+; CHECK-SPIRV:  [[a:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:  [[b:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:  [[mul:%[a-z0-9_]+]] = OpSMulExtended [[ext]] [[a]] [[b]]
+; CHECK-SPIRV:  [[low:%[a-z0-9_]+]] = OpCompositeExtract [[uint]] [[mul]] 0
+; CHECK-SPIRV:  [[high:%[a-z0-9_]+]] = OpCompositeExtract [[uint]] [[mul]] 1
+; CHECK-SPIRV:  [[sign:%[a-z0-9_]+]] = OpShiftRightArithmetic [[uint]] [[low]] [[uint_31]]
+; CHECK-SPIRV:  [[ovf:%[a-z0-9_]+]] = OpINotEqual [[bool]] [[high]] [[sign]]
+; CHECK-SPIRV:  {{%[a-z0-9_]+}} = OpCompositeConstruct [[struct]] [[low]] [[ovf]]
+
+; CHECK-LLVM-LABEL: define spir_func i32 @smul_i32
+; CHECK-LLVM:  call spir_func void @_Z20__spirv_SMulExtendedii(ptr sret({{%[a-z0-9_.]+}}) [[EXT:%[0-9]+]], i32 %a, i32 %b)
+; CHECK-LLVM:  [[PAIR:%[0-9]+]] = load {{%[a-z0-9_.]+}}, ptr [[EXT]]
+; CHECK-LLVM:  [[LOW:%[0-9]+]] = extractvalue {{%[a-z0-9_.]+}} [[PAIR]], 0
+; CHECK-LLVM:  [[HIGH:%[0-9]+]] = extractvalue {{%[a-z0-9_.]+}} [[PAIR]], 1
+; CHECK-LLVM:  [[SIGN:%[0-9]+]] = ashr i32 [[LOW]], 31
+; CHECK-LLVM:  {{%[0-9]+}} = icmp ne i32 [[HIGH]], [[SIGN]]
+
+define spir_func <4 x i32> @smul_v4i32(<4 x i32> %a, <4 x i32> %b) {
+entry:
+  %res = call { <4 x i32>, <4 x i1> } @llvm.smul.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+  %val = extractvalue { <4 x i32>, <4 x i1> } %res, 0
+  ret <4 x i32> %val
+}
+
+; CHECK-SPIRV:  [[va:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:  [[vb:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:  [[vmul:%[a-z0-9_]+]] = OpSMulExtended [[vext]] [[va]] [[vb]]
+; CHECK-SPIRV:  [[vlow:%[a-z0-9_]+]] = OpCompositeExtract [[v4uint]] [[vmul]] 0
+; CHECK-SPIRV:  [[vhigh:%[a-z0-9_]+]] = OpCompositeExtract [[v4uint]] [[vmul]] 1
+; CHECK-SPIRV:  [[vsign:%[a-z0-9_]+]] = OpShiftRightArithmetic [[v4uint]] [[vlow]] [[v4uint_31]]
+; CHECK-SPIRV:  [[vovf:%[a-z0-9_]+]] = OpINotEqual [[v4bool]] [[vhigh]] [[vsign]]
+; CHECK-SPIRV:  {{%[a-z0-9_]+}} = OpCompositeConstruct [[vstruct]] [[vlow]] [[vovf]]
+
+; CHECK-LLVM-LABEL: define spir_func <4 x i32> @smul_v4i32
+; CHECK-LLVM:  [[VSIGN:%[0-9]+]] = ashr <4 x i32> {{%[0-9]+}}, splat (i32 31)
+; CHECK-LLVM:  {{%[0-9]+}} = icmp ne <4 x i32> {{%[0-9]+}}, [[VSIGN]]
+
+declare { i32, i1 } @llvm.smul.with.overflow.i32(i32, i32)
+declare { <4 x i32>, <4 x i1> } @llvm.smul.with.overflow.v4i32(<4 x i32>, <4 x i32>)

--- a/test/llvm-intrinsics/ssub.with.overflow.ll
+++ b/test/llvm-intrinsics/ssub.with.overflow.ll
@@ -1,0 +1,73 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-dis --raw-id %t.spv | FileCheck --check-prefix CHECK-SPIRV %s
+; RUN: spirv-val %t.spv
+; RUN: llvm-spirv -r -o %t.rev.bc %t.spv
+; RUN: llvm-dis -o - %t.rev.bc | FileCheck --check-prefix CHECK-LLVM %s
+
+; SPIR-V has OpISubBorrow for the unsigned case only, so the signed case is
+; the difference plus the sign comparison that detects the overflow:
+; a subtraction overflows when the operands have different signs and the
+; result does not have the sign of the minuend.
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV-DAG:  [[uint:%[a-z0-9_]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG:  [[uint_0:%[a-z0-9_]+]] = OpConstant [[uint]] 0
+; CHECK-SPIRV-DAG:  [[bool:%[a-z0-9_]+]] = OpTypeBool
+; CHECK-SPIRV-DAG:  [[struct:%[a-z0-9_]+]] = OpTypeStruct [[uint]] [[bool]]
+; CHECK-SPIRV-DAG:  [[v4uint:%[a-z0-9_]+]] = OpTypeVector [[uint]] 4
+; CHECK-SPIRV-DAG:  [[v4bool:%[a-z0-9_]+]] = OpTypeVector [[bool]] 4
+; CHECK-SPIRV-DAG:  [[vstruct:%[a-z0-9_]+]] = OpTypeStruct [[v4uint]] [[v4bool]]
+; CHECK-SPIRV-DAG:  [[v4uint_0:%[a-z0-9_]+]] = OpConstantNull [[v4uint]]
+
+define spir_func i32 @ssub_i32(i32 %a, i32 %b) {
+entry:
+  %res = call { i32, i1 } @llvm.ssub.with.overflow.i32(i32 %a, i32 %b)
+  %val = extractvalue { i32, i1 } %res, 0
+  %ovf = extractvalue { i32, i1 } %res, 1
+  %sel = select i1 %ovf, i32 0, i32 %val
+  ret i32 %sel
+}
+
+; CHECK-SPIRV:  [[a:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:  [[b:%[a-z0-9_]+]] = OpFunctionParameter [[uint]]
+; CHECK-SPIRV:  [[diff:%[a-z0-9_]+]] = OpISub [[uint]] [[a]] [[b]]
+; CHECK-SPIRV:  [[x1:%[a-z0-9_]+]] = OpBitwiseXor [[uint]] [[a]] [[b]]
+; CHECK-SPIRV:  [[x2:%[a-z0-9_]+]] = OpBitwiseXor [[uint]] [[a]] [[diff]]
+; CHECK-SPIRV:  [[and:%[a-z0-9_]+]] = OpBitwiseAnd [[uint]] [[x1]] [[x2]]
+; CHECK-SPIRV:  [[ovf:%[a-z0-9_]+]] = OpSLessThan [[bool]] [[and]] [[uint_0]]
+; CHECK-SPIRV:  {{%[a-z0-9_]+}} = OpCompositeConstruct [[struct]] [[diff]] [[ovf]]
+
+; CHECK-LLVM-LABEL: define spir_func i32 @ssub_i32
+; CHECK-LLVM:  [[LDIFF:%[0-9]+]] = sub i32 %a, %b
+; CHECK-LLVM:  [[LX1:%[0-9]+]] = xor i32 %a, %b
+; CHECK-LLVM:  [[LX2:%[0-9]+]] = xor i32 %a, [[LDIFF]]
+; CHECK-LLVM:  [[LAND:%[0-9]+]] = and i32 [[LX1]], [[LX2]]
+; CHECK-LLVM:  {{%[0-9]+}} = icmp slt i32 [[LAND]], 0
+
+define spir_func <4 x i32> @ssub_v4i32(<4 x i32> %a, <4 x i32> %b) {
+entry:
+  %res = call { <4 x i32>, <4 x i1> } @llvm.ssub.with.overflow.v4i32(<4 x i32> %a, <4 x i32> %b)
+  %val = extractvalue { <4 x i32>, <4 x i1> } %res, 0
+  ret <4 x i32> %val
+}
+
+; CHECK-SPIRV:  [[va:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:  [[vb:%[a-z0-9_]+]] = OpFunctionParameter [[v4uint]]
+; CHECK-SPIRV:  [[vdiff:%[a-z0-9_]+]] = OpISub [[v4uint]] [[va]] [[vb]]
+; CHECK-SPIRV:  [[vx1:%[a-z0-9_]+]] = OpBitwiseXor [[v4uint]] [[va]] [[vb]]
+; CHECK-SPIRV:  [[vx2:%[a-z0-9_]+]] = OpBitwiseXor [[v4uint]] [[va]] [[vdiff]]
+; CHECK-SPIRV:  [[vand:%[a-z0-9_]+]] = OpBitwiseAnd [[v4uint]] [[vx1]] [[vx2]]
+; CHECK-SPIRV:  [[vovf:%[a-z0-9_]+]] = OpSLessThan [[v4bool]] [[vand]] [[v4uint_0]]
+; CHECK-SPIRV:  {{%[a-z0-9_]+}} = OpCompositeConstruct [[vstruct]] [[vdiff]] [[vovf]]
+
+; CHECK-LLVM-LABEL: define spir_func <4 x i32> @ssub_v4i32
+; CHECK-LLVM:  [[VDIFF:%[0-9]+]] = sub <4 x i32> %a, %b
+; CHECK-LLVM:  [[VX1:%[0-9]+]] = xor <4 x i32> %a, %b
+; CHECK-LLVM:  [[VX2:%[0-9]+]] = xor <4 x i32> %a, [[VDIFF]]
+; CHECK-LLVM:  [[VAND:%[0-9]+]] = and <4 x i32> [[VX1]], [[VX2]]
+; CHECK-LLVM:  {{%[0-9]+}} = icmp slt <4 x i32> [[VAND]], zeroinitializer
+
+declare { i32, i1 } @llvm.ssub.with.overflow.i32(i32, i32)
+declare { <4 x i32>, <4 x i1> } @llvm.ssub.with.overflow.v4i32(<4 x i32>, <4 x i32>)


### PR DESCRIPTION
Six intrinsics that have an exact expression in core SPIR-V are rejected by the writer, so ordinary hardened C++ (`__builtin_sub_overflow`, `__builtin_mul_overflow`) and `_FORTIFY_SOURCE` code turns into a translation failure with no source location:

```
InvalidFunctionCall: Unexpected llvm intrinsic:
 llvm.ssub.with.overflow.i32 [Src: lib/SPIRV/SPIRVWriter.cpp:5684 false ]
```

`llvm.sadd.with.overflow` and `llvm.ssub.with.overflow` now become `OpIAdd` / `OpISub` plus the sign comparison that detects the overflow. An addition overflows when both operands share a sign that the result does not have; a subtraction overflows when the operands have different signs and the result does not have the sign of the minuend. Both are `((X ^ A) & (Y ^ B)) < 0` over the appropriate operand pairs. The scalar `sadd` overloads still go through the hand written helper functions in `SPIRVLowerLLVMIntrinsic`, whose table is keyed on the exact intrinsic name; only the vector overloads, which that table does not name, reach the writer. Moving the scalar overloads onto the inline expansion as well would be a separate change.

`llvm.smul.with.overflow` becomes `OpSMulExtended`. From the SPIR-V specification, `specs/binary.adoc`, OpSMulExtended:

```
Member 0 of the result gets the low-order bits of the multiplication.

Member 1 of the result gets the high-order bits of the multiplication.
```

so the product is representable in the operand width exactly when the high half is the sign extension of the low half, which is `OpShiftRightArithmetic` of member 0 by `bits - 1` compared against member 1 with `OpINotEqual`. `OpSMulExtended` carries no capability requirement, and the reader already maps it to `__spirv_SMulExtended`, so the round trip works. All three predicates were checked exhaustively over every `i8` operand pair against `__builtin_{add,sub,mul}_overflow`, with zero mismatches.

`llvm.memcpy.inline` joins the `llvm.memcpy` path. LangRef says the intrinsics "copy a block of memory from the source location to the destination location and guarantees that no external functions are called", and `OpCopyMemorySized` is an instruction rather than a call, so the existing translation already satisfies that guarantee. The zero length case keeps dropping the intrinsic entirely, since `OpCopyMemorySized` with a Size of 0 is invalid SPIR-V.

`llvm.ptrmask` is expanded in `SPIRVRegularizeLLVM` into the sequence LangRef specifies, with `iPtrIdx` the index type size of the pointer:

```
%intptr = ptrtoint ptr %ptr to iPtrIdx ; this may truncate
%masked = and iPtrIdx %intptr, %mask
%diff = sub iPtrIdx %masked, %intptr
%result = getelementptr i8, ptr %ptr, iPtrIdx %diff
```

The existing GEP translation turns that into `OpConvertPtrToU` / `OpBitwiseAnd` / `OpISub` / `OpPtrAccessChain`, so the result keeps the storage class of the pointer operand. An `inttoptr` of the masked value would not preserve it. Doing this in the regularization pass rather than in the writer also means vectors of pointers and the untyped pointer mode need no special handling.

`llvm.objectsize` is folded to a constant. The static form goes to `lowerObjectSizeCall`, which recovers the real size for objects the module can see. For the dynamic form (fourth operand set) that function would splice an instruction sequence in front of the call, which is not possible while the enclosing function is already being translated, so it gets the conservative answer LangRef prescribes: "If the size cannot be determined, `llvm.objectsize` returns `i32/i64 -1 or 0` (depending on the `min` argument)."

Two commits, tests first. The six new tests under `test/llvm-intrinsics/` fail on the parent commit with the error above and pass after the fix; each one runs `llvm-spirv`, `spirv-dis`, `spirv-val` and an `llvm-spirv -r` round trip.

Caveat on local validation. This was built and tested against LLVM 23.1.0-rc2, not the LLVM 24 trunk that `main` targets, because no LLVM 24 install was available on the machine. The only version sensitive API used is `lowerObjectSizeCall(IntrinsicInst *, const DataLayout &, const TargetLibraryInfo *, bool)`, whose declaration in `llvm/Analysis/MemoryBuiltins.h` is unchanged on trunk, so CI should be the deciding check for the LLVM 24 configuration. In the LLVM 23 configuration the full suite goes from 1087 passed and 31 failed to 1093 passed and 25 failed, so exactly the six new tests flip and nothing else changes. The 25 that remain are pre-existing on that box and unrelated: a SPIRV-Tools v2025.2 that predates the capabilities and integer widths those tests use, plus backend comparisons against LLVM 23. Nothing was executed on a device.
