### PR TITLE
[CMake] Use relative paths for install destinations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ install(
     ${LLVM_SPIRV_INCLUDE_DIRS}/LLVMSPIRVOpts.h
     ${LLVM_SPIRV_INCLUDE_DIRS}/LLVMSPIRVExtensions.inc
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/include/LLVMSPIRVLib
+    include/LLVMSPIRVLib
 )
 
 configure_file(LLVMSPIRVLib.pc.in ${CMAKE_BINARY_DIR}/LLVMSPIRVLib.pc @ONLY)
@@ -172,5 +172,5 @@ install(
   FILES
     ${CMAKE_BINARY_DIR}/LLVMSPIRVLib.pc
   DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/lib${LLVM_LIBDIR_SUFFIX}/pkgconfig
+    lib${LLVM_LIBDIR_SUFFIX}/pkgconfig
 )


### PR DESCRIPTION
Currently, the `DESTINATION` arguments to `install()` all contain absolute paths prefixed with `${CMAKE_INSTALL_PREFIX}/`.

This PR gets rid of such prefixes as they are redundant (CMake already prepends it as needed) and advised against by CMake documentation (see `cmake-commands(7)` or [this link](https://cmake.org/cmake/help/latest/command/install.html#common-options)).

Passing absolute destinations to `install()` breaks situations where `cmake --install` is given the `--prefix` option, and also when specifying `CMAKE_STAGING_PREFIX` for cross-builds since it would get ignored in favor of the absolute path.