### PR TITLE
Fix handling of checkError calls on null pointer check

### DIFF
--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -2959,8 +2959,9 @@ void addFuncPointerCallArgumentAttributes(CallInst *CI,
     ErrLog.checkError(NumOperands == 2, SPIRVEC_InvalidLlvmModule,             \
                       #NAME " requires exactly 1 extra operand");              \
     auto *StrDecoEO = dyn_cast<MDString>(DecoMD->getOperand(1));               \
-    ErrLog.checkError(StrDecoEO, SPIRVEC_InvalidLlvmModule,                    \
-                      #NAME " requires extra operand to be a string");         \
+    if (!ErrLog.checkError(StrDecoEO, SPIRVEC_InvalidLlvmModule,               \
+                           #NAME " requires extra operand to be a string"))    \
+      return;                                                                  \
     Target->addDecorate(                                                       \
         new SPIRVDecorate##NAME##Attr(Target, StrDecoEO->getString().str()));  \
     break;                                                                     \
@@ -2972,8 +2973,9 @@ void addFuncPointerCallArgumentAttributes(CallInst *CI,
                       #NAME " requires exactly 1 extra operand");              \
     auto *IntDecoEO =                                                          \
         mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));              \
-    ErrLog.checkError(IntDecoEO, SPIRVEC_InvalidLlvmModule,                    \
-                      #NAME " requires extra operand to be an integer");       \
+    if (!ErrLog.checkError(IntDecoEO, SPIRVEC_InvalidLlvmModule,               \
+                           #NAME " requires extra operand to be an integer"))  \
+      return;                                                                  \
     Target->addDecorate(new SPIRVDecorate##NAME(                               \
         Target, static_cast<TYPE>(IntDecoEO->getZExtValue())));                \
     break;                                                                     \
@@ -2985,13 +2987,16 @@ void addFuncPointerCallArgumentAttributes(CallInst *CI,
                       #NAME " requires exactly 2 extra operands");             \
     auto *IntDecoEO1 =                                                         \
         mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));              \
-    ErrLog.checkError(IntDecoEO1, SPIRVEC_InvalidLlvmModule,                   \
-                      #NAME " requires first extra operand to be an integer"); \
+    if (!ErrLog.checkError(IntDecoEO1, SPIRVEC_InvalidLlvmModule,              \
+                           #NAME                                               \
+                           " requires first extra operand to be an integer"))  \
+      return;                                                                  \
     auto *IntDecoEO2 =                                                         \
         mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(2));              \
-    ErrLog.checkError(IntDecoEO2, SPIRVEC_InvalidLlvmModule,                   \
-                      #NAME                                                    \
-                      " requires second extra operand to be an integer");      \
+    if (!ErrLog.checkError(IntDecoEO2, SPIRVEC_InvalidLlvmModule,              \
+                           #NAME                                               \
+                           " requires second extra operand to be an integer")) \
+      return;                                                                  \
     Target->addDecorate(new SPIRVDecorate##NAME(                               \
         Target, static_cast<TYPE1>(IntDecoEO1->getZExtValue()),                \
         static_cast<TYPE2>(IntDecoEO2->getZExtValue())));                      \
@@ -3018,14 +3023,16 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
   assert(ArgDecoMD && "Decoration list must be a metadata node");
   for (unsigned I = 0, E = ArgDecoMD->getNumOperands(); I != E; ++I) {
     auto *DecoMD = dyn_cast<MDNode>(ArgDecoMD->getOperand(I));
-    ErrLog.checkError(DecoMD, SPIRVEC_InvalidLlvmModule,
-                      "Decoration does not name metadata");
+    if (!ErrLog.checkError(DecoMD, SPIRVEC_InvalidLlvmModule,
+                           "Decoration does not name metadata"))
+      return;
     ErrLog.checkError(DecoMD->getNumOperands() > 0, SPIRVEC_InvalidLlvmModule,
                       "Decoration metadata must have at least one operand");
     auto *DecoKindConst =
         mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(0));
-    ErrLog.checkError(DecoKindConst, SPIRVEC_InvalidLlvmModule,
-                      "First operand of decoration must be the kind");
+    if (!ErrLog.checkError(DecoKindConst, SPIRVEC_InvalidLlvmModule,
+                           "First operand of decoration must be the kind"))
+      return;
     auto DecoKind = static_cast<Decoration>(DecoKindConst->getZExtValue());
 
     const size_t NumOperands = DecoMD->getNumOperands();
@@ -3035,8 +3042,9 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
       // Alignment decorations.
       auto *Alignment =
           mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
-      ErrLog.checkError(Alignment, SPIRVEC_InvalidLlvmModule,
-                        "Alignment operand must be an integer.");
+      if (!ErrLog.checkError(Alignment, SPIRVEC_InvalidLlvmModule,
+                             "Alignment operand must be an integer."))
+        return;
       Target->setAlignment(Alignment->getZExtValue());
       break;
     }
@@ -3069,8 +3077,10 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
       ErrLog.checkError(NumOperands == 2, SPIRVEC_InvalidLlvmModule,
                         "UniformId requires exactly 1 extra operand");
       auto *ScopeEO = mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
-      ErrLog.checkError(ScopeEO, SPIRVEC_InvalidLlvmModule,
-                        "UniformId requires extra operand to be an integer");
+      if (!ErrLog.checkError(
+              ScopeEO, SPIRVEC_InvalidLlvmModule,
+              "UniformId requires extra operand to be an integer"))
+        return;
       SPIRVModule *BM = Target->getModule();
       SPIRVValue *ScopeConst = BM->addIntegerConstant(BM->addIntegerType(32),
                                                       ScopeEO->getZExtValue());
@@ -3106,13 +3116,15 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
       ErrLog.checkError(NumOperands == 3, SPIRVEC_InvalidLlvmModule,
                         "MergeINTEL requires exactly 3 extra operands");
       auto *Name = dyn_cast<MDString>(DecoMD->getOperand(1));
-      ErrLog.checkError(
-          Name, SPIRVEC_InvalidLlvmModule,
-          "MergeINTEL requires first extra operand to be a string");
+      if (!ErrLog.checkError(
+              Name, SPIRVEC_InvalidLlvmModule,
+              "MergeINTEL requires first extra operand to be a string"))
+        return;
       auto *Direction = dyn_cast<MDString>(DecoMD->getOperand(2));
-      ErrLog.checkError(
-          Direction, SPIRVEC_InvalidLlvmModule,
-          "MergeINTEL requires second extra operand to be a string");
+      if (!ErrLog.checkError(
+              Direction, SPIRVEC_InvalidLlvmModule,
+              "MergeINTEL requires second extra operand to be a string"))
+        return;
       Target->addDecorate(new SPIRVDecorateMergeINTELAttr(
           Target, Name->getString().str(), Direction->getString().str()));
       break;
@@ -3121,13 +3133,15 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
       ErrLog.checkError(NumOperands == 3, SPIRVEC_InvalidLlvmModule,
                         "LinkageAttributes requires exactly 3 extra operands");
       auto *Name = dyn_cast<MDString>(DecoMD->getOperand(1));
-      ErrLog.checkError(
-          Name, SPIRVEC_InvalidLlvmModule,
-          "LinkageAttributes requires first extra operand to be a string");
+      if (!ErrLog.checkError(
+              Name, SPIRVEC_InvalidLlvmModule,
+              "LinkageAttributes requires first extra operand to be a string"))
+        return;
       auto *Type = mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(2));
-      ErrLog.checkError(
-          Type, SPIRVEC_InvalidLlvmModule,
-          "LinkageAttributes requires second extra operand to be an int");
+      if (!ErrLog.checkError(
+              Type, SPIRVEC_InvalidLlvmModule,
+              "LinkageAttributes requires second extra operand to be an int"))
+        return;
       auto TypeKind = static_cast<SPIRVLinkageTypeKind>(Type->getZExtValue());
       Target->addDecorate(new SPIRVDecorateLinkageAttr(
           Target, Name->getString().str(), TypeKind));
@@ -3143,16 +3157,18 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
                         "after the decoration kind number");
       auto *AccessMode =
           mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
-      ErrLog.checkError(
-          AccessMode, SPIRVEC_InvalidLlvmModule,
-          "HostAccessINTEL requires first extra operand to be an int");
+      if (!ErrLog.checkError(
+              AccessMode, SPIRVEC_InvalidLlvmModule,
+              "HostAccessINTEL requires first extra operand to be an int"))
+        return;
 
       HostAccessQualifier Q =
           static_cast<HostAccessQualifier>(AccessMode->getZExtValue());
       auto *Name = dyn_cast<MDString>(DecoMD->getOperand(2));
-      ErrLog.checkError(
-          Name, SPIRVEC_InvalidLlvmModule,
-          "HostAccessINTEL requires second extra operand to be a string");
+      if (!ErrLog.checkError(
+              Name, SPIRVEC_InvalidLlvmModule,
+              "HostAccessINTEL requires second extra operand to be a string"))
+        return;
 
       if (DecoKind == DecorationHostAccessINTEL)
         Target->addDecorate(new SPIRVDecorateHostAccessINTEL(
@@ -3166,17 +3182,20 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
     case spv::internal::DecorationInitModeINTEL:
     case DecorationInitModeINTEL: {
       checkIsGlobalVar(Target, DecoKind);
-      ErrLog.checkError(
-          static_cast<SPIRVVariableBase *>(Target)->getInitializer(),
-          SPIRVEC_InvalidLlvmModule,
-          "InitModeINTEL only be applied to a global (module "
-          "scope) variable which has an Initializer operand");
+      if (!ErrLog.checkError(
+              static_cast<SPIRVVariableBase *>(Target)->getInitializer(),
+              SPIRVEC_InvalidLlvmModule,
+              "InitModeINTEL only be applied to a global (module "
+              "scope) variable which has an Initializer operand"))
+        return;
 
       ErrLog.checkError(NumOperands == 2, SPIRVEC_InvalidLlvmModule,
                         "InitModeINTEL requires exactly 1 extra operand");
       auto *Trigger = mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
-      ErrLog.checkError(Trigger, SPIRVEC_InvalidLlvmModule,
-                        "InitModeINTEL requires extra operand to be an int");
+      if (!ErrLog.checkError(
+              Trigger, SPIRVEC_InvalidLlvmModule,
+              "InitModeINTEL requires extra operand to be an int"))
+        return;
 
       InitializationModeQualifier Q =
           static_cast<InitializationModeQualifier>(Trigger->getZExtValue());
@@ -3193,9 +3212,10 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
       ErrLog.checkError(NumOperands == 2, SPIRVEC_InvalidLlvmModule,
                         "ImplementInCSRINTEL requires exactly 1 extra operand");
       auto *Value = mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
-      ErrLog.checkError(
-          Value, SPIRVEC_InvalidLlvmModule,
-          "ImplementInCSRINTEL requires extra operand to be an integer");
+      if (!ErrLog.checkError(
+              Value, SPIRVEC_InvalidLlvmModule,
+              "ImplementInCSRINTEL requires extra operand to be an integer"))
+        return;
 
       Target->addDecorate(
           new SPIRVDecorateImplementInCSRINTEL(Target, Value->getZExtValue()));
@@ -3207,9 +3227,11 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
           NumOperands == 2, SPIRVEC_InvalidLlvmModule,
           "ImplementInRegisterMapINTEL requires exactly 1 extra operand");
       auto *Value = mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
-      ErrLog.checkError(Value, SPIRVEC_InvalidLlvmModule,
-                        "ImplementInRegisterMapINTEL requires extra operand to "
-                        "be an integer");
+      if (!ErrLog.checkError(
+              Value, SPIRVEC_InvalidLlvmModule,
+              "ImplementInRegisterMapINTEL requires extra operand to "
+              "be an integer"))
+        return;
 
       Target->addDecorate(new SPIRVDecorateImplementInRegisterMapINTEL(
           Target, Value->getZExtValue()));
@@ -3225,12 +3247,15 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
           mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
       auto *CacheControl =
           mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(2));
-      ErrLog.checkError(CacheLevel, SPIRVEC_InvalidLlvmModule,
-                        "CacheControlLoadINTEL cache level operand is required "
-                        "to be an integer");
-      ErrLog.checkError(CacheControl, SPIRVEC_InvalidLlvmModule,
-                        "CacheControlLoadINTEL cache control operand is "
-                        "required to be an integer");
+      if (!ErrLog.checkError(
+              CacheLevel, SPIRVEC_InvalidLlvmModule,
+              "CacheControlLoadINTEL cache level operand is required "
+              "to be an integer"))
+        return;
+      if (!ErrLog.checkError(CacheControl, SPIRVEC_InvalidLlvmModule,
+                             "CacheControlLoadINTEL cache control operand is "
+                             "required to be an integer"))
+        return;
 
       Target->addDecorate(new SPIRVDecorateCacheControlLoadINTEL(
           Target, CacheLevel->getZExtValue(),
@@ -3245,12 +3270,14 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
           mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
       auto *CacheControl =
           mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(2));
-      ErrLog.checkError(CacheLevel, SPIRVEC_InvalidLlvmModule,
-                        "CacheControlStoreINTEL cache level operand is "
-                        "required to be an integer");
-      ErrLog.checkError(CacheControl, SPIRVEC_InvalidLlvmModule,
-                        "CacheControlStoreINTEL cache control operand is "
-                        "required to be an integer");
+      if (!ErrLog.checkError(CacheLevel, SPIRVEC_InvalidLlvmModule,
+                             "CacheControlStoreINTEL cache level operand is "
+                             "required to be an integer"))
+        return;
+      if (!ErrLog.checkError(CacheControl, SPIRVEC_InvalidLlvmModule,
+                             "CacheControlStoreINTEL cache control operand is "
+                             "required to be an integer"))
+        return;
 
       Target->addDecorate(new SPIRVDecorateCacheControlStoreINTEL(
           Target, CacheLevel->getZExtValue(),
@@ -3272,9 +3299,10 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
 
       auto *DecoValEO1 =
           mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(1));
-      ErrLog.checkError(
-          DecoValEO1, SPIRVEC_InvalidLlvmModule,
-          "First extra operand in default decoration case must be integer.");
+      if (!ErrLog.checkError(DecoValEO1, SPIRVEC_InvalidLlvmModule,
+                             "First extra operand in default decoration case "
+                             "must be integer."))
+        return;
       if (NumOperands == 2) {
         Target->addDecorate(
             new SPIRVDecorate(DecoKind, Target, DecoValEO1->getZExtValue()));
@@ -3283,9 +3311,10 @@ static void transMetadataDecorations(Metadata *MD, SPIRVValue *Target) {
 
       auto *DecoValEO2 =
           mdconst::dyn_extract<ConstantInt>(DecoMD->getOperand(2));
-      ErrLog.checkError(
-          DecoValEO2, SPIRVEC_InvalidLlvmModule,
-          "Second extra operand in default decoration case must be integer.");
+      if (!ErrLog.checkError(DecoValEO2, SPIRVEC_InvalidLlvmModule,
+                             "Second extra operand in default decoration case "
+                             "must be integer."))
+        return;
 
       ErrLog.checkError(NumOperands == 3, SPIRVEC_InvalidLlvmModule,
                         "At most 2 extra operands expected.");


### PR DESCRIPTION
Some `checkError` calls checks for non-null pointers, without checking its return value and no early return if it fails. This is fine if `SPIRVErrorLog` defaults to abort/exit; however, when it's set to "ignore" and the pointers are null, it will still continue execution and end up dereferencing null pointers.

This PR adds the check of the return value and an early return for `checkError` calls on null pointer checks, for a more graceful failure instead of a segfault by dereferencing null pointers in "ignore" mode. These are flagged by our internal static analysis tool and should be fixed.

NOTE: this PR fixes `checkError` on pointers only, to avoid segfault when dereferencing null pointers. `checkError` on non-pointer checks aren't included in this PR, as there are still _many_ inproper `checkError` calls across the entire repo; fixing them is out of scope for this PR, and at this point, they aren't as harmful as dereferencing null pointers.