### PR TITLE
Translate branch weight metadata to and from `OpBranchConditional`

### DIFF
--- a/lib/SPIRV/SPIRVReader.cpp
+++ b/lib/SPIRV/SPIRVReader.cpp
@@ -73,6 +73,7 @@
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassInstrumentation.h"
+#include "llvm/IR/ProfDataUtils.h"
 #include "llvm/IR/Type.h"
 #include "llvm/IR/TypedPointerType.h"
 #include "llvm/Support/Casting.h"
@@ -1986,6 +1987,9 @@ Value *SPIRVToLLVM::transValueWithoutDecoration(SPIRVValue *BV, Function *F,
         transValue(BR->getCondition(), F, BB),
         cast<BasicBlock>(transValue(BR->getTrueLabel(), F, BB)),
         cast<BasicBlock>(transValue(BR->getFalseLabel(), F, BB)), BB);
+    const std::vector<SPIRVWord> &Weights = BR->getBranchWeights();
+    if (Weights.size() == 2)
+      setBranchWeights(*BC, {Weights[0], Weights[1]}, /*IsExpected=*/false);
     // Loop metadata will be translated in the end of function translation.
     return mapValue(BV, BC);
   }

--- a/lib/SPIRV/SPIRVWriter.cpp
+++ b/lib/SPIRV/SPIRVWriter.cpp
@@ -67,6 +67,7 @@
 #include "VectorComputeUtil.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Analysis/LoopAnalysisManager.h"
 #include "llvm/Analysis/LoopInfo.h"
@@ -81,6 +82,7 @@
 #include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/IR/ProfDataUtils.h"
 #include "llvm/IR/TypedPointerType.h"
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
@@ -2609,9 +2611,17 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     if (SuccessorTrue == SuccessorFalse)
       return mapValue(V, BM->addBranchInst(SuccessorTrue, BB));
 
-    return mapValue(
-        V, BM->addBranchConditionalInst(transValue(Branch->getCondition(), BB),
-                                        SuccessorTrue, SuccessorFalse, BB));
+    std::vector<SPIRVWord> BranchWeights;
+    uint64_t TrueWeight = 0, FalseWeight = 0;
+    if (extractBranchWeights(*Branch, TrueWeight, FalseWeight)) {
+      SmallVector<uint32_t> Fitted =
+          downscaleWeights({TrueWeight, FalseWeight});
+      BranchWeights.assign(Fitted.begin(), Fitted.end());
+    }
+
+    return mapValue(V, BM->addBranchConditionalInst(
+                           transValue(Branch->getCondition(), BB),
+                           SuccessorTrue, SuccessorFalse, BB, BranchWeights));
   }
 
   if (auto *Branch = dyn_cast<UncondBrInst>(V)) {

--- a/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -996,6 +996,9 @@ public:
   SPIRVValue *getCondition() const { return getValue(ConditionId); }
   SPIRVLabel *getTrueLabel() const { return get<SPIRVLabel>(TrueLabelId); }
   SPIRVLabel *getFalseLabel() const { return get<SPIRVLabel>(FalseLabelId); }
+  const std::vector<SPIRVWord> &getBranchWeights() const {
+    return BranchWeights;
+  }
 
 protected:
   void setWordCount(SPIRVWord TheWordCount) override {

--- a/lib/SPIRV/libSPIRV/SPIRVModule.cpp
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.cpp
@@ -353,9 +353,9 @@ public:
 
   // Constant creation functions
   SPIRVInstruction *addBranchInst(SPIRVLabel *, SPIRVBasicBlock *) override;
-  SPIRVInstruction *addBranchConditionalInst(SPIRVValue *, SPIRVLabel *,
-                                             SPIRVLabel *,
-                                             SPIRVBasicBlock *) override;
+  SPIRVInstruction *addBranchConditionalInst(
+      SPIRVValue *, SPIRVLabel *, SPIRVLabel *, SPIRVBasicBlock *,
+      const std::vector<SPIRVWord> &BranchWeights = {}) override;
   SPIRVValue *addCompositeConstant(SPIRVType *,
                                    const std::vector<SPIRVValue *> &) override;
   SPIRVEntry *addCompositeConstantContinuedINTEL(
@@ -1832,7 +1832,12 @@ SPIRVInstruction *SPIRVModuleImpl::addBranchInst(SPIRVLabel *TargetLabel,
 
 SPIRVInstruction *SPIRVModuleImpl::addBranchConditionalInst(
     SPIRVValue *Condition, SPIRVLabel *TrueLabel, SPIRVLabel *FalseLabel,
-    SPIRVBasicBlock *BB) {
+    SPIRVBasicBlock *BB, const std::vector<SPIRVWord> &BranchWeights) {
+  if (BranchWeights.size() == 2)
+    return addInstruction(
+        new SPIRVBranchConditional(Condition, TrueLabel, FalseLabel, BB,
+                                   BranchWeights[0], BranchWeights[1]),
+        BB);
   return addInstruction(
       new SPIRVBranchConditional(Condition, TrueLabel, FalseLabel, BB), BB);
 }

--- a/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -349,9 +349,9 @@ public:
                     SPIRVBasicBlock *BB) = 0;
   virtual SPIRVInstruction *addBinaryInst(Op, SPIRVType *, SPIRVValue *,
                                           SPIRVValue *, SPIRVBasicBlock *) = 0;
-  virtual SPIRVInstruction *addBranchConditionalInst(SPIRVValue *, SPIRVLabel *,
-                                                     SPIRVLabel *,
-                                                     SPIRVBasicBlock *) = 0;
+  virtual SPIRVInstruction *addBranchConditionalInst(
+      SPIRVValue *, SPIRVLabel *, SPIRVLabel *, SPIRVBasicBlock *,
+      const std::vector<SPIRVWord> &BranchWeights = {}) = 0;
   virtual SPIRVInstruction *addBranchInst(SPIRVLabel *, SPIRVBasicBlock *) = 0;
   virtual SPIRVInstruction *addExtInst(SPIRVType *, SPIRVWord, SPIRVWord,
                                        const std::vector<SPIRVWord> &,

--- a/test/branching/OpBranchConditionalWeights.ll
+++ b/test/branching/OpBranchConditionalWeights.ll
@@ -1,0 +1,52 @@
+; REQUIRES: spirv-dis
+; RUN: llvm-spirv %s -o %t.spv
+; RUN: spirv-val %t.spv
+; RUN: spirv-dis %t.spv | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.spv -o %t.rev.bc -r --spirv-target-env=SPV-IR
+; RUN: llvm-dis %t.rev.bc -o %t.rev.ll
+; RUN: FileCheck --input-file=%t.rev.ll %s --check-prefix=CHECK-LLVM
+
+; Branch weight metadata (as produced by __builtin_expect, [[likely]]/
+; [[unlikely]], or PGO) is translated to and from the optional Branch
+; Weights operands of OpBranchConditional.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-G1"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-SPIRV: %weighted_branch = OpFunction
+; CHECK-SPIRV: OpBranchConditional %cmp %if_then %if_else 2000 1
+define spir_func i32 @weighted_branch(i32 %x) {
+entry:
+  %cmp = icmp sgt i32 %x, 10
+  br i1 %cmp, label %if.then, label %if.else, !prof !0
+
+if.then:
+  ret i32 %x
+
+if.else:
+  ret i32 %x
+}
+
+; CHECK-SPIRV: %unweighted_branch = OpFunction
+; CHECK-SPIRV: OpBranchConditional %cmp_0 %if_then_0 %if_else_0{{$}}
+define spir_func i32 @unweighted_branch(i32 %x) {
+entry:
+  %cmp = icmp sgt i32 %x, 10
+  br i1 %cmp, label %if.then, label %if.else
+
+if.then:
+  ret i32 %x
+
+if.else:
+  ret i32 %x
+}
+
+; CHECK-LLVM-LABEL: define spir_func i32 @weighted_branch
+; CHECK-LLVM: br i1 %{{.*}}, label %{{.*}}, label %{{.*}}, !prof ![[#PROF:]]
+
+; CHECK-LLVM-LABEL: define spir_func i32 @unweighted_branch
+; CHECK-LLVM-NOT: !prof
+
+; CHECK-LLVM: ![[#PROF]] = !{!"branch_weights", i32 2000, i32 1}
+
+!0 = !{!"branch_weights", i32 2000, i32 1}


### PR DESCRIPTION
Conditional branches carrying `!prof branch_weights` metadata (from `__builtin_expect`, `[[likely]]/[[unlikely]]`, or profile-guided optimization) now preserve those weights through the optional `Branch Weights` literal operands of `OpBranchConditional`.
Weights wider than 32 bits, or whose sum would overflow a 32-bit unsigned integer are downscaled to fit the SPIR-V literal format while preserving their ratio.

Translating such a SPIR-V module back to LLVM IR reconstructs the `!prof` metadata from the operands.
Branches without profiling metadata are unaffected and continue to emit the 4-word form of the instruction.

AI-assisted: Claude Sonnet 5 (commercial SaaS)
