### PR TITLE
Temporarily disable llc runs with SPV_EXT_long_vector

### DIFF
--- a/test/transcoding/builtin_vars_different_type.ll
+++ b/test/transcoding/builtin_vars_different_type.ll
@@ -1,10 +1,13 @@
 ; RUN: llvm-spirv %s -o %t.spv -spirv-ext=+SPV_INTEL_vector_compute
 ; RUN: llvm-spirv -r %t.spv --spirv-target-env=SPV-IR -o %t.out.bc
 ; RUN: llvm-dis %t.out.bc -o - | FileCheck %s --check-prefix=CHECK-SPV-IR
-; RUN: %if spirv-backend %{ llc -O0 -mtriple=spirv32-unknown-unknown -filetype=obj %s -o %t.llc.spv %}
-; RUN: %if spirv-backend %{ llvm-spirv -r %t.llc.spv --spirv-target-env=SPV-IR -o %t.llc.rev.bc %}
-; RUN: %if spirv-backend %{ llvm-dis %t.llc.rev.bc -o %t.llc.rev.ll %}
-; RUN: %if spirv-backend %{ FileCheck %s --check-prefix=CHECK-LLC < %t.llc.rev.ll %}
+
+; TODO: llc outputs OpTypeVectorIdEXT now which the reader can't consume;
+; re-enable them once OpTypeVectorIdEXT is supported by the reader.
+; RUNx: %if spirv-backend %{ llc -O0 -mtriple=spirv32-unknown-unknown --spirv-ext=+SPV_EXT_long_vector -filetype=obj %s -o %t.llc.spv %}
+; RUNx: %if spirv-backend %{ llvm-spirv -r %t.llc.spv --spirv-target-env=SPV-IR -o %t.llc.rev.bc %}
+; RUNx: %if spirv-backend %{ llvm-dis %t.llc.rev.bc -o %t.llc.rev.ll %}
+; RUNx: %if spirv-backend %{ FileCheck %s --check-prefix=CHECK-LLC < %t.llc.rev.ll %}
 ; TODO: rewrite the test as currently DCE removes IR through llc compilation flow
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
Fix the in-tree failure by temporarily disabling llc runs in builtin_vars_different_type.ll.

From https://github.com/llvm/llvm-project/pull/212685, LLC now requires `SPV_EXT_long_vector` to be enabled when a non-standard vector size is present; additionally, LLC outputs `OpTypeVectorIdEXT` (5288) which isn't supported by the Reader now.

I have a pending PR #3951 which adds support for `OpTypeVectorIdEXT` in the Reader. These LLC run can be re-enabled once #3951 is merged.